### PR TITLE
Fix GitHub Actions security alerts by adding explicit workflow permissions

### DIFF
--- a/.github/workflows/test-q-cli-provider.yml
+++ b/.github/workflows/test-q-cli-provider.yml
@@ -1,5 +1,8 @@
 name: Test Q CLI Provider
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
## Description
Fixes 3 Medium severity CodeQL security alerts (CWE-275) by adding explicit permissions to the test workflow.

## Changes
- Added `permissions: contents: read` block to `.github/workflows/test-q-cli-provider.yml`
- Limits GITHUB_TOKEN to read-only access, following the principle of least privilege

## Security Impact
- ✅ Resolves alert 2 (workflow-level permissions)
- ✅ Resolves alert 3 (integration-tests job)
- ✅ Resolves alert 4 (lint job)

## Testing
- All existing workflow functionality remains unchanged
- Jobs only need read access for checkout, test, and lint operations
- Codecov upload uses separate token authentication

Closes alerts 2, 3, 4