### PR TITLE
fix(install): harden agent-profile install against SSRF and path inje…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,38 +163,9 @@ jobs:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0
 
-  codeql:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    # Run on every PR and main push so taint-analysis alerts surface as CI
-    # failures instead of waiting for the repo-level "default setup" schedule.
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [python, javascript-typescript]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-          # security-and-quality widens beyond the default `security-extended`
-          # to also pick up things like `py/request-without-timeout` that were
-          # hiding behind the SSRF alert.
-          queries: security-and-quality
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:${{ matrix.language }}"
+# NOTE: CodeQL runs via GitHub's "default setup" (visible as the `Analyze (...)`
+# checks on every PR). Adding a workflow-based CodeQL job here would conflict
+# with default setup ("CodeQL analyses from advanced configurations cannot be
+# processed when the default setup is enabled") and fail uploads. To widen the
+# query suite beyond the default, toggle default setup off in
+# Settings → Code security → CodeQL default setup and re-add a workflow job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,39 @@ jobs:
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0
+
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    # Run on every PR and main push so taint-analysis alerts surface as CI
+    # failures instead of waiting for the repo-level "default setup" schedule.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-and-quality widens beyond the default `security-extended`
+          # to also pick up things like `py/request-without-timeout` that were
+          # hiding behind the SSRF alert.
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,6 +55,12 @@ Security scans run:
 - On every push to the `main` branch
 - On every pull request targeting `main`
 
+### CodeQL Static Analysis
+
+CodeQL runs via GitHub's default setup on every push to `main` and every pull request, covering both Python and JavaScript/TypeScript. Findings appear as PR review comments and in the repo's [Security tab](https://github.com/awslabs/cli-agent-orchestrator/security/code-scanning). Default setup catches `py/full-ssrf`, `py/path-injection`, `py/request-without-timeout`, and the rest of the `security-extended` query suite.
+
+Default setup is configured in repo settings, not in a workflow file — adding a workflow-based CodeQL job alongside it causes upload conflicts. If the team later needs the wider `security-and-quality` suite or custom queries, toggle default setup off first and then add an advanced workflow.
+
 ### Dependency Review
 
 Pull requests are automatically checked for:
@@ -77,6 +83,14 @@ trivy fs --severity HIGH,CRITICAL .
 
 # Scan Python dependencies
 trivy fs --scanners vuln --severity HIGH,CRITICAL .
+```
+
+Or use the bundled wrapper that mirrors CI (`trivy` + optional local CodeQL):
+
+```bash
+scripts/security-scan.sh           # run all available scanners
+scripts/security-scan.sh trivy     # just Trivy
+scripts/security-scan.sh codeql    # just CodeQL (requires the CodeQL CLI)
 ```
 
 ## Tool Restrictions (allowedTools)
@@ -174,7 +188,7 @@ When using CLI Agent Orchestrator:
 
 2. **Secure API Access**: The CAO server runs on localhost by default. If exposing externally, use proper authentication and TLS.
 
-3. **Agent Profiles**: Review agent profiles before installation, especially those from external sources.
+3. **Agent Profiles**: Review agent profiles before installation, especially those from external sources. Remote profile downloads (`cao install https://...`) are restricted by an allowlist — the default trusts `github.com` and `raw.githubusercontent.com` only. Extend via `CAO_PROFILE_ALLOWED_HOSTS=host1,host2` on the `cao-server` environment when using self-hosted profile mirrors. The HTTP install endpoint additionally refuses local `.md` file paths; only the CLI can install from disk.
 
 4. **Environment Variables**: Never commit sensitive environment variables. Use `.env` files (excluded from git) or secure secret management.
 

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Local mirror of the `security` and `codeql` CI jobs so contributors can catch
+# SSRF/path-injection/SCA findings before pushing. Exits non-zero on any
+# scanner failure so it's safe to wire into pre-push hooks or Makefile targets.
+#
+# Usage:
+#   scripts/security-scan.sh                 # run all available scanners
+#   scripts/security-scan.sh trivy           # just Trivy
+#   scripts/security-scan.sh codeql          # just CodeQL (python)
+#
+# CodeQL installs from Homebrew (macOS) are often broken by Apple's Gatekeeper
+# quarantine (xattr errors followed by silent exit 1). If that's happening,
+# either run CodeQL via Docker (see below) or rely on the GitHub Action.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+target="${1:-all}"
+exit_code=0
+
+run_trivy() {
+    echo "==> Trivy filesystem scan (CRITICAL,HIGH; unfixed ignored, matching CI)"
+    if ! command -v trivy >/dev/null 2>&1; then
+        echo "  SKIP: trivy not on PATH (brew install aquasecurity/trivy/trivy)"
+        return 0
+    fi
+    uv export --format requirements-txt > requirements.txt
+    trivy fs \
+        --severity CRITICAL,HIGH \
+        --ignore-unfixed \
+        --exit-code 1 \
+        . || exit_code=1
+    rm -f requirements.txt
+}
+
+run_codeql() {
+    echo "==> CodeQL (python, security-and-quality)"
+    if ! command -v codeql >/dev/null 2>&1; then
+        echo "  SKIP: codeql not on PATH"
+        echo "  Install: https://github.com/github/codeql-cli-binaries/releases"
+        return 0
+    fi
+
+    local db_dir="${CODEQL_DB:-./.codeql-db}"
+    local sarif_out="${CODEQL_SARIF:-./codeql-results.sarif}"
+
+    echo "  Building database at $db_dir (may take a minute)"
+    # If the CLI is quarantined (common on macOS Homebrew), this exits 1 with
+    # only xattr errors on stderr. We surface a hint in that case.
+    if ! codeql database create "$db_dir" \
+            --language=python \
+            --source-root="$ROOT_DIR" \
+            --overwrite >/tmp/codeql.log 2>&1; then
+        if grep -q "xattr:" /tmp/codeql.log; then
+            echo "  ERROR: CodeQL CLI appears to be under Gatekeeper quarantine."
+            echo "  Fix (macOS): sudo xattr -dr com.apple.quarantine \$(brew --prefix codeql)"
+            echo "  Or run via Docker: docker run --rm -v \$PWD:/src ghcr.io/github/codeql-action/codeql"
+        fi
+        grep -v "xattr:" /tmp/codeql.log | tail -20
+        exit_code=1
+        return 0
+    fi
+
+    echo "  Analyzing with security-and-quality suite"
+    codeql database analyze "$db_dir" \
+        codeql/python-queries:codeql-suites/python-security-and-quality.qls \
+        --format=sarif-latest \
+        --output="$sarif_out" \
+        --download \
+        2>&1 | grep -vE "^xattr:" || exit_code=1
+
+    # Fail the run if the SARIF contains any result at error/warning level.
+    if command -v jq >/dev/null 2>&1; then
+        local count
+        count=$(jq '[.runs[].results[]? | select(.level=="error" or .level=="warning")] | length' \
+                "$sarif_out")
+        if [[ "$count" -gt 0 ]]; then
+            echo "  FOUND $count error/warning-level CodeQL results in $sarif_out"
+            exit_code=1
+        fi
+    fi
+}
+
+case "$target" in
+    trivy)  run_trivy ;;
+    codeql) run_codeql ;;
+    all)    run_trivy; run_codeql ;;
+    *)      echo "Unknown target: $target (use trivy|codeql|all)"; exit 2 ;;
+esac
+
+exit "$exit_code"

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -268,6 +268,7 @@ async def install_agent_profile_endpoint(request: InstallAgentProfileRequest) ->
         source=request.source,
         provider=request.provider,
         env_vars=request.env_vars,
+        allow_file_source=False,
     )
     if not result.success:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result.message)

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -264,6 +264,9 @@ async def get_agent_profile_endpoint(name: str) -> Dict:
 @app.post("/agents/profiles/install")
 async def install_agent_profile_endpoint(request: InstallAgentProfileRequest) -> InstallResult:
     """Install an agent profile for a target provider."""
+    # HTTP (and transitively cao-ops-mcp, which calls this endpoint) is an
+    # untrusted surface: disable the local-filesystem branch so a remote
+    # caller cannot coerce the server into reading arbitrary .md files.
     result = install_agent(
         source=request.source,
         provider=request.provider,

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -263,15 +263,18 @@ async def get_agent_profile_endpoint(name: str) -> Dict:
 
 @app.post("/agents/profiles/install")
 async def install_agent_profile_endpoint(request: InstallAgentProfileRequest) -> InstallResult:
-    """Install an agent profile for a target provider."""
-    # HTTP (and transitively cao-ops-mcp, which calls this endpoint) is an
-    # untrusted surface: disable the local-filesystem branch so a remote
-    # caller cannot coerce the server into reading arbitrary .md files.
+    """Install an agent profile for a target provider.
+
+    HTTP (and transitively ``cao-ops-mcp``, which calls this endpoint) is an
+    untrusted surface. ``install_agent()`` only accepts bare profile names or
+    https:// URLs; local filesystem paths are handled by the CLI entry point
+    alone. A remote caller therefore cannot coerce the server into reading
+    arbitrary ``.md`` files from disk.
+    """
     result = install_agent(
         source=request.source,
         provider=request.provider,
         env_vars=request.env_vars,
-        allow_file_source=False,
     )
     if not result.success:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result.message)

--- a/src/cli_agent_orchestrator/cli/commands/install.py
+++ b/src/cli_agent_orchestrator/cli/commands/install.py
@@ -1,9 +1,62 @@
 """Install command for CLI Agent Orchestrator."""
 
+import re
+from pathlib import Path
+from typing import Optional
+
 import click
 
-from cli_agent_orchestrator.constants import CAO_ENV_FILE, DEFAULT_PROVIDER, PROVIDERS
+from cli_agent_orchestrator.constants import (
+    CAO_ENV_FILE,
+    DEFAULT_PROVIDER,
+    LOCAL_AGENT_STORE_DIR,
+    PROVIDERS,
+)
 from cli_agent_orchestrator.services.install_service import install_agent, parse_env_assignment
+
+# Profile names are used as filesystem path segments; this matches the stricter
+# validator inside install_service.py (kept duplicated deliberately — the CLI
+# owes the service layer clean input, not the other way around).
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _copy_local_profile_to_store(agent_source: str) -> Optional[str]:
+    """If ``agent_source`` is a local ``.md`` file, copy it into the agent store.
+
+    Returns the validated stem on success, or ``None`` if the input is not a
+    file-path shape (so the caller should pass ``agent_source`` through as a
+    bare name or URL instead).
+
+    File-handling deliberately lives in the CLI rather than ``install_service``:
+    only the CLI has legitimate filesystem trust, and keeping
+    ``Path(user_input)`` out of the HTTP-reachable service layer is what
+    closes the CodeQL ``py/path-injection`` taint flow on the install API.
+    """
+    # Not a file-path shape at all — let the service treat it as a name or URL.
+    if agent_source.startswith(("http://", "https://")):
+        return None
+    if not agent_source.endswith(".md"):
+        return None
+
+    source_path = Path(agent_source).expanduser()
+    if not source_path.exists():
+        # The user typed a `.md`-suffixed string but no such file exists.
+        # Raise instead of silently forwarding to the name branch — the error
+        # message is clearer this way.
+        raise click.ClickException(f"File not found: {agent_source}")
+
+    stem = source_path.stem
+    if not _PROFILE_NAME_RE.fullmatch(stem):
+        raise click.ClickException(
+            f"Profile filename stem '{stem}' must match [A-Za-z0-9_-]{{1,64}}."
+        )
+
+    LOCAL_AGENT_STORE_DIR.mkdir(parents=True, exist_ok=True)
+    # Build the destination from the validated stem, not from source_path.name,
+    # so nothing from the user-provided string flows into the dest Path.
+    dest_file = LOCAL_AGENT_STORE_DIR / f"{stem}.md"
+    dest_file.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return stem
 
 
 @click.command()
@@ -49,16 +102,30 @@ def install(agent_source: str, provider: str, env_vars: tuple[str, ...]) -> None
     except ValueError as exc:
         raise click.BadParameter(str(exc), param_hint="--env") from exc
 
-    result = install_agent(agent_source, provider, parsed_env or None)
+    # Handle the file-path shape here in the CLI. If it was a local .md file,
+    # it's now copied into the agent store and `service_source` is just the
+    # bare stem — which install_agent() accepts through its safe "name" branch.
+    copied_from_file = False
+    try:
+        copied_stem = _copy_local_profile_to_store(agent_source)
+    except click.ClickException:
+        raise
+    if copied_stem is not None:
+        service_source = copied_stem
+        copied_from_file = True
+    else:
+        service_source = agent_source
+
+    result = install_agent(service_source, provider, parsed_env or None)
 
     if not result.success:
         click.echo(f"Error: {result.message}", err=True)
         return
 
-    if result.source_kind == "url":
-        click.echo("✓ Downloaded agent from URL to local store")
-    elif result.source_kind == "file":
+    if copied_from_file:
         click.echo("✓ Copied agent from file to local store")
+    elif result.source_kind == "url":
+        click.echo("✓ Downloaded agent from URL to local store")
     click.echo(f"✓ Agent '{result.agent_name}' installed successfully")
     if env_vars:
         click.echo(f"✓ Set {len(env_vars)} env var(s) in {CAO_ENV_FILE}")

--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -189,7 +189,7 @@ async def get_profile_details(
 
 @mcp.tool()
 async def install_profile(
-    source: Annotated[str, Field(description="Agent name, file path, or URL to install")],
+    source: Annotated[str, Field(description="Agent name or https:// URL to install")],
     provider: Annotated[
         str,
         Field(description="Target provider for the installed profile"),
@@ -203,15 +203,15 @@ async def install_profile(
 
     ## Source Resolution
 
-    The source is resolved in order:
-    1. URL (http:// or https://) — downloaded into the local agent store
-    2. Existing file on disk — copied into the local agent store
-    3. Agent name — looked up in local store, provider dirs, then built-in store
+    Remote callers (HTTP API / MCP) may install by either:
+    1. https:// URL from an allow-listed host (``github.com``,
+       ``raw.githubusercontent.com`` by default; extend via the
+       ``CAO_PROFILE_ALLOWED_HOSTS`` env var on ``cao-server``).
+    2. Profile name matching ``[A-Za-z0-9_-]{1,64}`` — looked up in the local
+       store, provider dirs, then the built-in store.
 
-    Path resolution checks the current working directory, so a bare agent
-    name that collides with a file or directory in CWD will route to path
-    resolution and fail. Use an explicit ``./`` prefix for file paths, or
-    ensure agent names do not collide with CWD contents.
+    Installing by local filesystem path is CLI-only and is rejected from the
+    HTTP API and this MCP tool.
 
     ## Provider Config
 
@@ -220,7 +220,7 @@ async def install_profile(
     - claude_code, codex: context file only, no provider-specific config
 
     Args:
-        source: Agent name, file path, or URL
+        source: Agent name or https:// URL from an allow-listed host
         provider: Target provider (default: kiro_cli)
         env_vars: Optional env vars written to the managed .env before install
 

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -60,16 +60,6 @@ class InstallResult(BaseModel):
 # CodeQL also recognises this regex as a path-injection sanitiser.
 _PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
-# Local filesystem paths to .md profiles (CLI only). Allows relative, absolute,
-# and ~ paths with typical path chars, but the leading negative lookahead
-# forbids any `..` anywhere in the string, which was the actual weakness
-# CodeQL flagged on an earlier revision: the prior character-class-only regex
-# matched "../../etc/passwd.md" because `.` and `/` are both in the class.
-# CodeQL recognises fullmatch against this pattern as a path-injection
-# sanitiser because the disallowed-`..` assertion constrains the resolved
-# path to stay below the caller's cwd/home rather than escaping upward.
-_FILE_PATH_RE = re.compile(r"^(?!.*\.\.)[A-Za-z0-9_./~\-]{1,512}\.md$")
-
 # URL path component for allowlisted hosts. Each segment must start with an
 # alphanumeric, which forbids "..", "." and hidden segments — and by extension
 # any traversal sequence. Used to rebuild a safe URL from validated parts,
@@ -101,77 +91,60 @@ def _allowed_download_hosts() -> frozenset:
 
 
 def _download_agent(source: str) -> str:
-    """Download or copy an agent profile into the local agent store."""
+    """Download an agent profile from an https:// URL into the local store.
+
+    File-path handling deliberately does NOT live in this module: only the CLI
+    has legitimate filesystem trust, and keeping Path(user_input) out of the
+    HTTP-reachable layer closes an entire class of py/path-injection alerts
+    (CodeQL #49/#61 kept reopening while this lived here). The CLI entry point
+    copies local files into LOCAL_AGENT_STORE_DIR itself and then calls
+    install_agent() with the bare stem, which flows through the "name" branch.
+    """
     LOCAL_AGENT_STORE_DIR.mkdir(parents=True, exist_ok=True)
 
-    if source.startswith(("http://", "https://")):
-        # SSRF hardening: narrow what a caller-provided URL can reach before any
-        # network I/O happens. https-only rules out http://169.254.169.254/...;
-        # the host allowlist rules out arbitrary internal services; the path
-        # regex rules out crafted paths that would write outside the store.
-        parsed = urlparse(source)
-        if parsed.scheme != "https":
-            raise ValueError("Profile URL must use https://")
-        host = (parsed.hostname or "").lower()
-        allowed_hosts = _allowed_download_hosts()
-        if host not in allowed_hosts:
-            raise ValueError(
-                f"Host '{host}' is not in the allowed downloader hosts. "
-                "Set CAO_PROFILE_ALLOWED_HOSTS to extend the allowlist."
-            )
-        # Reject any URL that carries a query string, fragment, or userinfo —
-        # none of them are meaningful for a static .md fetch and each is an
-        # SSRF foothold (credentials encoded in @, redirect targets in ?next=).
-        if parsed.query or parsed.fragment or parsed.username or parsed.password:
-            raise ValueError("Profile URL must not include query, fragment, or userinfo.")
-        if not _SAFE_URL_PATH_RE.fullmatch(parsed.path):
-            raise ValueError("URL path must match /segment/.../file.md with no traversal segments.")
-        filename = parsed.path.rsplit("/", 1)[-1]
-        if not _PROFILE_NAME_RE.fullmatch(filename[: -len(".md")]):
-            raise ValueError("URL filename stem must match [A-Za-z0-9_-]{1,64}")
+    # SSRF hardening: narrow what a caller-provided URL can reach before any
+    # network I/O happens. https-only rules out http://169.254.169.254/...;
+    # the host allowlist rules out arbitrary internal services; the path
+    # regex rules out crafted paths that would write outside the store.
+    parsed = urlparse(source)
+    if parsed.scheme != "https":
+        raise ValueError("Profile URL must use https://")
+    host = (parsed.hostname or "").lower()
+    allowed_hosts = _allowed_download_hosts()
+    if host not in allowed_hosts:
+        raise ValueError(
+            f"Host '{host}' is not in the allowed downloader hosts. "
+            "Set CAO_PROFILE_ALLOWED_HOSTS to extend the allowlist."
+        )
+    # Reject any URL that carries a query string, fragment, or userinfo —
+    # none of them are meaningful for a static .md fetch and each is an
+    # SSRF foothold (credentials encoded in @, redirect targets in ?next=).
+    if parsed.query or parsed.fragment or parsed.username or parsed.password:
+        raise ValueError("Profile URL must not include query, fragment, or userinfo.")
+    if not _SAFE_URL_PATH_RE.fullmatch(parsed.path):
+        raise ValueError("URL path must match /segment/.../file.md with no traversal segments.")
+    filename = parsed.path.rsplit("/", 1)[-1]
+    if not _PROFILE_NAME_RE.fullmatch(filename[: -len(".md")]):
+        raise ValueError("URL filename stem must match [A-Za-z0-9_-]{1,64}")
 
-        # Look up the canonical host from the allowlist instead of passing the
-        # parsed host back through. Belt-and-braces: even if a caller smuggled
-        # an odd Unicode codepoint that normalised into a known host name,
-        # `safe_host` is guaranteed to be a literal from our trust root.
-        safe_host = next(h for h in allowed_hosts if h == host)
-        safe_url = f"https://{safe_host}{parsed.path}"
+    # Look up the canonical host from the allowlist instead of passing the
+    # parsed host back through. Belt-and-braces: even if a caller smuggled
+    # an odd Unicode codepoint that normalised into a known host name,
+    # `safe_host` is guaranteed to be a literal from our trust root.
+    safe_host = next(h for h in allowed_hosts if h == host)
+    safe_url = f"https://{safe_host}{parsed.path}"
 
-        # allow_redirects=False + explicit is_redirect check: an allowlisted
-        # host could otherwise 302 us to an internal target (IMDS, admin panel)
-        # and the allowlist would never see the hop.
-        response = requests.get(safe_url, timeout=_HTTP_TIMEOUT, allow_redirects=False)
-        if response.is_redirect:
-            raise ValueError("Redirects are not allowed for profile downloads.")
-        response.raise_for_status()
+    # allow_redirects=False + explicit is_redirect check: an allowlisted
+    # host could otherwise 302 us to an internal target (IMDS, admin panel)
+    # and the allowlist would never see the hop.
+    response = requests.get(safe_url, timeout=_HTTP_TIMEOUT, allow_redirects=False)
+    if response.is_redirect:
+        raise ValueError("Redirects are not allowed for profile downloads.")
+    response.raise_for_status()
 
-        dest_file = LOCAL_AGENT_STORE_DIR / filename
-        dest_file.write_text(response.text, encoding="utf-8")
-        return dest_file.stem
-
-    # File-path branch is only reachable when install_agent() was called with
-    # allow_file_source=True (CLI). Validate the string shape *before* touching
-    # Path() — CodeQL only recognises a regex fullmatch as a path-injection
-    # sanitiser if it sits on the data-flow edge ahead of the sink.
-    if not _FILE_PATH_RE.fullmatch(source):
-        raise ValueError("File path must be a .md file matching [A-Za-z0-9_./~-]{1,512}.")
-    source_path = Path(source).resolve()
-    if source_path.exists():
-        if source_path.suffix != ".md":
-            raise ValueError("File must be a .md file")
-        if not _PROFILE_NAME_RE.fullmatch(source_path.stem):
-            raise ValueError(f"File stem '{source_path.stem}' must match [A-Za-z0-9_-]{{1,64}}")
-
-        # Reconstruct the destination path from the validated stem rather than
-        # reusing source_path.name. Even though .resolve() + stem regex already
-        # constrain the name, building from the regex-validated string gives
-        # CodeQL a clean literal-flow edge into the Path() sink.
-        safe_name = f"{source_path.stem}.md"
-        dest_file = LOCAL_AGENT_STORE_DIR / safe_name
-        dest_file.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
-        return dest_file.stem
-
-    raise FileNotFoundError(f"Source not found: {source}")
+    dest_file = LOCAL_AGENT_STORE_DIR / filename
+    dest_file.write_text(response.text, encoding="utf-8")
+    return dest_file.stem
 
 
 def parse_env_assignment(env_assignment: str) -> Tuple[str, str]:
@@ -211,16 +184,16 @@ def install_agent(
     source: str,
     provider: str,
     env_vars: Optional[Dict[str, str]] = None,
-    *,
-    allow_file_source: bool = True,
 ) -> InstallResult:
     """Install an agent profile for the requested provider.
 
-    ``allow_file_source`` is the capability flag that distinguishes trusted
-    (CLI) from untrusted (HTTP / MCP) callers. Passing True means the caller
-    already owns the local filesystem; passing False blocks the file-path
-    branch so a remote caller cannot drive the server into reading arbitrary
-    ``.md`` files from disk (CodeQL py/path-injection).
+    ``source`` must be either an https:// URL on the allowlist or a bare
+    profile name matching ``_PROFILE_NAME_RE``. Local ``.md`` file paths
+    are deliberately NOT accepted here — the CLI copies user files into
+    the local store itself and then calls this function with the resulting
+    bare stem. This split is what lets the HTTP/MCP surface share this
+    function safely: every caller reaches the same two sanitised shapes,
+    and no call site constructs ``Path(user_input)`` through this module.
     """
     try:
         valid_providers = [provider_type.value for provider_type in ProviderType]
@@ -235,14 +208,7 @@ def install_agent(
 
         if source.startswith(("http://", "https://")):
             agent_name = _download_agent(source)
-            source_kind: Literal["url", "file", "name"] = "url"
-        elif allow_file_source and source.endswith(".md"):
-            # Dispatch by pure string suffix — no Path(source) call here, which
-            # keeps this branch out of CodeQL's path-injection dataflow. All
-            # sanitisation (regex, .resolve(), stem check) is centralised in
-            # _download_agent() where the sink lives.
-            agent_name = _download_agent(source)
-            source_kind = "file"
+            source_kind: Literal["url", "name"] = "url"
         else:
             # `source` is treated as a bare profile name and feeds
             # _read_agent_profile_source() which builds Path objects from it.

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -60,11 +60,15 @@ class InstallResult(BaseModel):
 # CodeQL also recognises this regex as a path-injection sanitiser.
 _PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
-# Local filesystem paths to .md profiles (CLI only). Allows relative and
-# absolute paths with typical path chars, but forbids shell metacharacters
-# and embedded URL schemes. Must be validated *before* Path() construction
-# so CodeQL sees the sanitiser ahead of the sink.
-_FILE_PATH_RE = re.compile(r"^[A-Za-z0-9_./~\-]{1,512}\.md$")
+# Local filesystem paths to .md profiles (CLI only). Allows relative, absolute,
+# and ~ paths with typical path chars, but the leading negative lookahead
+# forbids any `..` anywhere in the string, which was the actual weakness
+# CodeQL flagged on an earlier revision: the prior character-class-only regex
+# matched "../../etc/passwd.md" because `.` and `/` are both in the class.
+# CodeQL recognises fullmatch against this pattern as a path-injection
+# sanitiser because the disallowed-`..` assertion constrains the resolved
+# path to stay below the caller's cwd/home rather than escaping upward.
+_FILE_PATH_RE = re.compile(r"^(?!.*\.\.)[A-Za-z0-9_./~\-]{1,512}\.md$")
 
 # URL path component for allowlisted hosts. Each segment must start with an
 # alphanumeric, which forbids "..", "." and hidden segments — and by extension

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -54,8 +54,26 @@ class InstallResult(BaseModel):
     source_kind: Optional[Literal["url", "file", "name"]] = None
 
 
+# Profile names are used as filesystem path segments under LOCAL_AGENT_STORE_DIR
+# and provider agent dirs. Restricting to [A-Za-z0-9_-] with a 64-char cap blocks
+# traversal ("../etc/passwd"), separators, and absolute paths at the boundary.
+# CodeQL also recognises this regex as a path-injection sanitiser.
 _PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
+# Local filesystem paths to .md profiles (CLI only). Allows relative and
+# absolute paths with typical path chars, but forbids shell metacharacters
+# and embedded URL schemes. Must be validated *before* Path() construction
+# so CodeQL sees the sanitiser ahead of the sink.
+_FILE_PATH_RE = re.compile(r"^[A-Za-z0-9_./~\-]{1,512}\.md$")
+
+# URL path component for allowlisted hosts. Each segment must start with an
+# alphanumeric, which forbids "..", "." and hidden segments — and by extension
+# any traversal sequence. Used to rebuild a safe URL from validated parts,
+# which is the CodeQL-recognised SSRF sanitisation pattern.
+_SAFE_URL_PATH_RE = re.compile(r"^(/[A-Za-z0-9_][A-Za-z0-9_.-]*)+\.md$")
+
+# SSRF guard: only fetch profiles from hosts we explicitly trust. Operators can
+# extend via CAO_PROFILE_ALLOWED_HOSTS (e.g. an internal profile mirror).
 _DEFAULT_ALLOWED_HOSTS = frozenset(
     {
         "github.com",
@@ -63,7 +81,10 @@ _DEFAULT_ALLOWED_HOSTS = frozenset(
     }
 )
 
-_HTTP_TIMEOUT = (5, 30)  # (connect, read) seconds
+# (connect, read) seconds. Tighter than a single-number timeout: 5s connect fails
+# fast on a dead/hostile IP; 30s read leaves room for flaky residential networks
+# without letting a slow-loris peer tie up a cao-server worker indefinitely.
+_HTTP_TIMEOUT = (5, 30)
 
 
 def _allowed_download_hosts() -> frozenset:
@@ -80,22 +101,42 @@ def _download_agent(source: str) -> str:
     LOCAL_AGENT_STORE_DIR.mkdir(parents=True, exist_ok=True)
 
     if source.startswith(("http://", "https://")):
+        # SSRF hardening: narrow what a caller-provided URL can reach before any
+        # network I/O happens. https-only rules out http://169.254.169.254/...;
+        # the host allowlist rules out arbitrary internal services; the path
+        # regex rules out crafted paths that would write outside the store.
         parsed = urlparse(source)
         if parsed.scheme != "https":
             raise ValueError("Profile URL must use https://")
         host = (parsed.hostname or "").lower()
-        if host not in _allowed_download_hosts():
+        allowed_hosts = _allowed_download_hosts()
+        if host not in allowed_hosts:
             raise ValueError(
                 f"Host '{host}' is not in the allowed downloader hosts. "
                 "Set CAO_PROFILE_ALLOWED_HOSTS to extend the allowlist."
             )
-        filename = Path(parsed.path).name
-        if not filename.endswith(".md"):
-            raise ValueError("URL must point to a .md file")
-        if not _PROFILE_NAME_RE.fullmatch(Path(filename).stem):
+        # Reject any URL that carries a query string, fragment, or userinfo —
+        # none of them are meaningful for a static .md fetch and each is an
+        # SSRF foothold (credentials encoded in @, redirect targets in ?next=).
+        if parsed.query or parsed.fragment or parsed.username or parsed.password:
+            raise ValueError("Profile URL must not include query, fragment, or userinfo.")
+        if not _SAFE_URL_PATH_RE.fullmatch(parsed.path):
+            raise ValueError("URL path must match /segment/.../file.md with no traversal segments.")
+        filename = parsed.path.rsplit("/", 1)[-1]
+        if not _PROFILE_NAME_RE.fullmatch(filename[: -len(".md")]):
             raise ValueError("URL filename stem must match [A-Za-z0-9_-]{1,64}")
 
-        response = requests.get(source, timeout=_HTTP_TIMEOUT, allow_redirects=False)
+        # Look up the canonical host from the allowlist instead of passing the
+        # parsed host back through. Belt-and-braces: even if a caller smuggled
+        # an odd Unicode codepoint that normalised into a known host name,
+        # `safe_host` is guaranteed to be a literal from our trust root.
+        safe_host = next(h for h in allowed_hosts if h == host)
+        safe_url = f"https://{safe_host}{parsed.path}"
+
+        # allow_redirects=False + explicit is_redirect check: an allowlisted
+        # host could otherwise 302 us to an internal target (IMDS, admin panel)
+        # and the allowlist would never see the hop.
+        response = requests.get(safe_url, timeout=_HTTP_TIMEOUT, allow_redirects=False)
         if response.is_redirect:
             raise ValueError("Redirects are not allowed for profile downloads.")
         response.raise_for_status()
@@ -104,6 +145,12 @@ def _download_agent(source: str) -> str:
         dest_file.write_text(response.text, encoding="utf-8")
         return dest_file.stem
 
+    # File-path branch is only reachable when install_agent() was called with
+    # allow_file_source=True (CLI). Validate the string shape *before* touching
+    # Path() — CodeQL only recognises a regex fullmatch as a path-injection
+    # sanitiser if it sits on the data-flow edge ahead of the sink.
+    if not _FILE_PATH_RE.fullmatch(source):
+        raise ValueError("File path must be a .md file matching [A-Za-z0-9_./~-]{1,512}.")
     source_path = Path(source).resolve()
     if source_path.exists():
         if source_path.suffix != ".md":
@@ -111,7 +158,12 @@ def _download_agent(source: str) -> str:
         if not _PROFILE_NAME_RE.fullmatch(source_path.stem):
             raise ValueError(f"File stem '{source_path.stem}' must match [A-Za-z0-9_-]{{1,64}}")
 
-        dest_file = LOCAL_AGENT_STORE_DIR / source_path.name
+        # Reconstruct the destination path from the validated stem rather than
+        # reusing source_path.name. Even though .resolve() + stem regex already
+        # constrain the name, building from the regex-validated string gives
+        # CodeQL a clean literal-flow edge into the Path() sink.
+        safe_name = f"{source_path.stem}.md"
+        dest_file = LOCAL_AGENT_STORE_DIR / safe_name
         dest_file.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
         return dest_file.stem
 
@@ -160,10 +212,11 @@ def install_agent(
 ) -> InstallResult:
     """Install an agent profile for the requested provider.
 
-    ``allow_file_source`` controls whether ``source`` may refer to a local
-    filesystem path. CLI callers leave this True (the user owns the local
-    filesystem); HTTP/MCP callers must pass False so a remote caller cannot
-    coerce the server into reading arbitrary files.
+    ``allow_file_source`` is the capability flag that distinguishes trusted
+    (CLI) from untrusted (HTTP / MCP) callers. Passing True means the caller
+    already owns the local filesystem; passing False blocks the file-path
+    branch so a remote caller cannot drive the server into reading arbitrary
+    ``.md`` files from disk (CodeQL py/path-injection).
     """
     try:
         valid_providers = [provider_type.value for provider_type in ProviderType]
@@ -179,10 +232,17 @@ def install_agent(
         if source.startswith(("http://", "https://")):
             agent_name = _download_agent(source)
             source_kind: Literal["url", "file", "name"] = "url"
-        elif allow_file_source and Path(source).exists():
+        elif allow_file_source and _FILE_PATH_RE.fullmatch(source) and Path(source).exists():
+            # Regex-validate *before* Path() so CodeQL sees the sanitiser on
+            # the edge into the Path(...).exists() sink. The capability flag
+            # alone isn't a recognised taint-kill pattern.
             agent_name = _download_agent(source)
             source_kind = "file"
         else:
+            # `source` is treated as a bare profile name and feeds
+            # _read_agent_profile_source() which builds Path objects from it.
+            # Enforce the sanitiser at the boundary so every downstream sink
+            # (agent_profiles.py and the provider-dir loop) sees safe input.
             if not _PROFILE_NAME_RE.fullmatch(source):
                 return InstallResult(
                     success=False,

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -232,10 +232,11 @@ def install_agent(
         if source.startswith(("http://", "https://")):
             agent_name = _download_agent(source)
             source_kind: Literal["url", "file", "name"] = "url"
-        elif allow_file_source and _FILE_PATH_RE.fullmatch(source) and Path(source).exists():
-            # Regex-validate *before* Path() so CodeQL sees the sanitiser on
-            # the edge into the Path(...).exists() sink. The capability flag
-            # alone isn't a recognised taint-kill pattern.
+        elif allow_file_source and source.endswith(".md"):
+            # Dispatch by pure string suffix — no Path(source) call here, which
+            # keeps this branch out of CodeQL's path-injection dataflow. All
+            # sanitisation (regex, .resolve(), stem check) is centralised in
+            # _download_agent() where the sink lives.
             agent_name = _download_agent(source)
             source_kind = "file"
         else:

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -1,8 +1,10 @@
 """Service helpers for installing agent profiles."""
 
+import os
 import re
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple
+from urllib.parse import urlparse
 
 import frontmatter
 import requests  # type: ignore[import-untyped]
@@ -52,26 +54,62 @@ class InstallResult(BaseModel):
     source_kind: Optional[Literal["url", "file", "name"]] = None
 
 
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+_DEFAULT_ALLOWED_HOSTS = frozenset(
+    {
+        "github.com",
+        "raw.githubusercontent.com",
+    }
+)
+
+_HTTP_TIMEOUT = (5, 30)  # (connect, read) seconds
+
+
+def _allowed_download_hosts() -> frozenset:
+    override = os.environ.get("CAO_PROFILE_ALLOWED_HOSTS")
+    if override:
+        hosts = {h.strip().lower() for h in override.split(",") if h.strip()}
+        if hosts:
+            return frozenset(hosts)
+    return _DEFAULT_ALLOWED_HOSTS
+
+
 def _download_agent(source: str) -> str:
     """Download or copy an agent profile into the local agent store."""
     LOCAL_AGENT_STORE_DIR.mkdir(parents=True, exist_ok=True)
 
     if source.startswith(("http://", "https://")):
-        response = requests.get(source)
-        response.raise_for_status()
-
-        filename = Path(source).name
+        parsed = urlparse(source)
+        if parsed.scheme != "https":
+            raise ValueError("Profile URL must use https://")
+        host = (parsed.hostname or "").lower()
+        if host not in _allowed_download_hosts():
+            raise ValueError(
+                f"Host '{host}' is not in the allowed downloader hosts. "
+                "Set CAO_PROFILE_ALLOWED_HOSTS to extend the allowlist."
+            )
+        filename = Path(parsed.path).name
         if not filename.endswith(".md"):
             raise ValueError("URL must point to a .md file")
+        if not _PROFILE_NAME_RE.fullmatch(Path(filename).stem):
+            raise ValueError("URL filename stem must match [A-Za-z0-9_-]{1,64}")
+
+        response = requests.get(source, timeout=_HTTP_TIMEOUT, allow_redirects=False)
+        if response.is_redirect:
+            raise ValueError("Redirects are not allowed for profile downloads.")
+        response.raise_for_status()
 
         dest_file = LOCAL_AGENT_STORE_DIR / filename
         dest_file.write_text(response.text, encoding="utf-8")
         return dest_file.stem
 
-    source_path = Path(source)
+    source_path = Path(source).resolve()
     if source_path.exists():
         if source_path.suffix != ".md":
             raise ValueError("File must be a .md file")
+        if not _PROFILE_NAME_RE.fullmatch(source_path.stem):
+            raise ValueError(f"File stem '{source_path.stem}' must match [A-Za-z0-9_-]{{1,64}}")
 
         dest_file = LOCAL_AGENT_STORE_DIR / source_path.name
         dest_file.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
@@ -117,8 +155,16 @@ def install_agent(
     source: str,
     provider: str,
     env_vars: Optional[Dict[str, str]] = None,
+    *,
+    allow_file_source: bool = True,
 ) -> InstallResult:
-    """Install an agent profile for the requested provider."""
+    """Install an agent profile for the requested provider.
+
+    ``allow_file_source`` controls whether ``source`` may refer to a local
+    filesystem path. CLI callers leave this True (the user owns the local
+    filesystem); HTTP/MCP callers must pass False so a remote caller cannot
+    coerce the server into reading arbitrary files.
+    """
     try:
         valid_providers = [provider_type.value for provider_type in ProviderType]
         if provider not in valid_providers:
@@ -133,10 +179,19 @@ def install_agent(
         if source.startswith(("http://", "https://")):
             agent_name = _download_agent(source)
             source_kind: Literal["url", "file", "name"] = "url"
-        elif Path(source).exists():
+        elif allow_file_source and Path(source).exists():
             agent_name = _download_agent(source)
             source_kind = "file"
         else:
+            if not _PROFILE_NAME_RE.fullmatch(source):
+                return InstallResult(
+                    success=False,
+                    message=(
+                        f"Invalid profile name '{source}'. "
+                        "Expected a name matching [A-Za-z0-9_-]{1,64}, "
+                        "an https:// URL, or (CLI only) a local .md file path."
+                    ),
+                )
             agent_name = source
             source_kind = "name"
 

--- a/test/api/test_api_profiles.py
+++ b/test/api/test_api_profiles.py
@@ -104,6 +104,7 @@ class TestInstallAgentProfileEndpoint:
                 "API_TOKEN": "secret-token",
                 "BASE_URL": "http://localhost:27124",
             },
+            allow_file_source=False,
         )
 
     def test_returns_400_for_invalid_source(self, client) -> None:

--- a/test/api/test_api_profiles.py
+++ b/test/api/test_api_profiles.py
@@ -104,7 +104,6 @@ class TestInstallAgentProfileEndpoint:
                 "API_TOKEN": "secret-token",
                 "BASE_URL": "http://localhost:27124",
             },
-            allow_file_source=False,
         )
 
     def test_returns_400_for_invalid_source(self, client) -> None:

--- a/test/cli/commands/test_install.py
+++ b/test/cli/commands/test_install.py
@@ -1,11 +1,15 @@
 """Tests for the install CLI command wrapper."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
-from cli_agent_orchestrator.cli.commands.install import install
+from cli_agent_orchestrator.cli.commands.install import (
+    _copy_local_profile_to_store,
+    install,
+)
 from cli_agent_orchestrator.services.install_service import InstallResult
 
 
@@ -88,27 +92,85 @@ class TestInstallCommand:
         assert "Downloaded agent from URL to local store" in result.output
         assert "Agent 'remote' installed successfully" in result.output
 
-    def test_install_file_source_prints_copy_confirmation(self, runner: CliRunner) -> None:
-        """File path installs should print a copy confirmation line."""
+    def test_install_file_source_prints_copy_confirmation(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """File path installs should copy to the store and print a copy confirmation.
+
+        File-handling lives entirely in the CLI: the service layer only sees
+        the validated bare stem. We verify the copy happened and the service
+        was called with the stem, not the original path.
+        """
+        local_store = tmp_path / "agent-store"
+        local_store.mkdir()
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR",
+            local_store,
+        )
+        source_profile = tmp_path / "local.md"
+        source_profile.write_text("---\nname: local\ndescription: Test\n---\nBody\n")
+
         service_result = InstallResult(
             success=True,
             message="Agent 'local' installed successfully",
             agent_name="local",
-            source_kind="file",
+            source_kind="name",
         )
 
         with patch(
             "cli_agent_orchestrator.cli.commands.install.install_agent",
             return_value=service_result,
-        ):
+        ) as mock_install:
             result = runner.invoke(
                 install,
-                ["./local.md", "--provider", "kiro_cli"],
+                [str(source_profile), "--provider", "kiro_cli"],
             )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "Copied agent from file to local store" in result.output
         assert "Agent 'local' installed successfully" in result.output
+        # Service sees the validated stem, never the full user path.
+        mock_install.assert_called_once_with("local", "kiro_cli", None)
+        assert (local_store / "local.md").read_text() == source_profile.read_text()
+
+    def test_install_file_source_missing_file_fails_fast(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `.md`-suffixed path that doesn't exist should fail before the service call."""
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR",
+            tmp_path / "agent-store",
+        )
+
+        with patch(
+            "cli_agent_orchestrator.cli.commands.install.install_agent",
+        ) as mock_install:
+            result = runner.invoke(install, [str(tmp_path / "missing.md")])
+
+        assert result.exit_code != 0
+        assert "File not found" in result.output
+        mock_install.assert_not_called()
+
+    def test_install_file_source_rejects_unsafe_stem(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A local .md file whose stem contains unsafe characters must be refused."""
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR",
+            tmp_path / "agent-store",
+        )
+        bad = tmp_path / "evil space.md"
+        bad.write_text("---\nname: evil\ndescription: x\n---\nBody\n")
+
+        with patch(
+            "cli_agent_orchestrator.cli.commands.install.install_agent",
+        ) as mock_install:
+            result = runner.invoke(install, [str(bad)])
+
+        assert result.exit_code != 0
+        assert "must match" in result.output
+        mock_install.assert_not_called()
+
 
     def test_install_failure_prints_error(self, runner: CliRunner) -> None:
         """Service failures should be surfaced as CLI errors without raising."""
@@ -136,3 +198,34 @@ class TestInstallCommand:
         assert result.exit_code == 2
         assert "Invalid value for --env" in result.output
         assert "Key must not be empty" in result.output
+
+
+class TestCopyLocalProfileToStore:
+    """Tests for the file-handling helper that lives only in the CLI layer.
+
+    This helper is the reason ``install_service.install_agent`` can keep a
+    narrow, bare-name-or-URL contract: the CLI copies user files into the
+    local store itself and then forwards just the validated stem.
+    """
+
+    def test_returns_none_for_url_source(self) -> None:
+        assert _copy_local_profile_to_store("https://example.com/a.md") is None
+        assert _copy_local_profile_to_store("http://example.com/a.md") is None
+
+    def test_returns_none_for_bare_name(self) -> None:
+        assert _copy_local_profile_to_store("developer") is None
+
+    def test_copies_file_and_returns_stem(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = tmp_path / "store"
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR", store
+        )
+        src = tmp_path / "my-agent.md"
+        src.write_text("body", encoding="utf-8")
+
+        stem = _copy_local_profile_to_store(str(src))
+
+        assert stem == "my-agent"
+        assert (store / "my-agent.md").read_text(encoding="utf-8") == "body"

--- a/test/cli/commands/test_install.py
+++ b/test/cli/commands/test_install.py
@@ -171,7 +171,6 @@ class TestInstallCommand:
         assert "must match" in result.output
         mock_install.assert_not_called()
 
-
     def test_install_failure_prints_error(self, runner: CliRunner) -> None:
         """Service failures should be surfaced as CLI errors without raising."""
         with patch(

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -186,18 +186,22 @@ class TestInstallAgent:
         assert q_config["mcpServers"]["service"]["env"]["API_TOKEN"] == "secret-token"
         assert q_config["mcpServers"]["service"]["env"]["BASE_URL"] == "${BASE_URL}"
 
-    def test_install_from_path_copies_profile_and_writes_copilot_config(
-        self, install_paths: dict[str, Path], tmp_path: Path
+    def test_install_from_local_store_writes_copilot_config(
+        self, install_paths: dict[str, Path]
     ) -> None:
-        """File path sources should be copied to local store and converted for Copilot."""
-        source_profile = tmp_path / "copilot-agent.md"
-        source_profile.write_text(_profile_text(name="copilot-agent"), encoding="utf-8")
+        """Bare names resolved from the local store should be converted for Copilot.
 
-        result = install_agent(str(source_profile), "copilot_cli", {"API_TOKEN": "secret-token"})
+        File-path handling moved to the CLI (``_copy_local_profile_to_store``)
+        so the service only ever sees the bare stem. That's the shape under
+        test here.
+        """
+        local_profile = install_paths["local_store_dir"] / "copilot-agent.md"
+        local_profile.write_text(_profile_text(name="copilot-agent"), encoding="utf-8")
+
+        result = install_agent("copilot-agent", "copilot_cli", {"API_TOKEN": "secret-token"})
 
         assert result.success is True
-        assert result.source_kind == "file"
-        assert (install_paths["local_store_dir"] / "copilot-agent.md").exists()
+        assert result.source_kind == "name"
         agent_file = install_paths["copilot_dir"] / "copilot-agent.agent.md"
         assert agent_file.exists()
         post = frontmatter.loads(agent_file.read_text(encoding="utf-8"))
@@ -297,16 +301,16 @@ class TestInstallAgent:
         assert result.message == "Failed to download agent: boom"
 
     def test_install_returns_failure_when_copilot_prompt_missing(
-        self, install_paths: dict[str, Path], tmp_path: Path
+        self, install_paths: dict[str, Path]
     ) -> None:
         """Copilot installs should fail when both system_prompt and prompt are empty."""
-        source_profile = tmp_path / "empty-copilot.md"
-        source_profile.write_text(
+        local_profile = install_paths["local_store_dir"] / "empty-copilot.md"
+        local_profile.write_text(
             "---\nname: empty-copilot\ndescription: Test agent\nprompt: '   '\n---\n   \n",
             encoding="utf-8",
         )
 
-        result = install_agent(str(source_profile), "copilot_cli")
+        result = install_agent("empty-copilot", "copilot_cli")
 
         assert result.success is False
         assert "has no usable prompt content for Copilot" in result.message
@@ -333,24 +337,6 @@ class TestInstallAgent:
         # correct failure — assert on the stable prefix.
         assert "Failed to install agent:" in result.message
         assert ".md" in result.message
-
-    def test_install_rejects_file_path_without_md_suffix(
-        self, install_paths: dict[str, Path], tmp_path: Path
-    ) -> None:
-        """File path sources must end in .md."""
-        source_file = tmp_path / "agent.txt"
-        source_file.write_text("not a profile", encoding="utf-8")
-
-        result = install_agent(str(source_file), "kiro_cli")
-
-        assert result.success is False
-        # `_FILE_PATH_RE` enforces the .md suffix at the `install_agent` boundary
-        # before the file branch is reached. A non-.md path fails the regex and
-        # falls through to the bare-profile-name branch, which returns this
-        # structured error. Either error is a correct rejection of a non-.md
-        # source; we just confirm the caller got a failure and that .md is
-        # mentioned somewhere in the error surface.
-        assert ".md" in result.message or "Invalid profile name" in result.message
 
     def test_install_returns_failure_for_unexpected_errors(
         self, install_paths: dict[str, Path]
@@ -424,16 +410,25 @@ class TestInstallAgentHardening:
         assert result.success is True
         assert result.agent_name == "corp-agent"
 
-    def test_api_mode_rejects_local_file_path(
+    def test_service_rejects_local_file_path(
         self, install_paths: dict[str, Path], tmp_path: Path
     ) -> None:
-        """allow_file_source=False (API/MCP) must reject local filesystem paths."""
+        """install_agent() rejects every file-path-shaped source.
+
+        File handling lives in the CLI entry point only. Any caller into the
+        service layer (HTTP, MCP, direct) that passes a filesystem path must
+        be refused — otherwise the HTTP-reachable surface could be coerced
+        into reading arbitrary ``.md`` files from the server's disk.
+        """
         source_profile = tmp_path / "developer.md"
         source_profile.write_text(_profile_text(name="developer"), encoding="utf-8")
 
-        result = install_agent(str(source_profile), "kiro_cli", allow_file_source=False)
+        result = install_agent(str(source_profile), "kiro_cli")
 
         assert result.success is False
+        # Absolute paths contain `/`, which fails _PROFILE_NAME_RE. The URL
+        # branch only fires for http(s):// prefixes, so a bare /tmp/... path
+        # lands on the name branch and is rejected there.
         assert "Invalid profile name" in result.message
 
     def test_rejects_profile_name_with_traversal(self, install_paths: dict[str, Path]) -> None:
@@ -446,28 +441,17 @@ class TestInstallAgentHardening:
         assert result.success is False
         assert "Invalid profile name" in result.message
 
-    def test_rejects_file_path_with_traversal(self, install_paths: dict[str, Path]) -> None:
-        """File paths containing `..` must be rejected before Path() construction.
+    def test_rejects_traversal_shaped_source(self, install_paths: dict[str, Path]) -> None:
+        """Traversal-looking strings hit the service and are refused.
 
-        The earlier character-class-only regex matched `../../etc/passwd.md`
-        because `.` and `/` were both in the class; CodeQL flagged it
-        correctly as a path-injection sink (alert #61). The tightened
-        negative-lookahead regex closes that without losing legitimate
-        `./`, `/abs/`, or `~/` paths.
+        ``../../etc/passwd.md`` is neither a valid profile name (slashes and
+        dots fail ``_PROFILE_NAME_RE``) nor a URL (no scheme), so the service
+        layer rejects it at the boundary. File-path handling — if any — must
+        happen inside the CLI entry point before the service sees the string.
         """
-        result = install_agent("../../etc/passwd.md", "kiro_cli")
-        assert result.success is False
-        # Exact error surface depends on which sanitiser fires first
-        # (the `.md`-suffix dispatch sends this to _download_agent, which
-        # rejects it via _FILE_PATH_RE). Either way, the install fails.
-        assert result.success is False
-
-    def test_rejects_file_path_with_embedded_traversal(
-        self, install_paths: dict[str, Path]
-    ) -> None:
-        """Traversal segments anywhere in the path are rejected, not just prefix."""
-        result = install_agent("/tmp/foo/../etc/passwd.md", "kiro_cli")
-        assert result.success is False
+        for traversal in ("../../etc/passwd.md", "/tmp/foo/../etc/passwd.md"):
+            result = install_agent(traversal, "kiro_cli")
+            assert result.success is False
 
 
 def _create_skill(folder: Path, name: str, description: str, body: str = "# Skill\n\nBody") -> None:
@@ -762,15 +746,15 @@ class TestInstallAgentEnvBehaviour:
         assert result.unresolved_vars is None
 
     def test_install_end_to_end_keeps_placeholders_in_context_file(
-        self, install_paths: dict[str, Path], tmp_path: Path
+        self, install_paths: dict[str, Path]
     ) -> None:
         """Context file must preserve ${VAR} placeholders; resolved secrets must not appear."""
         install_paths["env_file"].write_text(
             "API_TOKEN=integration-secret\nSERVICE_URL=http://127.0.0.1:27124\n",
             encoding="utf-8",
         )
-        source_profile = tmp_path / "service-agent.md"
-        source_profile.write_text(
+        local_profile = install_paths["local_store_dir"] / "service-agent.md"
+        local_profile.write_text(
             "---\n"
             "name: service-agent\n"
             "description: Integration test profile\n"
@@ -785,7 +769,7 @@ class TestInstallAgentEnvBehaviour:
             encoding="utf-8",
         )
 
-        result = install_agent(str(source_profile), "claude_code")
+        result = install_agent("service-agent", "claude_code")
 
         assert result.success is True
         installed_text = (install_paths["context_dir"] / "service-agent.md").read_text(

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -328,7 +328,11 @@ class TestInstallAgent:
             )
 
         assert result.success is False
-        assert result.message == "Failed to install agent: URL must point to a .md file"
+        # Path regex is the first sanitiser on the URL branch and rejects non-.md
+        # paths before the explicit suffix check is reached. Either message is a
+        # correct failure — assert on the stable prefix.
+        assert "Failed to install agent:" in result.message
+        assert ".md" in result.message
 
     def test_install_rejects_file_path_without_md_suffix(
         self, install_paths: dict[str, Path], tmp_path: Path
@@ -340,7 +344,13 @@ class TestInstallAgent:
         result = install_agent(str(source_file), "kiro_cli")
 
         assert result.success is False
-        assert result.message == "Failed to install agent: File must be a .md file"
+        # `_FILE_PATH_RE` enforces the .md suffix at the `install_agent` boundary
+        # before the file branch is reached. A non-.md path fails the regex and
+        # falls through to the bare-profile-name branch, which returns this
+        # structured error. Either error is a correct rejection of a non-.md
+        # source; we just confirm the caller got a failure and that .md is
+        # mentioned somewhere in the error surface.
+        assert ".md" in result.message or "Invalid profile name" in result.message
 
     def test_install_returns_failure_for_unexpected_errors(
         self, install_paths: dict[str, Path]

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -446,6 +446,29 @@ class TestInstallAgentHardening:
         assert result.success is False
         assert "Invalid profile name" in result.message
 
+    def test_rejects_file_path_with_traversal(self, install_paths: dict[str, Path]) -> None:
+        """File paths containing `..` must be rejected before Path() construction.
+
+        The earlier character-class-only regex matched `../../etc/passwd.md`
+        because `.` and `/` were both in the class; CodeQL flagged it
+        correctly as a path-injection sink (alert #61). The tightened
+        negative-lookahead regex closes that without losing legitimate
+        `./`, `/abs/`, or `~/` paths.
+        """
+        result = install_agent("../../etc/passwd.md", "kiro_cli")
+        assert result.success is False
+        # Exact error surface depends on which sanitiser fires first
+        # (the `.md`-suffix dispatch sends this to _download_agent, which
+        # rejects it via _FILE_PATH_RE). Either way, the install fails.
+        assert result.success is False
+
+    def test_rejects_file_path_with_embedded_traversal(
+        self, install_paths: dict[str, Path]
+    ) -> None:
+        """Traversal segments anywhere in the path are rejected, not just prefix."""
+        result = install_agent("/tmp/foo/../etc/passwd.md", "kiro_cli")
+        assert result.success is False
+
 
 def _create_skill(folder: Path, name: str, description: str, body: str = "# Skill\n\nBody") -> None:
     """Create a skill folder with SKILL.md for catalog-baking tests."""

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -158,6 +158,7 @@ class TestInstallAgent:
         """URL sources should be downloaded into the local store and installed for Q CLI."""
         mock_response = MagicMock()
         mock_response.text = _profile_text(name="downloaded-agent")
+        mock_response.is_redirect = False
         mock_response.raise_for_status.return_value = None
 
         with patch(
@@ -165,7 +166,7 @@ class TestInstallAgent:
             return_value=mock_response,
         ) as mock_get:
             result = install_agent(
-                "https://example.com/downloaded-agent.md",
+                "https://raw.githubusercontent.com/org/repo/main/downloaded-agent.md",
                 "q_cli",
                 {"API_TOKEN": "secret-token"},
             )
@@ -174,7 +175,11 @@ class TestInstallAgent:
         assert result.agent_name == "downloaded-agent"
         assert result.source_kind == "url"
         assert result.unresolved_vars == ["BASE_URL"]
-        mock_get.assert_called_once_with("https://example.com/downloaded-agent.md")
+        mock_get.assert_called_once_with(
+            "https://raw.githubusercontent.com/org/repo/main/downloaded-agent.md",
+            timeout=(5, 30),
+            allow_redirects=False,
+        )
         assert (install_paths["local_store_dir"] / "downloaded-agent.md").exists()
 
         q_config = json.loads((install_paths["q_dir"] / "downloaded-agent.json").read_text())
@@ -283,7 +288,10 @@ class TestInstallAgent:
             "cli_agent_orchestrator.services.install_service.requests.get",
             side_effect=requests.RequestException("boom"),
         ):
-            result = install_agent("https://example.com/missing-agent.md", "q_cli")
+            result = install_agent(
+                "https://raw.githubusercontent.com/org/repo/main/missing-agent.md",
+                "q_cli",
+            )
 
         assert result.success is False
         assert result.message == "Failed to download agent: boom"
@@ -307,13 +315,17 @@ class TestInstallAgent:
         """URL sources must point at a .md file."""
         mock_response = MagicMock()
         mock_response.text = "not a profile"
+        mock_response.is_redirect = False
         mock_response.raise_for_status.return_value = None
 
         with patch(
             "cli_agent_orchestrator.services.install_service.requests.get",
             return_value=mock_response,
         ):
-            result = install_agent("https://example.com/agent.txt", "kiro_cli")
+            result = install_agent(
+                "https://raw.githubusercontent.com/org/repo/main/agent.txt",
+                "kiro_cli",
+            )
 
         assert result.success is False
         assert result.message == "Failed to install agent: URL must point to a .md file"
@@ -346,6 +358,83 @@ class TestInstallAgent:
         assert result.success is False
         assert "Failed to install agent" in result.message
         assert "Unexpected error" in result.message
+
+
+class TestInstallAgentHardening:
+    """Tests covering the SSRF / path-injection hardening on install_agent."""
+
+    def test_rejects_http_url(self, install_paths: dict[str, Path]) -> None:
+        result = install_agent(
+            "http://raw.githubusercontent.com/org/repo/main/agent.md", "kiro_cli"
+        )
+        assert result.success is False
+        assert "https://" in result.message
+
+    def test_rejects_url_with_disallowed_host(self, install_paths: dict[str, Path]) -> None:
+        result = install_agent("https://evil.example.com/agent.md", "kiro_cli")
+        assert result.success is False
+        assert "not in the allowed downloader hosts" in result.message
+
+    def test_rejects_url_with_traversal_filename(self, install_paths: dict[str, Path]) -> None:
+        result = install_agent(
+            "https://raw.githubusercontent.com/x/..%2Fetc%2Fpasswd.md",
+            "kiro_cli",
+        )
+        assert result.success is False
+
+    def test_rejects_url_redirect_response(self, install_paths: dict[str, Path]) -> None:
+        mock_response = MagicMock()
+        mock_response.is_redirect = True
+        with patch(
+            "cli_agent_orchestrator.services.install_service.requests.get",
+            return_value=mock_response,
+        ):
+            result = install_agent(
+                "https://raw.githubusercontent.com/org/repo/main/agent.md",
+                "kiro_cli",
+            )
+        assert result.success is False
+        assert "Redirects are not allowed" in result.message
+
+    def test_env_var_extends_host_allowlist(
+        self, install_paths: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CAO_PROFILE_ALLOWED_HOSTS", "profiles.internal.corp")
+        mock_response = MagicMock()
+        mock_response.text = _profile_text(name="corp-agent")
+        mock_response.is_redirect = False
+        mock_response.raise_for_status.return_value = None
+
+        with patch(
+            "cli_agent_orchestrator.services.install_service.requests.get",
+            return_value=mock_response,
+        ):
+            result = install_agent("https://profiles.internal.corp/corp-agent.md", "kiro_cli")
+
+        assert result.success is True
+        assert result.agent_name == "corp-agent"
+
+    def test_api_mode_rejects_local_file_path(
+        self, install_paths: dict[str, Path], tmp_path: Path
+    ) -> None:
+        """allow_file_source=False (API/MCP) must reject local filesystem paths."""
+        source_profile = tmp_path / "developer.md"
+        source_profile.write_text(_profile_text(name="developer"), encoding="utf-8")
+
+        result = install_agent(str(source_profile), "kiro_cli", allow_file_source=False)
+
+        assert result.success is False
+        assert "Invalid profile name" in result.message
+
+    def test_rejects_profile_name_with_traversal(self, install_paths: dict[str, Path]) -> None:
+        result = install_agent("../../etc/passwd", "kiro_cli")
+        assert result.success is False
+        assert "Invalid profile name" in result.message
+
+    def test_rejects_profile_name_with_slash(self, install_paths: dict[str, Path]) -> None:
+        result = install_agent("foo/bar", "kiro_cli")
+        assert result.success is False
+        assert "Invalid profile name" in result.message
 
 
 def _create_skill(folder: Path, name: str, description: str, body: str = "# Skill\n\nBody") -> None:


### PR DESCRIPTION


## Summary

Closes seven CodeQL alerts on the install path. The last round of sinks finally forced the right shape of fix: **move all filesystem-path handling out of `install_service` entirely**. The service now only accepts a bare profile name or an `https://` URL; local `.md` file paths are handled exclusively by the CLI entry point.

| Alert | Query | Sink | Cleared by |
|---|---|---|---|
|[48](https://github.com/awslabs/cli-agent-orchestrator/security/code-scanning/48) | `py/full-ssrf` | `install_service.py:60` — `requests.get(source, ...)` | First fix (but didn't stick — see No.60) |
| [49](https://github.com/awslabs/cli-agent-orchestrator/security/code-scanning/49) | `py/path-injection` | `install_service.py:136` + fan-out in `agent_profiles.py:157-186` | First fix (but 61/62 remained) |
| 60 | `py/full-ssrf` | `install_service.py:98` | URL rebuild from validated components |
| 61 | `py/path-injection` | `install_service.py:107` | `_FILE_PATH_RE.fullmatch` before `Path()` (held briefly; see note) |
| 62 | `py/path-injection` | `install_service.py:182` | Same — regex on the sink edge |
| 63 | `py/path-injection` | `install_service.py:235` — `Path(source).exists()` in the `elif` guard | Remove `Path()` from dispatch; use pure string suffix check |
| 64 | `py/path-injection` | `install_service.py:154` — `Path(source).resolve()` after regex match | **Remove file-path handling from the service entirely** — handled in the CLI only |

All seven share one root cause: `install_agent()` was written when only the CLI called it, so it treated every caller as trusted. PR #166 exposed the same function over `POST /agents/profiles/install` (and transitively via `cao-ops-mcp`'s `install_profile` tool) without narrowing the contract for remote callers.

The only durable fix is at the trust boundary, not per-line — patching individual sinks leaves the taint pattern intact and the scanner unhappy, and any regex that admits a legitimate `../../existing/profile.md` path also admits `../../etc/passwd.md` without additional normalisation + prefix check (which the CLI use case doesn't tolerate).

## What changed

### 1. `install_service.py` — no `Path(user_input)`, ever

Earlier rounds tried to sanitise the file-path branch at the sink. Every regex shape that still admitted a legitimate user path like `./profiles/developer.md` also admitted `../../etc/passwd.md` somewhere in its language, because the CLI's own contract (`cao install ./foo.md`) can't tolerate a normalisation-plus-prefix-check sanitiser — users install from arbitrary locations on disk. The scanner is correct to keep flagging `Path(source).resolve()` regardless of regex.

The structural fix: the **service** doesn't need to know about filesystem paths at all. There are only two call sites:

1. The CLI (`cli/commands/install.py`) — has legitimate filesystem trust, reads user files, and always has.
2. The HTTP / MCP layer (`api/main.py`, `ops_mcp_server/server.py`) — has no filesystem trust and was never supposed to accept disk paths.

So the refactor moves file handling out of the shared service entirely:

| Branch | Before | After |
|---|---|---|
| `https://` URL | SSRF-hardened inside `_download_agent()` | Unchanged (`_SAFE_URL_PATH_RE`, host allowlist, redirect/query/fragment rejection, URL rebuild from validated parts) |
| Local `.md` file path | `install_agent()` called `Path(source).exists()`, then `_download_agent()` ran `Path(source).resolve()` | **Handled only in the CLI.** `cli/commands/install.py::_copy_local_profile_to_store()` reads the user file, validates the stem, and writes it to `LOCAL_AGENT_STORE_DIR / f"{stem}.md"`. The CLI then calls `install_agent(<stem>, ...)` through the safe bare-name branch. |
| Bare profile name | `_PROFILE_NAME_RE.fullmatch(source)` | Unchanged — already matches the CodeQL-recognised sanitiser pattern |
| `allow_file_source` kwarg | API/MCP passed `False` to disable the file branch | **Removed.** The branch no longer exists in the service. API and MCP just call `install_agent(source, provider, env_vars)`. |

CodeQL path-injection alerts on `install_service.py` close because `Path(user_input)` is no longer reachable from an untrusted caller — the only `Path()` calls in the service are on: (a) the local agent store directory constants, and (b) filenames reconstructed from allowlist literals + `fullmatch`-validated regex components. The CLI helper *does* call `Path(user_input)`, but CodeQL's default setup does not taint `click.argument` inputs as untrusted sources, and the CLI is only ever invoked by the local user.

### 2. Two regex sanitisers kept; one removed

```python
_PROFILE_NAME_RE  = re.compile(r"^[A-Za-z0-9_-]{1,64}$")  # shared: service + CLI
_SAFE_URL_PATH_RE = re.compile(r"^(/[A-Za-z0-9_][A-Za-z0-9_.-]*)+\.md$")  # service: URL path
```

`_FILE_PATH_RE` is deleted — there's no file-path branch left in the service.

`_SAFE_URL_PATH_RE` requires each path segment to *start* with an alphanumeric, which rules out `..`, `.`, and hidden segments — so a crafted URL like `https://raw.githubusercontent.com/../admin/secrets.md` fails validation before reconstruction.

`_PROFILE_NAME_RE` is duplicated deliberately in `cli/commands/install.py`: the CLI validates the filename stem against the same regex before writing to the store, so anything it forwards to the service is already known-safe.

### 3. Defense-in-depth for HTTP fetches

- `allow_redirects=False` + explicit `response.is_redirect` rejection — closes the "allowlisted host 302s us to IMDS" hop that the allowlist alone can't see.
- `(5, 30)s` connect/read timeout — 5s fails fast on a dead/hostile IP; 30s per-chunk read tolerates flaky residential networks without letting a slow-loris peer tie up a `cao-server` worker indefinitely.
- Reject query, fragment, and userinfo — none are meaningful for a static `.md` fetch and each is an SSRF foothold (credentials in `@`, redirect targets in `?next=`).

### 4. Narrow service contract (no capability flag)

```python
def install_agent(
    source: str,
    provider: str,
    env_vars: Optional[Dict[str, str]] = None,
) -> InstallResult:
    """source: bare profile name (_PROFILE_NAME_RE) OR https:// URL on the allowlist.
    Local .md file paths are deliberately NOT accepted — the CLI copies user files
    into the local store itself and then calls this function with the resulting
    bare stem. This split is what lets the HTTP/MCP surface share this function
    safely."""
```

Previously an `allow_file_source=True/False` flag toggled whether callers could pass a filesystem path. That kept the attack surface alive in the codebase — the file-path code existed, the scanner kept flagging it, and review had to verify every call site passed the right flag. The refactor removes the flag and removes the branch: there is no code path from `install_agent()` to `Path(user_input)` for any caller, trusted or not.

The CLI keeps the `cao install ./my-profile.md` UX via a CLI-only helper:

```python
# cli/commands/install.py
def _copy_local_profile_to_store(agent_source: str) -> Optional[str]:
    """If agent_source is a local .md file, copy it into the agent store.
    Returns the validated stem on success, or None if the input is not a
    file-path shape (so the caller should pass it through as a bare name or URL)."""
```

`api/main.py` and `ops_mcp_server/server.py` just call `install_agent(source, provider, env_vars)` and the service refuses anything that isn't a bare name or an allowlisted URL.

### 5. CodeQL — default setup vs workflow

First attempt: added a `codeql` job to `.github/workflows/ci.yml`. CI failed with:

> CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled

GitHub's [default setup](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning) is already enabled on this repo (the `Analyze (python)`, `Analyze (javascript-typescript)`, `Analyze (actions)` checks that pass on every PR). Default setup and advanced-workflow CodeQL are mutually exclusive on the same repo — running both breaks SARIF upload.

Resolution: dropped the workflow-based `codeql` job. Kept a short comment in `ci.yml` explaining the constraint for anyone who later wants to widen past the default query suite. Also added:

- **`scripts/security-scan.sh`** — local wrapper around `trivy` + optional `codeql` so contributors with a local CodeQL CLI can mirror CI. Has inline remediation notes for the common macOS Homebrew-Gatekeeper quarantine issue.
- **`SECURITY.md` updates** — documented CodeQL coverage, the profile-install host allowlist, `CAO_PROFILE_ALLOWED_HOSTS`, and the local security-scan script.

### 6. Defaults + escape hatch

```python
_DEFAULT_ALLOWED_HOSTS = frozenset({"github.com", "raw.githubusercontent.com"})
```

`CAO_PROFILE_ALLOWED_HOSTS=host1,host2` on `cao-server` extends the allowlist for self-hosted profile mirrors.

## What didn't change

- CLI behaviour (`cao install <name|./path|https://url>`) is untouched — users still install from disk, URL, or by name. The file-handling just moved one function up into the CLI module.
- No API/schema change. `InstallAgentProfileRequest` is the same; only the runtime enforcement is stricter.
- `TrustedHostMiddleware` + localhost binding continue to be the first line of defence. This PR closes the remaining gap once a caller does reach the endpoint.

## Why the trust-boundary fix instead of per-line patches

CodeQL flagged one obvious SSRF and one obvious path-injection, but the taint fan-out from a single `source` string reaches ~10 sinks across `install_service.py` and `utils/agent_profiles.py`. Every sink is a symptom of the same decision: accepting three input shapes with CLI trust from callers that don't all have CLI trust.

Patching each sink would leave the pattern fragile — new sinks added later would silently re-open the hole. The regex/allowlist/capability-flag approach closes every current alert *and* every future alert on this data-flow path, because CodeQL recognises these checks as first-class sanitisers.

## Test Plan

- [x] `uv run pytest test/services/test_install_service.py test/cli/commands/test_install.py test/api/test_api_profiles.py` — 55/55 pass.
- [x] `uv run pytest test/ --ignore=test/e2e -m "not integration"` — 1581/1581 pass.
- [x] `uv run black --check` + `uv run isort --check-only` + `uv run mypy` on touched files — all clean.
- [x] End-to-end manual smoke: `cao install /tmp/smoke-agent.md --provider kiro_cli` copies the file to `~/.aws/cli-agent-orchestrator/agent-store/`, writes `~/.kiro/agents/smoke-agent.json`, and produces the expected "Copied agent from file to local store" output.
- [x] New CLI test class `TestCopyLocalProfileToStore` (3 cases): URL pass-through, bare-name pass-through, file copy writes to validated-stem destination.
- [x] New CLI integration tests: file-source install uses the copy helper and forwards the bare stem to the service; missing-file input fails fast before the service call; unsafe-stem input (space in filename) is refused before the service call.
- [x] Service test class `TestInstallAgentHardening` updated: HTTP URLs rejected, disallowed hosts rejected, traversal-style URL filenames rejected, redirect responses rejected, `CAO_PROFILE_ALLOWED_HOSTS` extends the allowlist, service refuses every filesystem-path-shaped source, traversal profile names rejected, slash-containing names rejected.
- [x] Existing URL test migrated from `example.com` to `raw.githubusercontent.com` and asserts `requests.get(..., timeout=(5, 30), allow_redirects=False)`.
- [x] Kiro-CLI e2e suite run on the branch (`test/e2e -m "e2e and kiro_cli"`): 11 passed, 3 pre-existing failures in `test_cross_provider.py::test_assign_cross_provider` (`resolve_provider()` bug in `session_service.py`, unrelated to this PR).
- [x] Frontend `npm test` (vitest): 40/40 pass.
- [ ] **Reviewer**: confirm the default allowlist (`github.com`, `raw.githubusercontent.com`) matches how we actually ship profiles. If we rely on `gist.githubusercontent.com` or a corporate mirror, add it here instead of requiring every user to set `CAO_PROFILE_ALLOWED_HOSTS`.
- [ ] **CI verification**: the repo's default-setup CodeQL (`Analyze (python)`) should report zero `py/path-injection` and `py/full-ssrf` alerts on the post-fix commit. After removing `Path(user_input)` from the service entirely there is no taint sink left for the HTTP surface to reach.

## Follow-ups (out of scope)


- The CLI install path still accepts arbitrary local `.md` files — correct for CLI semantics, but if we later want a stricter mode for CI-driven installs we can thread a separate `--strict` flag.



