### PR TITLE
fix(kiro_cli): add --legacy-ui flag for new Kiro CLI TUI compatibility

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -127,7 +127,7 @@ class KiroCliProvider(BaseProvider):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         # Step 2: Start the Kiro CLI chat session with the specified agent profile
-        command = shlex.join(["kiro-cli", "chat", "--agent", self._agent_profile])
+        command = shlex.join(["kiro-cli", "chat", "--legacy-ui", "--agent", self._agent_profile])
         tmux_client.send_keys(self.session_name, self.window_name, command)
 
         # Step 3: Wait for Kiro CLI to fully initialize and show the agent prompt.

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -36,7 +36,7 @@ class TestKiroCliProviderInitialization:
         assert result is True
         mock_wait_shell.assert_called_once()
         mock_tmux.send_keys.assert_called_once_with(
-            "test-session", "window-0", "kiro-cli chat --agent developer"
+            "test-session", "window-0", "kiro-cli chat --legacy-ui --agent developer"
         )
         mock_wait_status.assert_called_once()
 


### PR DESCRIPTION
The latest Kiro CLI defaults to a new TUI whose prompt format (e.g. "agent · model · ◔ 1%") doesn't match CAO's idle detection regex, causing a 30s timeout and 500 error on terminal creation. Adding --legacy-ui restores the old prompt format that CAO can detect.

