### PR TITLE
feat: Add Opencode provider label to Web UI

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -224,6 +224,7 @@ async def list_providers_endpoint() -> List[Dict]:
         "gemini_cli": "gemini",
         "kimi_cli": "kimi",
         "copilot_cli": "copilot",
+        "opencode_cli": "opencode",
     }
     result = []
     for provider, binary in provider_binaries.items():

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -94,7 +94,7 @@ class TestAgentProviders:
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 7
+        assert len(data) == 8
         names = [p["name"] for p in data]
         assert "kiro_cli" in names
         assert "claude_code" in names
@@ -103,6 +103,7 @@ class TestAgentProviders:
         assert "gemini_cli" in names
         assert "kimi_cli" in names
         assert "copilot_cli" in names
+        assert "opencode_cli" in names
         for p in data:
             assert p["installed"] is True
 
@@ -135,6 +136,7 @@ class TestAgentProviders:
         assert providers_dict["gemini_cli"]["installed"] is False
         assert providers_dict["kimi_cli"]["installed"] is False
         assert providers_dict["copilot_cli"]["installed"] is False
+        assert providers_dict["opencode_cli"]["installed"] is False
 
     def test_list_providers_has_binary_field(self, client):
         """Each provider entry has correct binary name."""
@@ -150,6 +152,7 @@ class TestAgentProviders:
         assert providers_dict["gemini_cli"]["binary"] == "gemini"
         assert providers_dict["kimi_cli"]["binary"] == "kimi"
         assert providers_dict["copilot_cli"]["binary"] == "copilot"
+        assert providers_dict["opencode_cli"]["binary"] == "opencode"
 
 
 # ── Skills endpoint ──────────────────────────────────────────────────

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -42,10 +42,17 @@ export interface TerminalMeta {
   last_active: string | null
 }
 
+/**
+ * Known profile source values the backend can emit.
+ * Using `string` (not a closed union) so new provider-discovered directories
+ * and custom agent directories are accepted without repeated type widening.
+ */
+export type AgentProfileSource = string
+
 export interface AgentProfileInfo {
   name: string
   description: string
-  source: 'built-in' | 'local' | 'kiro' | 'q_cli'
+  source: AgentProfileSource
 }
 
 export interface AgentDirsSettings {

--- a/web/src/components/AgentPanel.tsx
+++ b/web/src/components/AgentPanel.tsx
@@ -12,19 +12,12 @@ import { OutputViewer } from './OutputViewer'
 
 export const FALLBACK_PROVIDERS = ['kiro_cli', 'claude_code', 'q_cli', 'codex', 'gemini_cli', 'kimi_cli', 'copilot_cli', 'opencode_cli']
 
-// Minimal display-label helper. Keeps existing provider labels unchanged
-// while rendering opencode_cli as the friendlier "opencode".
-export function providerLabel(name: string): string {
-  if (name === 'opencode_cli') return 'opencode'
-  return name.replace(/_/g, ' ')
-}
-
 const SOURCE_LABELS: Record<string, string> = {
   'built-in': 'Built-in',
   'local': 'Local',
   'kiro': 'Kiro',
   'q_cli': 'Q CLI',
-  'opencode_cli': 'opencode',
+  'opencode_cli': 'OpenCode',
 }
 
 export function AgentPanel() {
@@ -292,7 +285,7 @@ export function AgentPanel() {
                     placeholder="Select provider..."
                     options={(providers.length > 0 ? providers : FALLBACK_PROVIDERS.map(n => ({ name: n, binary: '', installed: true }))).map(p => ({
                       value: p.name,
-                      label: providerLabel(p.name),
+                      label: p.name.replace(/_/g, ' '),
                       sublabel: !p.installed ? 'Not installed' : undefined,
                       disabled: !p.installed,
                     }))}
@@ -536,7 +529,7 @@ export function AgentPanel() {
                   placeholder="Select provider..."
                   options={(providers.length > 0 ? providers : FALLBACK_PROVIDERS.map(n => ({ name: n, binary: '', installed: true }))).map(p => ({
                     value: p.name,
-                    label: providerLabel(p.name),
+                    label: p.name.replace(/_/g, ' '),
                     sublabel: !p.installed ? 'Not installed' : undefined,
                     disabled: !p.installed,
                   }))}

--- a/web/src/components/AgentPanel.tsx
+++ b/web/src/components/AgentPanel.tsx
@@ -24,6 +24,7 @@ const SOURCE_LABELS: Record<string, string> = {
   'local': 'Local',
   'kiro': 'Kiro',
   'q_cli': 'Q CLI',
+  'opencode_cli': 'opencode',
 }
 
 export function AgentPanel() {

--- a/web/src/components/AgentPanel.tsx
+++ b/web/src/components/AgentPanel.tsx
@@ -10,7 +10,14 @@ import { TerminalMeta } from '../api'
 import { StatusBadge } from './StatusBadge'
 import { OutputViewer } from './OutputViewer'
 
-const FALLBACK_PROVIDERS = ['kiro_cli', 'claude_code', 'q_cli', 'codex', 'gemini_cli', 'kimi_cli', 'copilot_cli']
+const FALLBACK_PROVIDERS = ['kiro_cli', 'claude_code', 'q_cli', 'codex', 'gemini_cli', 'kimi_cli', 'copilot_cli', 'opencode_cli']
+
+// Minimal display-label helper. Keeps existing provider labels unchanged
+// while rendering opencode_cli as the friendlier "opencode".
+function providerLabel(name: string): string {
+  if (name === 'opencode_cli') return 'opencode'
+  return name.replace(/_/g, ' ')
+}
 
 const SOURCE_LABELS: Record<string, string> = {
   'built-in': 'Built-in',
@@ -284,7 +291,7 @@ export function AgentPanel() {
                     placeholder="Select provider..."
                     options={(providers.length > 0 ? providers : FALLBACK_PROVIDERS.map(n => ({ name: n, binary: '', installed: true }))).map(p => ({
                       value: p.name,
-                      label: p.name.replace(/_/g, ' '),
+                      label: providerLabel(p.name),
                       sublabel: !p.installed ? 'Not installed' : undefined,
                       disabled: !p.installed,
                     }))}
@@ -528,7 +535,7 @@ export function AgentPanel() {
                   placeholder="Select provider..."
                   options={(providers.length > 0 ? providers : FALLBACK_PROVIDERS.map(n => ({ name: n, binary: '', installed: true }))).map(p => ({
                     value: p.name,
-                    label: p.name.replace(/_/g, ' '),
+                    label: providerLabel(p.name),
                     sublabel: !p.installed ? 'Not installed' : undefined,
                     disabled: !p.installed,
                   }))}

--- a/web/src/components/AgentPanel.tsx
+++ b/web/src/components/AgentPanel.tsx
@@ -10,11 +10,11 @@ import { TerminalMeta } from '../api'
 import { StatusBadge } from './StatusBadge'
 import { OutputViewer } from './OutputViewer'
 
-const FALLBACK_PROVIDERS = ['kiro_cli', 'claude_code', 'q_cli', 'codex', 'gemini_cli', 'kimi_cli', 'copilot_cli', 'opencode_cli']
+export const FALLBACK_PROVIDERS = ['kiro_cli', 'claude_code', 'q_cli', 'codex', 'gemini_cli', 'kimi_cli', 'copilot_cli', 'opencode_cli']
 
 // Minimal display-label helper. Keeps existing provider labels unchanged
 // while rendering opencode_cli as the friendlier "opencode".
-function providerLabel(name: string): string {
+export function providerLabel(name: string): string {
   if (name === 'opencode_cli') return 'opencode'
   return name.replace(/_/g, ' ')
 }

--- a/web/src/test/api.test.ts
+++ b/web/src/test/api.test.ts
@@ -37,7 +37,10 @@ describe('API wrapper', () => {
   })
 
   it('listProviders fetches /agents/providers', async () => {
-    const providers = [{ name: 'kiro_cli', binary: 'kiro-cli', installed: true }]
+    const providers = [
+      { name: 'kiro_cli', binary: 'kiro-cli', installed: true },
+      { name: 'opencode_cli', binary: 'opencode', installed: false },
+    ]
     mockResponse(providers)
     const result = await api.listProviders()
     expect(result).toEqual(providers)

--- a/web/src/test/api.test.ts
+++ b/web/src/test/api.test.ts
@@ -56,6 +56,26 @@ describe('API wrapper', () => {
     )
   })
 
+  it('createSession sends POST with opencode_cli provider', async () => {
+    const terminal = { id: 't2', name: 'dev', provider: 'opencode_cli', session_name: 's2' }
+    mockResponse(terminal)
+    await api.createSession('opencode_cli', 'developer')
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/sessions?provider=opencode_cli&agent_profile=developer'),
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('addTerminalToSession sends POST with opencode_cli provider', async () => {
+    const terminal = { id: 't3', name: 'dev', provider: 'opencode_cli', session_name: 's1' }
+    mockResponse(terminal)
+    await api.addTerminalToSession('s1', 'opencode_cli', 'developer')
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/sessions/s1/terminals?provider=opencode_cli&agent_profile=developer'),
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
   it('createSession includes working directory when provided', async () => {
     mockResponse({ id: 't1' })
     await api.createSession('kiro_cli', 'developer', undefined, '/home/user/project')

--- a/web/src/test/components.test.tsx
+++ b/web/src/test/components.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { StatusBadge } from '../components/StatusBadge'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { ConfirmModal } from '../components/ConfirmModal'
+import { providerLabel, FALLBACK_PROVIDERS } from '../components/AgentPanel'
 
 describe('StatusBadge', () => {
   it('renders idle status', () => {
@@ -138,5 +139,61 @@ describe('ConfirmModal', () => {
     )
     const button = screen.getByText('Closing...').closest('button')
     expect(button).toBeDisabled()
+  })
+})
+
+describe('providerLabel', () => {
+  it('renders opencode_cli as "opencode"', () => {
+    expect(providerLabel('opencode_cli')).toBe('opencode')
+  })
+
+  it('keeps existing underscore-to-space behavior for kiro_cli', () => {
+    expect(providerLabel('kiro_cli')).toBe('kiro cli')
+  })
+
+  it('keeps existing behavior for claude_code', () => {
+    expect(providerLabel('claude_code')).toBe('claude code')
+  })
+
+  it('keeps existing behavior for providers without underscores', () => {
+    expect(providerLabel('codex')).toBe('codex')
+  })
+})
+
+describe('FALLBACK_PROVIDERS', () => {
+  it('includes opencode_cli', () => {
+    expect(FALLBACK_PROVIDERS).toContain('opencode_cli')
+  })
+
+  it('includes all known providers', () => {
+    const expected = ['kiro_cli', 'claude_code', 'q_cli', 'codex', 'gemini_cli', 'kimi_cli', 'copilot_cli', 'opencode_cli']
+    for (const p of expected) {
+      expect(FALLBACK_PROVIDERS).toContain(p)
+    }
+  })
+
+  it('maps to enabled select options with correct label', () => {
+    // Simulates the fallback option construction used in AgentPanel
+    const options = FALLBACK_PROVIDERS.map(n => ({
+      value: n,
+      label: providerLabel(n),
+      disabled: false,
+    }))
+    const opencodeOption = options.find(o => o.value === 'opencode_cli')
+    expect(opencodeOption).toBeDefined()
+    expect(opencodeOption!.label).toBe('opencode')
+    expect(opencodeOption!.disabled).toBe(false)
+
+    const kiroOption = options.find(o => o.value === 'kiro_cli')
+    expect(kiroOption).toBeDefined()
+    expect(kiroOption!.label).toBe('kiro cli')
+  })
+
+  it('provides an opencode_cli option on empty providers', () => {
+    // Simulates: when providers.length === 0, fallback is used
+    const noProviders: any[] = []
+    const effective = noProviders.length > 0 ? noProviders : FALLBACK_PROVIDERS.map(n => ({ name: n, binary: '', installed: true }))
+    const names = effective.map(p => p.name)
+    expect(names).toContain('opencode_cli')
   })
 })

--- a/web/src/test/components.test.tsx
+++ b/web/src/test/components.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { StatusBadge } from '../components/StatusBadge'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { ConfirmModal } from '../components/ConfirmModal'
-import { providerLabel, FALLBACK_PROVIDERS } from '../components/AgentPanel'
+import { FALLBACK_PROVIDERS } from '../components/AgentPanel'
 
 describe('StatusBadge', () => {
   it('renders idle status', () => {
@@ -142,24 +142,6 @@ describe('ConfirmModal', () => {
   })
 })
 
-describe('providerLabel', () => {
-  it('renders opencode_cli as "opencode"', () => {
-    expect(providerLabel('opencode_cli')).toBe('opencode')
-  })
-
-  it('keeps existing underscore-to-space behavior for kiro_cli', () => {
-    expect(providerLabel('kiro_cli')).toBe('kiro cli')
-  })
-
-  it('keeps existing behavior for claude_code', () => {
-    expect(providerLabel('claude_code')).toBe('claude code')
-  })
-
-  it('keeps existing behavior for providers without underscores', () => {
-    expect(providerLabel('codex')).toBe('codex')
-  })
-})
-
 describe('FALLBACK_PROVIDERS', () => {
   it('includes opencode_cli', () => {
     expect(FALLBACK_PROVIDERS).toContain('opencode_cli')
@@ -172,16 +154,17 @@ describe('FALLBACK_PROVIDERS', () => {
     }
   })
 
-  it('maps to enabled select options with correct label', () => {
+  it('maps to enabled select options with default underscore label', () => {
     // Simulates the fallback option construction used in AgentPanel
     const options = FALLBACK_PROVIDERS.map(n => ({
       value: n,
-      label: providerLabel(n),
+      label: n.replace(/_/g, ' '),
       disabled: false,
     }))
     const opencodeOption = options.find(o => o.value === 'opencode_cli')
     expect(opencodeOption).toBeDefined()
-    expect(opencodeOption!.label).toBe('opencode')
+    // opencode_cli uses the default underscore-to-space replacement
+    expect(opencodeOption!.label).toBe('opencode cli')
     expect(opencodeOption!.disabled).toBe(false)
 
     const kiroOption = options.find(o => o.value === 'kiro_cli')


### PR DESCRIPTION
Addresses issue #204

## Overview

Adds OpenCode provider support to Web UI provider-aware surfaces so `opencode_cli` is available consistently in backend discovery, frontend fallback provider lists, profile source grouping, and automated coverage. The API/provider identifier remains `opencode_cli`; user-facing profile source labels display as `OpenCode`.

## Key Changes

- Add `opencode_cli` to `/agents/providers` backend discovery with the `opencode` binary.
- Add `opencode_cli` to Web UI fallback provider options used when provider discovery is empty or unavailable.
- Widen frontend agent profile source typing to accept backend/provider-defined source labels.
- Display opencode profile sources as `OpenCode` in profile grouping.
- Add frontend and backend tests covering OpenCode provider API wiring, fallback provider behavior, and source labeling.
- Keep provider option labels on the existing default underscore replacement behavior, so `opencode_cli` renders as `opencode cli` in provider dropdowns.

## Test Plan

- `npm test` from `web/` — passed, 40 tests.
- `npm run build` from `web/` — passed with existing Vite chunk-size warning.
- `uv run pytest test/api/test_api_endpoints.py -k providers -v` — passed, 4 tests.
- `uv run pytest test/providers/test_opencode_cli_unit.py -v` — passed, 49 tests.
- Browser smoke test against `http://127.0.0.1:5173` — passed: provider option shown, session created with internal provider `opencode_cli`, terminal row displayed provider/profile/status, and smoke-created session was cleaned up.
