### PR TITLE
fix: MCP worker agent provider resolution

### DIFF
--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -14,6 +14,7 @@ from cli_agent_orchestrator.constants import API_BASE_URL, DEFAULT_PROVIDER
 from cli_agent_orchestrator.mcp_server.models import HandoffResult
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
 from cli_agent_orchestrator.utils.terminal import generate_session_name, wait_until_terminal_status
 
 logger = logging.getLogger(__name__)
@@ -124,7 +125,8 @@ def _create_terminal(
         response.raise_for_status()
         terminal_metadata = response.json()
 
-        provider = terminal_metadata["provider"]
+        # Treat the supervisor provider as a fallback, not an explicit override.
+        provider = resolve_provider(agent_profile, fallback_provider=terminal_metadata["provider"])
         session_name = terminal_metadata["session_name"]
         parent_allowed_tools = terminal_metadata.get("allowed_tools")
 
@@ -163,6 +165,7 @@ def _create_terminal(
     else:
         # Create new session with terminal
         session_name = generate_session_name()
+        provider = resolve_provider(agent_profile, fallback_provider=provider)
         params = {
             "provider": provider,
             "agent_profile": agent_profile,

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -1,11 +1,98 @@
 """Tests for assign MCP tool."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from cli_agent_orchestrator.constants import API_BASE_URL
 from cli_agent_orchestrator.mcp_server.server import _build_assign_description
+
+
+class TestCreateTerminalProviderResolution:
+    """Tests for provider resolution used by dispatched worker terminals."""
+
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
+    )
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="claude_code")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_existing_session_respects_child_profile_provider(
+        self, mock_requests, mock_resolve_provider, mock_allowed_tools
+    ):
+        """Worker profile provider should override the supervisor provider."""
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        metadata_response = MagicMock()
+        metadata_response.json.return_value = {
+            "provider": "kiro_cli",
+            "session_name": "cao-session",
+            "allowed_tools": None,
+        }
+        metadata_response.raise_for_status.return_value = None
+
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-1", "provider": "claude_code"}
+        post_response.raise_for_status.return_value = None
+
+        mock_requests.get.return_value = metadata_response
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervisor-1"}):
+            terminal_id, provider = _create_terminal("reviewer", "/repo")
+
+        assert terminal_id == "worker-1"
+        assert provider == "claude_code"
+        mock_resolve_provider.assert_called_once_with("reviewer", fallback_provider="kiro_cli")
+        mock_requests.post.assert_called_once_with(
+            f"{API_BASE_URL}/sessions/cao-session/terminals",
+            params={
+                "provider": "claude_code",
+                "agent_profile": "reviewer",
+                "working_directory": "/repo",
+            },
+        )
+
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
+    )
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="kiro_cli")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_existing_session_falls_back_to_supervisor_provider(
+        self, mock_requests, mock_resolve_provider, mock_allowed_tools
+    ):
+        """Worker without a provider should inherit the supervisor provider."""
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        metadata_response = MagicMock()
+        metadata_response.json.return_value = {
+            "provider": "kiro_cli",
+            "session_name": "cao-session",
+            "allowed_tools": None,
+        }
+        metadata_response.raise_for_status.return_value = None
+
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-2", "provider": "kiro_cli"}
+        post_response.raise_for_status.return_value = None
+
+        mock_requests.get.return_value = metadata_response
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervisor-1"}):
+            terminal_id, provider = _create_terminal("reviewer", "/repo")
+
+        assert terminal_id == "worker-2"
+        assert provider == "kiro_cli"
+        mock_resolve_provider.assert_called_once_with("reviewer", fallback_provider="kiro_cli")
+        mock_requests.post.assert_called_once_with(
+            f"{API_BASE_URL}/sessions/cao-session/terminals",
+            params={
+                "provider": "kiro_cli",
+                "agent_profile": "reviewer",
+                "working_directory": "/repo",
+            },
+        )
 
 
 class TestAssignSenderIdInjection:


### PR DESCRIPTION
## Overview

Fixes #223.

MCP-dispatched worker agents should honor the worker profile's `provider:` frontmatter, using the supervisor provider only as a fallback when the worker profile does not declare a valid provider.

After #198, the API correctly treats a present `provider` query parameter as an explicit override and only resolves `profile.provider` when `provider` is omitted. The MCP server was still sending the supervisor provider as if it were fallback metadata, so worker profile provider frontmatter was bypassed during `assign` / `handoff`.

## Key Changes

- Resolve the worker provider in `mcp_server.server._create_terminal()` before posting to the API.
- Use the supervisor terminal's provider as the fallback for `resolve_provider()`.
- Keep the existing API semantics intact: when MCP sends `provider`, it is now the already-resolved worker provider.
- Add regression coverage for:
  - worker profile provider overriding the supervisor provider
  - worker profile with no provider falling back to the supervisor provider

## Test Plan

- `uv run black src/cli_agent_orchestrator/mcp_server/server.py test/mcp_server/test_assign.py`
- `uv run pytest test/mcp_server/test_assign.py test/mcp_server/test_handoff.py -v`
- `uv run pytest test/api/test_terminals.py test/services/test_session_service.py -v`
