### PR TITLE
feat(cli): add cao session command, HTTP API refactor, and kiro-cli fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,41 @@ cao shutdown --session <session-name>
 
 ![Tmux Window Selector](./docs/assets/tmux_all_windows.png)
 
+
+## Session Management
+
+CAO provides CLI commands for managing sessions programmatically — useful for scripting, CI pipelines, or headless operation.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `cao session list` | List active sessions |
+| `cao session status <name>` | Show conductor status and last output |
+| `cao session status <name> --workers` | Include worker terminal statuses |
+| `cao session send <name> "msg"` | Send message and wait for completion |
+| `cao session send <name> "msg" --async` | Fire-and-forget without waiting |
+| `cao session send <name> "msg" --timeout N` | Wait up to N seconds |
+| `cao shutdown --session <name>` | Shut down a session |
+
+### Headless Launch
+
+```bash
+cao launch --agents supervisor --headless --yolo \
+  --session-name my-task --working-directory '/path/to/project' "Your task here"
+```
+
+Add `--async` to send the message and return immediately without waiting for completion:
+
+```bash
+cao launch --agents supervisor --headless --async --yolo \
+  --session-name my-task --working-directory '/path/to/project' "Your task here"
+```
+
+> **Note:** Session names are automatically prefixed with `cao-`. Use the prefixed form (e.g., `cao-my-task`) when referencing sessions in commands like `cao session send` and `cao shutdown`.
+
+For full details, see the [Session Management skill](skills/cao-session-management/SKILL.md).
+
 ## Web UI
 
 CAO includes a web dashboard for managing agents, terminals, and flows from the browser.

--- a/examples/plugins/cao-discord/tests/test_plugin.py
+++ b/examples/plugins/cao-discord/tests/test_plugin.py
@@ -4,12 +4,14 @@ import json
 
 import httpx
 import pytest
-
 from cao_discord.plugin import DiscordPlugin
+
 from cli_agent_orchestrator.plugins import PostSendMessageEvent
 
 
-def _timeout_values(plugin: DiscordPlugin) -> tuple[float | None, float | None, float | None, float | None]:
+def _timeout_values(
+    plugin: DiscordPlugin,
+) -> tuple[float | None, float | None, float | None, float | None]:
     """Return the configured timeout values from the plugin's HTTP client."""
 
     timeout = plugin._client.timeout

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: cao-session-management
+description: Interact with CAO (CLI Agent Orchestrator) — launch multi-agent sessions,
+  check status, send follow-up instructions, unblock stuck terminals, or shut down
+  sessions. Use when working with CAO sessions in any capacity.
+---
+
+# CAO Session Management
+
+## Overview
+
+CAO runs multi-agent workflows in named sessions. A conductor agent inside each
+session orchestrates the work.
+
+## Core Concepts
+
+- **Session**: A group of agent terminals working together
+- **Conductor**: The supervisor terminal — receives instructions, delegates to workers
+- **Provider**: LLM backend. Default `kiro_cli`, override with `--provider`
+
+## Launching a Session
+
+Every `cao launch` MUST include:
+
+- `--agents PROFILE` — for `kiro_cli` provider, run `kiro-cli agent list` to discover
+  profiles; otherwise ask the user
+- `--headless` — required from an LLM agent; without it cao tries to attach tmux
+- `--session-name NAME` — cao adds `cao-` prefix automatically
+- `--working-directory DIR` — a wrong path silently breaks the session with no
+  recovery short of shutdown and relaunch. Ask the user if unclear. Always wrap
+  in single quotes to pass the literal path to the server (prevents local shell
+  expansion of `~` or variables before the value reaches cao).
+
+```bash
+cao launch --agents <profile> --headless --yolo \
+  --session-name <name> --working-directory '<path>' "<task>"
+```
+
+`--yolo` skips confirmation prompts. Required when launching from an agent — interactive
+prompts will stall the session.
+
+For SOP-driven workflows (Kiro provider): launch with `/prompts` to discover
+available SOPs, then send the matched SOP name prefixed with `@` (e.g.,
+`@my-sop-name`), then send the task — each as separate messages after
+polling for `completed` status.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `cao session list` | List active sessions |
+| `cao session status SESSION` | Conductor status and last response |
+| `cao session status SESSION --workers` | Include worker terminals |
+| `cao session status SESSION --terminal ID` | Drill into a specific terminal |
+| `cao session status SESSION --json` | Machine-readable output; use to extract terminal IDs |
+| `cao session send SESSION "msg"` | Send and wait until completion (sync) |
+| `cao session send SESSION "msg" --timeout N` | Send and wait up to N seconds |
+| `cao session send SESSION "msg" --async` | Fire-and-forget without waiting |
+| `cao session send SESSION "msg" --terminal ID` | Send to a specific terminal |
+| `cao shutdown --session SESSION` | Shut down a session |
+| `cao shutdown --all` | Shut down all sessions |
+
+> `cao session send` waits for completion and returns output inline by default. With `--async`, it sends and returns immediately without waiting. With `--timeout N`, it waits up to N seconds — if the timeout expires, the agent is still running; check status later.
+> Session names in commands use the `cao-` prefixed form (e.g. `--session-name mywork` → use `cao-mywork`).
+
+## Worker Communication
+
+Inside a session, the conductor talks to workers via two MCP tools:
+
+**Prefer communicating through the conductor** (`cao session send SESSION "msg"`) rather
+than directly to worker terminals. Bypassing the conductor leaves it without state on
+what was asked or answered, which causes confusion. Two exceptions: unblocking a stuck
+worker, and follow-up questions to a persistent async worker (see below).
+
+**handoff** (blocking) — conductor sends task and waits for the worker to reach
+`COMPLETED` status, then reads the output. If it times out, the worker is still
+running — the conductor just stopped waiting.
+
+**assign** (non-blocking) — conductor sends task and returns immediately. The worker
+is expected to call `send_message` back to the conductor's terminal ID when done.
+Each terminal only knows its own ID via `$CAO_TERMINAL_ID`.
+
+By default the conductor uses sync (handoff). You can override this by explicitly
+asking it to use async or sync protocol when sending it a task.
+
+Async workers (assign) stay alive after completing their task and can answer follow-up
+questions — useful for ongoing investigation where you want to keep querying the same
+worker. In this case, sending directly to the worker terminal is appropriate:
+```bash
+cao session send SESSION "<follow-up question>" --terminal <worker-terminal-id>
+```
+
+## Common Mistakes
+
+**Wrong working directory** — agents won't find files, builds fail with confusing errors.
+
+**Stuck conductor** — conductor is waiting on a worker that stopped responding. Check
+the worker's status first, then decide: prompt it to continue and send results back,
+or ask it to resend if it already finished. Never re-delegate work that may still be
+running — it risks duplicate work.
+```bash
+cao session status SESSION --workers
+cao session status SESSION --terminal <worker-terminal-id>
+cao session send SESSION "continue your work, then send results to terminal <conductor-terminal-id>" --terminal <worker-terminal-id>
+```
+Get the conductor's terminal ID from `cao session status SESSION --json`.

--- a/src/cli_agent_orchestrator/cli/commands/init.py
+++ b/src/cli_agent_orchestrator/cli/commands/init.py
@@ -17,7 +17,7 @@ def seed_default_skills() -> int:
     seeded_count = 0
 
     for skill_dir in bundled_skills.iterdir():
-        if not skill_dir.is_dir():
+        if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").is_file():
             continue
 
         destination_dir = SKILLS_DIR / skill_dir.name

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -2,11 +2,20 @@
 
 import os
 import subprocess
+import time
 
 import click
 import requests
 
-from cli_agent_orchestrator.constants import DEFAULT_PROVIDER, PROVIDERS, SERVER_HOST, SERVER_PORT
+from cli_agent_orchestrator.constants import (
+    API_BASE_URL,
+    DEFAULT_PROVIDER,
+    PROVIDERS,
+    SERVER_HOST,
+    SERVER_PORT,
+)
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.utils.terminal import poll_until_done, wait_until_terminal_status
 
 # Providers that require workspace folder access
 PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
@@ -20,6 +29,7 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
 
 
 @click.command()
+@click.argument("message", required=False, default=None)
 @click.option("--agents", required=True, help="Agent profile to launch")
 @click.option("--session-name", help="Name of the session (default: auto-generated)")
 @click.option("--headless", is_flag=True, help="Launch in detached mode")
@@ -32,6 +42,12 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     help="Override allowedTools (CAO format: execute_bash, fs_read, @cao-mcp-server). Repeatable.",
 )
 @click.option(
+    "--async",
+    "is_async",
+    is_flag=True,
+    help="Send message and return immediately without waiting for completion",
+)
+@click.option(
     "--auto-approve",
     is_flag=True,
     help="Skip confirmation prompt (restrictions still enforced).",
@@ -42,7 +58,23 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     help="[DANGEROUS] Unrestricted tool access AND skip confirmation prompts. "
     "Agent can execute ANY command including aws, rm, curl.",
 )
-def launch(agents, session_name, headless, provider, allowed_tools, auto_approve, yolo):
+@click.option(
+    "--working-directory",
+    default=None,
+    help="Working directory for the session (default: current directory)",
+)
+def launch(
+    message,
+    agents,
+    session_name,
+    headless,
+    is_async,
+    provider,
+    allowed_tools,
+    auto_approve,
+    yolo,
+    working_directory,
+):
     """Launch cao session with specified agent profile."""
     try:
         # Validate provider
@@ -50,18 +82,18 @@ def launch(agents, session_name, headless, provider, allowed_tools, auto_approve
             raise click.ClickException(
                 f"Invalid provider '{provider}'. Available providers: {', '.join(PROVIDERS)}"
             )
-        working_directory = os.path.realpath(os.getcwd())
+        display_dir = working_directory or os.path.realpath(os.getcwd())
 
         # Resolve allowedTools: --yolo > --allowed-tools CLI > profile/role defaults
         from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
         from cli_agent_orchestrator.utils.tool_mapping import (
             format_tool_summary,
+            get_disallowed_tools,
             resolve_allowed_tools,
         )
 
         resolved_allowed_tools = None
         no_role_set = False
-        resolved_role = None
         if yolo:
             resolved_allowed_tools = ["*"]
         elif allowed_tools:
@@ -72,7 +104,6 @@ def launch(agents, session_name, headless, provider, allowed_tools, auto_approve
                 profile = load_agent_profile(agents)
                 mcp_server_names = list(profile.mcpServers.keys()) if profile.mcpServers else None
                 no_role_set = not profile.role and not profile.allowedTools
-                resolved_role = profile.role
                 resolved_allowed_tools = resolve_allowed_tools(
                     profile.allowedTools, profile.role, mcp_server_names
                 )
@@ -89,20 +120,19 @@ def launch(agents, session_name, headless, provider, allowed_tools, auto_approve
                 click.echo(
                     f"  Agent '{agents}' launching UNRESTRICTED on {provider}.\n"
                     f"  Agent can execute ANY command (aws, rm, curl, read credentials).\n"
-                    f"  Directory: {working_directory}\n"
+                    f"  Directory: {display_dir}\n"
                 )
             else:
                 # Normal launch: show tool summary and confirm
                 tool_summary = format_tool_summary(resolved_allowed_tools)
-                role_display = (
-                    resolved_role if resolved_role else "(not set — using developer defaults)"
-                )
+                blocked = get_disallowed_tools(provider, resolved_allowed_tools)
+                blocked_summary = ", ".join(blocked) if blocked else "(none)"
 
                 click.echo(
                     f"\nAgent '{agents}' launching on {provider}:\n"
-                    f"  Role:      {role_display}\n"
-                    f"  Allowed:   {tool_summary}\n"
-                    f"  Directory: {working_directory}\n"
+                    f"  Allowed:  {tool_summary}\n"
+                    f"  Blocked:  {blocked_summary}\n"
+                    f"  Directory: {display_dir}\n"
                 )
                 if no_role_set:
                     click.echo(
@@ -117,12 +147,13 @@ def launch(agents, session_name, headless, provider, allowed_tools, auto_approve
                 if not auto_approve and not click.confirm("Proceed?", default=True):
                     raise click.ClickException("Launch cancelled by user")
 
-        # Call API to create session
+        # Call API to create session — pass working_directory only if explicitly
+        # provided. When omitted, the server defaults to its own CWD.
         url = f"http://{SERVER_HOST}:{SERVER_PORT}/sessions"
         params = {
             "provider": provider,
             "agent_profile": agents,
-            "working_directory": working_directory,
+            "working_directory": working_directory or os.getcwd(),
         }
         if session_name:
             params["session_name"] = session_name
@@ -141,6 +172,34 @@ def launch(agents, session_name, headless, provider, allowed_tools, auto_approve
         # Attach to tmux session unless headless
         if not headless:
             subprocess.run(["tmux", "attach-session", "-t", terminal["session_name"]])
+        elif message:
+            ready = wait_until_terminal_status(
+                terminal["id"],
+                {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+                timeout=120,
+            )
+            if not ready:
+                raise click.ClickException(
+                    f"Conductor {terminal['id']} did not become ready within 120s"
+                )
+            response = requests.post(
+                f"{API_BASE_URL}/terminals/{terminal['id']}/input",
+                params={"message": message},
+            )
+            response.raise_for_status()
+            time.sleep(3)
+            if is_async:
+                click.echo(f"Message sent to {terminal['name']}. Running in background.")
+                return
+            poll_until_done(terminal["id"], timeout=300)
+            output_resp = requests.get(
+                f"{API_BASE_URL}/terminals/{terminal['id']}/output",
+                params={"mode": "last"},
+            )
+            output_resp.raise_for_status()
+            output = output_resp.json().get("output", "")
+            if output:
+                click.echo(output)
 
     except requests.exceptions.RequestException as e:
         raise click.ClickException(f"Failed to connect to cao-server: {str(e)}")

--- a/src/cli_agent_orchestrator/cli/commands/session.py
+++ b/src/cli_agent_orchestrator/cli/commands/session.py
@@ -1,0 +1,260 @@
+"""Session commands for CLI Agent Orchestrator."""
+
+import json
+import sys
+import time
+from urllib.parse import quote
+
+import click
+import requests
+
+from cli_agent_orchestrator.constants import API_BASE_URL
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.utils.terminal import poll_until_done
+
+# Default poll timeout for sync send (seconds). Pass --timeout to override.
+_DEFAULT_SEND_TIMEOUT = 300
+
+
+def _get_sessions():
+    response = requests.get(f"{API_BASE_URL}/sessions")
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_terminals(session_name):
+    response = requests.get(f"{API_BASE_URL}/sessions/{quote(session_name, safe='')}/terminals")
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_terminal(terminal_id):
+    response = requests.get(f"{API_BASE_URL}/terminals/{terminal_id}")
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_terminal_output(terminal_id):
+    response = requests.get(
+        f"{API_BASE_URL}/terminals/{terminal_id}/output", params={"mode": "last"}
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _resolve_conductor(session_name):
+    terminals = _get_terminals(session_name)
+    if not terminals:
+        raise click.ClickException(f"No terminals found for session '{session_name}'")
+    return terminals[0], terminals
+
+
+@click.group()
+def session():
+    """Manage CAO sessions."""
+
+
+@session.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def list_sessions(as_json):
+    """List all active CAO sessions."""
+    try:
+        sessions = _get_sessions()
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"Failed to connect to cao-server: {e}")
+
+    if not sessions:
+        if as_json:
+            click.echo("[]")
+        else:
+            click.echo("No active sessions")
+        return
+
+    rows = []
+    for s in sessions:
+        try:
+            terminals = _get_terminals(s["name"])
+            conductor = terminals[0] if terminals else None
+            if conductor:
+                conductor = _get_terminal(conductor["id"])
+            rows.append((s["name"], conductor, len(terminals)))
+        except requests.exceptions.RequestException:
+            continue
+
+    if as_json:
+        result = []
+        for name, conductor, terminal_count in rows:
+            result.append(
+                {
+                    "session": name,
+                    "conductor": (
+                        {
+                            "id": conductor["id"],
+                            "agent_profile": conductor.get("agent_profile"),
+                            "provider": conductor.get("provider"),
+                            "status": conductor.get("status"),
+                        }
+                        if conductor
+                        else None
+                    ),
+                    "terminal_count": terminal_count,
+                }
+            )
+        click.echo(json.dumps(result, indent=2))
+    else:
+        click.echo(f"{'SESSION':<25} {'CONDUCTOR':<12} {'STATUS':<15} {'TERMINALS':<10}")
+        click.echo("-" * 65)
+        for name, conductor, terminal_count in rows:
+            conductor_id = conductor["id"] if conductor else "N/A"
+            status = conductor.get("status", "N/A") if conductor else "N/A"
+            click.echo(f"{name:<25} {conductor_id:<12} {status:<15} {terminal_count:<10}")
+
+
+@session.command()
+@click.argument("session_name")
+@click.option("--terminal", "terminal_id", help="Target a specific terminal ID")
+@click.option(
+    "--workers",
+    is_flag=True,
+    help="Show all non-conductor terminals (ignored when --terminal is set)",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def status(session_name, terminal_id, workers, as_json):
+    """Show status of a session's conductor (or specific terminal)."""
+    try:
+        if terminal_id:
+            target = _get_terminal(terminal_id)
+            all_terminals = []
+        else:
+            conductor_raw, all_terminals = _resolve_conductor(session_name)
+            target = _get_terminal(conductor_raw["id"])
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"Failed to connect to cao-server: {e}")
+
+    try:
+        output_data = _get_terminal_output(target["id"])
+        last_output = output_data.get("output")
+    except requests.exceptions.RequestException:
+        last_output = None
+
+    if as_json:
+        result = {
+            "session": session_name,
+            "conductor": {
+                "id": target["id"],
+                "agent_profile": target.get("agent_profile"),
+                "provider": target.get("provider"),
+                "status": target.get("status"),
+                "last_output": last_output,
+            },
+        }
+        if workers and not terminal_id:
+            result["workers"] = [
+                {
+                    "id": t["id"],
+                    "agent_profile": t.get("agent_profile"),
+                    "provider": t.get("provider"),
+                    "status": t.get("status"),
+                }
+                for t in all_terminals[1:]
+            ]
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    click.echo(f"Session:  {session_name}")
+    click.echo(f"Terminal: {target['id']}")
+    click.echo(f"Agent:    {target.get('agent_profile', 'N/A')}")
+    click.echo(f"Provider: {target.get('provider', 'N/A')}")
+    click.echo(f"Status:   {target.get('status', 'N/A')}")
+
+    if last_output:
+        lines = last_output.splitlines()
+        truncated = lines[:20]
+        click.echo("\nLast response:")
+        click.echo("\n".join(truncated))
+        if len(lines) > 20:
+            click.echo(f"... ({len(lines) - 20} more lines)")
+    else:
+        click.echo("\nNo last response available")
+
+    if workers and not terminal_id:
+        worker_terminals = all_terminals[1:]
+        if worker_terminals:
+            click.echo(f"\n{'ID':<12} {'AGENT':<20} {'PROVIDER':<15} {'STATUS':<15}")
+            click.echo("-" * 65)
+            for t in worker_terminals:
+                click.echo(
+                    f"{t['id']:<12} {t.get('agent_profile', 'N/A'):<20} "
+                    f"{t.get('provider', 'N/A'):<15} {t.get('status', 'N/A'):<15}"
+                )
+        else:
+            click.echo("\nNo worker terminals")
+
+
+@session.command()
+@click.argument("session_name")
+@click.argument("message")
+@click.option("--terminal", "terminal_id", help="Send to a specific terminal ID")
+@click.option(
+    "--async", "is_async", is_flag=True, help="Send and return immediately without waiting"
+)
+@click.option(
+    "--timeout",
+    "timeout",
+    type=int,
+    default=None,
+    help=f"Timeout in seconds (default: {_DEFAULT_SEND_TIMEOUT}s; ignored with --async)",
+)
+def send(session_name, message, terminal_id, is_async, timeout):
+    """Send a message to a session's conductor (or specific terminal)."""
+    try:
+        if terminal_id:
+            target_id = terminal_id
+        else:
+            conductor, _ = _resolve_conductor(session_name)
+            target_id = conductor["id"]
+
+        status_resp = requests.get(f"{API_BASE_URL}/terminals/{target_id}")
+        status_resp.raise_for_status()
+        current_status = status_resp.json().get("status")
+        # "completed" is a valid pre-send state: the terminal has finished its
+        # previous task and is ready to accept a new message.
+        if current_status not in (TerminalStatus.IDLE, TerminalStatus.COMPLETED):
+            raise click.ClickException(
+                f"Terminal {target_id} is currently {current_status}. Wait for it to finish before sending."
+            )
+
+        response = requests.post(
+            f"{API_BASE_URL}/terminals/{target_id}/input",
+            params={"message": message},
+        )
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"Failed to connect to cao-server: {e}")
+
+    if is_async:
+        click.echo(f"Message sent to terminal {target_id}")
+        return
+
+    time.sleep(3)
+    effective_timeout = timeout if timeout is not None else _DEFAULT_SEND_TIMEOUT
+    interrupted = False
+    try:
+        poll_until_done(target_id, effective_timeout)
+    except KeyboardInterrupt:
+        interrupted = True
+
+    try:
+        output_resp = requests.get(
+            f"{API_BASE_URL}/terminals/{target_id}/output",
+            params={"mode": "last"},
+        )
+        output_resp.raise_for_status()
+        output = output_resp.json().get("output", "")
+        if output:
+            click.echo(output)
+    except requests.exceptions.RequestException:
+        pass
+
+    if interrupted:
+        sys.exit(130)

--- a/src/cli_agent_orchestrator/cli/commands/shutdown.py
+++ b/src/cli_agent_orchestrator/cli/commands/shutdown.py
@@ -1,8 +1,30 @@
 """Shutdown command for CLI Agent Orchestrator."""
 
 import click
+import requests
 
-from cli_agent_orchestrator.services.session_service import delete_session, list_sessions
+from cli_agent_orchestrator.constants import API_BASE_URL
+
+
+def _list_sessions():
+    try:
+        response = requests.get(f"{API_BASE_URL}/sessions")
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"Failed to connect to cao-server: {e}")
+
+
+def _delete_session(name):
+    try:
+        response = requests.delete(f"{API_BASE_URL}/sessions/{name}")
+        if response.status_code == 404:
+            click.echo(f"Session '{name}' already removed", err=True)
+            return False
+        response.raise_for_status()
+        return True
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"Failed to connect to cao-server: {e}")
 
 
 @click.command()
@@ -17,12 +39,9 @@ def shutdown(shutdown_all, session):
     if shutdown_all and session:
         raise click.ClickException("Cannot use --all and --session together")
 
-    # Determine sessions to shutdown
-    sessions_to_shutdown = []
-
     if shutdown_all:
-        sessions = list_sessions()
-        sessions_to_shutdown = [s["id"] for s in sessions]
+        sessions = _list_sessions()
+        sessions_to_shutdown = [s["name"] for s in sessions]
     else:
         sessions_to_shutdown = [session]
 
@@ -30,10 +49,11 @@ def shutdown(shutdown_all, session):
         click.echo("No cao sessions found to shutdown")
         return
 
-    # Shutdown each session
     for session_name in sessions_to_shutdown:
         try:
-            delete_session(session_name)
-            click.echo(f"✓ Shutdown session '{session_name}'")
-        except Exception as e:
-            click.echo(f"Error shutting down session '{session_name}': {e}", err=True)
+            if _delete_session(session_name):
+                click.echo(f"✓ Shutdown session '{session_name}'")
+        except click.ClickException as e:
+            if not shutdown_all:
+                raise
+            click.echo(f"Error: {e.format_message()}", err=True)

--- a/src/cli_agent_orchestrator/cli/main.py
+++ b/src/cli_agent_orchestrator/cli/main.py
@@ -9,6 +9,7 @@ from cli_agent_orchestrator.cli.commands.init import init
 from cli_agent_orchestrator.cli.commands.install import install
 from cli_agent_orchestrator.cli.commands.launch import launch
 from cli_agent_orchestrator.cli.commands.mcp_server import mcp_server
+from cli_agent_orchestrator.cli.commands.session import session
 from cli_agent_orchestrator.cli.commands.shutdown import shutdown
 from cli_agent_orchestrator.cli.commands.skills import skills
 
@@ -28,6 +29,7 @@ cli.add_command(env)
 cli.add_command(mcp_server)
 cli.add_command(info)
 cli.add_command(skills)
+cli.add_command(session)
 
 
 if __name__ == "__main__":

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -76,6 +76,11 @@ class TmuxClient:
         if working_directory is None:
             working_directory = os.getcwd()
 
+        # Expand ~ to the server's home directory so clients can use
+        # portable paths like ~/q/my-project without knowing the server's
+        # actual home path (e.g., /home/user vs /Users/user).
+        working_directory = os.path.expanduser(working_directory)
+
         # Step 1: Canonicalize the path via realpath to resolve symlinks
         # and .. sequences.  os.path.realpath is recognized by CodeQL as a
         # PathNormalization (transitions taint to NormalizedUnchecked).

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -136,6 +136,11 @@ class KiroCliProvider(BaseProvider):
         # New TUI header pattern: "agent_name · model · ◔ N%"
         self._new_tui_header_pattern = rf"{re.escape(self._agent_profile)}\s+·\s+.*·\s+◔\s*\d+%"
 
+    @property
+    def paste_enter_count(self) -> int:
+        """Kiro CLI submits on single Enter after bracketed paste."""
+        return 1
+
     def initialize(self) -> bool:
         """Initialize Kiro CLI provider by starting kiro-cli chat command.
 
@@ -311,6 +316,26 @@ class KiroCliProvider(BaseProvider):
         green_arrows = list(re.finditer(GREEN_ARROW_PATTERN, clean_output, re.MULTILINE))
         idle_prompts = list(re.finditer(self._idle_prompt_pattern, clean_output))
         new_tui_idles = list(re.finditer(NEW_TUI_IDLE_PATTERN, clean_output))
+
+        # Slash command fallback: if the most recent interaction (between the
+        # last two idle prompts) has no green arrow, it was a CLI-handled
+        # command like /context or /compact. Extract that output instead.
+        if len(idle_prompts) >= 2:
+            last_prompt_pos = idle_prompts[-1].start()
+            prev_prompt_pos = idle_prompts[-2].end()
+            has_arrow_in_last_interaction = any(
+                m.start() > prev_prompt_pos and m.start() < last_prompt_pos for m in green_arrows
+            )
+            if not has_arrow_in_last_interaction:
+                between = clean_output[prev_prompt_pos:last_prompt_pos]
+                # First line is the user's command text, skip it
+                lines = between.split("\n", 1)
+                if lines[0].lstrip().startswith("/"):
+                    output = lines[1].strip() if len(lines) > 1 else ""
+                    if output:
+                        output = re.sub(ESCAPE_SEQUENCE_PATTERN, "", output)
+                        output = re.sub(CONTROL_CHAR_PATTERN, "", output)
+                        return output.strip()
 
         if not green_arrows:
             # Fallback: try TUI extraction (separator + Credits pattern)

--- a/src/cli_agent_orchestrator/skills/cao-session-management/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-session-management/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: cao-session-management
+description: Interact with CAO (CLI Agent Orchestrator) — launch multi-agent sessions,
+  check status, send follow-up instructions, unblock stuck terminals, or shut down
+  sessions. Use when working with CAO sessions in any capacity.
+---
+
+# CAO Session Management
+
+## Overview
+
+CAO runs multi-agent workflows in named sessions. A conductor agent inside each
+session orchestrates the work.
+
+## Core Concepts
+
+- **Session**: A group of agent terminals working together
+- **Conductor**: The supervisor terminal — receives instructions, delegates to workers
+- **Provider**: LLM backend. Default `kiro_cli`, override with `--provider`
+
+## Launching a Session
+
+Every `cao launch` MUST include:
+
+- `--agents PROFILE` — for `kiro_cli` provider, run `kiro-cli agent list` to discover
+  profiles; otherwise ask the user
+- `--headless` — required from an LLM agent; without it cao tries to attach tmux
+- `--session-name NAME` — cao adds `cao-` prefix automatically
+- `--working-directory DIR` — a wrong path silently breaks the session with no
+  recovery short of shutdown and relaunch. Ask the user if unclear. Always wrap
+  in single quotes to pass the literal path to the server (prevents local shell
+  expansion of `~` or variables before the value reaches cao).
+
+```bash
+cao launch --agents <profile> --headless --yolo \
+  --session-name <name> --working-directory '<path>' "<task>"
+```
+
+`--yolo` skips confirmation prompts. Required when launching from an agent — interactive
+prompts will stall the session.
+
+For SOP-driven workflows (Kiro provider): launch with `/prompts` to discover
+available SOPs, then send the matched SOP name prefixed with `@` (e.g.,
+`@my-sop-name`), then send the task — each as separate messages after
+polling for `completed` status.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `cao session list` | List active sessions |
+| `cao session status SESSION` | Conductor status and last response |
+| `cao session status SESSION --workers` | Include worker terminals |
+| `cao session status SESSION --terminal ID` | Drill into a specific terminal |
+| `cao session status SESSION --json` | Machine-readable output; use to extract terminal IDs |
+| `cao session send SESSION "msg"` | Send and wait until completion (sync) |
+| `cao session send SESSION "msg" --timeout N` | Send and wait up to N seconds |
+| `cao session send SESSION "msg" --async` | Fire-and-forget without waiting |
+| `cao session send SESSION "msg" --terminal ID` | Send to a specific terminal |
+| `cao shutdown --session SESSION` | Shut down a session |
+| `cao shutdown --all` | Shut down all sessions |
+
+> `cao session send` waits for completion and returns output inline by default. With `--async`, it sends and returns immediately without waiting. With `--timeout N`, it waits up to N seconds — if the timeout expires, the agent is still running; check status later.
+> Session names in commands use the `cao-` prefixed form (e.g. `--session-name mywork` → use `cao-mywork`).
+
+## Worker Communication
+
+Inside a session, the conductor talks to workers via two MCP tools:
+
+**Prefer communicating through the conductor** (`cao session send SESSION "msg"`) rather
+than directly to worker terminals. Bypassing the conductor leaves it without state on
+what was asked or answered, which causes confusion. Two exceptions: unblocking a stuck
+worker, and follow-up questions to a persistent async worker (see below).
+
+**handoff** (blocking) — conductor sends task and waits for the worker to reach
+`COMPLETED` status, then reads the output. If it times out, the worker is still
+running — the conductor just stopped waiting.
+
+**assign** (non-blocking) — conductor sends task and returns immediately. The worker
+is expected to call `send_message` back to the conductor's terminal ID when done.
+Each terminal only knows its own ID via `$CAO_TERMINAL_ID`.
+
+By default the conductor uses sync (handoff). You can override this by explicitly
+asking it to use async or sync protocol when sending it a task.
+
+Async workers (assign) stay alive after completing their task and can answer follow-up
+questions — useful for ongoing investigation where you want to keep querying the same
+worker. In this case, sending directly to the worker terminal is appropriate:
+```bash
+cao session send SESSION "<follow-up question>" --terminal <worker-terminal-id>
+```
+
+## Common Mistakes
+
+**Wrong working directory** — agents won't find files, builds fail with confusing errors.
+
+**Stuck conductor** — conductor is waiting on a worker that stopped responding. Check
+the worker's status first, then decide: prompt it to continue and send results back,
+or ask it to resend if it already finished. Never re-delegate work that may still be
+running — it risks duplicate work.
+```bash
+cao session status SESSION --workers
+cao session status SESSION --terminal <worker-terminal-id>
+cao session send SESSION "continue your work, then send results to terminal <conductor-terminal-id>" --terminal <worker-terminal-id>
+```
+Get the conductor's terminal ID from `cao session status SESSION --json`.

--- a/src/cli_agent_orchestrator/utils/terminal.py
+++ b/src/cli_agent_orchestrator/utils/terminal.py
@@ -6,6 +6,7 @@ import uuid
 from typing import TYPE_CHECKING, Union
 
 import httpx
+import requests
 
 from cli_agent_orchestrator.constants import API_BASE_URL, SESSION_PREFIX
 from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -78,6 +79,33 @@ def wait_until_status(
         time.sleep(polling_interval)
 
     return False
+
+
+def poll_until_done(terminal_id: str, timeout: float, polling_interval: float = 1.0) -> None:
+    """Poll terminal status until completed/error or timeout.
+
+    Raises click.ClickException on error, timeout, or request failure.
+    """
+    import click
+
+    start = time.time()
+    while True:
+        elapsed = time.time() - start
+        if elapsed > timeout:
+            raise click.ClickException(
+                f"Timed out after {int(elapsed)}s waiting for terminal {terminal_id}"
+            )
+        try:
+            resp = requests.get(f"{API_BASE_URL}/terminals/{terminal_id}")
+            resp.raise_for_status()
+            status = resp.json().get("status")
+            if status == TerminalStatus.COMPLETED.value:
+                return
+            if status == TerminalStatus.ERROR.value:
+                raise click.ClickException("Terminal reached ERROR status")
+        except requests.exceptions.RequestException as e:
+            raise click.ClickException(f"Failed to poll terminal status: {e}")
+        time.sleep(polling_interval)
 
 
 def wait_until_terminal_status(

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -1,7 +1,7 @@
 """Tests for launch command."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -18,24 +18,96 @@ def test_launch_passes_cwd_by_default():
         patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
     ):
 
-        # Mock successful API response
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
             "name": "test-terminal",
         }
         mock_post.return_value.raise_for_status.return_value = None
 
-        # Run the command (--yolo to skip workspace confirmation)
         result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
 
-        # Verify the command succeeded
         assert result.exit_code == 0
-
-        # Verify requests.post was called with working_directory parameter
         mock_post.assert_called_once()
         params = mock_post.call_args.kwargs["params"]
         assert "working_directory" in params
         assert params["working_directory"] == os.path.realpath(os.getcwd())
+
+
+def test_launch_passes_explicit_working_directory():
+    """Test that --working-directory is passed to the API when provided."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+    ):
+
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--yolo",
+                "--working-directory",
+                "/remote/path",
+            ],
+        )
+
+        assert result.exit_code == 0
+        params = mock_post.call_args.kwargs["params"]
+        assert params["working_directory"] == "/remote/path"
+
+
+def test_launch_headless_message_sends_to_terminal():
+    """Test headless mode with message waits for IDLE then sends and polls for output."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "task done"}
+
+        mock_get.side_effect = [poll_resp, output_resp]
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--headless",
+                "--yolo",
+                "do something",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "task done" in result.output
+        mock_wait.assert_called_once()
+        # Two POST calls: create session + send message
+        assert mock_post.call_count == 2
 
 
 def test_launch_invalid_provider():
@@ -293,3 +365,119 @@ def test_launch_builtin_profile_resolves_role_defaults():
         params = call_args.kwargs["params"]
         # Supervisor should only have MCP server tools
         assert "@cao-mcp-server" in params["allowed_tools"]
+
+
+def test_launch_headless_message_conductor_not_ready():
+    """Test headless+message raises when conductor does not become ready."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = False
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--headless",
+                "--yolo",
+                "do something",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "did not become ready" in result.output
+
+
+def test_launch_headless_message_poll_error_status():
+    """Test headless+message raises when terminal reaches error status during poll."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "error"}
+        mock_get.return_value = poll_resp
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--headless",
+                "--yolo",
+                "do something",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "ERROR" in result.output
+
+
+def test_launch_headless_message_poll_processing_then_completed():
+    """Test headless+message poll loop sleeps when status is processing before completing."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        processing_resp = MagicMock()
+        processing_resp.raise_for_status.return_value = None
+        processing_resp.json.return_value = {"status": "processing"}
+
+        completed_resp = MagicMock()
+        completed_resp.raise_for_status.return_value = None
+        completed_resp.json.return_value = {"status": "completed"}
+
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "done"}
+
+        mock_get.side_effect = [processing_resp, completed_resp, output_resp]
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--headless",
+                "--yolo",
+                "do something",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "done" in result.output

--- a/test/cli/commands/test_session.py
+++ b/test/cli/commands/test_session.py
@@ -1,0 +1,565 @@
+"""Tests for the session CLI command."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from click.testing import CliRunner
+
+from cli_agent_orchestrator.cli.commands.session import session
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestListSessions:
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_list_sessions_success(self, mock_get, runner):
+        """Test listing sessions with conductor info."""
+        sessions_resp = MagicMock(status_code=200)
+        sessions_resp.json.return_value = [{"name": "cao-test"}]
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [{"id": "abc12345"}]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "abc12345",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        mock_get.side_effect = [sessions_resp, terminals_resp, terminal_resp]
+
+        result = runner.invoke(session, ["list"])
+
+        assert result.exit_code == 0
+        assert "cao-test" in result.output
+        assert "idle" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_list_sessions_empty(self, mock_get, runner):
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: [])
+
+        result = runner.invoke(session, ["list"])
+
+        assert result.exit_code == 0
+        assert "No active sessions" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_list_sessions_empty_json(self, mock_get, runner):
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: [])
+
+        result = runner.invoke(session, ["list", "--json"])
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "[]"
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_list_sessions_json(self, mock_get, runner):
+        sessions_resp = MagicMock(status_code=200)
+        sessions_resp.json.return_value = [{"name": "cao-test"}]
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [{"id": "abc12345"}]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "abc12345",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        mock_get.side_effect = [sessions_resp, terminals_resp, terminal_resp]
+
+        result = runner.invoke(session, ["list", "--json"])
+
+        assert result.exit_code == 0
+        assert '"session": "cao-test"' in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_list_sessions_server_down(self, mock_get, runner):
+        mock_get.side_effect = requests.exceptions.ConnectionError("refused")
+
+        result = runner.invoke(session, ["list"])
+
+        assert result.exit_code != 0
+        assert "Failed to connect to cao-server" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_list_sessions_terminal_fetch_error_skips_session(self, mock_get, runner):
+        sessions_resp = MagicMock(status_code=200)
+        sessions_resp.json.return_value = [{"name": "cao-test"}]
+        mock_get.side_effect = [sessions_resp, requests.exceptions.ConnectionError("refused")]
+
+        result = runner.invoke(session, ["list"])
+
+        assert result.exit_code == 0
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_list_sessions_no_conductor(self, mock_get, runner):
+        sessions_resp = MagicMock(status_code=200)
+        sessions_resp.json.return_value = [{"name": "cao-test"}]
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = []
+        mock_get.side_effect = [sessions_resp, terminals_resp]
+
+        result = runner.invoke(session, ["list"])
+
+        assert result.exit_code == 0
+        assert "N/A" in result.output
+
+
+class TestStatus:
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_success(self, mock_get, runner):
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [{"id": "abc12345"}]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "abc12345",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "completed",
+        }
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": "Hello world"}
+        mock_get.side_effect = [terminals_resp, terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test"])
+
+        assert result.exit_code == 0
+        assert "abc12345" in result.output
+        assert "completed" in result.output
+        assert "Hello world" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_json(self, mock_get, runner):
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [{"id": "abc12345"}]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "abc12345",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": "test output"}
+        mock_get.side_effect = [terminals_resp, terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test", "--json"])
+
+        assert result.exit_code == 0
+        assert '"status": "idle"' in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_specific_terminal(self, mock_get, runner):
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "xyz99999",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": None}
+        mock_get.side_effect = [terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test", "--terminal", "xyz99999"])
+
+        assert result.exit_code == 0
+        assert "xyz99999" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_specific_terminal_json(self, mock_get, runner):
+        """--terminal --json: workers key absent (--workers not set)."""
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "xyz99999",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": "some output"}
+        mock_get.side_effect = [terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test", "--terminal", "xyz99999", "--json"])
+
+        assert result.exit_code == 0
+        data = __import__("json").loads(result.output)
+        assert data["conductor"]["id"] == "xyz99999"
+        assert "workers" not in data
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_with_workers(self, mock_get, runner):
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [
+            {
+                "id": "cond1234",
+                "agent_profile": "conductor",
+                "provider": "kiro_cli",
+                "status": "idle",
+            },
+            {
+                "id": "work5678",
+                "agent_profile": "dev",
+                "provider": "kiro_cli",
+                "status": "processing",
+            },
+        ]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "cond1234",
+            "agent_profile": "conductor",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": None}
+        mock_get.side_effect = [terminals_resp, terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test", "--workers"])
+
+        assert result.exit_code == 0
+        assert "work5678" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_workers_json(self, mock_get, runner):
+        """--workers --json includes workers array in output."""
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [
+            {
+                "id": "cond1234",
+                "agent_profile": "conductor",
+                "provider": "kiro_cli",
+                "status": "idle",
+            },
+            {
+                "id": "work5678",
+                "agent_profile": "dev",
+                "provider": "kiro_cli",
+                "status": "processing",
+            },
+        ]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "cond1234",
+            "agent_profile": "conductor",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": None}
+        mock_get.side_effect = [terminals_resp, terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test", "--workers", "--json"])
+
+        assert result.exit_code == 0
+        data = __import__("json").loads(result.output)
+        assert "workers" in data
+        assert data["workers"][0]["id"] == "work5678"
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_no_workers(self, mock_get, runner):
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [
+            {
+                "id": "cond1234",
+                "agent_profile": "conductor",
+                "provider": "kiro_cli",
+                "status": "idle",
+            },
+        ]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "cond1234",
+            "agent_profile": "conductor",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": None}
+        mock_get.side_effect = [terminals_resp, terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test", "--workers"])
+
+        assert result.exit_code == 0
+        assert "No worker terminals" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_output_fetch_error(self, mock_get, runner):
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [{"id": "abc12345"}]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "abc12345",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "idle",
+        }
+        mock_get.side_effect = [
+            terminals_resp,
+            terminal_resp,
+            requests.exceptions.ConnectionError("refused"),
+        ]
+
+        result = runner.invoke(session, ["status", "cao-test"])
+
+        assert result.exit_code == 0
+        assert "No last response available" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_status_output_truncated(self, mock_get, runner):
+        terminals_resp = MagicMock(status_code=200)
+        terminals_resp.json.return_value = [{"id": "abc12345"}]
+        terminal_resp = MagicMock(status_code=200)
+        terminal_resp.json.return_value = {
+            "id": "abc12345",
+            "agent_profile": "dev",
+            "provider": "kiro_cli",
+            "status": "completed",
+        }
+        output_resp = MagicMock(status_code=200)
+        long_output = "\n".join(f"line {i}" for i in range(25))
+        output_resp.json.return_value = {"output": long_output}
+        mock_get.side_effect = [terminals_resp, terminal_resp, output_resp]
+
+        result = runner.invoke(session, ["status", "cao-test"])
+
+        assert result.exit_code == 0
+        assert "5 more lines" in result.output
+
+
+class TestSend:
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_async(self, mock_get, mock_post, runner):
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        status_resp = MagicMock(status_code=200)
+        status_resp.json.return_value = {"status": "idle"}
+        mock_get.side_effect = [resolve_resp, status_resp]
+        mock_post.return_value = MagicMock(status_code=200)
+
+        result = runner.invoke(session, ["send", "cao-test", "hello", "--async"])
+
+        assert result.exit_code == 0
+        assert "Message sent" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_specific_terminal(self, mock_get, mock_post, runner):
+        status_resp = MagicMock(status_code=200)
+        status_resp.json.return_value = {"status": "idle"}
+        mock_get.return_value = status_resp
+        mock_post.return_value = MagicMock(status_code=200)
+
+        result = runner.invoke(
+            session, ["send", "cao-test", "hello", "--terminal", "xyz99999", "--async"]
+        )
+
+        assert result.exit_code == 0
+        assert "Message sent" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_server_down(self, mock_get, mock_post, runner):
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        status_resp = MagicMock(status_code=200)
+        status_resp.json.return_value = {"status": "idle"}
+        mock_get.side_effect = [resolve_resp, status_resp]
+        mock_post.side_effect = requests.exceptions.ConnectionError("refused")
+
+        result = runner.invoke(session, ["send", "cao-test", "hello"])
+
+        assert result.exit_code != 0
+        assert "Failed to connect to cao-server" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_terminal_not_idle(self, mock_get, runner):
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        status_resp = MagicMock(status_code=200)
+        status_resp.json.return_value = {"status": "processing"}
+        mock_get.side_effect = [resolve_resp, status_resp]
+
+        result = runner.invoke(session, ["send", "cao-test", "hello"])
+
+        assert result.exit_code != 0
+        assert "processing" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_resolve_conductor_no_terminals(self, mock_get, runner):
+        resolve_resp = MagicMock(status_code=200, json=lambda: [])
+        mock_get.return_value = resolve_resp
+
+        result = runner.invoke(session, ["send", "cao-test", "hello"])
+
+        assert result.exit_code != 0
+        assert "No terminals found" in result.output
+
+
+class TestSendSync:
+    @patch("cli_agent_orchestrator.cli.commands.session.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_sync_completed(self, mock_get, mock_post, mock_time, runner):
+        """Default (sync) mode polls until completed, then prints output."""
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        pre_send_status_resp = MagicMock(status_code=200)
+        pre_send_status_resp.json.return_value = {"status": "idle"}
+        poll_resp = MagicMock(status_code=200)
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": "The answer is 42"}
+        mock_get.side_effect = [resolve_resp, pre_send_status_resp, poll_resp, output_resp]
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_time.time.return_value = 0
+        mock_time.sleep = MagicMock()
+
+        result = runner.invoke(session, ["send", "cao-test", "question"])
+
+        assert result.exit_code == 0
+        assert "The answer is 42" in result.output
+        assert "Message sent" not in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_sync_error_status(self, mock_get, mock_post, mock_time, runner):
+        """Default (sync) mode detects error status and raises."""
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        pre_send_status_resp = MagicMock(status_code=200)
+        pre_send_status_resp.json.return_value = {"status": "idle"}
+        poll_resp = MagicMock(status_code=200)
+        poll_resp.json.return_value = {"status": "error"}
+        mock_get.side_effect = [resolve_resp, pre_send_status_resp, poll_resp]
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_time.time.return_value = 0
+        mock_time.sleep = MagicMock()
+
+        result = runner.invoke(session, ["send", "cao-test", "question"])
+
+        assert result.exit_code != 0
+        assert "ERROR" in result.output
+
+    @patch("cli_agent_orchestrator.utils.terminal.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_sync_timeout(
+        self, mock_get, mock_post, mock_session_time, mock_terminal_time, runner
+    ):
+        """--timeout raises on expiry."""
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        pre_send_status_resp = MagicMock(status_code=200)
+        pre_send_status_resp.json.return_value = {"status": "idle"}
+        poll_resp = MagicMock(status_code=200)
+        poll_resp.json.return_value = {"status": "processing"}
+        mock_get.side_effect = [resolve_resp, pre_send_status_resp, poll_resp]
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_session_time.time.return_value = 0
+        mock_session_time.sleep = MagicMock()
+        mock_terminal_time.time.side_effect = [0, 31]
+        mock_terminal_time.sleep = MagicMock()
+
+        result = runner.invoke(session, ["send", "cao-test", "question", "--timeout", "30"])
+
+        assert result.exit_code != 0
+        assert "Timed out" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_sync_timeout_completes_before_expiry(
+        self, mock_get, mock_post, mock_time, runner
+    ):
+        """--timeout does not interfere when terminal completes in time."""
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        pre_send_status_resp = MagicMock(status_code=200)
+        pre_send_status_resp.json.return_value = {"status": "idle"}
+        poll_resp = MagicMock(status_code=200)
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": "done"}
+        mock_get.side_effect = [resolve_resp, pre_send_status_resp, poll_resp, output_resp]
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_time.time.return_value = 0
+        mock_time.sleep = MagicMock()
+
+        result = runner.invoke(session, ["send", "cao-test", "question", "--timeout", "60"])
+
+        assert result.exit_code == 0
+        assert "done" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_sync_poll_request_exception(self, mock_get, mock_post, mock_time, runner):
+        """Poll failure raises ClickException."""
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        pre_send_status_resp = MagicMock(status_code=200)
+        pre_send_status_resp.json.return_value = {"status": "idle"}
+        mock_get.side_effect = [
+            resolve_resp,
+            pre_send_status_resp,
+            requests.exceptions.ConnectionError("refused"),
+        ]
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_time.time.return_value = 0
+        mock_time.sleep = MagicMock()
+
+        result = runner.invoke(session, ["send", "cao-test", "question"])
+
+        assert result.exit_code != 0
+        assert "Failed to poll terminal status" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.session.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_sync_output_fetch_error(self, mock_get, mock_post, mock_time, runner):
+        """Output fetch failure after completion is silently ignored."""
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        pre_send_status_resp = MagicMock(status_code=200)
+        pre_send_status_resp.json.return_value = {"status": "idle"}
+        poll_resp = MagicMock(status_code=200)
+        poll_resp.json.return_value = {"status": "completed"}
+        mock_get.side_effect = [
+            resolve_resp,
+            pre_send_status_resp,
+            poll_resp,
+            requests.exceptions.ConnectionError("refused"),
+        ]
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_time.time.return_value = 0
+        mock_time.sleep = MagicMock()
+
+        result = runner.invoke(session, ["send", "cao-test", "question"])
+
+        assert result.exit_code == 0
+
+    @patch("cli_agent_orchestrator.cli.commands.session.sys.exit")
+    @patch("cli_agent_orchestrator.utils.terminal.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.time")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.post")
+    @patch("cli_agent_orchestrator.cli.commands.session.requests.get")
+    def test_send_sync_keyboard_interrupt(
+        self, mock_get, mock_post, mock_session_time, mock_terminal_time, mock_exit, runner
+    ):
+        """KeyboardInterrupt during poll calls sys.exit(130)."""
+        resolve_resp = MagicMock(status_code=200, json=lambda: [{"id": "abc12345"}])
+        pre_send_status_resp = MagicMock(status_code=200)
+        pre_send_status_resp.json.return_value = {"status": "idle"}
+        poll_resp = MagicMock(status_code=200)
+        poll_resp.json.return_value = {"status": "processing"}
+        output_resp = MagicMock(status_code=200)
+        output_resp.json.return_value = {"output": None}
+        mock_get.side_effect = [resolve_resp, pre_send_status_resp, poll_resp, output_resp]
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_session_time.time.return_value = 0
+        mock_session_time.sleep = MagicMock()
+        mock_terminal_time.time.return_value = 0
+        # sleep(1) in poll loop raises KeyboardInterrupt
+        mock_terminal_time.sleep.side_effect = KeyboardInterrupt()
+
+        runner.invoke(session, ["send", "cao-test", "question"])
+
+        mock_exit.assert_any_call(130)

--- a/test/cli/commands/test_shutdown.py
+++ b/test/cli/commands/test_shutdown.py
@@ -1,8 +1,9 @@
 """Tests for the shutdown CLI command."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from click.testing import CliRunner
 
 from cli_agent_orchestrator.cli.commands.shutdown import shutdown
@@ -30,15 +31,18 @@ class TestShutdownCommand:
         assert result.exit_code != 0
         assert "Cannot use --all and --session together" in result.output
 
-    @patch("cli_agent_orchestrator.cli.commands.shutdown.list_sessions")
-    @patch("cli_agent_orchestrator.cli.commands.shutdown.delete_session")
-    def test_shutdown_all_success(self, mock_delete, mock_list, runner):
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.get")
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.delete")
+    def test_shutdown_all_success(self, mock_delete, mock_get, runner):
         """Test shutdown all sessions successfully."""
-        mock_list.return_value = [
-            {"id": "cao-session1"},
-            {"id": "cao-session2"},
-        ]
-        mock_delete.return_value = None
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: [
+                {"name": "cao-session1"},
+                {"name": "cao-session2"},
+            ],
+        )
+        mock_delete.return_value = MagicMock(status_code=200)
 
         result = runner.invoke(shutdown, ["--all"])
 
@@ -47,51 +51,94 @@ class TestShutdownCommand:
         assert "Shutdown session 'cao-session2'" in result.output
         assert mock_delete.call_count == 2
 
-    @patch("cli_agent_orchestrator.cli.commands.shutdown.list_sessions")
-    def test_shutdown_all_no_sessions(self, mock_list, runner):
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.get")
+    def test_shutdown_all_no_sessions(self, mock_get, runner):
         """Test shutdown all when no sessions exist."""
-        mock_list.return_value = []
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: [])
 
         result = runner.invoke(shutdown, ["--all"])
 
         assert result.exit_code == 0
         assert "No cao sessions found to shutdown" in result.output
 
-    @patch("cli_agent_orchestrator.cli.commands.shutdown.delete_session")
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.delete")
     def test_shutdown_specific_session(self, mock_delete, runner):
         """Test shutdown specific session."""
-        mock_delete.return_value = None
+        mock_delete.return_value = MagicMock(status_code=200)
 
         result = runner.invoke(shutdown, ["--session", "cao-test"])
 
         assert result.exit_code == 0
         assert "Shutdown session 'cao-test'" in result.output
-        mock_delete.assert_called_once_with("cao-test")
 
-    @patch("cli_agent_orchestrator.cli.commands.shutdown.delete_session")
-    def test_shutdown_session_error(self, mock_delete, runner):
-        """Test shutdown session with error."""
-        mock_delete.side_effect = Exception("Session not found")
-
-        result = runner.invoke(shutdown, ["--session", "cao-nonexistent"])
-
-        assert result.exit_code == 0  # Command completes but reports error
-        assert "Error shutting down session 'cao-nonexistent'" in result.output
-        assert "Session not found" in result.output
-
-    @patch("cli_agent_orchestrator.cli.commands.shutdown.list_sessions")
-    @patch("cli_agent_orchestrator.cli.commands.shutdown.delete_session")
-    def test_shutdown_all_partial_failure(self, mock_delete, mock_list, runner):
-        """Test shutdown all with partial failure."""
-        mock_list.return_value = [
-            {"id": "cao-session1"},
-            {"id": "cao-session2"},
-        ]
-        # First call succeeds, second fails
-        mock_delete.side_effect = [None, Exception("Error deleting session")]
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.get")
+    def test_shutdown_all_server_not_running(self, mock_get, runner):
+        """Test shutdown all when server is not running raises ClickException."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
 
         result = runner.invoke(shutdown, ["--all"])
 
+        assert result.exit_code != 0
+        assert "Failed to connect to cao-server" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.delete")
+    def test_shutdown_session_server_not_running(self, mock_delete, runner):
+        """Test shutdown specific session when server is not running raises ClickException."""
+        mock_delete.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+        result = runner.invoke(shutdown, ["--session", "cao-test"])
+
+        assert result.exit_code != 0
+        assert "Failed to connect to cao-server" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.delete")
+    def test_shutdown_session_404_already_removed(self, mock_delete, runner):
+        """Test delete returns 404 — warns and continues without error."""
+        mock_delete.return_value = MagicMock(status_code=404)
+
+        result = runner.invoke(shutdown, ["--session", "cao-gone"])
+
         assert result.exit_code == 0
-        assert "Shutdown session 'cao-session1'" in result.output
-        assert "Error shutting down session 'cao-session2'" in result.output
+        assert "already removed" in result.output
+        assert "Shutdown session" not in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.get")
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.delete")
+    def test_shutdown_all_partial_failure(self, mock_delete, mock_get, runner):
+        """Test --all continues on per-session failures, reporting mixed results."""
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: [
+                {"name": "session-1"},
+                {"name": "session-2"},
+                {"name": "session-3"},
+            ],
+        )
+        ok_response = MagicMock(status_code=200)
+        err_response = MagicMock(status_code=500)
+        err_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Server Error"
+        )
+        mock_delete.side_effect = [ok_response, err_response, ok_response]
+
+        result = runner.invoke(shutdown, ["--all"])
+
+        assert mock_delete.call_count == 3
+        assert result.exit_code == 0
+        assert "Shutdown session 'session-1'" in result.output
+        assert "Shutdown session 'session-3'" in result.output
+        assert "Failed to connect to cao-server" in result.output
+
+    @patch("cli_agent_orchestrator.cli.commands.shutdown.requests.delete")
+    def test_shutdown_session_http_error(self, mock_delete, runner):
+        """Test delete returns 500 — raises ClickException."""
+        mock_response = MagicMock(status_code=500)
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Server Error"
+        )
+        mock_delete.return_value = mock_response
+
+        result = runner.invoke(shutdown, ["--session", "cao-test"])
+
+        assert result.exit_code != 0
+        assert "Failed to connect to cao-server" in result.output

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -410,6 +410,83 @@ class TestKiroCliProviderMessageExtraction:
         assert "How can I help?" not in message
         assert "User message" not in message
 
+    def test_paste_enter_count_returns_one(self):
+        """Kiro CLI submits on single Enter after bracketed paste."""
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        assert provider.paste_enter_count == 1
+
+    def test_extract_slash_command_output(self):
+        """Test extraction of slash command output (no green arrow)."""
+        output = (
+            "[developer] 5% λ > /context add foo.py\n"
+            "Added foo.py to context\n"
+            "[developer] 5% λ > "
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        message = provider.extract_last_message_from_script(output)
+
+        assert "Added foo.py to context" in message
+        assert "/context" not in message
+
+    def test_extract_slash_command_after_prior_response(self):
+        """Test slash command extraction when prior LLM response exists in buffer."""
+        output = (
+            "[developer] 4% λ > explain this\n"
+            "> Here is the explanation\n"
+            "The code does X, Y, Z\n"
+            "[developer] 5% λ > /compact\n"
+            "Compacting conversation...\n"
+            "Reduced from 50k to 10k tokens\n"
+            "[developer] 5% λ > "
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        message = provider.extract_last_message_from_script(output)
+
+        assert "Compacting conversation" in message
+        assert "Reduced from 50k to 10k tokens" in message
+        assert "explanation" not in message
+        assert "/compact" not in message
+
+    def test_extract_slash_command_multiline_output(self):
+        """Test extraction of slash command with multi-line output."""
+        output = (
+            "[developer] 5% λ > /compact\n"
+            "Compacting conversation...\n"
+            "Reduced from 50k to 10k tokens\n"
+            "[developer] 5% λ > "
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        message = provider.extract_last_message_from_script(output)
+
+        assert "Compacting conversation" in message
+        assert "Reduced from 50k to 10k tokens" in message
+        assert "/compact" not in message
+
+    def test_extract_slash_command_no_output(self):
+        """Test slash command with no output still raises ValueError."""
+        output = "[developer] 5% λ > /some-command\n" "[developer] 5% λ > "
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+
+        with pytest.raises(ValueError, match="No Kiro CLI response found"):
+            provider.extract_last_message_from_script(output)
+
+    def test_extract_no_arrow_no_slash_raises(self):
+        """No green arrow + no slash command = ValueError, not silent garbage."""
+        output = (
+            "[developer] 5% λ > some regular text\n"
+            "some output between prompts\n"
+            "[developer] 5% λ > "
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+
+        with pytest.raises(ValueError):
+            provider.extract_last_message_from_script(output)
+
 
 class TestKiroCliProviderRegexPatterns:
     """Test regex pattern matching."""

--- a/test/providers/test_tmux_working_directory.py
+++ b/test/providers/test_tmux_working_directory.py
@@ -137,6 +137,27 @@ class TestTmuxClientWorkingDirectory:
         call_args = self.mock_server.new_session.call_args
         assert call_args[1]["start_directory"] == "/home/user/project"
 
+    def test_create_session_expands_tilde_in_working_directory(self):
+        """Test create_session expands ~ to home directory for remote clients."""
+        mock_session = Mock()
+        mock_window = Mock()
+        mock_window.name = "test-window"
+        mock_session.windows = [mock_window]
+
+        self.mock_server.new_session.return_value = mock_session
+
+        client = TmuxClient()
+        with patch("os.path.expanduser", return_value="/home/user/q/my-project"):
+            with patch("os.path.isdir", return_value=True):
+                with patch("os.path.realpath", return_value="/home/user/q/my-project"):
+                    result = client.create_session(
+                        "test-session", "test-window", "terminal-1", "~/q/my-project"
+                    )
+
+        assert result == "test-window"
+        call_args = self.mock_server.new_session.call_args
+        assert call_args[1]["start_directory"] == "/home/user/q/my-project"
+
     def test_create_window_with_working_directory(self):
         """Test create_window passes working_directory to tmux."""
         mock_session = Mock()


### PR DESCRIPTION
## Summary

  Adds a new `cao session` command group for managing sessions without
  needing tmux access, and refactors CLI commands to use the HTTP API
  for remote server compatibility.

  ## Changes

  ### cao session command
  New command group for interacting with running sessions:

  - `cao session list [--json]` - list active sessions with conductor info
  - `cao session status <name> [--workers] [--terminal ID] [--json]` - show
    terminal status
  - `cao session send <name> <msg> [--async] [--timeout N]` - send a message
    to a session's conductor; waits for completion and prints output by
    default, use `--async` to fire-and-forget

  `session send` also validates terminal state before sending - raises an
  error if the terminal is not idle or completed.

  ### HTTP API refactor
  Refactors CLI commands to call the CAO server via HTTP instead of the
  service layer directly, enabling use against a remote server:

  - `shutdown` command now calls `DELETE /sessions` via HTTP
  - `launch` gains `--working-directory` flag for remote CWD control and
    an optional `message` argument for headless fire-and-forget
  - `launch` with a message now polls for completion and prints agent output
    instead of fire-and-forget
  - `tmux.py`: adds `expanduser()` for portable `~/path` from remote clients

  ### kiro-cli fixes
  - Fix double-enter on paste: kiro-cli submits on a single Enter after
    bracketed paste; sending two caused a blank second input
  - Fix slash command extraction: commands like `/context` and `/compact`
    produce output without green arrows, which previously raised
    "No Kiro CLI response found"; adds a fallback extraction path

  ### Skills
  - Added `cao-session-management` skill for different agents to manage cao sessions using command line. 