### PR TITLE
fix(ci): pin trivy-action to SHA instead of mutable master ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           uv export --format requirements-txt > requirements.txt
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.69.3
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
 ## Summary

  - Pin `aquasecurity/trivy-action` from `@master` to `@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.69.3, Mar 4 2026)
  - Using mutable branch refs (`@master`) means CI automatically pulls whatever the upstream repo pushes, without review
  - Pinning to a SHA ensures we only run code we've vetted

  ## Changes

  One line in `.github/workflows/ci.yml`:

  ```diff
  - uses: aquasecurity/trivy-action@master
  + uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.69.3

  Test plan

  - CI Security Scan job passes with pinned SHA
