### PR TITLE
fix: prevent permission prompt pattern from matching stale prompts

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -38,7 +38,7 @@ class KiroCliProvider(BaseProvider):
             rf"\[{re.escape(self._agent_profile)}\]\s*(?:\d+%\s*)?(?:\u03bb\s*)?!?>\s*"
         )
         self._permission_prompt_pattern = (
-            r"Allow this action\?.*\[.*y.*\/.*n.*\/.*t.*\]:\s*" + self._idle_prompt_pattern
+            r"Allow this action\?.*\[.*y.*\/.*n.*\/.*t.*\]:[ \t]*" + self._idle_prompt_pattern
         )
 
     def initialize(self) -> bool:

--- a/src/cli_agent_orchestrator/providers/q_cli.py
+++ b/src/cli_agent_orchestrator/providers/q_cli.py
@@ -39,7 +39,7 @@ class QCliProvider(BaseProvider):
             rf"\[{re.escape(self._agent_profile)}\]\s*(?:\d+%\s*)?(?:\u03bb\s*)?!?>\s*"
         )
         self._permission_prompt_pattern = (
-            r"Allow this action\?.*\[.*y.*\/.*n.*\/.*t.*\]:\s*" + self._idle_prompt_pattern
+            r"Allow this action\?.*\[.*y.*\/.*n.*\/.*t.*\]:[ \t]*" + self._idle_prompt_pattern
         )
 
     def initialize(self) -> bool:

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -447,6 +447,16 @@ class TestKiroCliProviderRegexPatterns:
         permission_text = "Allow this action? [y/n/t]: [developer]>"
         assert re.search(provider._permission_prompt_pattern, permission_text)
 
+    def test_permission_prompt_no_match_stale_history(self):
+        """Test that stale permission prompts separated by newlines don't match."""
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+
+        # Stale permission prompt on earlier line, current idle prompt on later line
+        stale = (
+            "Allow this action? [y/n/t]:\n\n[developer] 29% > y\nsome output\n[developer] 29% > "
+        )
+        assert not re.search(provider._permission_prompt_pattern, stale, re.MULTILINE | re.DOTALL)
+
     def test_ansi_code_cleaning(self):
         """Test ANSI code pattern cleaning."""
         from cli_agent_orchestrator.providers.kiro_cli import ANSI_CODE_PATTERN


### PR DESCRIPTION
Fixes #68

## Problem

After PR #61 removed the `$` anchor from `idle_prompt_pattern`, the combined `permission_prompt_pattern` matches stale `[y/n/t]:` text in scrollback. `\s*` between `]:` and the idle prompt bridges across `\n` characters, connecting old permission prompts with the current idle prompt. This causes `get_status()` to permanently return `WAITING_USER_ANSWER` after any permission prompt interaction.

## Fix

Replace `\s*` with `[ \t]*` in the permission prompt pattern in both `kiro_cli.py` and `q_cli.py`:

```python
# Before:
r"Allow this action\?.*\[.*y.*\/.*n.*\/.*t.*\]:\s*" + self._idle_prompt_pattern

# After:
r"Allow this action\?.*\[.*y.*\/.*n.*\/.*t.*\]:[ \t]*" + self._idle_prompt_pattern
```

`[ \t]*` only matches horizontal whitespace (spaces and tabs), blocking newline bridging.

`re.DOTALL` is intentionally **kept** — it is needed for narrow terminals where the permission prompt text wraps across lines.

## Testing

- Added unit test `test_stale_permission_prompt_not_matched` verifying stale prompts do not match
- Full test suite: 190 passed, 9 skipped
- E2E verified: trigger permission prompt → answer `y` → status correctly returns `completed` (not `waiting_user_answer`)
- Inbox messages deliver correctly after permission prompt interaction