### PR TITLE
fix: improve Web UI terminal scroll and paste reliability

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -593,7 +593,7 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
 
     # Start tmux attach inside the PTY
     proc = subprocess.Popen(
-        ["tmux", "attach-session", "-t", f"{session_name}:{window_name}"],
+        ["tmux", "-u", "attach-session", "-t", f"{session_name}:{window_name}"],
         stdin=slave_fd,
         stdout=slave_fd,
         stderr=slave_fd,
@@ -640,7 +640,7 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
             except asyncio.TimeoutError:
                 if proc.poll() is not None:
                     break
-            except Exception:
+            except (Exception, asyncio.CancelledError):
                 break
 
     async def _forward_input():
@@ -650,7 +650,13 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
                 msg = await websocket.receive_text()
                 payload = json.loads(msg)
                 if payload.get("type") == "input":
-                    os.write(master_fd, payload["data"].encode())
+                    raw = payload["data"].encode()
+                    # Write in chunks to avoid overflowing the PTY buffer
+                    chunk_size = 1024
+                    for i in range(0, len(raw), chunk_size):
+                        os.write(master_fd, raw[i : i + chunk_size])
+                        if i + chunk_size < len(raw):
+                            await asyncio.sleep(0.01)
                 elif payload.get("type") == "resize":
                     rows = payload.get("rows", 24)
                     cols = payload.get("cols", 80)
@@ -665,13 +671,15 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
                         pass
         except WebSocketDisconnect:
             pass
-        except Exception:
+        except (Exception, asyncio.CancelledError):
             pass
         finally:
             done.set()
 
     try:
         await asyncio.gather(_forward_output(), _forward_input())
+    except (Exception, asyncio.CancelledError):
+        pass
     finally:
         done.set()
         try:

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -22,6 +22,7 @@ export function TerminalView({ terminalId, provider, agentProfile, onClose }: Te
       cursorBlink: true,
       fontSize: 14,
       fontFamily: 'JetBrains Mono, Menlo, Monaco, Consolas, monospace',
+      scrollback: 10000,
       theme: {
         background: '#0d1117',
         foreground: '#c9d1d9',
@@ -71,24 +72,18 @@ export function TerminalView({ terminalId, provider, agentProfile, onClose }: Te
       }
     })
 
-    // Forward keystrokes to server, but intercept Ctrl+Shift+C for copy
+    // Ctrl+Shift+C to copy selection
     term.attachCustomKeyEventHandler((e) => {
       if (e.ctrlKey && e.shiftKey && e.key === 'C') {
         const selection = term.getSelection()
         if (selection) navigator.clipboard.writeText(selection).catch(() => {})
-        return false // prevent sending to terminal
-      }
-      if (e.ctrlKey && e.shiftKey && e.key === 'V') {
-        navigator.clipboard.readText().then(text => {
-          if (text && ws.readyState === WebSocket.OPEN) {
-            ws.send(JSON.stringify({ type: 'input', data: text }))
-          }
-        }).catch(() => {})
         return false
       }
       return true
     })
 
+    // onData handles ALL input including paste — xterm.js
+    // receives pasted text through the browser's input system
     term.onData((data) => {
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: 'input', data }))


### PR DESCRIPTION
## Problem

The Web UI terminal had two usability issues:

1. **No scrollback** — Users couldn't scroll up to see previous output. xterm.js defaulted to 1000 lines but the scrollback wasn't usable in practice.
2. **Paste hangs the terminal** — Pasting text (Ctrl+V / Cmd+V) caused the terminal to become unresponsive. Two root causes:
   - The `Ctrl+Shift+V` handler called `navigator.clipboard.readText()` (async, triggers browser permission popup) AND `onData` also fired for the same paste, causing double-sends and corruption.
   - Large pastes written as a single `os.write()` to the PTY overflowed the kernel PTY buffer (~4KB), blocking the write and hanging the tmux session.

## Changes

### `web/src/components/TerminalView.tsx`
- Added `scrollback: 10000` to the xterm.js Terminal constructor
- Removed the `Ctrl+Shift+V` paste handler that used `navigator.clipboard.readText()` — this was the primary cause of paste hangs (permission popup, double-send)
- `onData` is now the sole input path for all keystrokes and paste. xterm.js handles paste natively through the browser's input system.

### `src/cli_agent_orchestrator/api/main.py`
- Added `-u` flag to `tmux attach-session` for proper UTF-8 handling
- Changed `os.write(master_fd, data)` to write in 1KB chunks with 10ms delays between them, preventing PTY buffer overflow on large pastes

## Testing
1. Open the Web UI and connect to a terminal
2. Scroll: run a command with lots of output, scroll up with mouse wheel
3. Paste: copy a multi-line block and Cmd+V / Ctrl+V into the terminal
