### PR TITLE
feat: shell command tracking, flow recycling fixes, and inbox delivery reliability

### DIFF
--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -27,6 +27,7 @@ class TerminalModel(Base):
     provider = Column(String, nullable=False)  # "q_cli", "claude_code"
     agent_profile = Column(String)  # "developer", "reviewer" (optional)
     allowed_tools = Column(String, nullable=True)  # JSON-encoded list of CAO tool names
+    shell_command = Column(String, nullable=True)  # shell process name captured before kiro launch
     last_active = Column(DateTime, default=datetime.now)
 
 
@@ -68,11 +69,11 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 def init_db() -> None:
     """Initialize database tables and apply schema migrations."""
     Base.metadata.create_all(bind=engine)
-    _migrate_add_allowed_tools()
+    _migrate_terminals_schema()
 
 
-def _migrate_add_allowed_tools() -> None:
-    """Add allowed_tools column to terminals table if missing (schema migration)."""
+def _migrate_terminals_schema() -> None:
+    """Add allowed_tools and shell_command columns to terminals table if missing (schema migration)."""
     import sqlite3
 
     from cli_agent_orchestrator.constants import DATABASE_FILE
@@ -85,9 +86,13 @@ def _migrate_add_allowed_tools() -> None:
             conn.execute("ALTER TABLE terminals ADD COLUMN allowed_tools TEXT")
             conn.commit()
             logger.info("Migration: added allowed_tools column to terminals table")
+        if "shell_command" not in columns:
+            conn.execute("ALTER TABLE terminals ADD COLUMN shell_command TEXT")
+            conn.commit()
+            logger.info("Migration: added shell_command column to terminals table")
         conn.close()
     except Exception as e:
-        logger.warning(f"Migration check for allowed_tools failed: {e}")
+        logger.warning(f"Migration check for terminals schema failed: {e}")
 
 
 def create_terminal(
@@ -97,6 +102,7 @@ def create_terminal(
     provider: str,
     agent_profile: Optional[str] = None,
     allowed_tools: Optional[List[str]] = None,
+    shell_command: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create terminal metadata record."""
     import json as _json
@@ -109,6 +115,7 @@ def create_terminal(
             provider=provider,
             agent_profile=agent_profile,
             allowed_tools=_json.dumps(allowed_tools) if allowed_tools else None,
+            shell_command=shell_command,
         )
         db.add(terminal)
         db.commit()
@@ -119,6 +126,7 @@ def create_terminal(
             "provider": terminal.provider,
             "agent_profile": terminal.agent_profile,
             "allowed_tools": allowed_tools,
+            "shell_command": terminal.shell_command,
         }
 
 
@@ -142,6 +150,7 @@ def get_terminal_metadata(terminal_id: str) -> Optional[Dict[str, Any]]:
             "provider": terminal.provider,
             "agent_profile": terminal.agent_profile,
             "allowed_tools": allowed_tools,
+            "shell_command": terminal.shell_command,
             "last_active": terminal.last_active,
         }
 
@@ -169,6 +178,17 @@ def update_last_active(terminal_id: str) -> bool:
         terminal = db.query(TerminalModel).filter(TerminalModel.id == terminal_id).first()
         if terminal:
             terminal.last_active = datetime.now()
+            db.commit()
+            return True
+        return False
+
+
+def update_terminal_shell_command(terminal_id: str, shell_command: str) -> bool:
+    """Update the shell_command baseline for a terminal."""
+    with SessionLocal() as db:
+        terminal = db.query(TerminalModel).filter(TerminalModel.id == terminal_id).first()
+        if terminal:
+            terminal.shell_command = shell_command
             db.commit()
             return True
         return False

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -205,7 +205,12 @@ class TmuxClient:
             raise
 
     def send_keys(
-        self, session_name: str, window_name: str, keys: str, enter_count: int = 1
+        self,
+        session_name: str,
+        window_name: str,
+        keys: str,
+        enter_count: int = 1,
+        force_bracketed_paste: bool = False,
     ) -> None:
         """Send keys to window using tmux paste-buffer for instant delivery.
 
@@ -221,18 +226,34 @@ class TmuxClient:
             enter_count: Number of Enter keys to send after pasting (default 1).
                 Some TUIs enter multi-line mode after bracketed paste,
                 requiring 2 Enters to submit.
+            force_bracketed_paste: If True, unconditionally wrap content in
+                bracketed paste sequences (\x1b[200~...\x1b[201~) instead of
+                relying on paste-buffer -p. Use for message delivery to TUIs.
+                Do NOT use for shell commands sent to bash during initialization
+                (bash 4.x does not support bracketed paste and will inject the
+                escape sequences literally into the command line).
         """
         target = f"{session_name}:{window_name}"
         buf_name = f"cao_{uuid.uuid4().hex[:8]}"
         try:
             logger.info(f"send_keys: {target} - keys: {keys}")
+            if force_bracketed_paste:
+                # Wrap unconditionally and use -r (no newline→CR conversion).
+                # paste-buffer -p only adds bracketed sequences if tmux tracks
+                # ?2004h for the pane — some TUIs (e.g. current Kiro) don't
+                # send ?2004h so -p is a no-op and \n becomes CR (Enter).
+                buf_content = b"\x1b[200~" + keys.encode() + b"\x1b[201~"
+                paste_flags = ["-r"]
+            else:
+                buf_content = keys.encode()
+                paste_flags = ["-p"]
             subprocess.run(
                 ["tmux", "load-buffer", "-b", buf_name, "-"],
-                input=keys.encode(),
+                input=buf_content,
                 check=True,
             )
             subprocess.run(
-                ["tmux", "paste-buffer", "-p", "-b", buf_name, "-t", target],
+                ["tmux", "paste-buffer"] + paste_flags + ["-b", buf_name, "-t", target],
                 check=True,
             )
             # Brief delay to let the TUI process the bracketed paste end sequence
@@ -469,6 +490,25 @@ class TmuxClient:
             return None
         except Exception as e:
             logger.error(f"Failed to get working directory for {session_name}:{window_name}: {e}")
+            return None
+
+    def get_pane_current_command(self, session_name: str, window_name: str) -> Optional[str]:
+        """Get the current foreground command running in a pane."""
+        try:
+            session = self.server.sessions.get(session_name=session_name)
+            if not session:
+                return None
+            window = session.windows.get(window_name=window_name)
+            if not window:
+                return None
+            pane = window.active_pane
+            if pane:
+                result = pane.cmd("display-message", "-p", "#{pane_current_command}")
+                if result.stdout:
+                    return result.stdout[0].strip()
+            return None
+        except Exception as e:
+            logger.error(f"Failed to get pane command for {session_name}:{window_name}: {e}")
             return None
 
     def pipe_pane(self, session_name: str, window_name: str, file_path: str) -> None:

--- a/src/cli_agent_orchestrator/models/terminal.py
+++ b/src/cli_agent_orchestrator/models/terminal.py
@@ -31,6 +31,9 @@ class Terminal(BaseModel):
     session_name: str = Field(..., description="Session name")
     agent_profile: Optional[str] = Field(None, description="Agent profile")
     allowed_tools: Optional[List[str]] = Field(None, description="Allowed CAO tools")
+    shell_command: Optional[str] = Field(
+        None, description="Shell process name captured before kiro launch"
+    )
     status: Optional[TerminalStatus] = Field(
         None, description="Current terminal status (live only)"
     )

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -65,6 +65,20 @@ class BaseProvider(ABC):
         self._status = TerminalStatus.IDLE
         self._allowed_tools: Optional[List[str]] = allowed_tools
         self._skill_prompt: Optional[str] = skill_prompt
+        self._shell_baseline: Optional[str] = None
+
+    @property
+    def shell_baseline(self) -> Optional[str]:
+        """Shell process name captured before the CLI tool launched.
+
+        Used by providers to detect when the CLI tool has exited and the
+        shell is showing again (current pane command matches this baseline).
+        """
+        return self._shell_baseline
+
+    @shell_baseline.setter
+    def shell_baseline(self, value: Optional[str]) -> None:
+        self._shell_baseline = value
 
     @property
     def status(self) -> TerminalStatus:

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -187,6 +187,11 @@ class KiroCliProvider(BaseProvider):
         if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
+        # Capture the shell process name before launching kiro — used later to detect kiro exit
+        self.shell_baseline = tmux_client.get_pane_current_command(
+            self.session_name, self.window_name
+        )
+
         # Step 2: Start the Kiro CLI chat session.
         #
         # --trust-all-tools: bypass Kiro CLI's permission prompts when CAO
@@ -306,8 +311,16 @@ class KiroCliProvider(BaseProvider):
             if not idle_after_working:
                 return TerminalStatus.PROCESSING
 
-        # Check 3: If no idle prompt found at all the agent is still processing
+        # Check 3: If no idle prompt found, determine if kiro is still running.
+        # Compare current pane command against the shell captured before kiro launched.
+        # If they match, kiro has exited and the shell is showing again → IDLE.
         if not has_idle_prompt and not has_new_tui_idle:
+            if self.shell_baseline:
+                current_cmd = tmux_client.get_pane_current_command(
+                    self.session_name, self.window_name
+                )
+                if current_cmd == self.shell_baseline:
+                    return TerminalStatus.IDLE
             return TerminalStatus.PROCESSING
 
         # Check 2: Look for known error messages in the output
@@ -366,6 +379,10 @@ class KiroCliProvider(BaseProvider):
             for prompt in new_tui_idle_matches:
                 if prompt.start() > last_credits_pos:
                     logger.debug("get_status: returning COMPLETED (TUI credits)")
+                    return TerminalStatus.COMPLETED
+            for prompt in old_idle_matches:
+                if prompt.start() > last_credits_pos:
+                    logger.debug("get_status: returning COMPLETED (TUI credits + legacy idle)")
                     return TerminalStatus.COMPLETED
             # Credits marker found but no idle prompt after it — still processing
             return TerminalStatus.PROCESSING

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -156,6 +156,9 @@ class ProviderManager:
             metadata["tmux_window"],
             metadata["agent_profile"],
         )
+        # Restore shell_command baseline from DB so get_status() can detect kiro exit
+        if metadata.get("shell_command"):
+            provider.shell_baseline = metadata["shell_command"]
         logger.info(f"Created provider on-demand for terminal {terminal_id}")
         return provider
 

--- a/src/cli_agent_orchestrator/services/flow_service.py
+++ b/src/cli_agent_orchestrator/services/flow_service.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -12,18 +13,26 @@ from apscheduler.triggers.cron import CronTrigger  # type: ignore
 
 from cli_agent_orchestrator.clients.database import create_flow as db_create_flow
 from cli_agent_orchestrator.clients.database import delete_flow as db_delete_flow
+from cli_agent_orchestrator.clients.database import (
+    delete_terminals_by_session,
+)
 from cli_agent_orchestrator.clients.database import get_flow as db_get_flow
 from cli_agent_orchestrator.clients.database import get_flows_to_run as db_get_flows_to_run
 from cli_agent_orchestrator.clients.database import list_flows as db_list_flows
+from cli_agent_orchestrator.clients.database import (
+    list_terminals_by_session,
+)
 from cli_agent_orchestrator.clients.database import update_flow_enabled as db_update_flow_enabled
 from cli_agent_orchestrator.clients.database import (
     update_flow_run_times as db_update_flow_run_times,
 )
+from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.constants import DEFAULT_PROVIDER, PROVIDERS
 from cli_agent_orchestrator.models.flow import Flow
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.manager import provider_manager
 from cli_agent_orchestrator.services.terminal_service import create_terminal, send_input
 from cli_agent_orchestrator.utils.template import render_template
-from cli_agent_orchestrator.utils.terminal import generate_session_name
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +76,8 @@ def add_flow(file_path: str) -> Flow:
                 raise ValueError(f"Missing required field: {field}")
 
         name = metadata["name"]
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", str(name)):
+            raise ValueError(f"Invalid flow name '{name}': must match ^[A-Za-z0-9_-]{{1,64}}$")
         schedule = metadata["schedule"]
         agent_profile = metadata["agent_profile"]
         provider = metadata.get(
@@ -152,6 +163,13 @@ def enable_flow(name: str) -> bool:
     return True
 
 
+def _is_terminal_busy(terminal_id: str) -> bool:
+    try:
+        return provider_manager.get_provider(terminal_id).get_status() == TerminalStatus.PROCESSING
+    except Exception:
+        return False
+
+
 def execute_flow(name: str) -> bool:
     """Execute flow: run script, render prompt, launch session."""
     try:
@@ -211,7 +229,20 @@ def execute_flow(name: str) -> bool:
         rendered_prompt = render_template(prompt_template, output_dict)
 
         # Launch session
-        session_name = generate_session_name()
+        session_name = f"cao-flow-{flow.name}"
+        if tmux_client.session_exists(session_name):
+            terminals = list_terminals_by_session(session_name)
+            # Only check the first (conductor) terminal for busy status.
+            # Worker terminals spawned by the conductor may have stale status
+            # after /exit and should not block flow recycling.
+            conductor = terminals[0] if terminals else None
+            if conductor and _is_terminal_busy(conductor["id"]):
+                logger.info(f"Flow {name}: session {session_name} is busy, skipping")
+                return False
+            for t in terminals:
+                provider_manager.cleanup_provider(t["id"])
+            tmux_client.kill_session(session_name)
+            delete_terminals_by_session(session_name)
         terminal = create_terminal(
             session_name=session_name,
             provider=flow.provider,

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -28,6 +28,7 @@ from cli_agent_orchestrator.clients.database import delete_terminal as db_delete
 from cli_agent_orchestrator.clients.database import (
     get_terminal_metadata,
     update_last_active,
+    update_terminal_shell_command,
 )
 from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.constants import SESSION_PREFIX, TERMINAL_LOG_DIR
@@ -181,6 +182,13 @@ def create_terminal(
         )
         provider_instance.initialize()
 
+        # Persist shell_command baseline if the provider captured one
+        shell_command = provider_instance.shell_baseline
+        if not isinstance(shell_command, str):
+            shell_command = None
+        if shell_command:
+            update_terminal_shell_command(terminal_id, shell_command)
+
         # Step 5: Set up terminal logging via tmux pipe-pane
         # This captures all terminal output to a log file for inbox monitoring
         log_path = TERMINAL_LOG_DIR / f"{terminal_id}.log"
@@ -194,6 +202,7 @@ def create_terminal(
             provider=ProviderType(provider),
             session_name=session_name,
             agent_profile=agent_profile,
+            shell_command=shell_command,
             status=TerminalStatus.IDLE,
             last_active=datetime.now(),
         )
@@ -309,7 +318,11 @@ def send_input(
         enter_count = provider.paste_enter_count if provider else 1
 
         tmux_client.send_keys(
-            metadata["tmux_session"], metadata["tmux_window"], message, enter_count=enter_count
+            metadata["tmux_session"],
+            metadata["tmux_window"],
+            message,
+            enter_count=enter_count,
+            force_bracketed_paste=True,
         )
 
         # Notify the provider that external input was received.

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -32,6 +32,7 @@ from cli_agent_orchestrator.clients.database import (
     update_flow_run_times,
     update_last_active,
     update_message_status,
+    update_terminal_shell_command,
 )
 from cli_agent_orchestrator.models.inbox import MessageStatus
 
@@ -120,6 +121,41 @@ class TestTerminalOperations:
         update_last_active("test123")
 
         mock_session.commit.assert_called_once()
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_update_terminal_shell_command(self, mock_session_class):
+        """Test updating shell_command baseline for a terminal."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_terminal = MagicMock()
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_terminal
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = update_terminal_shell_command("test123", "bash")
+
+        assert result is True
+        assert mock_terminal.shell_command == "bash"
+        mock_session.commit.assert_called_once()
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_update_terminal_shell_command_not_found(self, mock_session_class):
+        """Test updating shell_command for a terminal that doesn't exist."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = None
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = update_terminal_shell_command("nonexistent", "bash")
+
+        assert result is False
 
     @patch("cli_agent_orchestrator.clients.database.SessionLocal")
     def test_delete_terminal(self, mock_session_class):

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -548,3 +548,42 @@ class TestStopPipePane:
 
         with pytest.raises(ValueError, match="not found"):
             tmux.stop_pipe_pane("ses", "nonexistent")
+
+
+class TestGetPaneCurrentCommand:
+    def test_get_pane_current_command_success(self, tmux):
+        mock_session = MagicMock()
+        mock_window = MagicMock()
+        mock_pane = MagicMock()
+        mock_pane.cmd.return_value.stdout = ["bash"]
+        mock_window.active_pane = mock_pane
+        mock_session.windows.get.return_value = mock_window
+        tmux.server.sessions.get.return_value = mock_session
+
+        result = tmux.get_pane_current_command("ses", "win")
+
+        assert result == "bash"
+        mock_pane.cmd.assert_called_once_with("display-message", "-p", "#{pane_current_command}")
+
+    def test_get_pane_current_command_session_not_found(self, tmux):
+        tmux.server.sessions.get.return_value = None
+
+        result = tmux.get_pane_current_command("nonexistent", "win")
+
+        assert result is None
+
+    def test_get_pane_current_command_window_not_found(self, tmux):
+        mock_session = MagicMock()
+        mock_session.windows.get.return_value = None
+        tmux.server.sessions.get.return_value = mock_session
+
+        result = tmux.get_pane_current_command("ses", "nonexistent")
+
+        assert result is None
+
+    def test_get_pane_current_command_exception_returns_none(self, tmux):
+        tmux.server.sessions.get.side_effect = Exception("tmux error")
+
+        result = tmux.get_pane_current_command("ses", "win")
+
+        assert result is None

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -1480,3 +1480,44 @@ class TestKiroCliTuiMode:
         # Should extract second turn only
         assert "Second answer" in message
         assert "First answer" not in message
+
+
+class TestKiroCliCheck3ShellBaseline:
+    """Tests for Check 3: shell-baseline IDLE detection."""
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_check3_shell_match_returns_idle(self, mock_tmux):
+        """No idle prompt + current command matches shell_baseline → IDLE."""
+        mock_tmux.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.get_pane_current_command.return_value = "bash"
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        provider.shell_baseline = "bash"
+        status = provider.get_status()
+
+        assert status == TerminalStatus.IDLE
+        mock_tmux.get_pane_current_command.assert_called_once_with("test-session", "window-0")
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_check3_shell_mismatch_returns_processing(self, mock_tmux):
+        """No idle prompt + current command differs from shell_baseline → PROCESSING."""
+        mock_tmux.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.get_pane_current_command.return_value = "kiro"
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        provider.shell_baseline = "bash"
+        status = provider.get_status()
+
+        assert status == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_check3_no_baseline_returns_processing_without_pane_query(self, mock_tmux):
+        """No idle prompt + shell_baseline is None → PROCESSING, no pane command query."""
+        mock_tmux.get_history.return_value = "Some processing output without idle prompt"
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        # shell_baseline defaults to None
+        status = provider.get_status()
+
+        assert status == TerminalStatus.PROCESSING
+        mock_tmux.get_pane_current_command.assert_not_called()

--- a/test/providers/test_provider_manager_unit.py
+++ b/test/providers/test_provider_manager_unit.py
@@ -201,3 +201,40 @@ def test_list_providers():
         "t1": "CodexProvider",
         "t2": "ClaudeCodeProvider",
     }
+
+
+def test_get_provider_restores_shell_baseline_from_metadata():
+    """get_provider sets shell_baseline on the provider when DB metadata has shell_command."""
+    manager = ProviderManager()
+
+    with patch(
+        "cli_agent_orchestrator.providers.manager.get_terminal_metadata",
+        return_value={
+            "provider": ProviderType.KIRO_CLI.value,
+            "tmux_session": "s1",
+            "tmux_window": "w1",
+            "agent_profile": "developer",
+            "shell_command": "bash",
+        },
+    ):
+        provider = manager.get_provider("t1")
+
+    assert provider.shell_baseline == "bash"
+
+
+def test_get_provider_no_shell_baseline_when_metadata_missing_shell_command():
+    """get_provider leaves shell_baseline as None when DB metadata has no shell_command."""
+    manager = ProviderManager()
+
+    with patch(
+        "cli_agent_orchestrator.providers.manager.get_terminal_metadata",
+        return_value={
+            "provider": ProviderType.KIRO_CLI.value,
+            "tmux_session": "s1",
+            "tmux_window": "w1",
+            "agent_profile": "developer",
+        },
+    ):
+        provider = manager.get_provider("t1")
+
+    assert provider.shell_baseline is None

--- a/test/services/test_flow_service.py
+++ b/test/services/test_flow_service.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cli_agent_orchestrator.models.flow import Flow
+from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.services.flow_service import (
     _get_next_run_time,
     _parse_flow_file,
@@ -147,6 +148,17 @@ Missing schedule and agent_profile.
             f.flush()
 
             with pytest.raises(ValueError, match="Missing required field"):
+                add_flow(f.name)
+
+    def test_add_flow_invalid_name(self):
+        """Test that invalid flow name raises error."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(
+                "---\nname: my/invalid flow\nschedule: '* * * * *'\nagent_profile: developer\n---\nPrompt.\n"
+            )
+            f.flush()
+
+            with pytest.raises(ValueError, match="Invalid flow name"):
                 add_flow(f.name)
 
     def test_add_flow_invalid_cron(self):
@@ -355,14 +367,16 @@ class TestExecuteFlow:
 
     @patch("cli_agent_orchestrator.services.flow_service.send_input")
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
-    @patch("cli_agent_orchestrator.services.flow_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_without_script(
         self,
         mock_db_get,
         mock_update_times,
-        mock_gen_session,
+        mock_tmux_client,
+        mock_list_terminals,
         mock_create_terminal,
         mock_send_input,
     ):
@@ -391,7 +405,7 @@ Simple prompt without variables.
             next_run=datetime.now(),
         )
         mock_db_get.return_value = mock_flow
-        mock_gen_session.return_value = "cao-test-session"
+        mock_tmux_client.session_exists.return_value = False
 
         mock_terminal = MagicMock()
         mock_terminal.id = "terminal-123"
@@ -406,14 +420,16 @@ Simple prompt without variables.
     @patch("cli_agent_orchestrator.services.flow_service.subprocess.run")
     @patch("cli_agent_orchestrator.services.flow_service.send_input")
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
-    @patch("cli_agent_orchestrator.services.flow_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_with_script_execute_true(
         self,
         mock_db_get,
         mock_update_times,
-        mock_gen_session,
+        mock_tmux_client,
+        mock_list_terminals,
         mock_create_terminal,
         mock_send_input,
         mock_subprocess,
@@ -447,7 +463,7 @@ Value is [[value]].
                 next_run=datetime.now(),
             )
             mock_db_get.return_value = mock_flow
-            mock_gen_session.return_value = "cao-test-session"
+            mock_tmux_client.session_exists.return_value = False
 
             # Mock script output
             mock_subprocess.return_value = MagicMock(
@@ -598,6 +614,202 @@ Prompt.
 
             with pytest.raises(ValueError, match="not valid JSON"):
                 execute_flow("bad-json-flow")
+
+    @patch("cli_agent_orchestrator.services.flow_service.send_input")
+    @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
+    @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
+    @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
+    def test_execute_flow_skips_when_session_busy(
+        self,
+        mock_db_get,
+        mock_update_times,
+        mock_tmux_client,
+        mock_list_terminals,
+        mock_provider_manager,
+        mock_create_terminal,
+        mock_send_input,
+    ):
+        """Session exists with a PROCESSING terminal — flow should skip."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(
+                "---\nname: busy-flow\nschedule: '* * * * *'\nagent_profile: developer\n---\nPrompt.\n"
+            )
+            f.flush()
+            mock_flow = Flow(
+                name="busy-flow",
+                file_path=f.name,
+                schedule="* * * * *",
+                agent_profile="developer",
+                provider="kiro_cli",
+                script="",
+                enabled=True,
+                next_run=datetime.now(),
+            )
+        mock_db_get.return_value = mock_flow
+        mock_tmux_client.session_exists.return_value = True
+        mock_list_terminals.return_value = [{"id": "t1", "agent_profile": "developer"}]
+        mock_provider = MagicMock()
+        mock_provider.get_status.return_value = TerminalStatus.PROCESSING
+        mock_provider_manager.get_provider.return_value = mock_provider
+
+        result = execute_flow("busy-flow")
+
+        assert result is False
+        mock_create_terminal.assert_not_called()
+        mock_tmux_client.kill_session.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.flow_service.delete_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.send_input")
+    @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
+    @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
+    @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
+    def test_execute_flow_kills_idle_session_and_proceeds(
+        self,
+        mock_db_get,
+        mock_update_times,
+        mock_tmux_client,
+        mock_list_terminals,
+        mock_provider_manager,
+        mock_create_terminal,
+        mock_send_input,
+        mock_delete_terminals,
+    ):
+        """Session exists with an IDLE terminal — flow should kill and proceed."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(
+                "---\nname: idle-flow\nschedule: '* * * * *'\nagent_profile: developer\n---\nPrompt.\n"
+            )
+            f.flush()
+            mock_flow = Flow(
+                name="idle-flow",
+                file_path=f.name,
+                schedule="* * * * *",
+                agent_profile="developer",
+                provider="kiro_cli",
+                script="",
+                enabled=True,
+                next_run=datetime.now(),
+            )
+        mock_db_get.return_value = mock_flow
+        mock_tmux_client.session_exists.return_value = True
+        mock_list_terminals.return_value = [{"id": "t1"}]
+        mock_provider = MagicMock()
+        mock_provider.get_status.return_value = TerminalStatus.IDLE
+        mock_provider_manager.get_provider.return_value = mock_provider
+        mock_terminal = MagicMock()
+        mock_terminal.id = "terminal-123"
+        mock_create_terminal.return_value = mock_terminal
+
+        result = execute_flow("idle-flow")
+
+        assert result is True
+        mock_tmux_client.kill_session.assert_called_once()
+        mock_provider_manager.cleanup_provider.assert_called_once_with("t1")
+        mock_create_terminal.assert_called_once()
+
+    @patch("cli_agent_orchestrator.services.flow_service.delete_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.send_input")
+    @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
+    @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
+    @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
+    def test_execute_flow_handles_unknown_provider_as_non_busy(
+        self,
+        mock_db_get,
+        mock_update_times,
+        mock_tmux_client,
+        mock_list_terminals,
+        mock_provider_manager,
+        mock_create_terminal,
+        mock_send_input,
+        mock_delete_terminals,
+    ):
+        """get_provider raises ValueError — terminal treated as non-busy, flow proceeds."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(
+                "---\nname: orphan-provider-flow\nschedule: '* * * * *'\nagent_profile: developer\n---\nPrompt.\n"
+            )
+            f.flush()
+            mock_flow = Flow(
+                name="orphan-provider-flow",
+                file_path=f.name,
+                schedule="* * * * *",
+                agent_profile="developer",
+                provider="kiro_cli",
+                script="",
+                enabled=True,
+                next_run=datetime.now(),
+            )
+        mock_db_get.return_value = mock_flow
+        mock_tmux_client.session_exists.return_value = True
+        mock_list_terminals.return_value = [{"id": "t1"}]
+        mock_provider_manager.get_provider.side_effect = ValueError("unknown terminal")
+        mock_terminal = MagicMock()
+        mock_terminal.id = "terminal-123"
+        mock_create_terminal.return_value = mock_terminal
+
+        result = execute_flow("orphan-provider-flow")
+
+        assert result is True
+        mock_tmux_client.kill_session.assert_called_once()
+        mock_create_terminal.assert_called_once()
+
+    @patch("cli_agent_orchestrator.services.flow_service.delete_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.send_input")
+    @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
+    @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
+    @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
+    def test_execute_flow_kills_orphaned_session(
+        self,
+        mock_db_get,
+        mock_update_times,
+        mock_tmux_client,
+        mock_list_terminals,
+        mock_provider_manager,
+        mock_create_terminal,
+        mock_send_input,
+        mock_delete_terminals,
+    ):
+        """Session exists but has no terminals — flow should kill and proceed without calling get_provider."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(
+                "---\nname: empty-session-flow\nschedule: '* * * * *'\nagent_profile: developer\n---\nPrompt.\n"
+            )
+            f.flush()
+            mock_flow = Flow(
+                name="empty-session-flow",
+                file_path=f.name,
+                schedule="* * * * *",
+                agent_profile="developer",
+                provider="kiro_cli",
+                script="",
+                enabled=True,
+                next_run=datetime.now(),
+            )
+        mock_db_get.return_value = mock_flow
+        mock_tmux_client.session_exists.return_value = True
+        mock_list_terminals.return_value = []
+        mock_terminal = MagicMock()
+        mock_terminal.id = "terminal-123"
+        mock_create_terminal.return_value = mock_terminal
+
+        result = execute_flow("empty-session-flow")
+
+        assert result is True
+        mock_tmux_client.kill_session.assert_called_once()
+        mock_create_terminal.assert_called_once()
+        mock_provider_manager.get_provider.assert_not_called()
 
 
 class TestGetFlowsToRun:

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -490,7 +490,11 @@ class TestSendInput:
 
         assert result is True
         mock_tmux.send_keys.assert_called_once_with(
-            "cao-session", "developer-abcd", "test message", enter_count=2
+            "cao-session",
+            "developer-abcd",
+            "test message",
+            enter_count=2,
+            force_bracketed_paste=True,
         )
         mock_update.assert_called_once_with("test1234")
 


### PR DESCRIPTION
## Summary

Three related reliability improvements to terminal lifecycle management and inbox message delivery.

## Changes

### Shell command tracking (kiro exit detection)

`get_status()` previously had no reliable way to detect when kiro had exited and the shell was showing again — it would return `PROCESSING` indefinitely. This adds a shell command baseline captured before kiro launches, persisted to the DB, and used in Check 3 to
compare against the current pane command.

- Add `shell_command` column to terminals table with automatic migration
- Capture shell process name before kiro launch; persist to DB; restore on provider recreation
- `get_status()` Check 3: if no idle prompt found, compare current pane command to shell baseline — if they match, kiro has exited → IDLE
- Add `get_pane_current_command()` to `TmuxClient`

### Flow session recycling fixes

- Handle `ValueError` in session busy check for named flow sessions
- Clean up DB terminal records when flow recycles a session
- Only check conductor terminal for busy status during recycling (not all terminals in the session)

### Inbox delivery reliability

Two bugs that caused inbox messages to get stuck as `pending` forever:

1. **Bracketed paste**: `send_input()` now uses `force_bracketed_paste=True` so messages reach TUI panes regardless of whether the pane has `?2004h` (bracketed paste mode) enabled. Previously, messages were silently dropped by some TUI configurations.

2. **Credits + legacy idle**: `get_status()` Check 5 only checked the new TUI idle pattern (`Ask a question...`) after a Credits marker. Legacy-UI terminals (e.g. `--legacy-ui`) use a different prompt pattern (`[agent] N% >`) which was never checked, causing those
terminals to always return `PROCESSING` after completing a response.

## Testing

- 108 kiro provider tests pass
- 1 pre-existing unrelated failure (`test_flow_daemon_executes_flows` — missing `pytest-asyncio` marker, not related to these changes)