### PR TITLE
[Docs]Reorganize README, split detail into topic docs, and add control-plane overview

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,7 @@ This command:
 uv run cao --help
 
 # Run a quick test to ensure everything is working
-uv run pytest test/providers/test_q_cli_unit.py -v -k "test_initialization"
+uv run pytest test/providers/test_kiro_cli_unit.py -v -k "test_initialization"
 ```
 
 ## Web UI Development
@@ -67,10 +67,10 @@ Unit tests are fast and use mocked dependencies:
 
 ```bash
 # Run all unit tests (excludes E2E and integration tests)
-uv run pytest test/ --ignore=test/e2e --ignore=test/providers/test_q_cli_integration.py -v
+uv run pytest test/ --ignore=test/e2e -m "not integration" -v
 
 # Run with coverage report
-uv run pytest test/ --ignore=test/e2e --cov=src --cov-report=term-missing -v
+uv run pytest test/ --ignore=test/e2e -m "not integration" --cov=src --cov-report=term-missing -v
 
 # Run specific test file
 uv run pytest test/providers/test_claude_code_unit.py -v
@@ -84,8 +84,8 @@ uv run pytest test/providers/test_codex_provider_unit.py::TestCodexBuildCommand 
 Integration tests require the provider CLI to be installed and authenticated:
 
 ```bash
-# Run Q CLI integration tests (requires Q CLI setup)
-uv run pytest test/providers/test_q_cli_integration.py -v
+# Run integration tests for a specific provider (example: Kiro CLI)
+uv run pytest test/providers/test_kiro_cli_integration.py -v
 
 # Skip integration tests
 uv run pytest test/providers/ -m "not integration" -v
@@ -196,7 +196,7 @@ Add or update tests in `test/`
 
 ```bash
 # Run unit tests (fast, excludes E2E and integration)
-uv run pytest test/ --ignore=test/e2e --ignore=test/providers/test_q_cli_integration.py -v
+uv run pytest test/ --ignore=test/e2e -m "not integration" -v
 
 # Run all tests with coverage
 uv run pytest test/ --ignore=test/e2e --cov=src --cov-report=term-missing -v
@@ -245,28 +245,34 @@ Each provider has a dedicated workflow that runs only when its files change:
 
 Each includes unit tests (Python 3.10/3.11/3.12) and code quality checks (black, isort, mypy).
 
-## Working with the Q CLI Provider
+## Working with Providers
 
 ### Regenerate Test Fixtures
 
-If Q CLI output format changes:
+If a provider's CLI output format changes, regenerate the captured fixtures:
 
 ```bash
 uv run python test/providers/fixtures/generate_fixtures.py
 ```
 
-### Test Against Real Q CLI
+### Test Against a Real Provider CLI
+
+Integration tests exercise a real provider binary, so the CLI must be installed and authenticated before they can run. Using Kiro CLI as an example:
 
 ```bash
-# Ensure Q CLI is available
-which q
+# Ensure the provider CLI is on PATH
+which kiro
 
-# Ensure Q CLI is authenticated
-q status
+# Ensure it is authenticated (provider-specific; see docs/<provider>.md)
+kiro --help
 
-# Run integration tests
-uv run pytest test/providers/test_q_cli_integration.py -v
+# Run that provider's integration tests
+uv run pytest test/providers/test_kiro_cli_integration.py -v
 ```
+
+The same pattern applies to every provider that ships an `<provider>_integration.py` file — substitute the binary and the test filename.
+
+> **Note:** Q CLI is slated for deprecation. Do not build new development workflows around Q CLI; prefer Kiro CLI, Claude Code, or Codex CLI as your default provider while contributing.
 
 ## Troubleshooting
 
@@ -337,7 +343,7 @@ cli-agent-orchestrator/
 │       ├── clients/                # Database and tmux clients
 │       ├── mcp_server/             # MCP server implementation
 │       ├── models/                 # Data models
-│       ├── providers/              # Agent providers (Q CLI, Claude Code)
+│       ├── providers/              # Agent providers (Kiro CLI, Claude Code, Codex, Gemini, Kimi, Copilot, OpenCode, Q CLI [deprecated])
 │       ├── services/               # Business logic services
 │       └── utils/                  # Utility functions
 ├── test/                           # Test suite (511 tests, 84% coverage)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,42 @@
-# CLI Agent Orchestrator
+# CLI Agent Orchestrator (CAO)
 
 [![PyPI version](https://img.shields.io/pypi/v/cli-agent-orchestrator.svg)](https://pypi.org/project/cli-agent-orchestrator/)
 [![Python versions](https://img.shields.io/pypi/pyversions/cli-agent-orchestrator.svg)](https://pypi.org/project/cli-agent-orchestrator/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/awslabs/cli-agent-orchestrator)
 
-CLI Agent Orchestrator (CAO, pronounced "kay-oh") is a lightweight orchestration system for managing multiple AI agent sessions in tmux terminals. Enables multi-agent collaboration via MCP server.
+**CLI Agent Orchestrator (CAO)** is an open-source multi-agent orchestration framework for AI coding CLIs — Claude Code, Kiro CLI, Codex CLI, Gemini CLI, Kimi CLI, GitHub Copilot CLI, OpenCode, and Amazon Q Developer CLI. CAO runs each agent in an isolated tmux session and coordinates them with a supervisor–worker pattern over the Model Context Protocol (MCP), so one supervisor agent can delegate tasks to multiple specialist agents in parallel, sequentially, or as a swarm.
+
+## What is CAO?
+
+CAO (pronounced "kay-oh") is a lightweight local orchestrator that sits between you and the CLI coding agents you already use. Instead of running a single agent at a time, CAO lets a supervisor agent launch, message, and coordinate multiple worker agents — each one a real CLI tool (Claude Code, Kiro, Codex, etc.) running in its own tmux terminal. Agents communicate through three MCP-exposed primitives (**handoff**, **assign**, **send_message**) and are managed via a CLI, a bundled Web UI, or an MCP management server. Because every agent is a full CLI process, CAO preserves tool behaviour, auth, and advanced features (Claude Code sub-agents, Q CLI custom agents, etc.) that a raw API wrapper cannot.
+
+## Common use cases
+
+- **Parallel code review / implementation** — supervisor assigns N reviewers to review N files concurrently, then merges their findings.
+- **Cross-provider workflows** — supervisor on one CLI (e.g. Kiro), worker on another (e.g. Claude Code), per-profile provider selection.
+- **Scheduled agent runs** — cron-style "every morning at 9am" triggers via [Flows](docs/flows.md).
+- **Headless agent execution in CI** — `cao launch --headless --async` to run tasks unattended.
+- **Multi-agent swarms with HITL** — humans can attach to any tmux session to intervene or steer.
+- **Agent-driven agent management** — a primary agent uses [`cao-ops-mcp`](#cao-ops-mcp-server) to spawn and monitor CAO sessions from its own chat loop.
 
 ## Hierarchical Multi-Agent System
 
-CAO implements a hierarchical multi-agent system that enables complex problem-solving through specialized division of CLI developer agents.
+CAO implements a hierarchical multi-agent system — one supervisor agent delegates to specialised worker agents rather than running everything in a single context.
 
-![CAO Architecture](./docs/assets/cao_architecture.png)
+![CAO architecture: supervisor agent delegating to worker agents in isolated tmux sessions via MCP](./docs/assets/cao_architecture.png)
 
 ### Key Features
 
-* **Hierarchical orchestration** – A supervisor agent coordinates workflow management and task delegation to specialized worker agents. The supervisor maintains overall project context while workers focus on their domains of expertise.
-* **Session-based isolation** – Each agent operates in an isolated tmux session, giving proper context separation while still enabling communication through Model Context Protocol (MCP) servers.
-* **Three orchestration patterns** – **Handoff** (synchronous task transfer with wait-for-completion), **Assign** (asynchronous task spawning for parallel execution), and **Send Message** (direct communication with existing agents). See [Multi-Agent Orchestration](#multi-agent-orchestration).
-* **Flow — scheduled runs** – Automated execution of workflows at specified intervals using cron-like scheduling. See [docs/flows.md](docs/flows.md).
-* **Context preservation** – The supervisor provides only necessary context to each worker, avoiding context pollution.
-* **Direct worker interaction** – Users can interact directly with worker agents to provide additional steering — real-time guidance and course correction, distinguishing CAO from traditional sub-agent features.
-* **Tool restrictions** – Control what each agent can do through `role` and `allowedTools`. Built-in roles (`supervisor`, `developer`, `reviewer`) give sensible defaults; `allowedTools` gives fine-grained override. See [docs/tool-restrictions.md](docs/tool-restrictions.md).
-* **Advanced CLI integration** – CAO agents have full access to advanced features of the underlying CLI, such as the [sub-agents](https://docs.claude.com/en/docs/claude-code/sub-agents) feature of Claude Code and [Custom Agent](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-custom-agents.html) of Amazon Q Developer CLI.
+- **Hierarchical supervisor–worker orchestration** — a supervisor agent coordinates and delegates; workers focus on their domain. Preserves overall context without polluting workers.
+- **Session isolation via tmux** — every agent runs in its own tmux session. Clean context separation, real PTY access, humans can `tmux attach` to steer at any time.
+- **Three orchestration primitives over MCP** — `handoff` (sync, wait for completion), `assign` (async, fire-and-forget), `send_message` (inbox delivery between agents). See [Multi-Agent Orchestration](#multi-agent-orchestration).
+- **Cross-provider mixing** — run workers on different CLIs in the same session. Pin a profile to a provider via agent frontmatter. See [Cross-Provider Orchestration](#cross-provider-orchestration).
+- **Scheduled flows** — cron-like scheduling for unattended agent runs. See [docs/flows.md](docs/flows.md).
+- **Web UI, CLI, and MCP control planes** — manage sessions from the browser, `cao session` commands, or the `cao-ops-mcp` server. See [docs/control-planes.md](docs/control-planes.md).
+- **Tool restrictions per agent** — `role` + `allowedTools` in the profile, translated to each provider's native enforcement (5 of 7 providers support hard enforcement). See [docs/tool-restrictions.md](docs/tool-restrictions.md).
+- **Direct worker steering** — unlike traditional "sub-agent" features, you can attach to a running worker and intervene mid-task.
+- **Full CLI feature access** — agents keep native CLI features: Claude Code [sub-agents](https://docs.claude.com/en/docs/claude-code/sub-agents), Amazon Q Developer [Custom Agent](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-custom-agents.html), provider-native auth, etc.
+- **Plugin system for outbound events** — forward inter-agent messages to Discord, Slack, Telegram, or any webhook target. See [Plugins](#plugins).
 
 For detailed project structure and architecture, see [CODEBASE.md](CODEBASE.md).
 
@@ -74,12 +89,16 @@ source $HOME/.local/bin/env   # Add uv to PATH (or restart your shell)
 uv tool install git+https://github.com/awslabs/cli-agent-orchestrator.git@main --upgrade
 ```
 
-Or from PyPI:
+This pulls the latest `main` commit and includes the pre-built Web UI inside the wheel, so **you do not need Node.js or `npm install` to use CAO**. Node.js is only required if you plan to run the frontend in dev mode (hot-reload) or rebuild the bundle yourself — see [docs/web-ui.md](docs/web-ui.md).
+
+#### Install from PyPI (optional)
+
+PyPI publishes tagged releases only, so it will lag behind `main` between releases. Prefer the `git+` install above if you want the latest fixes.
 
 ```bash
 uv tool install cli-agent-orchestrator --upgrade
 
-# Pin a specific version
+# Pin a specific release
 uv tool install cli-agent-orchestrator==2.1.0
 ```
 
@@ -155,7 +174,7 @@ All agent sessions run in tmux — you can `tmux attach -t <session-name>` to wa
 
 ## Web UI
 
-CAO ships a bundled web dashboard for managing agents, terminals, and flows from the browser. With the default install you just need `cao-server` running:
+CAO ships a bundled web dashboard for managing agents, terminals, and flows from the browser. The pre-built UI is packaged inside the wheel, so there is nothing extra to install — just start the server:
 
 ```bash
 cao-server
@@ -165,7 +184,7 @@ Then open http://localhost:9889.
 
 ![CAO Web UI](https://github.com/user-attachments/assets/e7db9261-62b1-4422-b9f5-6fe5f65bdea4)
 
-For development mode (hot-reload), remote access over SSH, rebuilding the frontend, and Node.js requirements, see [docs/web-ui.md](docs/web-ui.md). For frontend architecture, see [web/README.md](web/README.md).
+For hot-reload dev mode, remote access over SSH, and rebuilding the frontend from source (only these require Node.js), see [docs/web-ui.md](docs/web-ui.md). For frontend architecture, see [web/README.md](web/README.md).
 
 ## Multi-Agent Orchestration
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Add `--async` to return immediately without waiting for completion.
 
 For the command reference and the agent-facing skill, see the [Session Management skill](skills/cao-session-management/SKILL.md).
 
+Because `cao session` is just shell commands, any AI assistant that supports shell-callable skills should be able to drive CAO this way — e.g. Claude Code, Kiro CLI, [OpenClaw](https://github.com/openclaw/openclaw), or [Hermes Agent](https://github.com/NousResearch/hermes-agent).
+
 ### CAO Ops MCP Server
 
 `cao-ops-mcp` exposes the same management operations as structured MCP tools for a primary agent (Claude Code, Claude Desktop, etc.). It is the MCP-flavoured equivalent of `cao session` — pick `cao-ops-mcp` when your caller speaks MCP, `cao session` otherwise.

--- a/README.md
+++ b/README.md
@@ -4,28 +4,24 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/cli-agent-orchestrator.svg)](https://pypi.org/project/cli-agent-orchestrator/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/awslabs/cli-agent-orchestrator)
 
-CLI Agent Orchestrator(CAO, pronounced as "kay-oh"), is a lightweight orchestration system for managing multiple AI agent sessions in tmux terminals. Enables Multi-agent collaboration via MCP server.
+CLI Agent Orchestrator (CAO, pronounced "kay-oh") is a lightweight orchestration system for managing multiple AI agent sessions in tmux terminals. Enables multi-agent collaboration via MCP server.
 
 ## Hierarchical Multi-Agent System
 
-CLI Agent Orchestrator (CAO) implements a hierarchical multi-agent system that enables complex problem-solving through specialized division of CLI Developer Agents.
+CAO implements a hierarchical multi-agent system that enables complex problem-solving through specialized division of CLI developer agents.
 
 ![CAO Architecture](./docs/assets/cao_architecture.png)
 
 ### Key Features
 
-* **Hierarchical orchestration** – CAO's supervisor agent coordinates workflow management and task delegation to specialized worker agents. The supervisor maintains overall project context while agents focus on their domains of expertise.
-* **Session-based isolation** – Each agent operates in isolated tmux sessions, ensuring proper context separation while enabling seamless communication through Model Context Protocol (MCP) servers. This provides both coordination and parallel processing capabilities.
-* **Intelligent task delegation** – CAO automatically routes tasks to appropriate specialists based on project requirements, expertise matching, and workflow dependencies. The system adapts between individual agent work and coordinated team efforts through three orchestration patterns:
-    - **Handoff** - Synchronous task transfer with wait-for-completion
-    - **Assign** - Asynchronous task spawning for parallel execution  
-    - **Send Message** - Direct communication with existing agents
-* **Flexible workflow patterns** – CAO supports both sequential coordination for dependent tasks and parallel processing for independent work streams. This allows optimization of both development speed and quality assurance processes.
-* **Flow - Scheduled runs** – Automated execution of workflows at specified intervals using cron-like scheduling, enabling routine tasks and monitoring workflows to run unattended.
-* **Context preservation** – The supervisor agent provides only necessary context to each worker agent, avoiding context pollution while maintaining workflow coherence.
-* **Direct worker interaction and steering** – Users can interact directly with worker agents to provide additional steering, distinguishing from sub-agents features by allowing real-time guidance and course correction.
-* **Tool restrictions** – Control what each agent can do through `role` and `allowedTools`. Built-in roles (`supervisor`, `developer`, `reviewer`) provide sensible defaults, while `allowedTools` gives fine-grained control. CAO translates restrictions to each provider's native enforcement mechanism. See [Tool Restrictions](#tool-restrictions-allowedtools).
-* **Advanced CLI integration** – CAO agents have full access to advanced features of the developer CLI, such as the [sub-agents](https://docs.claude.com/en/docs/claude-code/sub-agents) feature of Claude Code, [Custom Agent](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-custom-agents.html) of Amazon Q Developer for CLI and so on.
+* **Hierarchical orchestration** – A supervisor agent coordinates workflow management and task delegation to specialized worker agents. The supervisor maintains overall project context while workers focus on their domains of expertise.
+* **Session-based isolation** – Each agent operates in an isolated tmux session, giving proper context separation while still enabling communication through Model Context Protocol (MCP) servers.
+* **Three orchestration patterns** – **Handoff** (synchronous task transfer with wait-for-completion), **Assign** (asynchronous task spawning for parallel execution), and **Send Message** (direct communication with existing agents). See [Multi-Agent Orchestration](#multi-agent-orchestration).
+* **Flow — scheduled runs** – Automated execution of workflows at specified intervals using cron-like scheduling. See [docs/flows.md](docs/flows.md).
+* **Context preservation** – The supervisor provides only necessary context to each worker, avoiding context pollution.
+* **Direct worker interaction** – Users can interact directly with worker agents to provide additional steering — real-time guidance and course correction, distinguishing CAO from traditional sub-agent features.
+* **Tool restrictions** – Control what each agent can do through `role` and `allowedTools`. Built-in roles (`supervisor`, `developer`, `reviewer`) give sensible defaults; `allowedTools` gives fine-grained override. See [docs/tool-restrictions.md](docs/tool-restrictions.md).
+* **Advanced CLI integration** – CAO agents have full access to advanced features of the underlying CLI, such as the [sub-agents](https://docs.claude.com/en/docs/claude-code/sub-agents) feature of Claude Code and [Custom Agent](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-custom-agents.html) of Amazon Q Developer CLI.
 
 For detailed project structure and architecture, see [CODEBASE.md](CODEBASE.md).
 
@@ -33,14 +29,12 @@ For detailed project structure and architecture, see [CODEBASE.md](CODEBASE.md).
 
 ### Requirements
 
-- **curl** and **git** — For downloading installers and cloning the repo
-- **Python 3.10 or higher** — CAO requires Python >=3.10 (see [pyproject.toml](pyproject.toml))
-- **tmux 3.3+** — Used for agent session isolation
-- **[uv](https://docs.astral.sh/uv/)** — Fast Python package installer and virtual environment manager
+- **curl** and **git** — for downloading installers and cloning the repo
+- **Python 3.10 or higher** — see [pyproject.toml](pyproject.toml)
+- **tmux 3.3+** — used for agent session isolation
+- **[uv](https://docs.astral.sh/uv/)** — fast Python package installer and virtual environment manager
 
 ### 1. Install Python 3.10+
-
-If you don't have Python 3.10+ installed, use your platform's package manager:
 
 ```bash
 # macOS (Homebrew)
@@ -53,15 +47,15 @@ sudo apt update && sudo apt install python3.12 python3.12-venv
 sudo dnf install python3.12
 ```
 
-Verify your Python version:
+Verify:
 
 ```bash
-python3 --version   # Should be 3.10 or higher
+python3 --version   # 3.10 or higher
 ```
 
-> **Note:** We recommend using [uv](https://docs.astral.sh/uv/) to manage Python environments instead of system-wide installations like Anaconda. `uv` automatically handles virtual environments and Python version resolution per-project.
+> We recommend using [uv](https://docs.astral.sh/uv/) rather than a system-wide Python install like Anaconda. `uv` handles virtual environments and Python version resolution per-project.
 
-### 2. Install tmux (version 3.3 or higher required)
+### 2. Install tmux (3.3+)
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/awslabs/cli-agent-orchestrator/refs/heads/main/tmux-install.sh)
@@ -80,36 +74,20 @@ source $HOME/.local/bin/env   # Add uv to PATH (or restart your shell)
 uv tool install git+https://github.com/awslabs/cli-agent-orchestrator.git@main --upgrade
 ```
 
-#### 4.1 Install via PyPI (Optional)
-
-Install the latest release from PyPI:
+Or from PyPI:
 
 ```bash
 uv tool install cli-agent-orchestrator --upgrade
-```
 
-To pin a specific version:
-
-```bash
+# Pin a specific version
 uv tool install cli-agent-orchestrator==2.1.0
 ```
 
-### Development Setup
+For local development (`git clone` + `uv sync`) and the testing/quality workflow, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
-For local development, clone the repo and install with `uv sync`:
+## Prerequisite: a CLI agent tool
 
-```bash
-git clone https://github.com/awslabs/cli-agent-orchestrator.git
-cd cli-agent-orchestrator/
-uv sync          # Creates .venv/ and installs all dependencies
-uv run cao --help  # Verify installation
-```
-
-For development workflow, testing, code quality checks, and project structure, see [DEVELOPMENT.md](DEVELOPMENT.md).
-
-## Prerequisites
-
-Before using CAO, install at least one supported CLI agent tool:
+CAO drives existing CLI agent tools — it does not replace them. Before using CAO, install at least one of the following. You can install more than one and mix them in the same orchestration.
 
 | Provider | Documentation | Authentication |
 |----------|---------------|----------------|
@@ -124,19 +102,12 @@ Before using CAO, install at least one supported CLI agent tool:
 
 ## Quick Start
 
-### 1. Install Agent Profiles
-
-Install the supervisor agent (the orchestrator that delegates to other agents):
+### 1. Install agent profiles
 
 ```bash
-cao install code_supervisor
-```
-
-Optionally install additional worker agents:
-
-```bash
-cao install developer
-cao install reviewer
+cao install code_supervisor      # the supervisor that delegates to workers
+cao install developer            # optional worker
+cao install reviewer             # optional worker
 ```
 
 You can also install agents from local files or URLs:
@@ -146,272 +117,163 @@ cao install ./my-custom-agent.md
 cao install https://example.com/agents/custom-agent.md
 ```
 
-For details on creating custom agent profiles, see [docs/agent-profile.md](docs/agent-profile.md).
+For creating custom agent profiles, see [docs/agent-profile.md](docs/agent-profile.md).
 
-### 2. Start the Server
+### 2. Start the server
 
 ```bash
 cao-server
 ```
 
-### 3. Launch the Supervisor
+### 3. Launch the supervisor
 
-In another terminal, launch the supervisor agent:
+In another terminal:
 
 ```bash
 cao launch --agents code_supervisor
 
 # Or specify a provider
-cao launch --agents code_supervisor --provider kiro_cli
 cao launch --agents code_supervisor --provider claude_code
-cao launch --agents code_supervisor --provider codex
-cao launch --agents code_supervisor --provider gemini_cli
-cao launch --agents code_supervisor --provider kimi_cli
-cao launch --agents code_supervisor --provider copilot_cli
-cao launch --agents code_supervisor --provider opencode_cli
-# Unrestricted access + skip confirmation (DANGEROUS)
+# Valid: kiro_cli | claude_code | codex | gemini_cli | kimi_cli | copilot_cli | opencode_cli
+
+# Unrestricted access, skip confirmation (DANGEROUS)
 cao launch --agents code_supervisor --yolo
 ```
 
-The supervisor will coordinate and delegate tasks to worker agents (developer, reviewer, etc.) as needed using the orchestration patterns.
+The supervisor coordinates and delegates tasks to worker agents using the orchestration patterns.
 
 ### 4. Shutdown
 
 ```bash
-# Shutdown all cao sessions
-cao shutdown --all
-
-# Shutdown specific session
-cao shutdown --session cao-my-session
+cao shutdown --all                      # shut down every CAO session
+cao shutdown --session cao-my-session   # shut down a specific session
 ```
 
-### Working with tmux Sessions
+### Sessions run in tmux
 
-All agent sessions run in tmux. Useful commands:
+All agent sessions run in tmux — you can `tmux attach -t <session-name>` to watch agents in real time. For the full list of tmux shortcuts and the interactive window selector, see [docs/tmux.md](docs/tmux.md).
+
+## Web UI
+
+CAO ships a bundled web dashboard for managing agents, terminals, and flows from the browser. With the default install you just need `cao-server` running:
 
 ```bash
-# List all sessions
-tmux list-sessions
-
-# Attach to a session
-tmux attach -t <session-name>
-
-# Detach from session (inside tmux)
-Ctrl+b, then d
-
-# Switch between windows (inside tmux)
-Ctrl+b, then n          # Next window
-Ctrl+b, then p          # Previous window
-Ctrl+b, then <number>   # Go to window number (0-9)
-Ctrl+b, then w          # List all windows (interactive selector)
-
-# Delete a session
-cao shutdown --session <session-name>
+cao-server
 ```
 
-**List all windows (Ctrl+b, w):**
+Then open http://localhost:9889.
 
-![Tmux Window Selector](./docs/assets/tmux_all_windows.png)
+![CAO Web UI](https://github.com/user-attachments/assets/e7db9261-62b1-4422-b9f5-6fe5f65bdea4)
 
+For development mode (hot-reload), remote access over SSH, rebuilding the frontend, and Node.js requirements, see [docs/web-ui.md](docs/web-ui.md). For frontend architecture, see [web/README.md](web/README.md).
 
-## Session Management
+## Multi-Agent Orchestration
 
-CAO provides CLI commands for managing sessions programmatically — useful for scripting, CI pipelines, or headless operation.
+CAO agents coordinate through a local HTTP server (default `localhost:9889`). CLI agents reach it via MCP tools to route messages, track status, and drive orchestration.
 
-### Commands
+Each agent terminal is assigned a unique `CAO_TERMINAL_ID` environment variable. The server uses this ID to route messages, track terminal status (IDLE / PROCESSING / COMPLETED / ERROR), and coordinate operations. When an agent calls an MCP tool, the server identifies the caller by their `CAO_TERMINAL_ID` and orchestrates accordingly.
+
+### Orchestration Modes
+
+> **Note:** All orchestration modes support an optional `working_directory` parameter when enabled via `CAO_ENABLE_WORKING_DIRECTORY=true`. See [docs/working-directory.md](docs/working-directory.md).
+
+**1. Handoff** — transfer control to another agent and wait for completion.
+
+- Creates a new terminal with the specified agent profile
+- Sends the task message and waits for the agent to finish
+- Returns the agent's output to the caller and exits the agent
+- Use when you need **synchronous** execution with results
+
+Example: sequential code review workflow.
+
+![Handoff Workflow](./docs/assets/handoff-workflow.png)
+
+**2. Assign** — spawn an agent to work independently (async).
+
+- Creates a new terminal, sends the task with callback instructions, returns immediately
+- The assigned agent sends results back via `send_message` when done; messages queue if the supervisor is busy
+- Use for **asynchronous** execution or fire-and-forget operations
+
+Example: a supervisor assigns parallel data-analysis tasks to multiple analysts while using handoff to generate a report template, then combines results. See [examples/assign](examples/assign).
+
+![Parallel Data Analysis](./docs/assets/parallel-data-analysis.png)
+
+**3. Send Message** — communicate with an existing agent.
+
+- Sends a message to a specific terminal's inbox; delivered when the terminal is idle
+- Enables ongoing collaboration and multi-turn conversations
+- Common in **swarm** operations
+
+Example: multi-role feature development.
+
+![Multi-role Feature Development](./docs/assets/multi-role-feature-development.png)
+
+### Cross-Provider Orchestration
+
+Workers inherit the provider of the terminal that spawned them by default. To pin a profile to a specific provider, add `provider` to its frontmatter:
+
+```markdown
+---
+name: developer
+provider: claude_code
+---
+```
+
+Valid values: `kiro_cli`, `claude_code`, `codex`, `q_cli`, `gemini_cli`, `kimi_cli`, `copilot_cli`. The `cao launch --provider` flag always takes precedence for the initial session. See [`examples/cross-provider/`](examples/cross-provider/).
+
+### Tool Restrictions
+
+CAO controls what each agent can do via `role` and `allowedTools` in the profile. CAO translates restrictions to each provider's native enforcement — 5 of 7 providers support hard enforcement. See [docs/tool-restrictions.md](docs/tool-restrictions.md) for the full reference.
+
+### Custom Orchestration
+
+`cao-server` exposes REST APIs for session management, terminal control, and messaging. The built-in CLI commands and MCP tools are just packagings of those APIs — you can combine the three orchestration modes into custom workflows or build new patterns on top of the underlying API. See [docs/api.md](docs/api.md).
+
+## Extensibility & Integration
+
+Three programmatic surfaces for driving CAO from outside, plus two extension points (skills and plugins). For the decision guide on which surface to use, see [docs/control-planes.md](docs/control-planes.md).
+
+### Session Management CLI
+
+`cao session` commands manage sessions programmatically — ideal for scripting, CI pipelines, or any caller that can run a shell command.
 
 | Command | Description |
 |---------|-------------|
 | `cao session list` | List active sessions |
 | `cao session status <name>` | Show conductor status and last output |
 | `cao session status <name> --workers` | Include worker terminal statuses |
-| `cao session send <name> "msg"` | Send message and wait for completion |
-| `cao session send <name> "msg" --async` | Fire-and-forget without waiting |
+| `cao session send <name> "msg"` | Send a message and wait for completion |
+| `cao session send <name> "msg" --async` | Fire-and-forget |
 | `cao session send <name> "msg" --timeout N` | Wait up to N seconds |
-| `cao shutdown --session <name>` | Shut down a session |
+| `cao launch --agents <profile>` | Launch a new supervisor session |
+| `cao shutdown --session <name>` | Shut down a specific session |
+| `cao shutdown --all` | Shut down every CAO session |
 
-### Headless Launch
+Headless launch (send an initial task without attaching):
 
 ```bash
 cao launch --agents supervisor --headless --yolo \
   --session-name my-task --working-directory '/path/to/project' "Your task here"
 ```
 
-Add `--async` to send the message and return immediately without waiting for completion:
+Add `--async` to return immediately without waiting for completion.
 
-```bash
-cao launch --agents supervisor --headless --async --yolo \
-  --session-name my-task --working-directory '/path/to/project' "Your task here"
-```
+> Session names are auto-prefixed with `cao-`. Use the prefixed form (e.g. `cao-my-task`) in later commands.
 
-> **Note:** Session names are automatically prefixed with `cao-`. Use the prefixed form (e.g., `cao-my-task`) when referencing sessions in commands like `cao session send` and `cao shutdown`.
+For the command reference and the agent-facing skill, see the [Session Management skill](skills/cao-session-management/SKILL.md).
 
-For full details, see the [Session Management skill](skills/cao-session-management/SKILL.md).
+### CAO Ops MCP Server
 
-## Web UI
-
-CAO includes a web dashboard for managing agents, terminals, and flows from the browser.
-
-![CAO Web UI](https://github.com/user-attachments/assets/e7db9261-62b1-4422-b9f5-6fe5f65bdea4)
-
-### Additional Requirements
-
-- **Node.js 18+** — Required for the frontend dev server and Codex CLI
-
-```bash
-# macOS (Homebrew)
-brew install node
-
-# Ubuntu/Debian
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash -
-sudo apt-get install -y nodejs
-
-# Amazon Linux 2023 / Fedora
-sudo dnf install nodejs20
-
-# Verify
-node --version   # Should be 18 or higher
-```
-
-### Starting the Web UI
-
-**Option A: Development mode** (hot-reload, two terminals needed)
-
-```bash
-# Terminal 1 — start the backend server
-cao-server
-
-# Terminal 2 — start the frontend dev server
-cd web/
-npm install        # First time only
-npm run dev        # Starts on http://localhost:5173
-```
-
-Open http://localhost:5173 in your browser.
-
-**Option B: Production mode** (single server, no Vite needed)
-
-The built Web UI is bundled into the CAO wheel, so a plain `uv tool install` ships everything you need. Just start the server:
-
-```bash
-cao-server
-```
-
-To rebuild the frontend from source:
-
-```bash
-cd web/
-npm install && npm run build   # Outputs to src/cli_agent_orchestrator/web_ui/
-uv tool install . --reinstall
-```
-
-Open http://localhost:9889 in your browser.
-
-> **Custom host/port:** `cao-server --host 0.0.0.0 --port 9889` exposes the server to the network — see Security note below.
-
-**Remote machine access** — If you're running CAO on a remote host (e.g. dev desktop), set up an SSH tunnel:
-
-```bash
-# Dev mode (proxy both frontend and backend)
-ssh -L 5173:localhost:5173 -L 9889:localhost:9889 your-remote-host
-
-# Production mode (backend serves UI directly)
-ssh -L 9889:localhost:9889 your-remote-host
-```
-
-Then open the same URLs (localhost:5173 or localhost:9889) in your local browser.
-
-### Features
-
-Manage sessions, spawn agents, create scheduled flows, configure agent directories, and interact with live terminals — all from the browser. Includes live status badges, an inbox for agent-to-agent messaging, output viewer, and provider auto-detection.
-
-For frontend architecture and component details, see [web/README.md](web/README.md). For agent directory configuration, see [docs/settings.md](docs/settings.md).
-
-## MCP Server Tools and Orchestration Modes
-
-CAO provides a local HTTP server that processes orchestration requests. CLI agents can interact with this server through MCP tools to coordinate multi-agent workflows.
-
-### How It Works
-
-Each agent terminal is assigned a unique `CAO_TERMINAL_ID` environment variable. The server uses this ID to:
-
-- Route messages between agents
-- Track terminal status (IDLE, PROCESSING, COMPLETED, ERROR)
-- Manage terminal-to-terminal communication via inbox
-- Coordinate orchestration operations
-
-When an agent calls an MCP tool, the server identifies the caller by their `CAO_TERMINAL_ID` and orchestrates accordingly.
-
-### Orchestration Modes
-
-CAO supports three orchestration patterns:
-
-> **Note:** All orchestration modes support optional `working_directory` parameter when enabled via `CAO_ENABLE_WORKING_DIRECTORY=true`. See [Working Directory Support](#working-directory-support) for details.
-
-**1. Handoff** - Transfer control to another agent and wait for completion
-
-- Creates a new terminal with the specified agent profile
-- Sends the task message and waits for the agent to finish
-- Returns the agent's output to the caller
-- Automatically exits the agent after completion
-- Use when you need **synchronous** task execution with results
-
-Example: Sequential code review workflow
-
-![Handoff Workflow](./docs/assets/handoff-workflow.png)
-
-**2. Assign** - Spawn an agent to work independently (async)
-
-- Creates a new terminal with the specified agent profile
-- Sends the task message with callback instructions
-- Returns immediately with the terminal ID
-- Agent continues working in the background
-- Assigned agent sends results back to supervisor via `send_message` when complete
-- Messages are queued for delivery if the supervisor is busy (common in parallel workflows)
-- Use for **asynchronous** task execution or fire-and-forget operations
-
-Example: A supervisor assigns parallel data analysis tasks to multiple analysts while using handoff to sequentially generate a report template, then combines all results.
-
-See [examples/assign](examples/assign) for the complete working example.
-
-![Parallel Data Analysis](./docs/assets/parallel-data-analysis.png)
-
-**3. Send Message** - Communicate with an existing agent
-
-- Sends a message to a specific terminal's inbox
-- Messages are queued and delivered when the terminal is idle
-- Enables ongoing collaboration between agents
-- Common for **swarm** operations where multiple agents coordinate dynamically
-- Use for iterative feedback or multi-turn conversations
-
-Example: Multi-role feature development
-
-![Multi-role Feature Development](./docs/assets/multi-role-feature-development.png)
-
-### Custom Orchestration
-
-The `cao-server` runs on `http://localhost:9889` by default and exposes REST APIs for session management, terminal control, and messaging. The CLI commands (`cao launch`, `cao shutdown`) and MCP server tools (`handoff`, `assign`, `send_message`) are just examples of how these APIs can be packaged together.
-
-You can combine the three orchestration modes above into custom workflows, or create entirely new orchestration patterns using the underlying APIs to fit your specific needs.
-
-For complete API documentation, see [docs/api.md](docs/api.md).
-
-## CAO Ops MCP Server
-
-`cao-ops-mcp` is an MCP server that exposes CAO management operations as structured tools for your primary agent. Add it to your primary agent's MCP configuration to install profiles and manage sessions directly from the agent interface — no separate terminal required.
-
-**How it differs from `cao-mcp-server`:**
+`cao-ops-mcp` exposes the same management operations as structured MCP tools for a primary agent (Claude Code, Claude Desktop, etc.). It is the MCP-flavoured equivalent of `cao session` — pick `cao-ops-mcp` when your caller speaks MCP, `cao session` otherwise.
 
 | Server | Who uses it | Purpose |
 |--------|-------------|---------|
-| `cao-mcp-server` | Agents **inside** a CAO session | Inter-agent orchestration: `handoff`, `assign`, `send_message` |
-| `cao-ops-mcp` | Your primary agent, **outside** a CAO session | Meta management: install profiles, launch and monitor sessions |
+| `cao-mcp-server` | Agents **inside** a CAO session | Inter-agent orchestration (`handoff`, `assign`, `send_message`) |
+| `cao-ops-mcp` | A primary agent **outside** a CAO session | Meta management (install profiles, launch/monitor sessions) |
 
-### Setup
+**Setup** — add to your primary agent's MCP configuration. Requires `cao-server` running at `localhost:9889`.
 
-Add `cao-ops-mcp` to your primary agent's MCP configuration. The server requires `cao-server` running at `localhost:9889`.
-
-**Claude Code** — add to `.mcp.json` in the project root:
+For Claude Code, add to `.mcp.json`:
 
 ```json
 {
@@ -424,307 +286,74 @@ Add `cao-ops-mcp` to your primary agent's MCP configuration. The server requires
 }
 ```
 
-**Other agents** — configure the equivalent stdio MCP server command in your agent's MCP settings:
+Other agents: use the equivalent stdio MCP command:
 
 ```
 uvx --from git+https://github.com/awslabs/cli-agent-orchestrator.git@main cao-ops-mcp-server
 ```
 
-### Available Tools
+**Available tools** — `list_profiles`, `get_profile_details`, `install_profile`, `launch_session`, `send_session_message`, `list_sessions`, `get_session_info`, `shutdown_session`.
 
-**Profile management:**
+Typical workflow: `list_profiles` → `install_profile` → `launch_session` → `send_session_message` → `get_session_info` → `shutdown_session`.
 
-| Tool | Description |
-|------|-------------|
-| `list_profiles` | List available agent profiles with name, description, and source |
-| `get_profile_details` | Inspect full content and metadata of a specific profile |
-| `install_profile` | Install a profile for a target provider (accepts name, file path, or URL) |
+### Flows — scheduled agent sessions
 
-**Session lifecycle:**
-
-| Tool | Description |
-|------|-------------|
-| `launch_session` | Create a new CAO session — returns `session_name` and `terminal_id` immediately |
-| `send_session_message` | Queue a message for delivery to a running terminal |
-| `list_sessions` | List active sessions with terminal counts and statuses |
-| `get_session_info` | Get per-terminal status, provider, profile, and last activity |
-| `shutdown_session` | Cleanly shut down a session — exits providers, kills tmux session |
-
-### Typical Workflow
-
-```
-list_profiles ──> install_profile ──> launch_session
-                                           │
-                                    send_session_message  (deliver task)
-                                           │
-                                    get_session_info      (poll for progress)
-                                           │
-                                    shutdown_session
-```
-
-1. **Discover** available profiles with `list_profiles`
-2. **Inspect** a profile's system prompt and metadata with `get_profile_details`
-3. **Install** the profile for your provider with `install_profile`
-4. **Launch** a session with `launch_session` — returns immediately with `session_name` and `terminal_id`
-5. **Deliver** the initial task with `send_session_message` using the returned `terminal_id`
-6. **Monitor** progress with `get_session_info` or `list_sessions`
-7. **Clean up** when done with `shutdown_session`
-
-## Flows - Scheduled Agent Sessions
-
-Flows allow you to schedule agent sessions to run automatically based on cron expressions.
-
-### Prerequisites
-
-Install the agent profile you want to use:
+Schedule agent sessions to run automatically using cron expressions:
 
 ```bash
-cao install developer
-```
-
-### Quick Start
-
-The example flow asks a simple world trivia question every morning at 7:30 AM.
-
-```bash
-# 1. Start the cao server
-cao-server
-
-# 2. In another terminal, add a flow
-cao flow add examples/flow/morning-trivia.md
-
-# 3. List flows to see schedule and status
-cao flow list
-
-# 4. Manually run a flow (optional - for testing)
-cao flow run morning-trivia
-
-# 5. View flow execution (after it runs)
-tmux list-sessions
-tmux attach -t <session-name>
-
-# 6. Cleanup session when done
-cao shutdown --session <session-name>
-```
-
-**IMPORTANT:** The `cao-server` must be running for flows to execute on schedule.
-
-### Example 1: Simple Scheduled Task
-
-A flow that runs at regular intervals with a static prompt (no script needed):
-
-**File: `daily-standup.md`**
-
-```yaml
----
-name: daily-standup
-schedule: "0 9 * * 1-5"  # 9am weekdays
-agent_profile: developer
-provider: kiro_cli  # Optional, defaults to kiro_cli
----
-
-Review yesterday's commits and create a standup summary.
-```
-
-### Example 2: Conditional Execution with Health Check
-
-A flow that monitors a service and only executes when there's an issue:
-
-**File: `monitor-service.md`**
-
-```yaml
----
-name: monitor-service
-schedule: "*/5 * * * *"  # Every 5 minutes
-agent_profile: developer
-script: ./health-check.sh
----
-
-The service at [[url]] is down (status: [[status_code]]).
-Please investigate and triage the issue:
-1. Check recent deployments
-2. Review error logs
-3. Identify root cause
-4. Suggest remediation steps
-```
-
-**Script: `health-check.sh`**
-
-```bash
-#!/bin/bash
-URL="https://api.example.com/health"
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
-
-if [ "$STATUS" != "200" ]; then
-  # Service is down - execute flow
-  echo "{\"execute\": true, \"output\": {\"url\": \"$URL\", \"status_code\": \"$STATUS\"}}"
-else
-  # Service is healthy - skip execution
-  echo "{\"execute\": false, \"output\": {}}"
-fi
-```
-
-### Flow Commands
-
-```bash
-# Add a flow
 cao flow add daily-standup.md
-
-# List all flows (shows schedule, next run time, enabled status)
 cao flow list
-
-# Enable/disable a flow
-cao flow enable daily-standup
-cao flow disable daily-standup
-
-# Manually run a flow (ignores schedule)
-cao flow run daily-standup
-
-# Remove a flow
-cao flow remove daily-standup
+cao flow run daily-standup   # manual run, ignores schedule
 ```
 
-## Working Directory Support
+Flows support static prompts or conditional execution via a gating script. `cao-server` must be running for scheduled execution.
 
-CAO supports specifying working directories for agent handoff/delegation operations. By default this is disabled to prevent agents from hallucinating directory paths.
+For the full guide — flow file format, the conditional-execution pattern, and all `cao flow` commands — see [docs/flows.md](docs/flows.md).
 
-All paths are canonicalized via `realpath` and validated against a security policy:
+### Skills
 
-- **Allowed:** any real directory that is not a blocked system path — including `~/`, external volumes (e.g., `/Volumes/workplace`), and custom paths like `/opt/projects`
-- **Blocked:** system directories (`/`, `/etc`, `/var`, `/tmp`, `/proc`, `/sys`, `/root`, `/boot`, `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`, `/lib`, `/lib64`, `/dev`)
+Skills are portable, structured guides (following the universal [SKILL.md](https://github.com/anthropics/skills) format) that encode domain knowledge for agents. They work across coding assistants (Claude Code, Kiro CLI, Gemini CLI, Codex CLI, Kimi CLI, GitHub Copilot, Cursor, OpenCode, LobeHub) and frameworks ([Strands Agents SDK](https://strandsagents.com/docs/user-guide/concepts/plugins/skills/), [Microsoft Agent Framework](https://devblogs.microsoft.com/agent-framework/give-your-agents-domain-expertise-with-agent-skills-in-microsoft-agent-framework/)).
 
-For configuration and usage details, see [docs/working-directory.md](docs/working-directory.md).
-
-## Cross-Provider Orchestration
-
-By default, worker agents inherit the provider of the terminal that spawned them. To run specific agents on different providers, add a `provider` key to the agent profile frontmatter:
-
-```markdown
----
-name: developer
-description: Developer Agent
-provider: claude_code
----
-```
-
-Valid values: `kiro_cli`, `claude_code`, `codex`, `q_cli`, `gemini_cli`, `kimi_cli`, `copilot_cli`.
-
-When a supervisor calls `assign` or `handoff`, CAO reads the worker's agent profile and uses the declared provider if present. If the key is missing or invalid, the worker falls back to the supervisor's provider.
-
-The `cao launch --provider` flag always takes precedence — it is treated as an explicit override and the profile's `provider` key is not consulted for the initial session.
-
-For ready-to-use examples, see [`examples/cross-provider/`](examples/cross-provider/).
-
-## Tool Restrictions
-
-CAO controls what tools each agent can use through `role` in the agent profile. Built-in roles (`supervisor`, `developer`, `reviewer`) map to sensible defaults, and `allowedTools` provides fine-grained override when needed. CAO translates restrictions to each provider's native enforcement mechanism — 5 of 7 providers support hard enforcement.
-
-```yaml
----
-name: my_agent
-role: supervisor  # @cao-mcp-server, fs_read, fs_list
----
-```
+CAO ships built-in skills and also manages "managed skills" shared across all agent sessions. Built-ins (`cao-supervisor-protocols`, `cao-worker-protocols`) are auto-seeded at server startup. You can add your own:
 
 ```bash
-cao launch --agents code_supervisor                  # Uses role defaults (confirmation prompt shown)
-cao launch --agents code_supervisor --auto-approve   # Skip prompt (restrictions still enforced)
-cao launch --agents code_supervisor --yolo           # Unrestricted access (WARNING shown)
-```
-
-For the full reference — roles, tool vocabulary, custom roles, launch prompts, provider enforcement, and known limitations — see [docs/tool-restrictions.md](docs/tool-restrictions.md).
-
-## Skills
-
-Skills are portable, structured guides (following the universal [SKILL.md](https://github.com/anthropics/skills) format) that encode domain knowledge for AI agents. They work across AI coding assistants (Claude Code, Kiro CLI, Gemini CLI, Codex CLI, Kimi CLI, GitHub Copilot, Cursor, OpenCode, LobeHub), agent frameworks ([Strands Agents SDK](https://strandsagents.com/docs/user-guide/concepts/plugins/skills/), [Microsoft Agent Framework](https://devblogs.microsoft.com/agent-framework/give-your-agents-domain-expertise-with-agent-skills-in-microsoft-agent-framework/)), and other tools that support the SKILL.md format — allowing any agent to follow the same expert playbook regardless of provider.
-
-CAO includes the following built-in skills:
-
-| Skill | Description |
-|-------|-------------|
-| **[cao-provider](skills/cao-provider/SKILL.md)** | Scaffold a new CLI agent provider for CAO. Guides through the full implementation: ProviderType enum, provider class with regex patterns and status detection, ProviderManager registration, tool restriction wiring, unit/e2e tests, and documentation. Includes 20 lessons learnt from building 7 existing providers. |
-
-### Loading Skills
-
-Each AI coding tool loads skills from a different location. Copy or symlink the skill directory to the appropriate path for your tool:
-
-| Tool | Skill Location | Command |
-|------|---------------|---------|
-| **Claude Code** | `.claude/skills/` | `cp -r skills/cao-provider .claude/skills/` |
-| **Kiro CLI** | `.kiro/skills/` | `cp -r skills/cao-provider .kiro/skills/` |
-| **Amazon Q CLI** | `.amazonq/skills/` | `cp -r skills/cao-provider .amazonq/skills/` |
-| **Other tools** | Check your tool's docs for skill/prompt loading conventions |
-
-Then ask your AI coding assistant to create a new provider:
-
-```
-> I want to add support for Aider CLI as a new CAO provider
-```
-
-The assistant will follow the skill's step-by-step guide, reference the provider template, and apply lessons learnt from existing providers.
-
-### Managed Skills
-
-CAO also manages skills that are shared across all agent sessions. Builtin skills (`cao-supervisor-protocols`, `cao-worker-protocols`) are auto-seeded when the `cao-server` starts — no `cao init` required.
-
-```bash
-# List installed skills
 cao skills list
-
-# Install a custom skill from a local folder
 cao skills add ./my-coding-standards
-
-# Update an existing skill (overwrite)
-cao skills add ./my-coding-standards --force
-
-# Remove a skill
+cao skills add ./my-coding-standards --force   # overwrite
 cao skills remove my-coding-standards
 ```
 
-Skills are delivered to each provider automatically:
+Skills are delivered to providers automatically (native `skill://` resources for Kiro CLI; runtime prompt injection for Claude Code / Codex / Gemini / Kimi; baked-in `.agent.md` for Copilot).
 
-| Provider | Delivery Method |
-|----------|----------------|
-| Kiro CLI | Native `skill://` resources (progressive loading) |
-| Claude Code, Codex, Gemini CLI, Kimi CLI | Runtime prompt injection (every terminal creation) |
-| Copilot CLI | Baked into `.agent.md` at install time |
+For the full reference — authoring, loading, delivery mechanics — see [docs/skills.md](docs/skills.md).
 
-When you add or remove a skill, all providers pick up the change automatically. Copilot agent files are refreshed immediately; other providers pick up changes on the next terminal creation.
+### Plugins
 
-**Updating skills:** Use `cao skills add ./my-skill --force` to overwrite an existing skill. Without `--force`, the command errors if the skill already exists. Builtin skills are auto-seeded on server startup but are never overwritten — to update a builtin after a CAO upgrade, remove it first with `cao skills remove` then restart the server.
+Plugins are observer-only Python extensions that react to server-side events inside `cao-server` — lifecycle changes and message delivery. They are the **outbound** surface of CAO: the interfaces above drive CAO in; plugins stream events out. Typical uses: forwarding inter-agent messages to Discord/Slack/Telegram, audit logging, metrics export.
 
-For full details, see [docs/skills.md](docs/skills.md).
-
-## Plugins
-
-Plugins are observer-only extensions that react to server-side events inside `cao-server` — session and terminal lifecycle changes, and message delivery between agents. Typical uses include forwarding inter-agent messages to external chat (Discord, Slack), audit logging, and observability/metrics export.
-
-Plugins are standard Python packages discovered automatically via the `cao.plugins` entry-point group at server startup. Install a plugin into the same environment as `cao-server`, configure it, and restart the server — no registration step required.
-
-- **Installation, events, and troubleshooting:** [docs/plugins.md](docs/plugins.md)
+- **Installation, events, troubleshooting:** [docs/plugins.md](docs/plugins.md)
 - **Ready-to-run example:** [examples/plugins/cao-discord/](examples/plugins/cao-discord/)
-- **Author your own plugin:** use the [cao-plugin skill](skills/cao-plugin/SKILL.md)
+- **Author your own:** [cao-plugin skill](skills/cao-plugin/SKILL.md)
+- **How plugins fit with the inbound surfaces:** [docs/control-planes.md](docs/control-planes.md)
 
 ## Security
 
-The server is designed for **localhost-only use**. The WebSocket terminal endpoint (`/terminals/{id}/ws`) provides full PTY access and will reject connections from non-loopback addresses. Do not expose the server to untrusted networks without adding authentication.
+`cao-server` is designed for **localhost-only use**. The WebSocket terminal endpoint (`/terminals/{id}/ws`) provides full PTY access and rejects non-loopback connections. Do not expose the server to untrusted networks without adding authentication.
 
-### DNS Rebinding Protection
+**DNS rebinding protection** — the server validates HTTP `Host` headers and rejects requests where the host is not `localhost` or `127.0.0.1` with `400 Bad Request`. This guards against [DNS rebinding attacks](https://owasp.org/www-community/attacks/DNS_Rebinding).
 
-The CAO server validates HTTP `Host` headers to prevent [DNS rebinding attacks](https://owasp.org/www-community/attacks/DNS_Rebinding). Only `localhost` and `127.0.0.1` are accepted by default — requests with other hostnames are rejected with `400 Bad Request`.
+If you need to expose the server on a network (not recommended for development), the Host header validation will also reject those requests unless the hostname is in the allowed list.
 
-**Note:** If you need to expose the server on a network (not recommended for development use), be aware that the Host header validation will reject requests unless the hostname matches the allowed list.
-
-See [SECURITY.md](SECURITY.md) for vulnerability reporting, security scanning, and best practices.
+See [SECURITY.md](SECURITY.md) for vulnerability reporting and best practices.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to this project.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Releases
 
-CAO publishes to [PyPI](https://pypi.org/project/cli-agent-orchestrator/) via an OIDC-authenticated GitHub Actions pipeline (TestPyPI → smoke test → maintainer-approved prod). See [docs/RELEASING.md](docs/RELEASING.md) for the cut-a-release runbook, one-time setup, and troubleshooting.
+CAO publishes to [PyPI](https://pypi.org/project/cli-agent-orchestrator/) via an OIDC-authenticated GitHub Actions pipeline (TestPyPI → smoke test → maintainer-approved prod). See [docs/RELEASING.md](docs/RELEASING.md).
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
+Apache-2.0.

--- a/docs/control-planes.md
+++ b/docs/control-planes.md
@@ -1,0 +1,125 @@
+# Control Planes
+
+CAO exposes several different ways to drive sessions and to observe what they do. They are not alternatives to each other — they occupy different positions on two axes: who is in charge, and which direction the traffic flows.
+
+This guide explains what each surface is for, when to use it, and how they fit together.
+
+## The four surfaces at a glance
+
+| Surface | Direction | Who calls it | Transport | Typical use |
+|---|---|---|---|---|
+| **Web UI** | Inbound (outside → CAO) | Human in a browser | HTTP + WebSocket | Interactive management from the browser |
+| **`cao session` CLI + [`cao-session-management`](../skills/cao-session-management/SKILL.md) skill** | Inbound | Human in a terminal, OR an external agent that can run shell commands | Shell → HTTP | Scripts, CI pipelines, headless jobs, agents that cannot speak MCP |
+| **`cao-ops-mcp` server** | Inbound | Any external agent that speaks MCP | MCP (stdio) → HTTP | A primary agent managing CAO from inside its own chat loop |
+| **Plugins** (e.g. `cao-discord`) | **Outbound** (CAO → outside) | `cao-server` itself, fire-and-forget | Python hooks → whatever the plugin chooses (webhook, log, metric) | Forwarding events to chat apps, observability, audit logging |
+
+Separately, the in-session MCP server (`cao-mcp-server`) handles agent-to-agent orchestration *within* a CAO session. That is orthogonal to this document — see [MCP Server Tools and Orchestration Modes](../README.md#mcp-server-tools-and-orchestration-modes) in the README for `handoff` / `assign` / `send_message`.
+
+## Inbound vs outbound
+
+The first thing to internalise is that **Web UI, `cao session`, and `cao-ops-mcp` are all inbound** — they are ways to tell CAO what to do. **Plugins are outbound** — they are how CAO tells the outside world what it is doing.
+
+So "should I use plugins or `cao-ops-mcp`?" is not the right question. The right question is:
+
+- Who is initiating? → inbound surface.
+- Does something need to know when CAO did something? → plugin.
+
+A bidirectional bridge (e.g. a Telegram bot that lets Telegram users drive CAO and also streams CAO events back to the channel) is two components: one plugin for outbound, one inbound call path for commands.
+
+## Inbound surfaces
+
+All three inbound surfaces ultimately hit the same HTTP API at `localhost:9889`. They differ only in *how* a caller gets there.
+
+### Web UI
+
+Browser-based dashboard bundled with `cao-server`. See [Web UI](../README.md#web-ui) in the README.
+
+- **Strength:** interactive, visual, no configuration for a human operator.
+- **Weakness:** human only — no scripting, no agent access.
+
+### `cao session` CLI and the `cao-session-management` skill
+
+A set of `cao session <verb>` commands (`list`, `status`, `send`, plus `cao launch` / `cao shutdown`) wrapped into a [skill](../skills/cao-session-management/SKILL.md) so any agent that follows the SKILL.md format can drive CAO by running shell commands.
+
+- **Strength:** universal — works from bash, Python, `subprocess`, any agent framework, any external tool that can run a command. Zero protocol requirements on the caller.
+- **When to use:**
+  - Scripting, CI pipelines, headless jobs.
+  - An external AI assistant that does not speak MCP — e.g. [OpenClaw](https://www.digitalocean.com/resources/articles/what-is-openclaw), a custom Strands agent, a shell function.
+  - Quick one-shots where spinning up an MCP client is overkill.
+
+See [Session Management](../README.md#session-management) in the README for the command reference.
+
+### `cao-ops-mcp` server
+
+An MCP server that exposes the same set of management operations as structured tool calls. Add it to a primary agent's MCP configuration and that agent can call `launch_session`, `list_sessions`, `install_profile`, etc. as typed tools.
+
+- **Strength:** structured tool calls instead of shell parsing. Typed arguments, typed results, errors surface as tool-call errors.
+- **When to use:**
+  - A primary agent (Claude Code, Claude Desktop, etc.) that already uses MCP should prefer this over shell.
+  - Multi-step workflows where an agent benefits from tool-level discoverability.
+- **When *not* to use:** if your caller cannot speak MCP or you are writing a shell script — use `cao session` instead.
+
+See [CAO Ops MCP Server](../README.md#cao-ops-mcp-server) in the README for setup and the tool catalog.
+
+### Choosing between `cao session` and `cao-ops-mcp`
+
+| If your caller is… | Prefer |
+|---|---|
+| A human in a browser | Web UI |
+| A shell script, cron job, CI step | `cao session` |
+| An MCP-capable agent (Claude Code, Claude Desktop, etc.) | `cao-ops-mcp` |
+| An AI assistant that can only run shell commands | `cao session` via the skill |
+| A custom Python service polling CAO | Call the HTTP API at `localhost:9889` directly (see [docs/api.md](api.md)) |
+
+They are functionally equivalent — both end up calling the same HTTP endpoints. The choice is purely ergonomic.
+
+## Outbound surface: plugins
+
+Plugins are Python packages loaded into `cao-server` at startup. They subscribe to lifecycle and message events via `@hook("<event_type>")` and react — typically by forwarding the event somewhere else.
+
+- **Strength:** zero polling. The event is dispatched the moment it happens, with typed payload and direct DB access.
+- **Constraint:** plugins today are **observer only**. They cannot block, modify, or reject CAO operations. See `docs/plugins.md` and the Plugins section in the README.
+
+### Why plugins instead of polling
+
+You could build a Discord bridge by polling `/terminals/{id}/inbox/messages` or tailing logs. Plugins exist because they sidestep that:
+
+1. Events are dispatched from inside `cao-server`, so there is no polling lag or wasted calls.
+2. Events are pydantic models, not JSON blobs to parse.
+3. Plugins run in-process and can query the DB directly via `get_terminal_metadata()` — no HTTP round-trip.
+4. Hook exceptions are caught and logged, so a broken plugin cannot take the server down.
+5. Lifecycle is tied to `cao-server`, so there is no extra daemon to babysit.
+
+### What plugins are commonly used for
+
+- Forwarding inter-agent messages to chat apps (Discord, Slack, Telegram, Teams).
+- Audit logging of session and terminal lifecycle.
+- Metrics export (Prometheus, CloudWatch).
+- Alerting on specific events (errors, long-running sessions).
+
+### Authoring a plugin
+
+- **Reference implementation:** [`examples/plugins/cao-discord/`](../examples/plugins/cao-discord/) — ~75 lines, forwards `post_send_message` events to a Discord webhook. The pattern is directly reusable for Slack, Telegram, or any webhook-style integration — swap the URL format and JSON payload shape.
+- **Guided scaffolding:** the [`cao-plugin`](../skills/cao-plugin/SKILL.md) skill. Point any skill-aware agent at it and ask "create a CAO plugin for Telegram"; it will scaffold the package layout, entry-point, and hook registration and show you which events are available.
+- **Installing and configuring:** see [docs/plugins.md](plugins.md).
+
+## Putting it all together
+
+A practical example: "I want a Telegram channel where my team can type `/cao launch …` and see the agents talk back."
+
+That is three parts:
+
+1. **Outbound:** a `cao-telegram` plugin that subscribes to `post_send_message` (and possibly session lifecycle events) and posts them into the channel.
+2. **Inbound:** a Telegram bot process that listens for chat commands and translates them into calls against `cao-ops-mcp` or `cao session` (either works).
+3. **Glue:** whatever mapping layer you like between Telegram user IDs and CAO session names.
+
+Each component is small. The surface split keeps each one focused on a single direction.
+
+## Related reading
+
+- [Session Management](../README.md#session-management) in the README — command reference for `cao session` / `cao launch` / `cao shutdown`.
+- [CAO Ops MCP Server](../README.md#cao-ops-mcp-server) in the README — setup and tool catalog for `cao-ops-mcp`.
+- [docs/plugins.md](plugins.md) — plugin installation, event catalog, troubleshooting.
+- [docs/api.md](api.md) — the underlying HTTP API that every inbound surface calls.
+- [skills/cao-session-management/SKILL.md](../skills/cao-session-management/SKILL.md) — teach an agent to drive CAO via shell.
+- [skills/cao-plugin/SKILL.md](../skills/cao-plugin/SKILL.md) — scaffold a new plugin.

--- a/docs/control-planes.md
+++ b/docs/control-planes.md
@@ -44,7 +44,7 @@ A set of `cao session <verb>` commands (`list`, `status`, `send`, plus `cao laun
 - **Strength:** universal — works from bash, Python, `subprocess`, any agent framework, any external tool that can run a command. Zero protocol requirements on the caller.
 - **When to use:**
   - Scripting, CI pipelines, headless jobs.
-  - An external AI assistant that does not speak MCP — e.g. [OpenClaw](https://www.digitalocean.com/resources/articles/what-is-openclaw), a custom Strands agent, a shell function.
+  - An external AI assistant that does not speak MCP — e.g. [OpenClaw](https://github.com/openclaw/openclaw) or [Hermes Agent](https://github.com/NousResearch/hermes-agent). Any assistant that supports shell-callable skills should work.
   - Quick one-shots where spinning up an MCP client is overkill.
 
 See [Session Management](../README.md#session-management) in the README for the command reference.

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -1,0 +1,113 @@
+# Flows — Scheduled Agent Sessions
+
+Flows let you schedule agent sessions to run automatically using cron expressions.
+
+## Prerequisites
+
+Install the agent profile you want to use:
+
+```bash
+cao install developer
+```
+
+## Quick start
+
+The example flow asks a simple world trivia question every morning at 7:30 AM.
+
+```bash
+# 1. Start the cao server
+cao-server
+
+# 2. In another terminal, add a flow
+cao flow add examples/flow/morning-trivia.md
+
+# 3. List flows to see schedule and status
+cao flow list
+
+# 4. Manually run a flow (optional - for testing)
+cao flow run morning-trivia
+
+# 5. View flow execution (after it runs)
+tmux list-sessions
+tmux attach -t <session-name>
+
+# 6. Cleanup session when done
+cao shutdown --session <session-name>
+```
+
+> **Important:** `cao-server` must be running for flows to execute on schedule.
+
+## Example 1: simple scheduled task
+
+A flow that runs at regular intervals with a static prompt (no script needed).
+
+**File: `daily-standup.md`**
+
+```yaml
+---
+name: daily-standup
+schedule: "0 9 * * 1-5"  # 9am weekdays
+agent_profile: developer
+provider: kiro_cli  # Optional, defaults to kiro_cli
+---
+
+Review yesterday's commits and create a standup summary.
+```
+
+## Example 2: conditional execution with a health check
+
+A flow that monitors a service and only executes when there's an issue.
+
+**File: `monitor-service.md`**
+
+```yaml
+---
+name: monitor-service
+schedule: "*/5 * * * *"  # Every 5 minutes
+agent_profile: developer
+script: ./health-check.sh
+---
+
+The service at [[url]] is down (status: [[status_code]]).
+Please investigate and triage the issue:
+1. Check recent deployments
+2. Review error logs
+3. Identify root cause
+4. Suggest remediation steps
+```
+
+**Script: `health-check.sh`**
+
+```bash
+#!/bin/bash
+URL="https://api.example.com/health"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+
+if [ "$STATUS" != "200" ]; then
+  # Service is down - execute flow
+  echo "{\"execute\": true, \"output\": {\"url\": \"$URL\", \"status_code\": \"$STATUS\"}}"
+else
+  # Service is healthy - skip execution
+  echo "{\"execute\": false, \"output\": {}}"
+fi
+```
+
+## Flow commands
+
+```bash
+# Add a flow
+cao flow add daily-standup.md
+
+# List all flows (shows schedule, next run time, enabled status)
+cao flow list
+
+# Enable/disable a flow
+cao flow enable daily-standup
+cao flow disable daily-standup
+
+# Manually run a flow (ignores schedule)
+cao flow run daily-standup
+
+# Remove a flow
+cao flow remove daily-standup
+```

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -1,0 +1,36 @@
+# Working with tmux Sessions
+
+All CAO agent sessions run in tmux. You can attach directly to a session to watch or interact with agents in real time.
+
+## Useful commands
+
+```bash
+# List all sessions
+tmux list-sessions
+
+# Attach to a session
+tmux attach -t <session-name>
+
+# Detach from session (inside tmux)
+Ctrl+b, then d
+
+# Switch between windows (inside tmux)
+Ctrl+b, then n          # Next window
+Ctrl+b, then p          # Previous window
+Ctrl+b, then <number>   # Go to window number (0-9)
+Ctrl+b, then w          # List all windows (interactive selector)
+
+# Delete a session (cleanly, via CAO)
+cao shutdown --session <session-name>
+```
+
+## Interactive window selector
+
+**List all windows (Ctrl+b, w):**
+
+![Tmux Window Selector](./assets/tmux_all_windows.png)
+
+## Notes
+
+- CAO session names are automatically prefixed with `cao-`. Use the prefixed name (e.g. `cao-my-task`) when referencing a session in `tmux attach`, `cao session send`, or `cao shutdown`.
+- Prefer `cao shutdown` over `tmux kill-session`: `cao shutdown` exits each provider cleanly before tearing down the tmux session, which avoids leaked CLI processes.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,0 +1,84 @@
+# Web UI
+
+CAO includes a web dashboard for managing agents, terminals, and flows from the browser.
+
+![CAO Web UI](https://github.com/user-attachments/assets/e7db9261-62b1-4422-b9f5-6fe5f65bdea4)
+
+## Additional requirements
+
+- **Node.js 18+** — required for the frontend dev server and Codex CLI.
+
+```bash
+# macOS (Homebrew)
+brew install node
+
+# Ubuntu/Debian
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash -
+sudo apt-get install -y nodejs
+
+# Amazon Linux 2023 / Fedora
+sudo dnf install nodejs20
+
+# Verify
+node --version   # Should be 18 or higher
+```
+
+## Starting the Web UI
+
+### Option A: Development mode (hot-reload, two terminals)
+
+```bash
+# Terminal 1 — start the backend server
+cao-server
+
+# Terminal 2 — start the frontend dev server
+cd web/
+npm install        # First time only
+npm run dev        # Starts on http://localhost:5173
+```
+
+Open http://localhost:5173 in your browser.
+
+### Option B: Production mode (single server, no Vite needed)
+
+The built Web UI is bundled into the CAO wheel, so a plain `uv tool install` ships everything you need. Just start the server:
+
+```bash
+cao-server
+```
+
+Open http://localhost:9889 in your browser.
+
+To rebuild the frontend from source:
+
+```bash
+cd web/
+npm install && npm run build   # Outputs to src/cli_agent_orchestrator/web_ui/
+uv tool install . --reinstall
+```
+
+> **Custom host/port:** `cao-server --host 0.0.0.0 --port 9889` exposes the server to the network — see [Security](../README.md#security) in the root README before doing this.
+
+## Remote machine access
+
+If you are running CAO on a remote host (e.g. a dev desktop), forward the ports over SSH:
+
+```bash
+# Dev mode (proxy both frontend and backend)
+ssh -L 5173:localhost:5173 -L 9889:localhost:9889 your-remote-host
+
+# Production mode (backend serves UI directly)
+ssh -L 9889:localhost:9889 your-remote-host
+```
+
+Then open the same URLs (localhost:5173 or localhost:9889) in your local browser.
+
+## Features
+
+Manage sessions, spawn agents, create scheduled flows, configure agent directories, and interact with live terminals — all from the browser. Includes live status badges, an inbox for agent-to-agent messaging, output viewer, and provider auto-detection.
+
+## Related
+
+- [web/README.md](../web/README.md) — frontend architecture and component details
+- [docs/settings.md](settings.md) — agent directory configuration
+- [docs/control-planes.md](control-planes.md) — where the Web UI fits alongside `cao session` and `cao-ops-mcp`

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -4,9 +4,16 @@ CAO includes a web dashboard for managing agents, terminals, and flows from the 
 
 ![CAO Web UI](https://github.com/user-attachments/assets/e7db9261-62b1-4422-b9f5-6fe5f65bdea4)
 
-## Additional requirements
+## When you need Node.js
 
-- **Node.js 18+** — required for the frontend dev server and Codex CLI.
+The pre-built Web UI is bundled inside the CAO wheel (at `src/cli_agent_orchestrator/web_ui/`), so a regular `uv tool install` ships everything you need. **You do not need Node.js or `npm install` to use the Web UI.**
+
+Node.js 18+ is only required if you want to:
+
+- Run the frontend dev server for hot-reload development (Option A below), or
+- Rebuild the bundle from source.
+
+Install Node only if one of those applies:
 
 ```bash
 # macOS (Homebrew)
@@ -20,7 +27,7 @@ sudo apt-get install -y nodejs
 sudo dnf install nodejs20
 
 # Verify
-node --version   # Should be 18 or higher
+node --version   # 18 or higher
 ```
 
 ## Starting the Web UI


### PR DESCRIPTION

## Summary

This PR does three related things to the project docs:

1. **Reorganizes `README.md`** into a proper landing-page structure so the core user flow (install → server → launch → Web UI) is upfront, and programmatic/extensibility surfaces (`cao session`, `cao-ops-mcp`, Flows, Skills, Plugins) are grouped together at the end.
2. **Moves heavy detail out of the README** into topic-scoped pages under `docs/`. The README drops from 736 to ~370 lines with no content loss.
3. **Adds a new `docs/control-planes.md`** that explains how the different ways to drive CAO (Web UI, `cao session`, `cao-ops-mcp`) and the outbound plugin surface relate to each other — filling a gap in the prior docs, where each surface was documented in isolation with no decision guide.

Plus two smaller, related tidy-ups:

- Clarifies that the pre-built Web UI is bundled inside the wheel (no Node required for normal use) and that PyPI lags `main` between releases.
- Stops steering contributors in `DEVELOPMENT.md` to Q CLI as the default exemplar, since Q CLI is slated for deprecation. (Q CLI code, tests, and CI workflow are untouched — only doc guidance changes here; the actual removal will happen in a separate PR.)

## Motivation

The README had grown to 736 lines of mostly flat `##` sections with no grouping — Web UI detail, full Flows walkthrough, tmux tips, and every extensibility surface were all competing for space on the landing page. Three separate review discussions asked the same question: *how do I pick between `cao session`, `cao-ops-mcp`, the Web UI, and plugins?* The answer was spread across three different sections and never written down.

## Structure changes (README)

**Before** — flat list of 18 H2 sections, no grouping:
```
Installation / Prerequisites / Quick Start / Session Management /
Web UI / MCP Server Tools / CAO Ops MCP Server / Flows /
Working Directory / Cross-Provider / Tool Restrictions / Skills /
Plugins / Security / ...
```

**After** — grouped by intent:
```
1. Hierarchical Multi-Agent System    (intro + Key Features)
2. Installation                        (CAO itself: Python/tmux/uv/CAO)
3. Prerequisite: a CLI agent tool      (renamed from "Prerequisites" —
                                        now obviously still setup)
4. Quick Start                         (install profile → start server →
                                        launch → shutdown)
5. Web UI                              (core feature, short; detail in
                                        docs/web-ui.md)
6. Multi-Agent Orchestration           (handoff/assign/send_message,
                                        cross-provider, tool restrictions,
                                        custom orchestration)
7. Extensibility & Integration         (Session CLI, cao-ops-mcp, Flows,
                                        Skills, Plugins)
8. Security / Contributing / Releases / License
```

## New docs under `docs/`

| File | Purpose |
|---|---|
| `docs/control-planes.md` | **New.** Decision guide: Web UI vs `cao session` CLI vs `cao-ops-mcp` (inbound surfaces) vs plugins (outbound). Covers the inbound-vs-outbound split, when to pick each, and the Telegram-bridge pattern as a canonical "combine them" example. |
| `docs/web-ui.md` | **New.** Full Web UI detail that used to live in the README — dev-mode setup, SSH remote access, rebuilding from source, Node.js requirements (explicitly scoped to dev/rebuild only). |
| `docs/flows.md` | **New.** Full Flows walkthrough — example flow files, the health-check gating script pattern, all `cao flow` commands. |
| `docs/tmux.md` | **New.** tmux shortcuts and the window-selector screenshot, previously cluttering the Quick Start. |

## SEO / GEO additions (README intro)

Added two new sections to help search engines and LLMs (ChatGPT, Claude, Perplexity) surface CAO correctly:

- **"What is CAO?"** — a canonical self-contained paragraph LLMs can lift verbatim when asked "what is CLI Agent Orchestrator?"
- **"Common use cases"** — short bullets matching how users actually phrase queries ("how do I run multiple Claude Code agents in parallel?").

Also rewrote Key Features with keyword-leading bullets, enumerated every supported provider by name in the opening paragraph, and gave the architecture image a descriptive `alt` attribute.

Under Session Management CLI, added a one-liner naming shell-skill-capable AI assistants that can drive `cao session` — Claude Code, Kiro CLI, [OpenClaw](https://github.com/openclaw/openclaw), [Hermes Agent](https://github.com/NousResearch/hermes-agent). Surfaces CAO to users searching for those assistants; only Claude Code and Kiro CLI are end-to-end tested today, but the shell surface is the same for all of them.

## Clarifications

- **Web UI** — explicit statement in Installation and in `docs/web-ui.md` that the pre-built UI is bundled inside the CAO wheel (`pyproject.toml:62-64`) and Node.js is **only** required for hot-reload dev mode or rebuilding the frontend.
- **PyPI** — flagged that PyPI only publishes tagged releases and will lag `main` between releases; prefer `uv tool install git+…@main` for the latest fixes.
- **Q CLI in DEVELOPMENT.md** — replaced Q-CLI-as-example throughout with Kiro CLI; added an explicit note that Q CLI is slated for deprecation so new contributors don't pick it as their default. Q CLI code, tests, and CI workflow are intentionally **untouched** — those should be removed in a dedicated deprecation PR.

## Out of scope

- Removing Q CLI code, its test files, or `.github/workflows/test-q-cli-provider.yml` (deprecation PR).
- Any changes to feature behaviour. This PR is docs-only.

## Test Plan

- [x] `README.md` — rendered in preview, all internal anchors resolve, all `docs/<page>.md` links valid.
- [x] `docs/control-planes.md`, `docs/web-ui.md`, `docs/flows.md`, `docs/tmux.md` — rendered in preview, all cross-links resolve.
- [x] `DEVELOPMENT.md` — `uv run pytest test/providers/test_kiro_cli_unit.py -v -k "test_initialization"` works (replacement for the previous Q-CLI-based smoke test).
- [x] `uv run pytest test/ --ignore=test/e2e -m "not integration" -v` runs the same coverage as the old `--ignore=test/providers/test_q_cli_integration.py` form.
- [ ] Reviewer: confirm the intro/Key-Features rewrite still reads correctly to a first-time visitor (biggest subjective change).

