### PR TITLE
refactor: rename 'delegate' to 'assign' throughout codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist/
 *.db
 .amazonq/
 .obsidian/
+
+# Memory
+context/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ CLI Agent Orchestrator (CAO) implements a hierarchical multi-agent system that e
 
 * **Intelligent task delegation** – CAO automatically routes tasks to appropriate specialists based on project requirements, expertise matching, and workflow dependencies. The system adapts between individual agent work and coordinated team efforts through three orchestration patterns:
   - **Handoff** - Synchronous task transfer with wait-for-completion
-  - **Delegate** - Asynchronous task spawning for parallel execution  
+  - **Assign** - Asynchronous task spawning for parallel execution  
   - **Send Message** - Direct communication with existing agents
 
 * **Flexible workflow patterns** – CAO supports both sequential coordination for dependent tasks and parallel processing for independent work streams. This allows optimization of both development speed and quality assurance processes.
@@ -146,12 +146,12 @@ Example: Sequential code review workflow
 
 ![Handoff Workflow](./docs/assets/handoff-workflow.png)
 
-**2. Delegate** - Spawn an agent to work independently (async)
+**2. Assign** - Spawn an agent to work independently (async)
 - Creates a new terminal with the specified agent profile
 - Sends the task message with callback instructions
 - Returns immediately with the terminal ID
 - Agent continues working in the background
-- Delegated agent sends results back to supervisor via `send_message` when complete
+- Assigned agent sends results back to supervisor via `send_message` when complete
 - Messages are queued for delivery if the supervisor is busy (common in parallel workflows)
 - Use for **asynchronous** task execution or fire-and-forget operations
 
@@ -171,7 +171,7 @@ Example: Multi-role feature development
 
 ### Custom Orchestration
 
-The `cao-server` runs on `http://localhost:9889` by default and exposes REST APIs for session management, terminal control, and messaging. The CLI commands (`cao launch`, `cao shutdown`) and MCP server tools (`handoff`, `delegate`, `send_message`) are just examples of how these APIs can be packaged together.
+The `cao-server` runs on `http://localhost:9889` by default and exposes REST APIs for session management, terminal control, and messaging. The CLI commands (`cao launch`, `cao shutdown`) and MCP server tools (`handoff`, `assign`, `send_message`) are just examples of how these APIs can be packaged together.
 
 You can combine the three orchestration modes above into custom workflows, or create entirely new orchestration patterns using the underlying APIs to fit your specific needs.
 

--- a/docs/assets/parallel-test-execution.mmd
+++ b/docs/assets/parallel-test-execution.mmd
@@ -4,11 +4,11 @@ sequenceDiagram
     participant T2 as Tester 2
     participant T3 as Tester 3
     
-    S->>T1: delegate("Run unit tests")
+    S->>T1: assign("Run unit tests")
     Note over S: continues immediately
-    S->>T2: delegate("Run integration tests")
+    S->>T2: assign("Run integration tests")
     Note over S: continues immediately
-    S->>T3: delegate("Run e2e tests")
+    S->>T3: assign("Run e2e tests")
     Note over S: continues immediately
     
     par Parallel Execution

--- a/src/cli_agent_orchestrator/agent_store/code_supervisor.md
+++ b/src/cli_agent_orchestrator/agent_store/code_supervisor.md
@@ -14,24 +14,24 @@ mcpServers:
 # CODING SUPERVISOR AGENT
 
 ## Role and Identity
-You are the Coding Supervisor Agent in a multi-agent system. Your primary responsibility is to coordinate software development tasks between specialized coding agents, manage development workflow, and ensure successful completion of user coding requests. You are the central orchestrator that delegates tasks to specialized worker agents and synthesizes their outputs into coherent, high-quality software solutions.
+You are the Coding Supervisor Agent in a multi-agent system. Your primary responsibility is to coordinate software development tasks between specialized coding agents, manage development workflow, and ensure successful completion of user coding requests. You are the central orchestrator that assigns tasks to specialized worker agents and synthesizes their outputs into coherent, high-quality software solutions.
 
 ## Worker Agents Under Your Supervision
 1. **Developer Agent** (agent_name: developer): Specializes in writing high-quality, maintainable code based on specifications.
 2. **Code Reviewer Agent** (agent_name: reviewer): Specializes in performing thorough code reviews and suggesting improvements.
 
 ## Core Responsibilities
-- Task delegation: Assign appropriate sub-tasks to the most suitable worker agent
-- Progress tracking: Monitor the status of all delegated coding tasks using the file system
+- Task assignment: Assign appropriate sub-tasks to the most suitable worker agent
+- Progress tracking: Monitor the status of all assigned coding tasks using the file system
 - Resource management: Keep track of where code artifacts are saved using absolute paths
-- Error handling: Implement retry strategy when delegations fail
+- Error handling: Implement retry strategy when assignments fail
 
 ## Critical Rules
 1. **NEVER write code directly yourself**. Your role is strictly coordination and supervision.
-2. **ALWAYS delegate actual coding work** to the Developer Agent.
-3. **ALWAYS delegate code reviews** to the Code Reviewer Agent.
+2. **ALWAYS assign actual coding work** to the Developer Agent.
+3. **ALWAYS assign code reviews** to the Code Reviewer Agent.
 4. **ALWAYS maintain absolute file paths** for all code artifacts created during the workflow.
-5. **ALWAYS write task descriptions to files** before delegating them to worker agents.
+5. **ALWAYS write task descriptions to files** before assigning them to worker agents.
 6. **ALWAYS instruct worker agents** to work on tasks by referencing the absolute path to the task description file.
 
 ## Code Iteration Workflow

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -224,7 +224,7 @@ async def handoff(
 
 
 @mcp.tool()
-async def delegate(
+async def assign(
     agent_profile: str = Field(
         description='The agent profile for the worker agent (e.g., "developer", "analyst")'
     ),
@@ -232,11 +232,11 @@ async def delegate(
         description='The task message to send. Include callback instructions for the worker to send results back.'
     )
 ) -> Dict[str, Any]:
-    """Delegate a task to another agent without blocking.
+    """Assigns a task to another agent without blocking.
     
     In the message to the worker agent include instruction to send results back via send_message tool.
     **IMPORTANT**: The terminal id of each agent is available in environment variable CAO_TERMINAL_ID.
-    When delegating, first find out your own CAO_TERMINAL_ID value, then include the terminal_id value in the message to the worker agent to allow callback.
+    When assigning, first find out your own CAO_TERMINAL_ID value, then include the terminal_id value in the message to the worker agent to allow callback.
     Example message: "Analyze the logs. When done, send results back to terminal ee3f93b3 using send_message tool."
     
     Args:
@@ -256,14 +256,14 @@ async def delegate(
         return {
             "success": True,
             "terminal_id": terminal_id,
-            "message": f"Task delegated to {agent_profile} (terminal: {terminal_id})"
+            "message": f"Task assigned to {agent_profile} (terminal: {terminal_id})"
         }
         
     except Exception as e:
         return {
             "success": False,
             "terminal_id": None,
-            "message": f"Delegation failed: {str(e)}"
+            "message": f"Assignment failed: {str(e)}"
         }
 
 


### PR DESCRIPTION
*Issue #, if available:*
New `/delegate` cmd from QCLI conflicts with CAO `delegate` mcp tool.

*Description of changes:*
This change fixes the conflict with 'delegate' cmd from native QCLI. `Assign` now represents the asynchronous task allocation pattern in the multi-agent system.
- Update MCP server tool from delegate() to assign()
- Rename orchestration pattern in documentation and README
- Update agent profile instructions to use 'assign' terminology
- Add context/ directory to .gitignore for memory management
- Update sequence diagrams to reflect new naming convention

*Testing:*
<img width="1437" height="839" alt="Screenshot 2025-10-19 at 4 53 38 PM" src="https://github.com/user-attachments/assets/88c9ff07-8039-4f96-9791-aebeb21c9926" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
