### PR TITLE
fix(copilot_cli): recognise Copilot v1.0.31+ status bar as footer for idle detection

### DIFF
--- a/src/cli_agent_orchestrator/providers/copilot_cli.py
+++ b/src/cli_agent_orchestrator/providers/copilot_cli.py
@@ -38,6 +38,10 @@ WAITING_PROMPT_PATTERN = (
 )
 ERROR_PATTERN = r"(?:Error:|ERROR:|Traceback \(most recent call last\):|panic:)"
 PROMPT_HELPER_CONTINUATION_PATTERN = r"^(?:shortcuts|for shortcuts)$"
+# Copilot v1.0.31+ renders a status bar below the ❯ prompt:
+# " autopilot · / commands    Claude Sonnet 4.6 · (0%)"
+# This must be treated as a footer line so idle detection works correctly.
+COPILOT_STATUS_BAR_PATTERN = r"^\s*(?:autopilot|plan|interactive)\s*[·•]"
 PROCESSING_LINE_PATTERN = r"^(?:[●◐◑◒◓◉◎∙]\s*)?.*\besc to cancel\b.*$"
 
 
@@ -320,6 +324,9 @@ class CopilotCliProvider(BaseProvider):
         if re.match(PROMPT_HELPER_CONTINUATION_PATTERN, stripped):
             return True
         if stripped.startswith("╭") or stripped.startswith("╰") or stripped.startswith("│"):
+            return True
+        # Copilot v1.0.31+ status bar: " autopilot · / commands    Claude Sonnet 4.6 · (0%)"
+        if re.match(COPILOT_STATUS_BAR_PATTERN, stripped):
             return True
         return False
 


### PR DESCRIPTION
## Problem

Copilot CLI v1.0.31+ renders a mode status bar **below** the `❯` input prompt:

```
────────────────────────────────────────────────────────────────────────────────
❯
────────────────────────────────────────────────────────────────────────────────
 autopilot · / commands ​                        Claude Sonnet 4.6 · (0%)
```

`_has_idle_prompt_near_end()` scans lines after the last `❯` and expects them all to be footer/empty lines. The status bar line (`autopilot · / commands ...`) is non-empty and not matched by any existing `_is_footer_line()` check, so idle detection **always returns `False`**.

CAO then polls for the full 60 s init window, raises `TimeoutError`, and `POST /sessions` returns **500 Internal Server Error**. The tmux pane is created and Copilot launches successfully — but CAO never recognises it as idle.

## Root cause

`_is_footer_line()` recognises horizontal rule lines, `shift+tab switch mode`, `type @ to mention files`, box-drawing characters, and the `shortcuts` continuation hint — but has no pattern for the Copilot mode indicator line introduced in v1.0.31.

## Fix

Add `COPILOT_STATUS_BAR_PATTERN` to match lines starting with a Copilot mode keyword (`autopilot`, `plan`, `interactive`) followed by the `·` separator, and treat them as footer lines in `_is_footer_line()`.

```python
COPILOT_STATUS_BAR_PATTERN = r"^\s*(?:autopilot|plan|interactive)\s*[·•]"
```

This covers all three known Copilot modes. The `[·•]` character class handles both the middle dot (U+00B7) and bullet (U+2022) variants that may appear across platforms.

## Testing

Verified locally against Copilot CLI v1.0.31:
- `POST /sessions?provider=copilot_cli&agent_profile=developer` now returns `201 Created` with `"status": "idle"` within ~10 s
- Copilot UI is visible and responsive in the tmux pane
- All three modes (`autopilot`, `plan`, `interactive`) match the pattern

## Affected versions

Copilot CLI ≥ v1.0.31 (status bar introduced in this release). Earlier versions are unaffected — the extra pattern check is a no-op if the status bar line is absent.