### PR TITLE
fix: Update failing Q CLI unit tests due to working directory validation

### DIFF
--- a/test/providers/test_q_cli_integration.py
+++ b/test/providers/test_q_cli_integration.py
@@ -2,8 +2,8 @@
 
 import json
 import shutil
-import subprocess
 import time
+import uuid
 from pathlib import Path
 
 import pytest
@@ -60,8 +60,6 @@ def ensure_test_agent(q_cli_available):
 @pytest.fixture
 def test_session_name():
     """Generate a unique test session name."""
-    import uuid
-
     return f"test-q-cli-{uuid.uuid4().hex[:8]}"
 
 
@@ -422,9 +420,6 @@ class TestQCliProviderWorkingDirectory:
     @pytest.fixture
     def home_tmp_path(self):
         """Create a temporary directory inside home directory to pass path validation."""
-        import shutil
-        import uuid
-
         path = Path.home() / f".cao_test_tmp_{uuid.uuid4().hex[:8]}"
         path.mkdir(parents=True, exist_ok=True)
         yield path


### PR DESCRIPTION

*Description of changes:*
Fix failing Q CLI tests that were introduced in working directory validation logic introduced in commit 2b1128d966acdd9536d0

```bash
FAILED test/providers/test_q_cli_integration.py::TestQCliProviderWorkingDirectory::test_session_starts_in_custom_directory - ValueError: Working directory not allowed: /tmp/pytest-of-bajablast69/pytest-14/test_session_starts_in_custom_0 (resolves to /tmp/pyte...
FAILED test/providers/test_q_cli_integration.py::TestQCliProviderWorkingDirectory::test_working_directory_changes_are_detected - ValueError: Working directory not allowed: /tmp/pytest-of-bajablast69/pytest-14/test_working_directory_changes0 (resolves to /tmp/pyte...
FAILED test/providers/test_q_cli_integration.py::TestQCliProviderWorkingDirectory::test_symlink_resolution - ValueError: Working directory not allowed: /tmp/pytest-of-bajablast69/pytest-14/test_symlink_resolution0/link (resolves to /tmp/pytest...
```