### PR TITLE
fix(claude_code): structural PROCESSING detection immune to ❯ position race

### DIFF
--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -33,7 +33,23 @@ RESPONSE_PATTERN = r"⏺(?:\x1b\[[0-9;]*m)*\s+"  # Handle any ANSI codes between
 # - New format: "✽ Cooking… (6s · ↓ 174 tokens · thinking)"
 # - Minimal format: "✻ Orbiting…" (no parenthesized status)
 # Common: spinner char + text + ellipsis, optionally followed by parenthesized status
-PROCESSING_PATTERN = r"[✶✢✽✻✳].*…"
+PROCESSING_PATTERN = r"[✶✢✽✻✳·].*\u2026"
+# Structural PROCESSING indicator: a spinner line (spinner char + … ) immediately
+# before the ──────── separator line that Claude Code draws before the input prompt.
+# Requires a known spinner character on the same line as … to avoid false-positives
+# from response text or tool outputs that happen to contain … .
+# Allows 0–2 blank lines between the spinner and the separator.
+# The separator line starts with an ANSI colour code (\x1b[38;5;244m) before the
+# box-drawing characters (U+2500), so the pattern skips that prefix explicitly.
+#
+# Processing: "✻ Skedaddling…\n\n────────\n❯ " → spinner+… before separator → PROCESSING
+# Idle/done: "⏺ response text\n────────\n❯ " → no spinner before separator → not PROCESSING
+# Stale spinner: "✢ Thinking…" far back in scrollback, current separator has
+# no spinner immediately before it → not PROCESSING
+THINKING_BEFORE_SEPARATOR_PATTERN = re.compile(
+    r"[^\n]*[✶✢✽✻✳·][^\n]*\u2026[^\n]*\n(?:[^\n]*\n){0,2}(?:\x1b\[[0-9;]*m)*\u2500{20,}",
+    re.MULTILINE,
+)
 IDLE_PROMPT_PATTERN = r"[>❯][\s\xa0]"  # Handle both old ">" and new "❯" prompt styles
 WAITING_USER_ANSWER_PATTERN = (
     r"↑/↓ to navigate"  # Ink TUI footer shown only while a selection widget is active
@@ -258,24 +274,48 @@ class ClaudeCodeProvider(BaseProvider):
     def get_status(self, tail_lines: Optional[int] = None) -> TerminalStatus:
         """Get Claude Code status by analyzing terminal output.
 
-        Uses position-based comparison to prevent stale spinner text in
-        scrollback from masking the current idle state.  Claude Code renders
-        inline (not in the alternate screen buffer), so old spinner lines can
-        persist in tmux scrollback after the cursor-up overwrite fails to
-        reach them.  By comparing the last position of the processing spinner
-        against the last idle prompt, we let the more recent marker decide
-        the current state.  See: https://github.com/awslabs/cli-agent-orchestrator/issues/104
+        Uses a structural "thinking-before-separator" check as the primary
+        PROCESSING indicator, plus position-based fallbacks for edge cases.
+
+        Bug history:
+        1. Stale-spinner bug (#104): Old spinner lines persist in the tmux
+           scrollback after the agent returns to idle (Claude Code renders
+           inline, not alt-screen, inside a tmux pane). Position comparison
+           of last spinner vs last idle prompt catches this.
+
+        2. Mid-tool-execution race (this issue): The ❯ input prompt is ALWAYS
+           rendered at the bottom of the tmux pane (last position in the
+           scrollback buffer). Position-based comparisons against ❯ are
+           therefore unreliable — last_idle.start() is always greater than
+           any other marker when anything has been typed/executed.
+
+        V3 fix (structural): Check whether any line containing … (U+2026,
+        the ellipsis used in all Claude Code thinking/spinner text) appears
+        immediately before the ──────── separator line. Claude Code draws
+        this separator between the active-execution area and the input prompt.
+        When the agent is thinking/processing:
+        "· Swirling… (thinking)\n\n──────────────────────\n❯ "
+        When idle or completed:
+        "some response text\n──────────────────────\n❯ "
+        A stale old spinner line far back in scrollback will NOT be
+        immediately before the separator, so the structural check is immune
+        to the stale-spinner false-positive.
+
+        See: https://github.com/awslabs/cli-agent-orchestrator/issues/104
         """
 
-        # Use tmux client singleton to get window history
         output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
 
         if not output:
             return TerminalStatus.ERROR
 
-        # Find the LAST occurrence of processing spinner and idle prompt.
-        # Only the relative position matters — whichever appears later in
-        # the buffer reflects the current terminal state.
+        # PRIMARY PROCESSING check: structural — thinking line immediately
+        # before the ──────── separator. Catches ALL spinner variants (including
+        # newer "· Swirling…" format) and is immune to the ❯ position problem.
+        if THINKING_BEFORE_SEPARATOR_PATTERN.search(output):
+            return TerminalStatus.PROCESSING
+
+        # Find the LAST occurrence of each marker for fallback position checks.
         last_processing = None
         for m in re.finditer(PROCESSING_PATTERN, output):
             last_processing = m
@@ -284,9 +324,14 @@ class ClaudeCodeProvider(BaseProvider):
         for m in re.finditer(IDLE_PROMPT_PATTERN, output):
             last_idle = m
 
-        # Currently processing only if spinner appears AFTER the last idle
-        # prompt (or if there is no idle prompt at all).
-        if last_processing:
+        last_response = None
+        for m in re.finditer(RESPONSE_PATTERN, output):
+            last_response = m
+
+        # FALLBACK PROCESSING: spinner visible AND no separator follows it yet
+        # (early in execution before the separator appears). Position comparison
+        # is used here only when no separator is present (safe case).
+        if last_processing and not re.search(r"\u2500{20,}", output):
             if last_idle is None or last_processing.start() > last_idle.start():
                 return TerminalStatus.PROCESSING
 
@@ -299,15 +344,14 @@ class ClaudeCodeProvider(BaseProvider):
         ):
             return TerminalStatus.WAITING_USER_ANSWER
 
-        # Check for completed state (has response + ready prompt)
-        if re.search(RESPONSE_PATTERN, output) and last_idle:
+        # COMPLETED: ⏺ response exists AND ❯ prompt is visible (agent finished).
+        if last_response and last_idle:
             return TerminalStatus.COMPLETED
 
-        # Check for idle state (just ready prompt, no response)
+        # IDLE: shell prompt visible but no response yet (e.g. just initialized).
         if last_idle:
             return TerminalStatus.IDLE
 
-        # If no recognizable state, return ERROR
         return TerminalStatus.ERROR
 
     def get_idle_pattern_for_log(self) -> str:

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -258,6 +258,77 @@ class TestClaudeCodeProviderStatusDetection:
         assert provider.get_status() == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_processing_spinner_before_separator(self, mock_tmux):
+        """Spinner immediately before ──────── separator → PROCESSING (structural check)."""
+        mock_tmux.get_history.return_value = (
+            "❯ do the task\n"
+            "⏺ Let me read the file\n"
+            "✢ Thinking…\n"
+            "\n"
+            "────────────────────────\n"
+            "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_completed_no_spinner_before_separator(self, mock_tmux):
+        """Response text (no spinner) before separator → COMPLETED, not PROCESSING."""
+        mock_tmux.get_history.return_value = (
+            "❯ do the task\n" "⏺ Here is the completed response\n" "────────────────────────\n" "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_stale_spinner_far_back_not_processing(self, mock_tmux):
+        """Stale spinner far back in scrollback + current separator with no spinner → COMPLETED."""
+        mock_tmux.get_history.return_value = (
+            "✢ Thinking…\n"
+            "⏺ Old response from first task line 1\n"
+            "Old response from first task line 2\n"
+            "Old response from first task line 3\n"
+            "Old response from first task line 4\n"
+            "────────────────────────\n"
+            "❯ second task\n"
+            "⏺ Completed second response\n"
+            "────────────────────────\n"
+            "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_processing_no_separator_yet(self, mock_tmux):
+        """Early execution with spinner but no separator yet → position fallback PROCESSING."""
+        mock_tmux.get_history.return_value = "✻ Orbiting…"
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_processing_ansi_separator(self, mock_tmux):
+        """Spinner before separator with ANSI colour codes on separator → PROCESSING."""
+        mock_tmux.get_history.return_value = (
+            "❯ do the task\n"
+            "⏺ Reading file…\n"
+            "✽ Cooking…\n"
+            "\n"
+            "\x1b[38;5;244m────────────────────────\x1b[0m\n"
+            "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_processing_middle_dot_spinner(self, mock_tmux):
+        """New · Swirling… spinner variant → PROCESSING via structural check."""
+        mock_tmux.get_history.return_value = (
+            "❯ do the task\n" "· Swirling…\n" "\n" "────────────────────────\n" "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
     def test_get_status_idle_not_false_processing_from_status_bar(self, mock_tmux):
         """Status bar '· latest:…' must not false-positive as PROCESSING."""
         mock_tmux.get_history.return_value = (


### PR DESCRIPTION
Fixes #176

## Summary

`get_status()` returns `COMPLETED` during tool execution because the `❯` input prompt is always at the bottom of the tmux scrollback buffer, making position-based comparisons unreliable.

## Changes

1. **Updated `PROCESSING_PATTERN`** — added `·` (U+00B7) for the `· Swirling…` spinner variant, switched to explicit `\u2026`
2. **Added `THINKING_BEFORE_SEPARATOR_PATTERN`** — structural regex that checks if a spinner line appears immediately before the `────────` separator Claude Code draws before the input prompt
3. **Replaced `get_status()` body** — structural check is the primary PROCESSING indicator; position-based fallback only when no separator is present yet (early execution)

## Why structural detection?

Claude Code draws a `────────` separator between the active-execution area and the `❯` input prompt. When the agent is thinking/processing, a spinner line (`✢ Thinking…`, `· Swirling…`, etc.) appears immediately before this separator. When idle or completed, no spinner precedes the separator.

This is immune to:
- **Stale-spinner bug (#104)**: old spinner lines far back in scrollback are not immediately before the current separator
- **❯ position race (this issue)**: the structural check does not compare positions against `❯` at all

## Validation

| Agent | Tool calls | Runtime | Outcome |
|---|---|---|---|
| `deploy_agent` | 3 | ~45s | `/exit` only after completion ✓ |
| `monitor_agent` | 4 | ~3min | `/exit` only after SUCCEEDED ✓ |
| `dhp_git_agent` | 20+ | 9min 2s | `/exit` only after full publish ✓ |

All 48 existing unit tests pass.