### PR TITLE
refactor: update idle prompt pattern for Q CLI to use consistent colo…

### DIFF
--- a/src/cli_agent_orchestrator/providers/q_cli.py
+++ b/src/cli_agent_orchestrator/providers/q_cli.py
@@ -33,8 +33,8 @@ class QCliProvider(BaseProvider):
         self._agent_profile = agent_profile
         # Create dynamic prompt pattern based on agent profile
         # Matches: [agent] !> or [agent] > or [agent] X% > with optional color reset and optional trailing whitespace/newlines
-        # The percentage has its own ANSI color codes: \x1b[38;5;10m2% 
-        self._idle_prompt_pattern = rf'\x1b\[38;5;14m\[{re.escape(self._agent_profile)}\]\s*(?:\x1b\[38;5;10m\d+%\s*)?(?:\x1b\[38;5;9m!\s*)?\x1b\[38;5;13m>\s*(?:\x1b\[39m)?[\s\n]*$'
+        # Q CLI uses 16-color codes: \x1b[36m (cyan) for [agent], \x1b[35m (magenta) for >
+        self._idle_prompt_pattern = rf'\x1b\[36m\[{re.escape(self._agent_profile)}\]\s*(?:\x1b\[32m\d+%\s*)?\x1b\[35m>\s*(?:\x1b\[39m)?[\s\n]*$'
         self._permission_prompt_pattern = r'Allow this action\?.*\[.*y.*\/.*n.*\/.*t.*\]:\x1b\[39m\s*' + self._idle_prompt_pattern
     
     


### PR DESCRIPTION
*Issue #14 *

*Description of changes:*

The new version of Q CLI has changed the colour coding of its commands.

Tested on Mac and Ubuntu
