### PR TITLE
fix(kiro_cli): fix handoff hang for Q Developer Pro — Credits marker not emitted in TUI mode

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -157,8 +157,16 @@ class KiroCliProvider(BaseProvider):
 
     @property
     def extraction_tail_lines(self) -> int:
-        """Use full scrollback for extraction — long responses exceed 200 lines."""
-        return 5000
+        """Capture enough scrollback for no-credits extraction.
+
+        The no-credits fallback (_extract_tui_message) needs both the
+        start_separator (before the response) and end_separator (TUI frame
+        before the idle prompt) in the same capture window. For long agent
+        responses the start_separator can be hundreds of lines above the
+        idle prompt. 2000 lines covers responses up to ~1800 lines of
+        content, which exceeds any realistic single-turn agent response.
+        """
+        return 2000
 
     def _get_profile_model(self) -> Optional[str]:
         """Return profile.model if the agent profile can be loaded, else None.
@@ -423,7 +431,9 @@ class KiroCliProvider(BaseProvider):
                     if re.search(TUI_SEPARATOR_PATTERN, lines[i].strip()):
                         content_between = [l for l in lines[i + 1 : idle_line_idx] if l.strip()]
                         if len(content_between) >= 3:
-                            logger.debug("get_status: returning COMPLETED (TUI no-credits fallback)")
+                            logger.debug(
+                                "get_status: returning COMPLETED (TUI no-credits fallback)"
+                            )
                             return TerminalStatus.COMPLETED
                         break
 
@@ -564,7 +574,7 @@ class KiroCliProvider(BaseProvider):
                     if start_separator_idx is not None and end_separator_idx is not None:
                         content_lines = lines[start_separator_idx + 1 : end_separator_idx]
                         # Skip header line (agent · model · N%)
-                        content_lines = [l for l in content_lines if not re.search(r'·.*·.*%', l)]
+                        content_lines = [l for l in content_lines if not re.search(r"·.*·.*%", l)]
                         # Skip first paragraph (user message echo)
                         agent_start = 0
                         found_blank = False
@@ -582,15 +592,6 @@ class KiroCliProvider(BaseProvider):
                             final_answer = re.sub(ESCAPE_SEQUENCE_PATTERN, "", final_answer)
                             final_answer = re.sub(CONTROL_CHAR_PATTERN, "", final_answer)
                             return final_answer.strip()
-
-                # Last resort: separator not found but input was sent —
-                # handles truncated captures where separator scrolled out.
-                raw = re.sub(ANSI_CODE_PATTERN, "", "\n".join(lines))
-                raw = re.sub(ESCAPE_SEQUENCE_PATTERN, "", raw)
-                raw = re.sub(CONTROL_CHAR_PATTERN, "", raw)
-                raw = raw.strip()
-                if raw:
-                    return raw
 
             raise ValueError(
                 "No Kiro CLI response found - no Credits marker or green arrow detected"

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -573,8 +573,12 @@ class KiroCliProvider(BaseProvider):
 
                     if start_separator_idx is not None and end_separator_idx is not None:
                         content_lines = lines[start_separator_idx + 1 : end_separator_idx]
-                        # Skip header line (agent · model · N%)
-                        content_lines = [l for l in content_lines if not re.search(r"·.*·.*%", l)]
+                        # Skip only the actual TUI header line (agent · model · N%)
+                        content_lines = [
+                            l
+                            for l in content_lines
+                            if not re.search(self._new_tui_header_pattern, l)
+                        ]
                         # Skip first paragraph (user message echo)
                         agent_start = 0
                         found_blank = False

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -128,6 +128,7 @@ class KiroCliProvider(BaseProvider):
         """
         super().__init__(terminal_id, session_name, window_name, allowed_tools)
         self._initialized = False
+        self._input_received = False
         self._agent_profile = agent_profile
 
         # Build dynamic prompt pattern based on agent profile
@@ -149,6 +150,15 @@ class KiroCliProvider(BaseProvider):
     def paste_enter_count(self) -> int:
         """Kiro CLI submits on single Enter after bracketed paste."""
         return 1
+
+    def mark_input_received(self) -> None:
+        """Track that input was sent, enabling separator-free completion detection."""
+        self._input_received = True
+
+    @property
+    def extraction_tail_lines(self) -> int:
+        """Use full scrollback for extraction — long responses exceed 200 lines."""
+        return 5000
 
     def _get_profile_model(self) -> Optional[str]:
         """Return profile.model if the agent profile can be loaded, else None.
@@ -387,6 +397,36 @@ class KiroCliProvider(BaseProvider):
             # Credits marker found but no idle prompt after it — still processing
             return TerminalStatus.PROCESSING
 
+        # Check 6: Kiro CLI 2.3.0+ — no Credits marker emitted. Detect completion
+        # by presence of idle prompt after input was sent. For long responses the
+        # separator may have scrolled out of the capture buffer, so we search the
+        # entire buffer. If no separator is found but input was previously received,
+        # the idle prompt alone signals completion.
+        if has_new_tui_idle:
+            lines = clean_output.split("\n")
+            idle_line_idx = None
+            for i in range(len(lines) - 1, -1, -1):
+                if re.search(NEW_TUI_IDLE_PATTERN, lines[i]):
+                    idle_line_idx = i
+                    break
+            if idle_line_idx is not None:
+                # If input was sent, idle prompt alone means completion.
+                # The >=3 content check was blocking detection because the
+                # TUI's final frame only has the header between separator
+                # and idle prompt.
+                if self._input_received:
+                    logger.debug("get_status: returning COMPLETED (TUI idle after input)")
+                    return TerminalStatus.COMPLETED
+                # Before any input is sent, require separator + content to
+                # distinguish startup chrome from a real response.
+                for i in range(idle_line_idx - 1, -1, -1):
+                    if re.search(TUI_SEPARATOR_PATTERN, lines[i].strip()):
+                        content_between = [l for l in lines[i + 1 : idle_line_idx] if l.strip()]
+                        if len(content_between) >= 3:
+                            logger.debug("get_status: returning COMPLETED (TUI no-credits fallback)")
+                            return TerminalStatus.COMPLETED
+                        break
+
         # Default: Agent is IDLE, waiting for user input
         return TerminalStatus.IDLE
 
@@ -494,6 +534,64 @@ class KiroCliProvider(BaseProvider):
                 break
 
         if credits_idx is None:
+            # Kiro CLI 2.3.0+ may not emit a Credits line. Fall back to
+            # extracting content between separators around the response.
+            # Only attempt this when we know input was sent — without
+            # _input_received the original error contract is preserved.
+            if self._input_received:
+                idle_idx = None
+                for i in range(len(lines) - 1, -1, -1):
+                    if re.search(NEW_TUI_IDLE_PATTERN, lines[i]):
+                        idle_idx = i
+                        break
+
+                if idle_idx is not None:
+                    # Find the last separator before idle (TUI frame boundary)
+                    end_separator_idx = None
+                    for i in range(idle_idx - 1, -1, -1):
+                        if re.search(TUI_SEPARATOR_PATTERN, lines[i].strip()):
+                            end_separator_idx = i
+                            break
+
+                    # Find the separator before that (start of response area)
+                    start_separator_idx = None
+                    if end_separator_idx is not None:
+                        for i in range(end_separator_idx - 1, -1, -1):
+                            if re.search(TUI_SEPARATOR_PATTERN, lines[i].strip()):
+                                start_separator_idx = i
+                                break
+
+                    if start_separator_idx is not None and end_separator_idx is not None:
+                        content_lines = lines[start_separator_idx + 1 : end_separator_idx]
+                        # Skip header line (agent · model · N%)
+                        content_lines = [l for l in content_lines if not re.search(r'·.*·.*%', l)]
+                        # Skip first paragraph (user message echo)
+                        agent_start = 0
+                        found_blank = False
+                        for i, line in enumerate(content_lines):
+                            stripped = line.strip()
+                            if not found_blank and not stripped:
+                                found_blank = True
+                                continue
+                            if found_blank and stripped:
+                                agent_start = i
+                                break
+                        response_lines = content_lines[agent_start:]
+                        final_answer = "\n".join(response_lines).strip()
+                        if final_answer:
+                            final_answer = re.sub(ESCAPE_SEQUENCE_PATTERN, "", final_answer)
+                            final_answer = re.sub(CONTROL_CHAR_PATTERN, "", final_answer)
+                            return final_answer.strip()
+
+                # Last resort: separator not found but input was sent —
+                # handles truncated captures where separator scrolled out.
+                raw = re.sub(ANSI_CODE_PATTERN, "", "\n".join(lines))
+                raw = re.sub(ESCAPE_SEQUENCE_PATTERN, "", raw)
+                raw = re.sub(CONTROL_CHAR_PATTERN, "", raw)
+                raw = raw.strip()
+                if raw:
+                    return raw
+
             raise ValueError(
                 "No Kiro CLI response found - no Credits marker or green arrow detected"
             )

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -1580,3 +1580,159 @@ class TestKiroCliCheck3ShellBaseline:
 
         assert status == TerminalStatus.PROCESSING
         mock_tmux.get_pane_current_command.assert_not_called()
+
+
+class TestKiroCliCheck6NoCredits:
+    """Tests for Check 6: no-Credits completion detection and extraction.
+
+    Covers the case where Kiro CLI is used with a Q Developer Pro subscription,
+    which does not emit the '▸ Credits:' marker after responses. Check 6 detects
+    completion via the idle prompt after input is received, and extraction falls
+    back to finding content between two TUI separator lines.
+    """
+
+    SEP = "─" * 52
+
+    def _tui_output(self, user_msg: str, agent_response: str) -> str:
+        """Build a synthetic no-credits TUI capture."""
+        return (
+            f"{self.SEP}\n"
+            f"  {user_msg}\n"
+            "\n"
+            f"  {agent_response}\n"
+            "\n"
+            f"{self.SEP}\n"
+            "developer · claude-sonnet-4.6 · ◔ 3%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+    # -------------------------------------------------------------------------
+    # Check 6 — get_status()
+    # -------------------------------------------------------------------------
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_check6_completed_after_input_received(self, mock_tmux):
+        """Check 6 returns COMPLETED when idle prompt present and input was sent."""
+        mock_tmux.get_history.return_value = self._tui_output("validate this", "All checks pass.")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        provider._input_received = True
+        status = provider.get_status()
+
+        assert status == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_check6_idle_before_input_received(self, mock_tmux):
+        """Check 6 must NOT fire during startup before any input is sent.
+
+        The TUI renders the idle prompt during initialization. Without the
+        _input_received guard, get_status() would return COMPLETED immediately
+        after launch before the agent has done any work.
+        """
+        mock_tmux.get_history.return_value = (
+            f"{self.SEP}\n"
+            "developer · claude-sonnet-4.6 · ◔ 0%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        # _input_received is False by default
+        status = provider.get_status()
+
+        assert status == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    def test_check6_not_triggered_while_processing(self, mock_tmux):
+        """Check 6 must not fire when 'Kiro is working' appears after idle prompt."""
+        mock_tmux.get_history.return_value = (
+            "developer · auto · ◔ 3%\n"
+            " Ask a question or describe a task ↵\n"
+            " Kiro is working\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        provider._input_received = True
+        status = provider.get_status()
+
+        assert status == TerminalStatus.PROCESSING
+
+    # -------------------------------------------------------------------------
+    # No-credits extraction — _extract_tui_message()
+    # -------------------------------------------------------------------------
+
+    def test_no_credits_extraction_returns_agent_response(self):
+        """Two-separator extraction returns agent response, not user echo or chrome."""
+        output = self._tui_output("What is 2+2?", "The answer is 4.")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        provider._input_received = True
+        message = provider.extract_last_message_from_script(output)
+
+        assert "The answer is 4." in message
+        assert "What is 2+2?" not in message
+        assert "Ask a question" not in message
+
+    def test_no_credits_extraction_multiline_response(self):
+        """Two-separator extraction handles multi-line agent responses."""
+        output = (
+            f"{self.SEP}\n"
+            "  user question\n"
+            "\n"
+            "  Line one of response.\n"
+            "  Line two of response.\n"
+            "  Line three of response.\n"
+            "\n"
+            f"{self.SEP}\n"
+            "developer · claude-sonnet-4.6 · ◔ 3%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        provider._input_received = True
+        message = provider.extract_last_message_from_script(output)
+
+        assert "Line one of response." in message
+        assert "Line two of response." in message
+        assert "Line three of response." in message
+        assert "user question" not in message
+
+    def test_no_credits_extraction_only_one_separator_raises(self):
+        """When only one separator is found (truncated capture), raise ValueError.
+
+        The last-resort raw-scrollback fallback was removed to prevent corrupted
+        data masquerading as a valid agent response. A clear ValueError is
+        preferable so the orchestrator can surface a recoverable error.
+        """
+        output = (
+            f"{self.SEP}\n"
+            "developer · claude-sonnet-4.6 · ◔ 3%\n"
+            " Ask a question or describe a task ↵\n"
+        )
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        provider._input_received = True
+
+        with pytest.raises(ValueError, match="No Kiro CLI response found"):
+            provider.extract_last_message_from_script(output)
+
+    def test_no_credits_extraction_without_input_received_raises(self):
+        """Without _input_received, no-credits path is skipped and ValueError raised.
+
+        Preserves the original error contract for callers that have not sent input.
+        """
+        output = self._tui_output("question", "response")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        # _input_received is False by default
+
+        with pytest.raises(ValueError, match="No Kiro CLI response found"):
+            provider.extract_last_message_from_script(output)
+
+    # -------------------------------------------------------------------------
+    # extraction_tail_lines regression guard
+    # -------------------------------------------------------------------------
+
+    def test_extraction_tail_lines_value(self):
+        """extraction_tail_lines must be 2000 to cover long no-credits responses."""
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        assert provider.extraction_tail_lines == 2000


### PR DESCRIPTION
Fixes #237

## Problem

When using Kiro CLI with a Q Developer Pro subscription, the `▸ Credits:` marker
is never emitted after a response completes — only `▸ Time:` is shown. CAO's
`get_status()` relies on this marker (Check 5) to detect turn completion in TUI
mode. Without it, `handoff()` calls poll indefinitely until the 600s timeout.

This affects all Q Developer Pro users using CAO with Kiro CLI in TUI mode.
Pay-per-use plans likely show `▸ Credits:` because there is an actual cost to
display. Q Developer Pro is unlimited so no credits are tracked or shown.

Confirmed via `/usage` in Kiro CLI:
- Plan: Q Developer Pro (managed by admin)
- Output after response: `▸ Time: 1s` only — no `▸ Credits:` line

## Root Cause

Two issues:

**1. Completion detection** — Check 5 requires `▸ Credits:` followed by the idle
prompt. Q Developer Pro never emits this line, so Check 5 never fires and
`get_status()` falls through to `return IDLE`, causing the handoff to poll forever.

**2. Response extraction** — `_extract_tui_message()` no-credits fallback searched
backward from the idle prompt for the nearest separator, found only the TUI frame
boundary (1-2 lines of header content), and fell through to last-resort which
returned the entire scrollback as garbage.

## Fix

**`_input_received` flag** — overrides `mark_input_received()` to track that a task
was sent. This distinguishes "idle at startup" from "idle after completing a task".

**Check 6 (get_status)** — once `_input_received` is True, the idle prompt alone
signals COMPLETED. Before any input is sent, the original separator+content check
applies to avoid false positives during TUI initialization.

**No-credits extraction** — when `_input_received` is True and no Credits marker is
present, finds TWO separators: `end_separator` (TUI frame before idle) and
`start_separator` (before that, bounding the response start). Extracts content
between them, strips header and user message echo.

**`extraction_tail_lines=2000`** — default 200 lines is insufficient for long
responses where the start separator scrolls out of the capture buffer.

All new behavior is gated on `_input_received` to preserve the original error
contract for callers when no input has been sent.

## Testing

- Tested with Kiro CLI 2.3.0 and Q Developer Pro subscription in TUI mode
- Handoff completes in ~39s (previously timed out at 600s)
- Classic mode (`--legacy-ui`) unaffected
- All 97 existing tests pass unchanged
