### PR TITLE
feat: standardize inbox API parameters with backward compatibility

### DIFF
--- a/test/api/test_inbox_messages.py
+++ b/test/api/test_inbox_messages.py
@@ -73,7 +73,9 @@ class TestGetInboxMessagesEndpoint:
 
     def test_get_messages_with_status_filter(self, client, sample_inbox_messages):
         """Test getting messages with status filter."""
-        pending_messages = [msg for msg in sample_inbox_messages if msg.status == MessageStatus.PENDING]
+        pending_messages = [
+            msg for msg in sample_inbox_messages if msg.status == MessageStatus.PENDING
+        ]
 
         with patch("cli_agent_orchestrator.api.main.get_inbox_messages") as mock_get:
             mock_get.return_value = pending_messages
@@ -182,21 +184,22 @@ class TestGetInboxMessagesEndpoint:
             created_at = data[0]["created_at"]
             assert isinstance(created_at, str)
             # Should be able to parse as ISO datetime
-            parsed_datetime = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+            parsed_datetime = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
             assert isinstance(parsed_datetime, datetime)
 
     def test_all_status_values(self, client, sample_inbox_messages):
         """Test filtering by each possible status value."""
         for status_value in ["pending", "delivered", "failed"]:
             filtered_messages = [
-                msg for msg in sample_inbox_messages
-                if msg.status.value == status_value
+                msg for msg in sample_inbox_messages if msg.status.value == status_value
             ]
 
             with patch("cli_agent_orchestrator.api.main.get_inbox_messages") as mock_get:
                 mock_get.return_value = filtered_messages
 
-                response = client.get(f"/terminals/terminal123/inbox/messages?status={status_value}")
+                response = client.get(
+                    f"/terminals/terminal123/inbox/messages?status={status_value}"
+                )
 
                 assert response.status_code == 200
                 data = response.json()
@@ -212,11 +215,12 @@ class TestDatabaseFunctionCompatibility:
     def test_get_inbox_messages_function_exists(self):
         """Test that the new get_inbox_messages function is properly imported."""
         from cli_agent_orchestrator.clients.database import get_inbox_messages
+
         assert callable(get_inbox_messages)
 
     def test_get_pending_messages_backward_compatibility(self):
         """Test that get_pending_messages still works as before."""
-        from cli_agent_orchestrator.clients.database import get_pending_messages, get_inbox_messages
+        from cli_agent_orchestrator.clients.database import get_inbox_messages, get_pending_messages
 
         # Both functions should be callable
         assert callable(get_pending_messages)


### PR DESCRIPTION
## Summary
This PR standardizes the inbox API parameters while maintaining full backward compatibility.

## What changed
- **Terminal ID parameter**: Changed from `TerminalId` to `str` with `Path()` validation for better type safety
- **Status parameter**: Renamed from `status` to `message_status` with `alias="status"` for backward compatibility
- **Code formatting**: Applied proper Black and isort formatting to affected files

## Why this PR is needed
- Improves API design consistency with better parameter naming
- Resolves potential naming conflicts between API parameters and internal variables  
- Maintains full backward compatibility through FastAPI aliases
- Follows best practices for API parameter naming and validation

## Backward Compatibility
- The `status` query parameter continues to work via FastAPI alias
- No breaking changes for existing API clients
- Response format remains unchanged

## Files changed
- `src/cli_agent_orchestrator/api/main.py` - Core API parameter changes
- `test/api/test_inbox_messages.py` - Updated test formatting

## Test plan
- [x] All existing tests pass with new parameter structure
- [x] API documentation reflects parameter changes  
- [x] Backward compatibility maintained through alias
- [x] Code formatting checks pass

This change improves the API design while ensuring no disruption to existing users.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
via [Happy](https://happy.engineering)