### PR TITLE
fix: Fix regex to catch Claude Code Processing spinner

### DIFF
--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -31,7 +31,7 @@ RESPONSE_PATTERN = r"⏺(?:\x1b\[[0-9;]*m)*\s+"  # Handle any ANSI codes between
 # - New format: "✽ Cooking… (6s · ↓ 174 tokens · thinking)"
 # - Minimal format: "✻ Orbiting…" (no parenthesized status)
 # Common: spinner char + text + ellipsis, optionally followed by parenthesized status
-PROCESSING_PATTERN = r"[✶✢✽✻·✳].*…"
+PROCESSING_PATTERN = r"[✶✢✽✻✳].*…"
 IDLE_PROMPT_PATTERN = r"[>❯][\s\xa0]"  # Handle both old ">" and new "❯" prompt styles
 WAITING_USER_ANSWER_PATTERN = (
     r"❯.*\d+\."  # Pattern for Claude showing selection options with arrow cursor

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -29,8 +29,9 @@ RESPONSE_PATTERN = r"⏺(?:\x1b\[[0-9;]*m)*\s+"  # Handle any ANSI codes between
 # Match Claude Code processing spinners:
 # - Old format: "✽ Cooking… (esc to interrupt)" / "✶ Thinking… (esc to interrupt)"
 # - New format: "✽ Cooking… (6s · ↓ 174 tokens · thinking)"
-# Common: spinner char + text + ellipsis + parenthesized status
-PROCESSING_PATTERN = r"[✶✢✽✻·✳].*….*\(.*\)"
+# - Minimal format: "✻ Orbiting…" (no parenthesized status)
+# Common: spinner char + text + ellipsis, optionally followed by parenthesized status
+PROCESSING_PATTERN = r"[✶✢✽✻·✳].*…"
 IDLE_PROMPT_PATTERN = r"[>❯][\s\xa0]"  # Handle both old ">" and new "❯" prompt styles
 WAITING_USER_ANSWER_PATTERN = (
     r"❯.*\d+\."  # Pattern for Claude showing selection options with arrow cursor

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -197,6 +197,31 @@ class TestClaudeCodeProviderStatusDetection:
         assert status == TerminalStatus.PROCESSING
 
     @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_processing_minimal_spinner(self, mock_tmux):
+        """Test PROCESSING detection with minimal spinner format (no parenthesized text)."""
+        mock_tmux.get_history.return_value = "✻ Orbiting…"
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_processing_beats_stale_completed(self, mock_tmux):
+        """Test that PROCESSING is detected even when stale ⏺ and ❯ markers are in scrollback."""
+        mock_tmux.get_history.return_value = (
+            "⏺ Previous response from init\n"
+            "❯ user task message\n"
+            "⏺ Let me read the file\n"
+            "✻ Orbiting…"
+        )
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
     def test_get_status_waiting_user_answer(self, mock_tmux):
         """Test WAITING_USER_ANSWER status detection."""
         mock_tmux.get_history.return_value = "❯ 1. Option one\n  2. Option two"

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -222,6 +222,19 @@ class TestClaudeCodeProviderStatusDetection:
         assert status == TerminalStatus.PROCESSING
 
     @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_idle_not_false_processing_from_status_bar(self, mock_tmux):
+        """Status bar '· latest:…' must not false-positive as PROCESSING."""
+        mock_tmux.get_history.return_value = (
+            "Claude Code v2.1.63\n"
+            "────────────────────\n"
+            "❯ \n"
+            "────────────────────\n"
+            "  current: 2.1.63 · latest:…"
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
     def test_get_status_waiting_user_answer(self, mock_tmux):
         """Test WAITING_USER_ANSWER status detection."""
         mock_tmux.get_history.return_value = "❯ 1. Option one\n  2. Option two"


### PR DESCRIPTION
This PR addresses Issue #91, where Claude Code v2.1.62 processing spinner is not caught correctly by the current regex. This affects orchestrator handoff flow where subagents will exit early as soon as the task is delegated.

### Description of Changes

- **Updated `PROCESSING_PATTERN` in `claude_code.py`**: Modified the regex from `r"[✶✢✽✻·✳].*….*\(.*\)"` to `r"[✶✢✽✻·✳].*…"`. This makes the parenthesized status text optional, allowing the provider to correctly recognize minimal spinner formats like `✻ Orbiting…` as `PROCESSING`.
- **Added unit tests in `test_claude_code_unit.py`**:
  - `test_get_status_processing_minimal_spinner`: Verifies that `✻ Orbiting…` is detected as `PROCESSING`.
  - `test_get_status_processing_beats_stale_completed`: Verifies that when a valid `PROCESSING` spinner is present, it correctly takes precedence over stale `COMPLETED` markers (`⏺` and `❯`) leftover from previous responses in the scrollback.
