### PR TITLE
fix(security): honor child allowedTools=["*"] instead of inheriting p…

### DIFF
--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -72,9 +72,13 @@ def _resolve_child_allowed_tools(
             return ",".join(child_allowed)
         return None
 
-    # If child has no restrictions, inherit parent's
-    if child_allowed is None or "*" in child_allowed:
+    # If child has no opinion (None), inherit parent's restrictions
+    if child_allowed is None:
         return ",".join(parent_allowed_tools)
+
+    # If child explicitly requests unrestricted ("*"), honor it
+    if "*" in child_allowed:
+        return None
 
     # Both have restrictions: child gets its own profile tools
     # (the child profile defines what it needs; parent's restrictions

--- a/test/mcp_server/test_resolve_child_allowed_tools.py
+++ b/test/mcp_server/test_resolve_child_allowed_tools.py
@@ -1,0 +1,100 @@
+"""Tests for _resolve_child_allowed_tools in MCP server."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.mcp_server.server import _resolve_child_allowed_tools
+
+
+class TestResolveChildAllowedTools:
+    """Tests for _resolve_child_allowed_tools function."""
+
+    @patch("cli_agent_orchestrator.utils.tool_mapping.resolve_allowed_tools")
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_child_wildcard_with_restricted_parent_returns_unrestricted(
+        self, mock_load, mock_resolve
+    ):
+        """Issue #141: child with allowedTools=["*"] should NOT inherit parent restrictions."""
+        mock_profile = MagicMock()
+        mock_profile.allowedTools = ["*"]
+        mock_profile.role = "developer"
+        mock_profile.mcpServers = None
+        mock_load.return_value = mock_profile
+        mock_resolve.return_value = ["*"]
+
+        result = _resolve_child_allowed_tools(
+            parent_allowed_tools=["@cao-mcp-server", "fs_read", "fs_list"],
+            child_profile_name="code-reviewer",
+        )
+
+        assert result is None  # unrestricted
+
+    @patch("cli_agent_orchestrator.utils.tool_mapping.resolve_allowed_tools")
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_child_none_inherits_parent_restrictions(self, mock_load, mock_resolve):
+        """Child with no profile (FileNotFoundError) inherits parent's tools."""
+        mock_load.side_effect = FileNotFoundError("not found")
+
+        result = _resolve_child_allowed_tools(
+            parent_allowed_tools=["fs_read", "fs_list"],
+            child_profile_name="nonexistent",
+        )
+
+        assert result == "fs_read,fs_list"
+
+    @patch("cli_agent_orchestrator.utils.tool_mapping.resolve_allowed_tools")
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_unrestricted_parent_uses_child_tools(self, mock_load, mock_resolve):
+        """Unrestricted parent lets child use its own tools."""
+        mock_profile = MagicMock()
+        mock_profile.allowedTools = ["fs_read", "execute_bash"]
+        mock_profile.role = None
+        mock_profile.mcpServers = None
+        mock_load.return_value = mock_profile
+        mock_resolve.return_value = ["fs_read", "execute_bash"]
+
+        result = _resolve_child_allowed_tools(
+            parent_allowed_tools=None,
+            child_profile_name="developer",
+        )
+
+        assert result == "fs_read,execute_bash"
+
+    @patch("cli_agent_orchestrator.utils.tool_mapping.resolve_allowed_tools")
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_both_restricted_uses_child_tools(self, mock_load, mock_resolve):
+        """Both parent and child restricted: child gets its own tools."""
+        mock_profile = MagicMock()
+        mock_profile.allowedTools = ["fs_read", "execute_bash"]
+        mock_profile.role = None
+        mock_profile.mcpServers = None
+        mock_load.return_value = mock_profile
+        mock_resolve.return_value = ["fs_read", "execute_bash"]
+
+        result = _resolve_child_allowed_tools(
+            parent_allowed_tools=["@cao-mcp-server", "fs_read"],
+            child_profile_name="developer",
+        )
+
+        assert result == "fs_read,execute_bash"
+
+    @patch("cli_agent_orchestrator.utils.tool_mapping.resolve_allowed_tools")
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_parent_wildcard_child_wildcard_returns_unrestricted(self, mock_load, mock_resolve):
+        """Both parent and child unrestricted: returns None (unrestricted)."""
+        mock_profile = MagicMock()
+        mock_profile.allowedTools = ["*"]
+        mock_profile.role = None
+        mock_profile.mcpServers = None
+        mock_load.return_value = mock_profile
+        mock_resolve.return_value = ["*"]
+
+        result = _resolve_child_allowed_tools(
+            parent_allowed_tools=["*"],
+            child_profile_name="developer",
+        )
+
+        # Parent is unrestricted, child has ["*"] → child_allowed is truthy → joins it
+        # But ["*"] joined is "*", which is fine
+        assert result == "*"


### PR DESCRIPTION
## Summary
                       
  - **Fix**: `_resolve_child_allowed_tools()` in `server.py` treated `allowedTools: ["*"]` (explicitly unrestricted) the same as `None` (no opinion), causing a restricted parent's tool set to silently override the child's intentional wildcard. Split the single `if child_allowed is None or "*" in child_allowed` into two branches — `None` inherits parent restrictions, `["*"]` returns unrestricted.                                                                     
- **Tests**: Added 5 unit tests covering all branches of `_resolve_child_allowed_tools()`: wildcard child with restricted parent, missing child profile, unrestricted parent, both restricted, and both unrestricted.
                                                                                                                   
 ## Problem
When a supervisor (e.g., `role: supervisor` → `allowedTools: ["@cao-mcp-server", "fs_read", "fs_list"]`) delegates to a child with `allowedTools: ["*"]`, the child inherits the parent's restricted set instead of being unrestricted:
  
```python                                                                                                
  # Before (buggy) — lines 75-77 in server.py                                                                            
  if child_allowed is None or "*" in child_allowed: 
      return ",".join(parent_allowed_tools)  # parent restrictions override child's "*"
```                             
                                                                                                                         
  This produced `--disallowedTools Bash --disallowedTools Edit --disallowedTools` Write on the child's Claude Code launch, 
  despite the profile explicitly requesting all tools.                                                                   
                                                                                                                         
 ## Fix                                                                                                                    

```python                                                                                                              
  # After — distinguish "no opinion" from "explicitly unrestricted"
if child_allowed is None: 
      return ",".join(parent_allowed_tools)  # inherit parent's                    
if "*" in child_allowed:
      return None  # honor explicit wildcard
```
                                                                                                                        
## Test plan                                                                                                              
                                                                                                                         
  - 5 new unit tests for _resolve_child_allowed_tools() — all pass                                                       
  - 1049 existing unit tests — all pass                                                                                  
  - black formatting check — clean                                                                                       
  - CI pipeline (black, pytest, coverage)                                                                                
  - E2e: supervisor with restricted role assigns to child with allowedTools: ["*"] — child should have no                
  --disallowedTools flags                                                                                                
                                                                                                                         
  Closes #141 