### PR TITLE
fix: improve Enter key sending reliability (issue #78)

### DIFF
--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -237,7 +237,7 @@ class TmuxClient:
                     # process the previous Enter (e.g., Ink adding a newline)
                     # before the next Enter triggers form submission.
                     time.sleep(0.5)
-                
+
                 # Retry Enter key sending up to 3 times if it fails
                 max_retries = 3
                 for attempt in range(max_retries):

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -237,11 +237,21 @@ class TmuxClient:
                     # process the previous Enter (e.g., Ink adding a newline)
                     # before the next Enter triggers form submission.
                     time.sleep(0.5)
-                subprocess.run(
-                    ["tmux", "send-keys", "-t", target, "Enter"],
-                    check=True,
-                )
-            logger.debug(f"Sent keys to {target}")
+                try:
+                    result = subprocess.run(
+                        ["tmux", "send-keys", "-t", target, "Enter"],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    logger.debug(f"Sent Enter key {i+1}/{enter_count} to {target}")
+                except subprocess.CalledProcessError as e:
+                    logger.error(
+                        f"Failed to send Enter key {i+1}/{enter_count} to {target}: "
+                        f"returncode={e.returncode}, stderr={e.stderr}"
+                    )
+                    raise
+            logger.debug(f"Sent keys to {target} with {enter_count} Enter key(s)")
         except Exception as e:
             logger.error(f"Failed to send keys to {target}: {e}")
             raise

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -237,21 +237,37 @@ class TmuxClient:
                     # process the previous Enter (e.g., Ink adding a newline)
                     # before the next Enter triggers form submission.
                     time.sleep(0.5)
-                try:
-                    result = subprocess.run(
-                        ["tmux", "send-keys", "-t", target, "Enter"],
-                        check=True,
-                        capture_output=True,
-                        text=True,
-                    )
-                    logger.debug(f"Sent Enter key {i+1}/{enter_count} to {target}")
-                except subprocess.CalledProcessError as e:
-                    logger.error(
-                        f"Failed to send Enter key {i+1}/{enter_count} to {target}: "
-                        f"returncode={e.returncode}, stderr={e.stderr}"
-                    )
-                    raise
-            logger.debug(f"Sent keys to {target} with {enter_count} Enter key(s)")
+                
+                # Retry Enter key sending up to 3 times if it fails
+                max_retries = 3
+                for attempt in range(max_retries):
+                    try:
+                        result = subprocess.run(
+                            ["tmux", "send-keys", "-t", target, "Enter"],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                            timeout=5,
+                        )
+                        logger.debug(f"Sent Enter key {i+1}/{enter_count} to {target}")
+                        break  # Success, exit retry loop
+                    except subprocess.TimeoutExpired:
+                        logger.warning(
+                            f"Timeout sending Enter key {i+1}/{enter_count} to {target}, "
+                            f"attempt {attempt+1}/{max_retries}"
+                        )
+                        if attempt == max_retries - 1:
+                            raise
+                        time.sleep(0.2)
+                    except subprocess.CalledProcessError as e:
+                        logger.error(
+                            f"Failed to send Enter key {i+1}/{enter_count} to {target}: "
+                            f"returncode={e.returncode}, stderr={e.stderr}, attempt {attempt+1}/{max_retries}"
+                        )
+                        if attempt == max_retries - 1:
+                            raise
+                        time.sleep(0.2)
+            logger.info(f"Successfully sent {enter_count} Enter key(s) to {target}")
         except Exception as e:
             logger.error(f"Failed to send keys to {target}: {e}")
             raise

--- a/test/clients/test_issue_78_enter_keys.py
+++ b/test/clients/test_issue_78_enter_keys.py
@@ -16,13 +16,14 @@ class TestEnterKeySending:
     def test_single_enter_key_sent(self, mock_sleep, mock_run):
         """Test that single Enter key is sent successfully."""
         mock_run.return_value = MagicMock(returncode=0)
-        
+
         client = TmuxClient()
         client.send_keys("test-session", "test-window", "Hello", enter_count=1)
-        
+
         # Verify Enter was sent once
         enter_calls = [
-            c for c in mock_run.call_args_list 
+            c
+            for c in mock_run.call_args_list
             if c[0][0][:2] == ["tmux", "send-keys"] and "Enter" in c[0][0]
         ]
         assert len(enter_calls) == 1
@@ -32,17 +33,18 @@ class TestEnterKeySending:
     def test_double_enter_keys_sent(self, mock_sleep, mock_run):
         """Test that two Enter keys are sent for TUI multi-line mode."""
         mock_run.return_value = MagicMock(returncode=0)
-        
+
         client = TmuxClient()
         client.send_keys("test-session", "test-window", "Hello", enter_count=2)
-        
+
         # Verify Enter was sent twice
         enter_calls = [
-            c for c in mock_run.call_args_list 
+            c
+            for c in mock_run.call_args_list
             if c[0][0][:2] == ["tmux", "send-keys"] and "Enter" in c[0][0]
         ]
         assert len(enter_calls) == 2
-        
+
         # Verify delay between Enter keys
         assert mock_sleep.call_count >= 2  # 0.3s initial + 0.5s between Enters
 
@@ -50,23 +52,22 @@ class TestEnterKeySending:
     @patch("cli_agent_orchestrator.clients.tmux.time.sleep")
     def test_enter_key_failure_raises_exception(self, mock_sleep, mock_run):
         """Test that Enter key send failure raises exception with details."""
+
         # Make load-buffer and paste-buffer succeed, but send-keys fail
         def run_side_effect(*args, **kwargs):
             cmd = args[0]
             if "send-keys" in cmd and "Enter" in cmd:
                 raise subprocess.CalledProcessError(
-                    returncode=1, 
-                    cmd=cmd,
-                    stderr="no server running on /tmp/tmux-1000/default"
+                    returncode=1, cmd=cmd, stderr="no server running on /tmp/tmux-1000/default"
                 )
             return MagicMock(returncode=0)
-        
+
         mock_run.side_effect = run_side_effect
-        
+
         client = TmuxClient()
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             client.send_keys("test-session", "test-window", "Hello", enter_count=1)
-        
+
         assert "no server running" in str(exc_info.value.stderr)
 
     @patch("cli_agent_orchestrator.clients.tmux.subprocess.run")
@@ -74,10 +75,10 @@ class TestEnterKeySending:
     def test_enter_keys_sent_with_correct_timing(self, mock_sleep, mock_run):
         """Test that timing delays are applied correctly."""
         mock_run.return_value = MagicMock(returncode=0)
-        
+
         client = TmuxClient()
         client.send_keys("test-session", "test-window", "Hello", enter_count=2)
-        
+
         # Verify sleep calls: 0.3s after paste, 0.5s between Enters
         sleep_calls = [c[0][0] for c in mock_sleep.call_args_list]
         assert 0.3 in sleep_calls  # Initial delay after paste
@@ -89,6 +90,7 @@ class TestEnterKeySending:
         """Test that Enter key sending retries on transient failures."""
         # Make first attempt fail, second succeed
         call_count = 0
+
         def run_side_effect(*args, **kwargs):
             nonlocal call_count
             cmd = args[0]
@@ -102,16 +104,17 @@ class TestEnterKeySending:
                 # Second attempt succeeds
                 return MagicMock(returncode=0)
             return MagicMock(returncode=0)
-        
+
         mock_run.side_effect = run_side_effect
-        
+
         client = TmuxClient()
         # Should succeed after retry
         client.send_keys("test-session", "test-window", "Hello", enter_count=1)
-        
+
         # Verify retry happened (2 attempts for Enter key)
         enter_calls = [
-            c for c in mock_run.call_args_list 
+            c
+            for c in mock_run.call_args_list
             if c[0][0][:2] == ["tmux", "send-keys"] and "Enter" in c[0][0]
         ]
         assert len(enter_calls) == 2  # First failed, second succeeded

--- a/test/clients/test_issue_78_enter_keys.py
+++ b/test/clients/test_issue_78_enter_keys.py
@@ -82,3 +82,36 @@ class TestEnterKeySending:
         sleep_calls = [c[0][0] for c in mock_sleep.call_args_list]
         assert 0.3 in sleep_calls  # Initial delay after paste
         assert 0.5 in sleep_calls  # Delay between Enter keys
+
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.tmux.time.sleep")
+    def test_enter_key_retry_on_failure(self, mock_sleep, mock_run):
+        """Test that Enter key sending retries on transient failures."""
+        # Make first attempt fail, second succeed
+        call_count = 0
+        def run_side_effect(*args, **kwargs):
+            nonlocal call_count
+            cmd = args[0]
+            if "send-keys" in cmd and "Enter" in cmd:
+                call_count += 1
+                if call_count == 1:
+                    # First attempt fails
+                    raise subprocess.CalledProcessError(
+                        returncode=1, cmd=cmd, stderr="session not found"
+                    )
+                # Second attempt succeeds
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=0)
+        
+        mock_run.side_effect = run_side_effect
+        
+        client = TmuxClient()
+        # Should succeed after retry
+        client.send_keys("test-session", "test-window", "Hello", enter_count=1)
+        
+        # Verify retry happened (2 attempts for Enter key)
+        enter_calls = [
+            c for c in mock_run.call_args_list 
+            if c[0][0][:2] == ["tmux", "send-keys"] and "Enter" in c[0][0]
+        ]
+        assert len(enter_calls) == 2  # First failed, second succeeded

--- a/test/clients/test_issue_78_enter_keys.py
+++ b/test/clients/test_issue_78_enter_keys.py
@@ -1,0 +1,84 @@
+"""Tests for issue #78: Prompt not always returned after agents receive messages."""
+
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from cli_agent_orchestrator.clients.tmux import TmuxClient
+
+
+class TestEnterKeySending:
+    """Test that Enter keys are reliably sent after message paste."""
+
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.tmux.time.sleep")
+    def test_single_enter_key_sent(self, mock_sleep, mock_run):
+        """Test that single Enter key is sent successfully."""
+        mock_run.return_value = MagicMock(returncode=0)
+        
+        client = TmuxClient()
+        client.send_keys("test-session", "test-window", "Hello", enter_count=1)
+        
+        # Verify Enter was sent once
+        enter_calls = [
+            c for c in mock_run.call_args_list 
+            if c[0][0][:2] == ["tmux", "send-keys"] and "Enter" in c[0][0]
+        ]
+        assert len(enter_calls) == 1
+
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.tmux.time.sleep")
+    def test_double_enter_keys_sent(self, mock_sleep, mock_run):
+        """Test that two Enter keys are sent for TUI multi-line mode."""
+        mock_run.return_value = MagicMock(returncode=0)
+        
+        client = TmuxClient()
+        client.send_keys("test-session", "test-window", "Hello", enter_count=2)
+        
+        # Verify Enter was sent twice
+        enter_calls = [
+            c for c in mock_run.call_args_list 
+            if c[0][0][:2] == ["tmux", "send-keys"] and "Enter" in c[0][0]
+        ]
+        assert len(enter_calls) == 2
+        
+        # Verify delay between Enter keys
+        assert mock_sleep.call_count >= 2  # 0.3s initial + 0.5s between Enters
+
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.tmux.time.sleep")
+    def test_enter_key_failure_raises_exception(self, mock_sleep, mock_run):
+        """Test that Enter key send failure raises exception with details."""
+        # Make load-buffer and paste-buffer succeed, but send-keys fail
+        def run_side_effect(*args, **kwargs):
+            cmd = args[0]
+            if "send-keys" in cmd and "Enter" in cmd:
+                raise subprocess.CalledProcessError(
+                    returncode=1, 
+                    cmd=cmd,
+                    stderr="no server running on /tmp/tmux-1000/default"
+                )
+            return MagicMock(returncode=0)
+        
+        mock_run.side_effect = run_side_effect
+        
+        client = TmuxClient()
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            client.send_keys("test-session", "test-window", "Hello", enter_count=1)
+        
+        assert "no server running" in str(exc_info.value.stderr)
+
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.tmux.time.sleep")
+    def test_enter_keys_sent_with_correct_timing(self, mock_sleep, mock_run):
+        """Test that timing delays are applied correctly."""
+        mock_run.return_value = MagicMock(returncode=0)
+        
+        client = TmuxClient()
+        client.send_keys("test-session", "test-window", "Hello", enter_count=2)
+        
+        # Verify sleep calls: 0.3s after paste, 0.5s between Enters
+        sleep_calls = [c[0][0] for c in mock_sleep.call_args_list]
+        assert 0.3 in sleep_calls  # Initial delay after paste
+        assert 0.5 in sleep_calls  # Delay between Enter keys

--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -52,6 +52,8 @@ class TestSendKeys:
         assert calls[2] == call(
             ["tmux", "send-keys", "-t", "sess:win", "Enter"],
             check=True,
+            capture_output=True,
+            text=True,
         )
         # delete-buffer (best-effort)
         assert calls[3] == call(
@@ -130,10 +132,14 @@ class TestSendKeys:
         assert calls[2] == call(
             ["tmux", "send-keys", "-t", "sess:win", "Enter"],
             check=True,
+            capture_output=True,
+            text=True,
         )
         assert calls[3] == call(
             ["tmux", "send-keys", "-t", "sess:win", "Enter"],
             check=True,
+            capture_output=True,
+            text=True,
         )
 
     def test_large_message(self, client, mock_subprocess, mock_uuid):

--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -54,6 +54,7 @@ class TestSendKeys:
             check=True,
             capture_output=True,
             text=True,
+            timeout=5,
         )
         # delete-buffer (best-effort)
         assert calls[3] == call(
@@ -134,12 +135,14 @@ class TestSendKeys:
             check=True,
             capture_output=True,
             text=True,
+            timeout=5,
         )
         assert calls[3] == call(
             ["tmux", "send-keys", "-t", "sess:win", "Enter"],
             check=True,
             capture_output=True,
             text=True,
+            timeout=5,
         )
 
     def test_large_message(self, client, mock_subprocess, mock_uuid):


### PR DESCRIPTION
This PR addresses issue #78 by adding a retry mechanism and improving the reliability of Enter key sending in the terminal.

Changes:
- Added retry mechanism for Enter key sending
- Improved reliability of terminal input handling