### PR TITLE
perf(tmux): replace chunked send_keys with paste-buffer for instant delivery

### DIFF
--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -1,0 +1,131 @@
+"""Tests for TmuxClient.send_keys paste-buffer implementation."""
+
+from unittest.mock import call, patch
+
+import pytest
+
+from cli_agent_orchestrator.clients.tmux import TmuxClient
+
+
+@pytest.fixture
+def client():
+    with patch("cli_agent_orchestrator.clients.tmux.libtmux"):
+        return TmuxClient()
+
+
+@pytest.fixture
+def mock_subprocess():
+    with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock:
+        mock.run.return_value = None
+        yield mock
+
+
+@pytest.fixture
+def mock_uuid():
+    with patch("cli_agent_orchestrator.clients.tmux.uuid") as mock:
+        mock.uuid4.return_value.hex = "abcd1234efgh"
+        yield mock
+
+
+class TestSendKeys:
+    """Tests for the paste-buffer based send_keys implementation."""
+
+    def test_basic_message(self, client, mock_subprocess, mock_uuid):
+        """Sends load-buffer, paste-buffer -p, send-keys Enter, delete-buffer."""
+        client.send_keys("sess", "win", "hello")
+
+        assert mock_subprocess.run.call_count == 4
+        calls = mock_subprocess.run.call_args_list
+
+        # load-buffer with unique name and message as stdin
+        assert calls[0] == call(
+            ["tmux", "load-buffer", "-b", "cao_abcd1234", "-"],
+            input=b"hello",
+            check=True,
+        )
+        # paste-buffer with -p (bracketed paste)
+        assert calls[1] == call(
+            ["tmux", "paste-buffer", "-p", "-b", "cao_abcd1234", "-t", "sess:win"],
+            check=True,
+        )
+        # send Enter
+        assert calls[2] == call(
+            ["tmux", "send-keys", "-t", "sess:win", "Enter"],
+            check=True,
+        )
+        # delete-buffer (best-effort)
+        assert calls[3] == call(
+            ["tmux", "delete-buffer", "-b", "cao_abcd1234"],
+            check=False,
+        )
+
+    def test_multiline_message(self, client, mock_subprocess, mock_uuid):
+        """Multi-line content is sent as-is; -p flag handles newlines."""
+        msg = "line 1\nline 2\nline 3"
+        client.send_keys("sess", "win", msg)
+
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call == call(
+            ["tmux", "load-buffer", "-b", "cao_abcd1234", "-"],
+            input=msg.encode(),
+            check=True,
+        )
+
+    def test_special_characters(self, client, mock_subprocess, mock_uuid):
+        """Quotes, backticks, dollars are sent raw (no tmux key interpretation)."""
+        msg = """He said "hello" and ran `cmd` with $VAR"""
+        client.send_keys("sess", "win", msg)
+
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call[1]["input"] == msg.encode()
+
+    def test_empty_message(self, client, mock_subprocess, mock_uuid):
+        """Empty string still goes through the full pipeline."""
+        client.send_keys("sess", "win", "")
+
+        assert mock_subprocess.run.call_count == 4
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call[1]["input"] == b""
+
+    def test_buffer_cleanup_on_error(self, client, mock_subprocess, mock_uuid):
+        """Buffer is deleted even when paste-buffer fails."""
+        mock_subprocess.run.side_effect = [
+            None,  # load-buffer succeeds
+            Exception("paste failed"),  # paste-buffer fails
+            None,  # delete-buffer in finally
+        ]
+
+        with pytest.raises(Exception, match="paste failed"):
+            client.send_keys("sess", "win", "msg")
+
+        # delete-buffer still called in finally block
+        last_call = mock_subprocess.run.call_args_list[-1]
+        assert last_call == call(
+            ["tmux", "delete-buffer", "-b", "cao_abcd1234"],
+            check=False,
+        )
+
+    def test_unique_buffer_per_call(self, client, mock_subprocess):
+        """Each call gets a unique buffer name to prevent race conditions."""
+        with patch("cli_agent_orchestrator.clients.tmux.uuid") as mock_uuid:
+            mock_uuid.uuid4.return_value.hex = "aaaa1111bbbb"
+            client.send_keys("sess", "win", "msg1")
+
+            mock_uuid.uuid4.return_value.hex = "cccc2222dddd"
+            client.send_keys("sess", "win", "msg2")
+
+        calls = mock_subprocess.run.call_args_list
+        # First call uses cao_aaaa1111
+        assert calls[0][0][0][3] == "cao_aaaa1111"
+        # Second call (index 4, after 4 calls from first send_keys) uses cao_cccc2222
+        assert calls[4][0][0][3] == "cao_cccc2222"
+
+    def test_large_message(self, client, mock_subprocess, mock_uuid):
+        """Large messages go through in a single load-buffer call (no chunking)."""
+        msg = "X" * 50000
+        client.send_keys("sess", "win", msg)
+
+        # Still exactly 4 subprocess calls — no chunking
+        assert mock_subprocess.run.call_count == 4
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert len(load_call[1]["input"]) == 50000

--- a/test/providers/test_q_cli_integration.py
+++ b/test/providers/test_q_cli_integration.py
@@ -11,6 +11,7 @@ import pytest
 from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.q_cli import QCliProvider
+from cli_agent_orchestrator.utils.terminal import wait_for_shell
 
 # Mark all tests in this module as integration and slow
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
@@ -444,6 +445,9 @@ class TestQCliProviderWorkingDirectory:
         subdir.mkdir()
 
         # Change directory in tmux pane
+        # wait_for_shell ensures shell is initialized before sending commands
+        # (paste-buffer delivery is instant, so shell must be ready first)
+        wait_for_shell(tmux_client, test_session_name, window_name, timeout=10.0)
         tmux_client.send_keys(test_session_name, window_name, f"cd {subdir}")
         time.sleep(0.5)  # Wait for command to execute
 


### PR DESCRIPTION
## Summary

Replaces the chunked `send_keys` approach (100-char chunks, 0.5s delay each) with `tmux load-buffer` + `paste-buffer -p` for constant-time message delivery regardless of size.

Closes #66

## Problem

`SEND_KEYS_CHUNK_INTERVAL = 0.5` makes message delivery painfully slow:

| Message size | Before | After |
|---|---|---|
| 2,500 chars | 12.9s | <100ms |
| 10,000 chars | 50.5s | <100ms |
| 50,000 chars | ~250s | <100ms |

## Changes

- **`src/cli_agent_orchestrator/clients/tmux.py`**: Replace chunking loop with `load-buffer` + `paste-buffer -p` + `send-keys Enter` + `delete-buffer`
- **`test/clients/test_tmux_send_keys.py`**: 7 unit tests covering basic delivery, multi-line, special characters, empty messages, error cleanup, unique buffers, large messages
- **`test/providers/test_q_cli_integration.py`**: Add `wait_for_shell()` before `send_keys` in integration test (was relying on implicit delay from chunked delivery)

## Design Decisions

| Decision | Reason |
|---|---|
| `-p` flag on `paste-buffer` | **Mandatory.** Enables bracketed paste so multi-line content is a single input. Without it, each newline acts as Enter — only first line is submitted. |
| Unique buffer name per call (`uuid`) | Prevents race conditions when concurrent async `send_message` calls hit `send_keys` simultaneously. |
| `delete-buffer` in `finally` | Prevents unbounded tmux buffer accumulation over long sessions. |
| `subprocess.run` instead of libtmux | libtmux does not expose `load-buffer` / `paste-buffer`. |

## Testing

**Unit tests** (7/7 passing):
- Basic message delivery pipeline
- Multi-line content preserved
- Special characters sent raw
- Empty message handling
- Buffer cleanup on error (finally block)
- Unique buffer per concurrent call
- Large message (50K) — single call, no chunking

**Live testing** on kiro-cli terminals in running CAO session:
- Short (27 chars), medium (508), large (2.5K), very large (10K, 50K) — all <100ms ✅
- Multi-line (3 lines) — received as single input ✅
- Special characters (quotes, backticks, $) — all preserved ✅
- End-to-end via CAO `send_message` API — delivered correctly ✅
- Buffer cleanup — zero `cao_` buffers lingering ✅
- Zero errors in server logs ✅

**Full test suite**: 179 passed, 0 failed, 9 skipped

## Requirements

- tmux >= 2.6 (2017) for `paste-buffer -p`

## Additional Notes

- Also eliminates the need for `literal=True` (PR #63) since `paste-buffer` sends raw buffer content without tmux key interpretation
- All production code paths already call `wait_for_shell()` or check terminal status before `send_keys`, so instant delivery does not cause initialization races