### PR TITLE
feat: add changelog and automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Bump version and generate changelog
+        id: bump
+        run: |
+          python scripts/bump_version.py ${{ inputs.bump }}
+          VERSION=$(grep 'version = ' pyproject.toml | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml CHANGELOG.md
+          git commit -m "chore: release v${{ steps.bump.outputs.version }}"
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push && git push --tags
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.bump.outputs.version }}
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.0.0] - 2026-01-23
+
+### Added
+
+- async delegate (#3)
+
+- add badge to deepwiki for weekly auto-refresh (#13)
+
+- add Codex CLI provider (#39)
+
+
+### Changed
+
+- rename 'delegate' to 'assign' throughout codebase (#10)
+
+
+### Fixed
+
+- Handle percentage in agent prompt pattern (#4)
+
+- resolve code formatting issues in upstream main (#40)
+
+
+### Other
+
+- Initial commit
+
+- Initial Launch (#1)
+
+- Inbox Service (#2)
+
+- tmux install script (#5)
+
+- update README: orchestration modes (#6)
+
+- Update README.md (#7)
+
+- Update issue templates (#8)
+
+- Document update with Mermaid process diagram (#9)
+
+- Adding examples for assign (async parallel) (#11)
+
+- update idle prompt pattern for Q CLI to use consistent color codes (#15)
+
+- Add comprehensive test suite for Q CLI provider (#16)
+
+- Add code formatting and type checking with Black, isort, and mypy (#20)
+
+- Make Q CLI Prompt Pattern Matching ANSI color-agnostic (#18)
+
+- Add explicit permissions to workflow
+
+- Kiro CLI provider (#25)
+
+- Add GET endpoint for inbox messages with status filtering (#30)
+
+- Adding git to the install dependencies message (#28)
+
+- Bump to v0.51.0, update method name (#31)
+
+- accept optional U+03BB (λ) after % in kiro and q CLIs (#44)
+
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,43 @@
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | trim }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^add", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore", group = "Other" },
+  { body = ".*", group = "Other" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+
+[remote.github]
+owner = "awslabs"
+repo = "cli-agent-orchestrator"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cli-agent-orchestrator"
-version = "0.1.2"
+version = "1.0.0"
 description = "CLI Agent Orchestrator"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Version bump script for cli-agent-orchestrator."""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def get_version() -> str:
+    content = PYPROJECT.read_text()
+    match = re.search(r'version = "([^"]+)"', content)
+    return match.group(1) if match else "0.0.0"
+
+
+def bump(part: str, version: str) -> str:
+    major, minor, patch = map(int, version.split("."))
+    if part == "major":
+        return f"{major + 1}.0.0"
+    elif part == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def update_pyproject(new_version: str) -> None:
+    content = PYPROJECT.read_text()
+    content = re.sub(r'version = "[^"]+"', f'version = "{new_version}"', content)
+    PYPROJECT.write_text(content)
+
+
+def generate_changelog(new_version: str) -> None:
+    subprocess.run(
+        ["git-cliff", "--tag", f"v{new_version}", "-o", "CHANGELOG.md"],
+        cwd=ROOT,
+        check=True,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] not in ("major", "minor", "patch"):
+        print(f"Usage: {sys.argv[0]} <major|minor|patch>")
+        print(f"Current version: {get_version()}")
+        sys.exit(1)
+
+    old = get_version()
+    new = bump(sys.argv[1], old)
+
+    update_pyproject(new)
+    generate_changelog(new)
+
+    print(f"Bumped {old} -> {new}")
+    print(f"\nNext steps:")
+    print(f"  1. git add pyproject.toml CHANGELOG.md")
+    print(f"  2. git commit -m 'chore: release v{new}'")
+    print(f"  3. git tag v{new}")
+    print(f"  4. git push && git push --tags")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds automated changelog generation and version management using git-cliff.

## Changes
- CHANGELOG.md - Auto-generated changelog following Keep a Changelog format
- cliff.toml - git-cliff configuration for parsing conventional commits
- scripts/bump_version.py - Script to bump version and regenerate changelog
- .github/workflows/release.yml - GitHub Action for one-click releases
- pyproject.toml - Updated version to 1.0.0

## How to release
1. Go to Actions → Release → Run workflow
2. Select patch, minor, or major
3. Click Run - it will bump version, update changelog, tag, and create a GitHub release

## For developers
No changes needed - just write conventional commit messages (feat:, fix:, etc.) and they'll be automatically included in the changelog.