### PR TITLE
fix(claude-code): eliminate PROCESSING false-positives from compaction and /exit

### DIFF
--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -34,18 +34,11 @@ RESPONSE_PATTERN = r"⏺(?:\x1b\[[0-9;]*m)*\s+"  # Handle any ANSI codes between
 # - Minimal format: "✻ Orbiting…" (no parenthesized status)
 # Common: spinner char + text + ellipsis, optionally followed by parenthesized status
 PROCESSING_PATTERN = r"[✶✢✽✻✳·].*\u2026"
-# Structural PROCESSING indicator: a spinner line (spinner char + … ) immediately
-# before the ──────── separator line that Claude Code draws before the input prompt.
-# Requires a known spinner character on the same line as … to avoid false-positives
-# from response text or tool outputs that happen to contain … .
-# Allows 0–2 blank lines between the spinner and the separator.
-# The separator line starts with an ANSI colour code (\x1b[38;5;244m) before the
-# box-drawing characters (U+2500), so the pattern skips that prefix explicitly.
-#
-# Processing: "✻ Skedaddling…\n\n────────\n❯ " → spinner+… before separator → PROCESSING
-# Idle/done: "⏺ response text\n────────\n❯ " → no spinner before separator → not PROCESSING
-# Stale spinner: "✢ Thinking…" far back in scrollback, current separator has
-# no spinner immediately before it → not PROCESSING
+# Structural PROCESSING indicator (reference pattern — get_status uses an
+# inline last-separator-anchored version to avoid false positives from
+# mid-conversation compaction events like "✢ Compacting conversation…"):
+# a spinner line (spinner char + … ) immediately before the ────────
+# separator, allowing 0–2 blank lines between them.
 THINKING_BEFORE_SEPARATOR_PATTERN = re.compile(
     r"[^\n]*[✶✢✽✻✳·][^\n]*\u2026[^\n]*\n(?:[^\n]*\n){0,2}(?:\x1b\[[0-9;]*m)*\u2500{20,}",
     re.MULTILINE,
@@ -335,11 +328,22 @@ class ClaudeCodeProvider(BaseProvider):
         if not output:
             return TerminalStatus.ERROR
 
-        # PRIMARY PROCESSING check: structural — thinking line immediately
-        # before the ──────── separator. Catches ALL spinner variants (including
-        # newer "· Swirling…" format) and is immune to the ❯ position problem.
-        if THINKING_BEFORE_SEPARATOR_PATTERN.search(output):
-            return TerminalStatus.PROCESSING
+        # PRIMARY PROCESSING check: walk backwards from the *last* separator.
+        # If we encounter a spinner line (spinner char + …) before we encounter
+        # another separator, the agent is actively processing.
+        # If we hit another separator first, the spinner belongs to a previously
+        # completed task — covers two distinct false-positive patterns:
+        # 1. Mid-conversation compaction: "✢ Compacting…" → sep → more output → last sep
+        # 2. Post-exit: live spinner → sep (task done) → ❯ /exit → last sep (exit menu)
+        _sep_re = re.compile(r"(?:\x1b\[[0-9;]*m)*\u2500{20,}")
+        _sep_positions = [m.start() for m in _sep_re.finditer(output)]
+        if _sep_positions:
+            pre_sep_lines = output[: _sep_positions[-1]].rstrip("\n").split("\n")
+            for line in reversed(pre_sep_lines):
+                if re.search(r"[✶✢✽✻✳·][^\n]*\u2026", line):
+                    return TerminalStatus.PROCESSING  # spinner before another separator
+                if _sep_re.search(line):
+                    break  # hit another separator first — spinner is from a completed task
 
         # Find the LAST occurrence of each marker for fallback position checks.
         last_processing = None

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -425,6 +425,52 @@ class TestClaudeCodeProviderStatusDetection:
 
         mock_tmux.get_history.assert_called_with("test-session", "window-0", tail_lines=50)
 
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_completed_after_compaction_not_false_processing(self, mock_tmux):
+        """Compaction spinner before its own separator, then more output; last sep has no spinner → COMPLETED."""
+        mock_tmux.get_history.return_value = (
+            "❯ do the task\n"
+            "⏺ Starting work…\n"
+            "✢ Compacting conversation…\n"
+            "────────────────────────\n"
+            "⏺ Here is the completed response\n"
+            "────────────────────────\n"
+            "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_processing_after_compaction_when_still_running(self, mock_tmux):
+        """Spinner before the last separator (agent resumes after compaction) → PROCESSING."""
+        mock_tmux.get_history.return_value = (
+            "❯ do the task\n"
+            "✢ Compacting conversation…\n"
+            "────────────────────────\n"
+            "⏺ Resuming work…\n"
+            "✻ Orbiting…\n"
+            "────────────────────────\n"
+            "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    def test_get_status_completed_after_exit_not_false_processing(self, mock_tmux):
+        """Spinner → sep (task done) → /exit → second sep; spinner NOT before last sep → not PROCESSING."""
+        mock_tmux.get_history.return_value = (
+            "❯ do the task\n"
+            "⏺ Working on it…\n"
+            "✻ Orbiting…\n"
+            "────────────────────────\n"
+            "❯ /exit\n"
+            "⏺ Goodbye!\n"
+            "────────────────────────\n"
+            "❯ "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider.get_status() != TerminalStatus.PROCESSING
+
 
 class TestClaudeCodeProviderMessageExtraction:
     """Tests for ClaudeCodeProvider message extraction."""


### PR DESCRIPTION
## Problem

`get_status()` uses `THINKING_BEFORE_SEPARATOR_PATTERN.search(output)` which matches any spinner+ellipsis line before *any* separator in the scrollback. This causes two false-positive PROCESSING detections:

1. **Mid-conversation compaction**: `✢ Compacting…` → separator → more output → last separator. The compaction spinner sits before its own separator, not the last one — agent is actually idle/completed.

2. **Post-exit**: spinner → separator (task done) → `❯ /exit` → second separator (exit menu). The spinner belongs to the completed task, not the exit separator.

## Fix

Replace the regex-based `THINKING_BEFORE_SEPARATOR_PATTERN.search()` with a last-separator-anchored walk-back algorithm:

1. Find all separator positions in the output
2. Walk backwards from the *last* separator line-by-line
3. If a spinner line is found before another separator → genuinely PROCESSING
4. If another separator is hit first → spinner belongs to a completed task, not PROCESSING

This is immune to both false-positive patterns because it only considers the content between the last two separators.

## Files changed

| File | Change |
|------|--------|
| `src/cli_agent_orchestrator/providers/claude_code.py` | Replace PRIMARY PROCESSING check + update docstring |
| `test/providers/test_claude_code_unit.py` | Add 3 regression tests |

## New tests

- `test_get_status_completed_after_compaction_not_false_processing` — compaction spinner before its own separator, completed response after → COMPLETED
- `test_get_status_processing_after_compaction_when_still_running` — spinner before last separator after compaction → PROCESSING
- `test_get_status_completed_after_exit_not_false_processing` — spinner → sep → /exit → sep → not PROCESSING

## Verification

All 59 Claude Code unit tests pass. black/isort clean.