### PR TITLE
fix(kiro_cli): detect TUI Initializing... to prevent false IDLE (#211)

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -74,6 +74,14 @@ TUI_CREDITS_PATTERN = r"▸\s*Credits:\s*[\d.]+"
 # TUI processing indicator: ghost text shown while agent is working
 TUI_PROCESSING_PATTERN = r"Kiro is working"
 
+# TUI initialization indicator: shown during startup before chat is ready.
+# Kiro TUI renders the idle prompt placeholder ("Ask a question or describe
+# a task") *before* the "● Initializing..." phase completes, which caused a
+# premature IDLE verdict. "Initializing..." is cleared by Kiro once startup
+# finishes, so its presence unconditionally means PROCESSING (unlike the
+# "Kiro is working" ghost text, which can linger as stale after a redraw).
+TUI_INITIALIZING_PATTERN = r"Initializing\.\.\."
+
 # TUI permission prompt: shown instead of legacy [y/n/t] format.
 # Requires all three options together to avoid false positives on "Yes"/"No" in agent output.
 TUI_PERMISSION_PATTERN = r"Yes\s+No\s+Always [Aa]llow"
@@ -267,6 +275,15 @@ class KiroCliProvider(BaseProvider):
         # Strip ANSI codes once for all pattern matching
         # This simplifies regex patterns and improves reliability
         clean_output = re.sub(ANSI_CODE_PATTERN, "", output)
+
+        # Check 0: TUI startup — the new TUI renders the idle-prompt
+        # placeholder ("Ask a question or describe a task") before the
+        # "● Initializing..." phase completes, so a naive idle match would
+        # declare IDLE ~1s into launch and the first user message would be
+        # dropped. "Initializing..." is always cleared once init finishes, so
+        # its presence unconditionally means PROCESSING.
+        if re.search(TUI_INITIALIZING_PATTERN, clean_output):
+            return TerminalStatus.PROCESSING
 
         # Check 1: Detect idle prompts early — required for the position-aware
         # processing check below.

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -1372,6 +1372,53 @@ class TestKiroCliTuiMode:
         assert re.search(TUI_PROCESSING_PATTERN, " Kiro is working ")
         assert not re.search(TUI_PROCESSING_PATTERN, "Kiro is idle")
 
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_tui_initializing_yields_processing_despite_idle_placeholder(self, mock_tmux):
+        """Test PROCESSING while Kiro TUI is initializing.
+
+        The new TUI renders the idle-prompt placeholder ("Ask a question or
+        describe a task") before the "● Initializing..." phase completes.
+        Without the TUI_INITIALIZING_PATTERN check, get_status() would return
+        IDLE ~1s after launch and the first user message would be sent before
+        Kiro can accept input (issue #211).
+        """
+        mock_tmux.get_history.return_value = (
+            "● Initializing...\n"
+            "────────────────────────────────────────────────────\n"
+            "agent-ops · auto · ◔ 0%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "agent-ops")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_tui_initializing_cleared_allows_idle(self, mock_tmux):
+        """After init completes, Kiro clears 'Initializing...' and IDLE resolves."""
+        mock_tmux.get_history.return_value = (
+            "────────────────────────────────────────────────────\n"
+            "agent-ops · auto · ◔ 0%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "agent-ops")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.IDLE
+
+    def test_tui_initializing_pattern(self):
+        """Test TUI initializing pattern matches expected format."""
+        from cli_agent_orchestrator.providers.kiro_cli import TUI_INITIALIZING_PATTERN
+
+        assert re.search(TUI_INITIALIZING_PATTERN, "● Initializing...")
+        assert re.search(TUI_INITIALIZING_PATTERN, "Initializing...")
+        assert re.search(TUI_INITIALIZING_PATTERN, " Initializing... ")
+        # Must require three dots to avoid matching the word alone
+        assert not re.search(TUI_INITIALIZING_PATTERN, "Initializing")
+        assert not re.search(TUI_INITIALIZING_PATTERN, "Initialized")
+
     def test_tui_permission_pattern(self):
         """Test TUI permission pattern matches expected formats."""
         from cli_agent_orchestrator.providers.kiro_cli import TUI_PERMISSION_PATTERN


### PR DESCRIPTION
## Summary

Fixes #211. The new Kiro CLI TUI renders the idle-prompt placeholder (`Ask a question or describe a task`) **before** the `● Initializing...` phase completes. CAO's `get_status()` matched the placeholder and declared `IDLE` ~1s into launch, so the first user message was sent before Kiro could accept input — the message was silently dropped and the session appeared stuck.

## Root cause

`get_status()` had three processing-related checks:

1. `TUI_PROCESSING_PATTERN` (`Kiro is working`) — position-aware (lingers as ghost text in buffer after in-place redraws).
2. Idle-prompt presence check — if absent, return `PROCESSING`.
3. Default IDLE.

Nothing covered the startup phase: the TUI paints the full layout (separator, agent header, idle-prompt line) while `Initializing...` is still animating, so the naive idle match fires and the caller sees IDLE before Kiro is ready.

## Fix

Add `TUI_INITIALIZING_PATTERN = r"Initializing\.\.\."` and check for it at the top of `get_status()` — before any idle-prompt match. Unlike `Kiro is working`, `Initializing...` is **always cleared** by Kiro once startup completes, so its presence unconditionally means `PROCESSING`. No position-aware logic needed.

### Failing session (before fix)

```
19:43:16 - send_keys: kiro-cli chat --agent agent-ops
19:43:17 - Waiting for {idle, completed}, status: PROCESSING
19:43:18 - Waiting for {idle, completed}, status: IDLE        ← false IDLE
19:43:28 - ERROR: No Kiro CLI response found - no Credits marker or green arrow detected
```

### After fix

```
19:55:08 - send_keys: kiro-cli chat --model claude-sonnet-4.6 --agent agent-ops
19:55:08 - PROCESSING
19:55:09 - PROCESSING    ← correctly stays PROCESSING during Initializing
19:55:11 - IDLE          ← real IDLE after init completed (~3s)
```

## Changes

`src/cli_agent_orchestrator/providers/kiro_cli.py`:
- Add `TUI_INITIALIZING_PATTERN` constant with a comment explaining the asymmetry with `Kiro is working`.
- In `get_status()`, add a pre-idle check: if `Initializing...` is present anywhere in the buffer, return `PROCESSING`.

`test/providers/test_kiro_cli_unit.py`:
- `test_tui_initializing_yields_processing_despite_idle_placeholder` — reproduces issue #211: buffer contains `Initializing...` + separator + idle-prompt placeholder, must return `PROCESSING`.
- `test_tui_initializing_cleared_allows_idle` — once `Initializing...` is gone, IDLE resolves normally.
- `test_tui_initializing_pattern` — pattern matches expected forms; rejects bare `Initializing` / `Initialized` to avoid false positives on agent output.

## Test plan

- [x] `test/providers/test_kiro_cli_unit.py` passes (94 tests, +3 new)
- [x] Full unit/integration suite passes (1522 passed, 14 skipped)
- [x] `black --check` clean on changed files
- [ ] Live `cao launch` on a fresh kiro-cli 2.x session: first user message arrives after the real idle, not during `Initializing...`


