### PR TITLE
fix: update IDLE_PROMPT_PATTERN_LOG to match actual kiro-cli ANSI output

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -17,7 +17,7 @@ ANSI_CODE_PATTERN = r"\x1b\[[0-9;]*m"
 ESCAPE_SEQUENCE_PATTERN = r"\[[?0-9;]*[a-zA-Z]"
 CONTROL_CHAR_PATTERN = r"[\x00-\x1f\x7f-\x9f]"
 BELL_CHAR = "\x07"
-IDLE_PROMPT_PATTERN_LOG = r"\x1b\[38;5;13m>\s*\x1b\[39m"
+IDLE_PROMPT_PATTERN_LOG = r"\x1b\[38;5;\d+m\[.+?\].*\x1b\[38;5;\d+m>\s*\x1b\[\d*m"
 
 # Error indicators
 ERROR_INDICATORS = ["Kiro is having trouble responding right now"]


### PR DESCRIPTION
## Problem

The watchdog's `IDLE_PROMPT_PATTERN_LOG` in `kiro_cli.py` hardcodes ANSI color `38;5;13` and reset `\x1b[39m]`, but kiro-cli actually uses color `38;5;93` and reset `\x1b[0m]`. The pattern never matches, so the watchdog never detects idle state and pending inbox messages are never delivered.

Related to #43 (same class of bug — brittle regex not tolerating prompt variations), but affects a different code path (log file pattern matching vs tmux output status detection).

## Root Cause

```python
# Before (broken — wrong color and reset code)
IDLE_PROMPT_PATTERN_LOG = r"\x1b\[38;5;13m>\s*\x1b\[39m"
```

Kiro-cli actually writes: `\x1b[38;5;93m> \x1b[0m]` (color 93, reset 0).

## Fix

```python
# After (structural match with [agent-name] prefix)
IDLE_PROMPT_PATTERN_LOG = r"\x1b\[38;5;\d+m\[.+?\].*\x1b\[38;5;\d+m>\s*\x1b\[\d*m"
```

Uses `\d+` for color codes (future-proof) and requires `[agent-name]` bracket prefix to distinguish idle prompts from kiro-cli's response-start `>` marker (color 141), which would cause message injection mid-response if matched.

## Verification

- 0 false positives, 0 missed matches across 300+ terminal log files
- Fix tested live: watchdog delivered pending messages within ~3 seconds of terminal going idle

Fixes #64