### PR TITLE
fix: honor profile provider in ops MCP session launch

### DIFF
--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -92,7 +92,7 @@ def _serialize_allowed_tools(allowed_tools: Optional[List[str]]) -> Optional[str
 
 async def _launch_session_impl(
     agent_profile: str,
-    provider: str = DEFAULT_PROVIDER,
+    provider: Optional[str] = None,
     session_name: Optional[str] = None,
     working_directory: Optional[str] = None,
     allowed_tools: Optional[List[str]] = None,
@@ -100,10 +100,11 @@ async def _launch_session_impl(
     """Create a new CAO session and return the session identifiers."""
     resolved_session_name = session_name or generate_session_name()
     params: Dict[str, Any] = {
-        "provider": provider,
         "agent_profile": agent_profile,
         "session_name": resolved_session_name,
     }
+    if provider is not None:
+        params["provider"] = provider
     if working_directory:
         params["working_directory"] = working_directory
 
@@ -248,9 +249,9 @@ async def install_profile(
 async def launch_session(
     agent_profile: Annotated[str, Field(description="The agent profile to launch")],
     provider: Annotated[
-        str,
+        Optional[str],
         Field(description="The provider to use for the launched session"),
-    ] = DEFAULT_PROVIDER,
+    ] = None,
     session_name: Annotated[
         Optional[str],
         Field(description="Optional custom CAO session name"),
@@ -272,7 +273,7 @@ async def launch_session(
 
     Args:
         agent_profile: Agent profile for the new session
-        provider: CLI provider (default: kiro_cli)
+        provider: CLI provider (default: profile provider or kiro_cli)
         session_name: Optional custom session name (auto-generated if omitted)
         working_directory: Optional working directory for the session
         allowed_tools: Optional list of tool restrictions

--- a/test/ops_mcp_server/test_server.py
+++ b/test/ops_mcp_server/test_server.py
@@ -252,8 +252,8 @@ class TestProfileTools:
 class TestSessionLifecycleTools:
     """Tests for session lifecycle tools."""
 
-    async def test_launch_session_returns_success_with_session_identifiers(self) -> None:
-        """Launching a session should return session_name and terminal_id immediately."""
+    async def test_launch_session_omits_provider_when_not_explicit(self) -> None:
+        """Omitted provider should let the session API resolve the profile provider."""
         with (
             patch(
                 "cli_agent_orchestrator.ops_mcp_server.server.generate_session_name",
@@ -266,7 +266,6 @@ class TestSessionLifecycleTools:
         ):
             result = await _launch_session_impl(
                 agent_profile="developer",
-                provider="kiro_cli",
                 allowed_tools=["fs_read", "execute_bash"],
             )
 
@@ -280,7 +279,6 @@ class TestSessionLifecycleTools:
             "post",
             "http://127.0.0.1:9889/sessions",
             params={
-                "provider": "kiro_cli",
                 "agent_profile": "developer",
                 "session_name": "cao-generated",
                 "allowed_tools": "fs_read,execute_bash",


### PR DESCRIPTION
## Problem

Launching a CAO session through `cao-ops-mcp-server` ignores an agent profile `provider` value when the caller does not explicitly pass a provider. The session still starts with the default `kiro_cli` provider instead of the provider declared in the profile. PR #196 addresses a similar issue.

## Root Cause

`cao-ops-mcp` defaulted `launch_session.provider` and `_launch_session_impl.provider` to `DEFAULT_PROVIDER`, then always forwarded that value as the `/sessions` `provider` query parameter. The session service only resolves `profile.provider` when `provider is None`, so the MCP wrapper accidentally converted an omitted provider into an explicit `kiro_cli` override.

## Proposed Changes

- Make the ops MCP launch provider optional instead of defaulting it to `DEFAULT_PROVIDER`.
- Omit the `provider` query parameter when the MCP caller does not provide one, matching the CLI launch behavior.
- Keep forwarding explicit providers unchanged so caller overrides still win.
- Update ops MCP tests to cover omitted-provider behavior while preserving explicit-provider coverage.

## Behavior

- `launch_session(agent_profile="...")` now lets the API/session service resolve the profile provider, falling back to `kiro_cli` only when the profile has no valid provider.
- `launch_session(agent_profile="...", provider="codex")` continues to send `provider=codex` and preserves the explicit override semantics.

## Test Plan

- `uv run pytest test/ops_mcp_server/test_server.py test/services/test_session_service.py -q`
- `uv run mypy src/cli_agent_orchestrator/ops_mcp_server/server.py`
- `uv run mypy src/` was also run and still fails on existing baseline issues outside this change, including missing `requests` stubs and unrelated type errors in settings/database/provider modules.
