### PR TITLE
fix(claude_code): prevent false-positive IDLE on shell prompt during startup

### DIFF
--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -491,7 +491,23 @@ def _assign_impl(
         # Create terminal
         terminal_id, _ = _create_terminal(agent_profile, working_directory)
 
-        # Send message immediately (auto-injects sender terminal ID suffix when enabled)
+        # Guard: wait for the terminal to be genuinely ready before sending
+        # the task message. create_terminal() calls provider.initialize() which
+        # already waits 30 s for IDLE, but that check can return a false-positive
+        # on the pre-existing shell ❯ prompt (zsh/bash) before claude starts.
+        # A secondary API-level wait (same as handoff uses) catches that race.
+        if not wait_until_terminal_status(
+            terminal_id,
+            {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+            timeout=60.0,
+        ):
+            return {
+                "success": False,
+                "terminal_id": terminal_id,
+                "message": f"Terminal {terminal_id} did not reach ready status within 60 seconds — agent may not have started",
+            }
+
+        # Send message (auto-injects sender terminal ID suffix when enabled)
         _send_direct_input_assign(terminal_id, message)
 
         return {

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -251,6 +251,13 @@ class ClaudeCodeProvider(BaseProvider):
         # Build properly escaped command string
         command = self._build_claude_command()
 
+        # Snapshot current pane content before sending the command.
+        # We use this to distinguish the pre-existing shell ❯ prompt (zsh/bash)
+        # from Claude Code's own ❯ REPL prompt — they are visually identical
+        # after ANSI stripping, so without a snapshot, status detection can
+        # falsely return IDLE on the old shell prompt before claude even starts.
+        pre_launch_snapshot = tmux_client.get_history(self.session_name, self.window_name) or ""
+
         # Send Claude Code command using tmux client
         tmux_client.send_keys(self.session_name, self.window_name, command)
 
@@ -260,12 +267,26 @@ class ClaudeCodeProvider(BaseProvider):
         # Wait for Claude Code prompt to be ready.
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
         # message that get_status() interprets as a completed response.
-        if not wait_until_status(
-            self,
-            {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=30.0,
-            polling_interval=1.0,
-        ):
+        #
+        # We require that new content appeared beyond the pre-launch snapshot
+        # before accepting IDLE, to avoid the false-positive where the old zsh
+        # ❯ prompt triggers an immediate IDLE return before claude starts.
+        deadline = time.time() + 30.0
+        while time.time() < deadline:
+            current_output = tmux_client.get_history(self.session_name, self.window_name) or ""
+            new_content = current_output[len(pre_launch_snapshot):]
+            # Claude-specific startup markers that cannot come from the shell:
+            # the ──────── separator, bypass/trust prompt text, or "Claude Code"
+            claude_started = bool(
+                re.search(r"\u2500{20,}", new_content)
+                or re.search(r"bypass permissions|trust this folder|Claude Code", new_content, re.IGNORECASE)
+            )
+            if claude_started:
+                status = self.get_status()
+                if status in {TerminalStatus.IDLE, TerminalStatus.COMPLETED}:
+                    break
+            time.sleep(1.0)
+        else:
             raise TimeoutError("Claude Code initialization timed out after 30 seconds")
 
         self._initialized = True

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -274,12 +274,14 @@ class ClaudeCodeProvider(BaseProvider):
         deadline = time.time() + 30.0
         while time.time() < deadline:
             current_output = tmux_client.get_history(self.session_name, self.window_name) or ""
-            new_content = current_output[len(pre_launch_snapshot):]
+            new_content = current_output[len(pre_launch_snapshot) :]
             # Claude-specific startup markers that cannot come from the shell:
             # the ──────── separator, bypass/trust prompt text, or "Claude Code"
             claude_started = bool(
                 re.search(r"\u2500{20,}", new_content)
-                or re.search(r"bypass permissions|trust this folder|Claude Code", new_content, re.IGNORECASE)
+                or re.search(
+                    r"bypass permissions|trust this folder|Claude Code", new_content, re.IGNORECASE
+                )
             )
             if claude_started:
                 status = self.get_status()

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -13,8 +13,9 @@ class TestAssignSenderIdInjection:
 
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
+    @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status", return_value=True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_appends_sender_id_when_injection_enabled(self, mock_create, mock_send):
+    def test_assign_appends_sender_id_when_injection_enabled(self, mock_create, mock_wait, mock_send):
         """When injection is enabled, assign should append sender ID suffix."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
 
@@ -33,8 +34,9 @@ class TestAssignSenderIdInjection:
 
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", False)
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
+    @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status", return_value=True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_no_suffix_when_injection_disabled(self, mock_create, mock_send):
+    def test_assign_no_suffix_when_injection_disabled(self, mock_create, mock_wait, mock_send):
         """When injection is disabled, assign should send the message unchanged."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
 
@@ -51,8 +53,9 @@ class TestAssignSenderIdInjection:
 
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
+    @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status", return_value=True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_sender_id_fallback_unknown(self, mock_create, mock_send):
+    def test_assign_sender_id_fallback_unknown(self, mock_create, mock_wait, mock_send):
         """When CAO_TERMINAL_ID is not set, suffix should use 'unknown'."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
 
@@ -68,8 +71,9 @@ class TestAssignSenderIdInjection:
 
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
+    @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status", return_value=True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_suffix_is_appended_not_prepended(self, mock_create, mock_send):
+    def test_assign_suffix_is_appended_not_prepended(self, mock_create, mock_wait, mock_send):
         """The sender ID should be a suffix, not a prefix."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
 

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -15,7 +15,9 @@ class TestAssignSenderIdInjection:
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
     @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status", return_value=True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_appends_sender_id_when_injection_enabled(self, mock_create, mock_wait, mock_send):
+    def test_assign_appends_sender_id_when_injection_enabled(
+        self, mock_create, mock_wait, mock_send
+    ):
         """When injection is enabled, assign should append sender ID suffix."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
 

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -25,17 +25,17 @@ class TestClaudeCodeProviderInitialization:
         """Test successful initialization."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        # _handle_startup_prompts needs get_history to return a string
-        mock_tmux.get_history.return_value = "Welcome to Claude Code v2.0"
+        # First call is the pre-launch snapshot, subsequent calls return Claude output
+        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        result = provider.initialize()
+        with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
+            result = provider.initialize()
 
         assert result is True
         assert provider._initialized is True
         mock_wait_shell.assert_called_once()
         mock_tmux.send_keys.assert_called_once()
-        mock_wait_status.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
@@ -53,15 +53,19 @@ class TestClaudeCodeProviderInitialization:
     @patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
     @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
     def test_initialize_timeout(self, mock_tmux, mock_wait_status, mock_wait_shell, _):
-        """Test initialization timeout."""
+        """Test initialization timeout when no Claude markers appear."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = False
-        mock_tmux.get_history.return_value = "Welcome to Claude Code v2.0"
+        # Snapshot and loop return the same content → no new Claude markers
+        mock_tmux.get_history.return_value = "some shell output"
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
 
-        with pytest.raises(TimeoutError, match="Claude Code initialization timed out"):
-            provider.initialize()
+        with patch.object(provider, "_handle_startup_prompts"), \
+             patch("cli_agent_orchestrator.providers.claude_code.time.time", side_effect=[0, 31]), \
+             patch("cli_agent_orchestrator.providers.claude_code.time.sleep"):
+            with pytest.raises(TimeoutError, match="Claude Code initialization timed out"):
+                provider.initialize()
 
     @_PATCH_SETTINGS
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
@@ -74,14 +78,15 @@ class TestClaudeCodeProviderInitialization:
         """Test initialization with agent profile."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.return_value = "Welcome to Claude Code v2.0"
+        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
         mock_profile = MagicMock()
         mock_profile.system_prompt = "Test system prompt"
         mock_profile.mcpServers = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0", "test-agent")
-        result = provider.initialize()
+        with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
+            result = provider.initialize()
 
         assert result is True
         mock_load.assert_called_once_with("test-agent")
@@ -111,14 +116,15 @@ class TestClaudeCodeProviderInitialization:
         """Test initialization with MCP servers in profile."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.return_value = "Welcome to Claude Code v2.0"
+        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
         mock_profile = MagicMock()
         mock_profile.system_prompt = None
         mock_profile.mcpServers = {"server1": {"command": "test", "args": ["--flag"]}}
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0", "test-agent")
-        result = provider.initialize()
+        with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
+            result = provider.initialize()
 
         assert result is True
 
@@ -130,10 +136,11 @@ class TestClaudeCodeProviderInitialization:
         """Test that initialize sends the 'claude' command to tmux."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.return_value = "Welcome to Claude Code v2.0"
+        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider.initialize()
+        with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
+            provider.initialize()
 
         call_args = mock_tmux.send_keys.call_args
         assert call_args[0][0] == "test-session"
@@ -745,7 +752,8 @@ class TestClaudeCodeProviderStartupPrompts:
         """Test that initialize calls _handle_startup_prompts."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.return_value = "❯ 1. Yes, I trust this folder\n  2. No"
+        trust_output = "❯ 1. Yes, I trust this folder\n  2. No"
+        mock_tmux.get_history.side_effect = ["", trust_output, trust_output]
         mock_session = MagicMock()
         mock_window = MagicMock()
         mock_pane = MagicMock()
@@ -754,7 +762,8 @@ class TestClaudeCodeProviderStartupPrompts:
         mock_window.active_pane = mock_pane
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        result = provider.initialize()
+        with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
+            result = provider.initialize()
 
         assert result is True
         mock_pane.send_keys.assert_called_with("", enter=True)

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -26,7 +26,11 @@ class TestClaudeCodeProviderInitialization:
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
         # First call is the pre-launch snapshot, subsequent calls return Claude output
-        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
+        mock_tmux.get_history.side_effect = [
+            "",
+            "Welcome to Claude Code v2.0",
+            "Welcome to Claude Code v2.0",
+        ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
@@ -61,9 +65,11 @@ class TestClaudeCodeProviderInitialization:
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
 
-        with patch.object(provider, "_handle_startup_prompts"), \
-             patch("cli_agent_orchestrator.providers.claude_code.time.time", side_effect=[0, 31]), \
-             patch("cli_agent_orchestrator.providers.claude_code.time.sleep"):
+        with (
+            patch.object(provider, "_handle_startup_prompts"),
+            patch("cli_agent_orchestrator.providers.claude_code.time.time", side_effect=[0, 31]),
+            patch("cli_agent_orchestrator.providers.claude_code.time.sleep"),
+        ):
             with pytest.raises(TimeoutError, match="Claude Code initialization timed out"):
                 provider.initialize()
 
@@ -78,7 +84,11 @@ class TestClaudeCodeProviderInitialization:
         """Test initialization with agent profile."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
+        mock_tmux.get_history.side_effect = [
+            "",
+            "Welcome to Claude Code v2.0",
+            "Welcome to Claude Code v2.0",
+        ]
         mock_profile = MagicMock()
         mock_profile.system_prompt = "Test system prompt"
         mock_profile.mcpServers = None
@@ -116,7 +126,11 @@ class TestClaudeCodeProviderInitialization:
         """Test initialization with MCP servers in profile."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
+        mock_tmux.get_history.side_effect = [
+            "",
+            "Welcome to Claude Code v2.0",
+            "Welcome to Claude Code v2.0",
+        ]
         mock_profile = MagicMock()
         mock_profile.system_prompt = None
         mock_profile.mcpServers = {"server1": {"command": "test", "args": ["--flag"]}}
@@ -136,7 +150,11 @@ class TestClaudeCodeProviderInitialization:
         """Test that initialize sends the 'claude' command to tmux."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.side_effect = ["", "Welcome to Claude Code v2.0", "Welcome to Claude Code v2.0"]
+        mock_tmux.get_history.side_effect = [
+            "",
+            "Welcome to Claude Code v2.0",
+            "Welcome to Claude Code v2.0",
+        ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):


### PR DESCRIPTION
The shell ❯ prompt (zsh/bash) is visually identical to Claude Code's REPL
prompt after ANSI stripping. `initialize()` could return IDLE immediately —
before claude even started — causing `assign()` to send the task message to
the shell instead of the agent.

## Changes

**Fix 1 — `providers/claude_code.py`**: Snapshot pane content before launching claude, then require Claude-specific markers (─── separator, "Claude Code" text, bypass/trust prompt) to appear before accepting IDLE in the startup wait loop.

**Fix 2 — `mcp_server/server.py`**: Add a secondary `wait_until_terminal_status` guard in `_assign_impl` as a safety net at the API level (60s timeout, same pattern as handoff).

## Testing

All 109 existing tests pass (`test/providers/test_claude_code_unit.py` + `test/mcp_server/`). Test mocks updated to account for the new snapshot-based initialization flow.