### PR TITLE
fix(tmux): start panes at 220x50 to avoid kiro-cli SIGWINCH input dea…

### DIFF
--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -145,12 +145,21 @@ class TmuxClient:
             }
             environment["CAO_TERMINAL_ID"] = terminal_id
 
+            # Explicit 220x50 pane size avoids the default 80x24 that tmux
+            # assigns to detached sessions. kiro-cli 2.1.x's TUI v2 fails to
+            # repaint after a SIGWINCH from the attach-time resize (80x24 →
+            # user's real terminal): the screen goes blank and input is
+            # silently dropped. Starting at a larger size makes the attach
+            # resize a no-op/shrink, which kiro handles correctly. All other
+            # providers tolerate wider panes. See issue #216.
             session = self.server.new_session(
                 session_name=session_name,
                 window_name=window_name,
                 start_directory=working_directory,
                 detach=True,
                 environment=environment,
+                x=220,
+                y=50,
             )
             logger.info(
                 f"Created tmux session: {session_name} with window: {window_name} in directory: {working_directory}"

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -78,6 +78,27 @@ class TestCreateSession:
         with pytest.raises(Exception, match="tmux error"):
             tmux.create_session("ses", "w", "tid1", str(tmp_path))
 
+    def test_create_session_uses_explicit_dimensions(self, tmux, tmp_path):
+        """Guard against regressing the kiro-cli 2.1.x SIGWINCH-repaint bug (#216).
+
+        Default detached pane is 80x24. When the user attaches, tmux resizes
+        the pane to their real terminal size and kiro-cli 2.1.x fails to
+        repaint (blank screen, input silently dropped). Creating the pane at
+        220x50 makes the attach-time resize a no-op or shrink, which kiro
+        handles correctly.
+        """
+        mock_window = MagicMock()
+        mock_window.name = "my-window"
+        mock_session = MagicMock()
+        mock_session.windows = [mock_window]
+        tmux.server.new_session.return_value = mock_session
+
+        tmux.create_session("ses", "my-window", "tid1", str(tmp_path))
+
+        kwargs = tmux.server.new_session.call_args.kwargs
+        assert kwargs.get("x") == 220
+        assert kwargs.get("y") == 50
+
 
 # ── create_window ────────────────────────────────────────────────────
 


### PR DESCRIPTION


## Summary

Fixes #216. kiro-cli 2.1.x's TUI v2 fails to repaint after a `SIGWINCH` from tmux's attach-time resize. CAO created detached sessions at tmux's default **80×24**, and `cao launch` immediately attached the user's terminal — triggering an 80×24 → real-terminal-size resize that kiro handled by blanking the screen and silently dropping all subsequent input.

## Reproduction (on latest main, kiro-cli 2.1.1, tmux 3.5a)

10/10 runs fail with the following flow:

1. CAO creates detached pane at default 80×24
2. `tmux resize-window -x 220 -y 50` (equivalent to `tmux attach-session` resizing to user's terminal)
3. Pane goes completely blank — kiro-cli cleared the screen and never repainted
4. `tmux send-keys "hello"` lands in the buffer but nothing appears on-screen
5. CAO `POST /input` — status stays `idle` for 30+ s, never transitions to `processing`/`completed`

## Fix

Add explicit `x=220, y=50` to `TmuxClient.create_session()`'s `new_session(...)` call so the pane is born at a realistic size. The attach-time resize is then a no-op or small shrink (e.g. 220×50 → 200×48), which kiro handles correctly.

Why 220×50: wider than nearly any real terminal, so the attach is always a shrink rather than a grow. Shrinks redraw cleanly; grows are what kiro 2.1.x breaks on.

## Changes

`src/cli_agent_orchestrator/clients/tmux.py`
- `create_session()`: pass `x=220, y=50` to `server.new_session(...)`, with an inline comment linking to #216 explaining why the parameters are load-bearing.

`test/clients/test_tmux_client.py`
- `test_create_session_uses_explicit_dimensions`: asserts `x=220, y=50` land on the `new_session` call. Guards against accidental removal during future cleanup.

## Why scoped to `create_session` only

All CAO providers share this session-creation path. None of the other providers tested (claude_code, codex, gemini_cli, copilot_cli, kimi_cli, opencode_cli, q_cli) show any input sensitivity to pane size — only kiro-cli's new TUI has the repaint bug. But since every provider benefits from consistent starting dimensions (no surprise resize on attach), a global change is simpler and safer than a provider-specific override.

## Verification

- Unit tests: 1517 passed, 1 skipped (CI invocation)
- tmux-client tests: 52 passed
- `black --check src/ test/` clean
- `isort --check-only src/ test/` clean
- Live repro: before fix, 10/10 runs fail post-resize; after fix, `send_message` completes in ~5 s with correct output.

## Upstream

The root cause is a kiro-cli 2.1.x bug in its `SIGWINCH` handler — tmux and all other TUI providers handle grow-resizes correctly. Worth filing at [kirodotdev/Kiro](https://github.com/kirodotdev/Kiro/issues) with the exact repro above, but we can't block on that fix landing.

## Test plan

- [x] Unit suite passes
- [x] Lint + formatters clean
- [x] Reproduces issue #216 before the fix (10/10)
- [x] Does not reproduce after the fix
- [ ] `cao launch --agents developer --auto-approve` (non-headless) accepts keyboard input on the user's terminal after attach
