### PR TITLE
Fix git cliff timeout issue to unblock the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Bump version and generate changelog
         id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/bump_version.py ${{ inputs.bump }}
           VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -4,6 +4,7 @@
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -32,11 +33,29 @@ def update_pyproject(new_version: str) -> None:
 
 
 def generate_changelog(new_version: str) -> None:
-    subprocess.run(
-        ["git-cliff", "--tag", f"v{new_version}", "-o", "CHANGELOG.md"],
-        cwd=ROOT,
-        check=True,
-    )
+    # git-cliff calls the GitHub API when [remote.github] is configured in
+    # cliff.toml. Transient 502s / rate-limit bumps bubble up as non-zero
+    # exit. Retry 3x with 10s backoff to ride through transient hiccups;
+    # authenticated requests (via GITHUB_TOKEN env in CI) make this rare.
+    last_err: subprocess.CalledProcessError | None = None
+    for attempt in range(3):
+        try:
+            subprocess.run(
+                ["git-cliff", "--tag", f"v{new_version}", "-o", "CHANGELOG.md"],
+                cwd=ROOT,
+                check=True,
+            )
+            return
+        except subprocess.CalledProcessError as e:
+            last_err = e
+            if attempt < 2:
+                print(
+                    f"git-cliff attempt {attempt + 1} failed; retrying in 10s...",
+                    file=sys.stderr,
+                )
+                time.sleep(10)
+    assert last_err is not None
+    raise last_err
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

The first real PyPI release attempt (2026-04-28, `v2.1.1` patch bump) failed
at the `release.yml` bump step:

Could not get github metadata: HttpClientError(Status(502, None), ...)
subprocess.CalledProcessError: git-cliff exited with status 101

`cliff.toml` has `[remote.github]` configured, so git-cliff calls
`api.github.com/repos/.../commits` to enrich commits with PR/author
metadata. Unauthenticated calls are rate-limited to 60/hr per shared
runner IP — we hit the limit and got a 502.

## Fix

Two small changes that together close the failure mode:

1. **`release.yml`** — pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
   to the bump step so git-cliff's GitHub client authenticates. Authed
   calls get 5000 req/hr instead of 60. This eliminates the common case.

2. **`scripts/bump_version.py`** — wrap the `git-cliff` subprocess in a
   3-attempt retry loop with 10s backoff. Catches residual transient
   502s that slip through even with auth.

Neither change touches `cliff.toml` or the CHANGELOG body template — the
enrichment is kept as-is so future template work (PR links, contributor
lists) can use it without further setup.