### PR TITLE
fix(launch): honour profile.provider when --provider flag is not given

### DIFF
--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -34,7 +34,9 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
 @click.option("--session-name", help="Name of the session (default: auto-generated)")
 @click.option("--headless", is_flag=True, help="Launch in detached mode")
 @click.option(
-    "--provider", default=DEFAULT_PROVIDER, help=f"Provider to use (default: {DEFAULT_PROVIDER})"
+    "--provider",
+    default=None,
+    help=f"Provider to use (default: profile provider or {DEFAULT_PROVIDER})",
 )
 @click.option(
     "--allowed-tools",
@@ -77,11 +79,6 @@ def launch(
 ):
     """Launch cao session with specified agent profile."""
     try:
-        # Validate provider
-        if provider not in PROVIDERS:
-            raise click.ClickException(
-                f"Invalid provider '{provider}'. Available providers: {', '.join(PROVIDERS)}"
-            )
         display_dir = working_directory or os.path.realpath(os.getcwd())
 
         # Resolve allowedTools: --yolo > --allowed-tools CLI > profile/role defaults
@@ -107,11 +104,26 @@ def launch(
                 resolved_allowed_tools = resolve_allowed_tools(
                     profile.allowedTools, profile.role, mcp_server_names
                 )
+                # Honour profile.provider when --provider not explicitly passed
+                if provider is None:
+                    from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
+
+                    provider = resolve_provider(agents, DEFAULT_PROVIDER)
             except (FileNotFoundError, RuntimeError):
                 # Profile not found — use developer defaults (backward compatible)
                 no_role_set = True
                 resolved_allowed_tools = resolve_allowed_tools(None, None, None)
 
+        # Fall back to DEFAULT_PROVIDER when --provider was not given and
+        # profile resolution didn't set it (yolo, --allowed-tools, or missing profile)
+        if provider is None:
+            provider = DEFAULT_PROVIDER
+
+        # Validate provider
+        if provider not in PROVIDERS:
+            raise click.ClickException(
+                f"Invalid provider '{provider}'. Available providers: {', '.join(PROVIDERS)}"
+            )
         # Confirmation / warning prompts
         if provider in PROVIDERS_REQUIRING_WORKSPACE_ACCESS:
             if yolo:

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -481,3 +481,33 @@ def test_launch_headless_message_poll_processing_then_completed():
 
         assert result.exit_code == 0
         assert "done" in result.output
+
+
+def test_launch_honors_profile_provider_when_flag_not_given():
+    """Test that profile.provider is used when --provider is not passed."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch(
+            "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
+            return_value="claude_code",
+        ) as mock_resolve,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            launch,
+            ["--agents", "code_supervisor", "--headless"],
+            input="y\n",
+        )
+
+        assert result.exit_code == 0
+        mock_resolve.assert_called_once()
+        params = mock_post.call_args.kwargs["params"]
+        assert params["provider"] == "claude_code"


### PR DESCRIPTION
## Problem

`cao launch --agents <profile>` always defaults to `kiro_cli`, even when the agent profile's frontmatter declares `provider: claude_code` (or any other provider). The `--provider` CLI flag must be passed explicitly every time, which defeats the purpose of declaring a provider in the profile.

## Root Cause

`launch.py` hardcodes `default=DEFAULT_PROVIDER` (`kiro_cli`) on the `--provider` Click option. When the profile is loaded to resolve `allowedTools`, the `profile.provider` field is never consulted for the launch provider.

A `resolve_provider()` helper already exists in `agent_profiles.py` that reads `profile.provider`, validates it against the known provider list, and falls back gracefully — it was simply never called from `launch.py`.

## Changes

Single file change in `src/cli_agent_orchestrator/cli/commands/launch.py`:

1. Changed `--provider` default from `DEFAULT_PROVIDER` to `None` so we can distinguish "not passed" from "explicitly passed kiro_cli"
2. After loading the agent profile, call `resolve_provider()` when `provider is None`
3. Fall back to `DEFAULT_PROVIDER` if provider is still `None` (yolo, --allowed-tools, or missing profile)
4. Moved provider validation after resolution

## Behaviour

| Scenario | Before | After |
|----------|--------|-------|
| Profile has `provider: claude_code`, no `--provider` flag | kiro_cli | claude_code |
| Profile has no `provider` field, no `--provider` flag | kiro_cli | kiro_cli (unchanged) |
| `--provider kiro_cli` passed explicitly | kiro_cli | kiro_cli (unchanged) |
| `--provider claude_code` passed explicitly | claude_code | claude_code (unchanged) |

## Testing

- `python3 -m py_compile` passes
- All 13 launch tests pass
- `black` and `isort` checks pass
- `mypy` has only pre-existing errors (none from this change)