### PR TITLE
fix(kiro_cli): position-aware 'Kiro is working' check prevents stale PROCESSING blocking handoffs

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -214,16 +214,29 @@ class KiroCliProvider(BaseProvider):
         # This simplifies regex patterns and improves reliability
         clean_output = re.sub(ANSI_CODE_PATTERN, "", output)
 
-        # Check 1: Look for TUI "Kiro is working" ghost text — positive PROCESSING signal
-        if re.search(TUI_PROCESSING_PATTERN, clean_output):
-            return TerminalStatus.PROCESSING
-
-        # Check 2: Look for the agent's IDLE prompt pattern (old or new TUI)
-        # If not found, the agent is still processing a response
-        has_idle_prompt = re.search(self._idle_prompt_pattern, clean_output)
+        # Check 1: Detect idle prompts early — required for the position-aware
+        # processing check below.
+        old_idle_matches = list(re.finditer(self._idle_prompt_pattern, clean_output))
         new_tui_idle_matches = list(re.finditer(NEW_TUI_IDLE_PATTERN, clean_output))
+        has_idle_prompt = old_idle_matches[0] if old_idle_matches else None
         has_new_tui_idle = bool(new_tui_idle_matches)
 
+        # Check 2: Look for TUI "Kiro is working" ghost text.
+        # Kiro TUI redraws the screen in-place, so the buffer can retain a stale
+        # "Kiro is working" line from an earlier render even after the agent has
+        # finished and the idle prompt has appeared below it.  Only return
+        # PROCESSING when no idle prompt appears *after* the last match.
+        tui_working_matches = list(re.finditer(TUI_PROCESSING_PATTERN, clean_output))
+        if tui_working_matches:
+            last_working_pos = tui_working_matches[-1].end()
+            idle_after_working = any(
+                m.start() > last_working_pos
+                for m in new_tui_idle_matches + old_idle_matches
+            )
+            if not idle_after_working:
+                return TerminalStatus.PROCESSING
+
+        # Check 3: If no idle prompt found at all the agent is still processing
         if not has_idle_prompt and not has_new_tui_idle:
             return TerminalStatus.PROCESSING
 

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -230,8 +230,7 @@ class KiroCliProvider(BaseProvider):
         if tui_working_matches:
             last_working_pos = tui_working_matches[-1].end()
             idle_after_working = any(
-                m.start() > last_working_pos
-                for m in new_tui_idle_matches + old_idle_matches
+                m.start() > last_working_pos for m in new_tui_idle_matches + old_idle_matches
             )
             if not idle_after_working:
                 return TerminalStatus.PROCESSING

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -1020,7 +1020,12 @@ class TestKiroCliTuiMode:
 
     @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
     def test_tui_kiro_is_working_takes_priority(self, mock_tmux):
-        """Test 'Kiro is working' returns PROCESSING even if idle prompt is also present."""
+        """Test 'Kiro is working' after idle prompt still returns PROCESSING.
+
+        Idle prompt appears BEFORE 'Kiro is working' in the buffer — the agent
+        started a new task after the previous idle.  The last 'Kiro is working'
+        has no idle prompt after it, so the result must be PROCESSING.
+        """
         mock_tmux.get_history.return_value = (
             "developer · auto · ◔ 3%\n"
             " Ask a question or describe a task ↵\n"
@@ -1030,8 +1035,71 @@ class TestKiroCliTuiMode:
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
-        # "Kiro is working" is checked before idle prompt — PROCESSING wins
+        # idle prompt is BEFORE "Kiro is working" → no idle after last working → PROCESSING
         assert status == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_tui_stale_kiro_is_working_before_idle_yields_idle(self, mock_tmux):
+        """Test that a stale 'Kiro is working' line does not block IDLE detection.
+
+        Kiro TUI redraws in-place.  After the agent finishes the buffer retains
+        the old 'Kiro is working' ghost text above the newly rendered idle prompt.
+        The fix: only return PROCESSING when no idle prompt appears *after* the
+        last 'Kiro is working' occurrence.
+        """
+        mock_tmux.get_history.return_value = (
+            "────────────────────────────────────────────────────\n"
+            " Kiro is working\n"
+            "────────────────────────────────────────────────────\n"
+            "developer · auto · ◔ 0%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_tui_stale_kiro_is_working_with_credits_yields_completed(self, mock_tmux):
+        """Test COMPLETED when stale 'Kiro is working' precedes credits + idle prompt.
+
+        After a successful response the buffer may contain:
+          1. stale 'Kiro is working' from the in-progress render
+          2. '▸ Credits:' completion marker
+          3. idle prompt
+
+        The stale ghost text must not block the COMPLETED detection.
+        """
+        mock_tmux.get_history.return_value = (
+            " Kiro is working\n"
+            "────────────────────────────────────────────────────\n"
+            "> Here is the result you asked for.\n"
+            "▸ Credits: 0.05 • Time: 3s\n"
+            "developer · auto · ◔ 0%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_tui_multiple_stale_kiro_is_working_lines_yield_idle(self, mock_tmux):
+        """Test that multiple stale 'Kiro is working' lines all before the idle
+        prompt still resolve to IDLE (uses the *last* working-line position)."""
+        mock_tmux.get_history.return_value = (
+            " Kiro is working\n"
+            " Kiro is working\n"
+            "developer · auto · ◔ 0%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
     def test_tui_permission_prompt_detection(self, mock_tmux):


### PR DESCRIPTION
Closes #182

## Problem

Kiro CLI 2.0 TUI redraws the screen in-place. When the agent finishes a task, the tmux pane buffer retains the old `Kiro is working` ghost text **above** the newly rendered idle prompt:

```
 Kiro is working          ← stale, from in-progress render
────────────────────────
developer · auto · ◔ 0%
 Ask a question or describe a task ↵   ← agent is actually idle
```

Because `get_status()` used `re.search(TUI_PROCESSING_PATTERN, clean_output)` which matches anywhere in the buffer, it always returned `PROCESSING` — even after the agent finished. This caused **supervisor handoff delegations to wait indefinitely**.

## Fix

Moved the idle-prompt detection before the processing check, then made the check position-aware: only return `PROCESSING` when no idle prompt appears **after** the last `Kiro is working` occurrence.

```python
# Before (position-unaware — always returns PROCESSING if ghost text present)
if re.search(TUI_PROCESSING_PATTERN, clean_output):
    return TerminalStatus.PROCESSING

# After (position-aware — stale ghost text above idle prompt is ignored)
tui_working_matches = list(re.finditer(TUI_PROCESSING_PATTERN, clean_output))
if tui_working_matches:
    last_working_pos = tui_working_matches[-1].end()
    idle_after_working = any(
        m.start() > last_working_pos
        for m in new_tui_idle_matches + old_idle_matches
    )
    if not idle_after_working:
        return TerminalStatus.PROCESSING
```

## Tests

4 new test cases added to `TestKiroCliTuiMode`:

| Test | Buffer layout | Expected |
|---|---|---|
| `test_tui_stale_kiro_is_working_before_idle_yields_idle` | stale ghost text → idle prompt | `IDLE` |
| `test_tui_stale_kiro_is_working_with_credits_yields_completed` | stale ghost text → credits → idle | `COMPLETED` |
| `test_tui_multiple_stale_kiro_is_working_lines_yield_idle` | 2× stale ghost text → idle | `IDLE` |
| `test_tui_kiro_is_working_takes_priority` *(updated comment)* | idle prompt → ghost text (active task) | `PROCESSING` ✓ |

All 79 tests pass (`uv run pytest test/providers/test_kiro_cli_unit.py -v`).