### PR TITLE
fix(terminal-service): gracefully handle missing agent profiles in CAO store

### DIFF
--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -135,20 +135,20 @@ def create_terminal(
         # Step 3b: Load the profile once for allowed tool resolution before
         # provider initialization. The skill catalog is global and does not
         # depend on profile contents.
-        profile = load_agent_profile(agent_profile)
+        try:
+            profile = load_agent_profile(agent_profile)
+        except FileNotFoundError:
+            profile = None
         skill_prompt = build_skill_catalog()
 
         # Step 3c: Resolve allowed_tools from profile if not explicitly provided
-        if allowed_tools is None:
-            try:
-                from cli_agent_orchestrator.utils.tool_mapping import resolve_allowed_tools
+        if allowed_tools is None and profile is not None:
+            from cli_agent_orchestrator.utils.tool_mapping import resolve_allowed_tools
 
-                mcp_server_names = list(profile.mcpServers.keys()) if profile.mcpServers else None
-                allowed_tools = resolve_allowed_tools(
-                    profile.allowedTools, profile.role, mcp_server_names
-                )
-            except FileNotFoundError:
-                pass  # Profile not found; no tool restrictions
+            mcp_server_names = list(profile.mcpServers.keys()) if profile.mcpServers else None
+            allowed_tools = resolve_allowed_tools(
+                profile.allowedTools, profile.role, mcp_server_names
+            )
 
         # Step 4: Create and initialize the CLI provider
         # This starts the agent (e.g., runs "kiro-cli chat --agent developer")

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -9,8 +9,8 @@ from click.testing import CliRunner
 from cli_agent_orchestrator.cli.commands.launch import launch
 
 
-def test_launch_includes_working_directory():
-    """Test that launch command includes current working directory in the params passed to subprocess."""
+def test_launch_passes_cwd_by_default():
+    """Test that launch command sends current working directory when not explicitly provided."""
     runner = CliRunner()
 
     with (
@@ -33,9 +33,7 @@ def test_launch_includes_working_directory():
 
         # Verify requests.post was called with working_directory parameter
         mock_post.assert_called_once()
-        call_args = mock_post.call_args
-        params = call_args.kwargs["params"]
-
+        params = mock_post.call_args.kwargs["params"]
         assert "working_directory" in params
         assert params["working_directory"] == os.path.realpath(os.getcwd())
 

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -280,6 +280,43 @@ class TestCreateTerminal:
 
         assert mock_provider_manager.create_provider.call_args.kwargs["skill_prompt"] is None
 
+    @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    def test_create_terminal_profile_not_found(
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_log_dir,
+    ):
+        """Terminal creation succeeds when agent profile is not in CAO store (e.g. JSON-only profiles)."""
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "my-agent-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.side_effect = FileNotFoundError("Agent profile not found: my-agent")
+        mock_provider = MagicMock()
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_log_path = MagicMock()
+        mock_log_dir.__truediv__.return_value = mock_log_path
+
+        result = create_terminal("kiro_cli", "my-agent", new_session=True)
+
+        assert result.id == "test1234"
+        mock_provider.initialize.assert_called_once()
+        # allowed_tools should be None since profile was not found
+        assert mock_provider_manager.create_provider.call_args.kwargs.get("allowed_tools") is None
+
 
 class TestGetTerminal:
     """Tests for get_terminal function."""


### PR DESCRIPTION
  ## Problem

  `load_agent_profile()` raises `FileNotFoundError` for agents whose profiles
  only exist as `.json` files (e.g. `~/.kiro/agents/my-agent.json`). The call
  in `terminal_service.create_terminal()` was unguarded, causing terminal
  creation to fail with:

  Failed to create terminal: Agent profile not found: my-agent

  This was introduced in #145 when profile loading was hoisted to a top-level
  call outside the `allowed_tools` block, but the `FileNotFoundError` guard
  was not moved with it.

  ## Fix

  Wrap `load_agent_profile()` in `try/except FileNotFoundError` and gate
  `allowed_tools` resolution on `profile is not None`. For `kiro_cli`, the
  profile is resolved natively by `kiro-cli` itself — CAO not finding it in
  its own store is expected and non-fatal.

  This matches the documented behavior in `docs/kiro-cli.md`:
  > If the agent is not found, CAO gracefully falls back — kiro-cli resolves
  > .json profiles natively

  ## Changes

  - `services/terminal_service.py`: guard `load_agent_profile()` call
  - `test/cli/commands/test_launch.py`: update test to reflect that CWD is
    always passed (working-directory inheritance behavior)