### PR TITLE
Docs/openclaw cao session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,18 @@ For the command reference and the agent-facing skill, see the [Session Managemen
 
 Because `cao session` is just shell commands, any AI assistant that supports shell-callable skills should be able to drive CAO this way — e.g. Claude Code, Kiro CLI, [OpenClaw](https://github.com/openclaw/openclaw), or [Hermes Agent](https://github.com/NousResearch/hermes-agent).
 
+### OpenClaw Integration
+
+[OpenClaw](https://github.com/openclaw/openclaw) is an open-source AI agent harness with a built-in `cao-session-management` skill that wraps the `cao` CLI. An OpenClaw agent translates plain-language requests into the right `cao launch`, `cao session status`, `cao session send`, or `cao shutdown` command, so you can drive CAO from any channel OpenClaw is connected to (Telegram, Discord, local TUI, etc.) without sitting at a terminal.
+
+Typical uses:
+
+- Launch and monitor headless CAO sessions from chat.
+- Stream conductor status and worker output back to chat instead of attaching to tmux.
+- Stop, restart, or kill stuck sessions remotely.
+
+For prerequisites, the full command reference, and common pitfalls, see [examples/assign/README.md — Managing CAO Sessions via OpenClaw](examples/assign/README.md#managing-cao-sessions-via-openclaw).
+
 ### CAO Ops MCP Server
 
 `cao-ops-mcp` exposes the same management operations as structured MCP tools for a primary agent (Claude Code, Claude Desktop, etc.). It is the MCP-flavoured equivalent of `cao session` — pick `cao-ops-mcp` when your caller speaks MCP, `cao session` otherwise.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Because `cao session` is just shell commands, any AI assistant that supports she
 
 ### OpenClaw Integration
 
-[OpenClaw](https://github.com/openclaw/openclaw) is an open-source AI agent harness with a built-in `cao-session-management` skill that wraps the `cao` CLI. An OpenClaw agent translates plain-language requests into the right `cao launch`, `cao session status`, `cao session send`, or `cao shutdown` command, so you can drive CAO from any channel OpenClaw is connected to (Telegram, Discord, local TUI, etc.) without sitting at a terminal.
+[OpenClaw](https://github.com/openclaw/openclaw) is an open-source AI agent harness that can drive CAO using the [`cao-session-management` skill](skills/cao-session-management/SKILL.md) shipped in this repo. Point an OpenClaw agent at the skill and it translates plain-language requests into the right `cao launch`, `cao session status`, `cao session send`, or `cao shutdown` command — so you can drive CAO from any channel OpenClaw is connected to (Telegram, Discord, local TUI, etc.) without sitting at a terminal.
 
 Typical uses:
 

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -332,11 +332,7 @@ The `cao-session-management` skill ships in this repo at [`skills/cao-session-ma
 
 ### Prerequisites
 
-- CAO installed on the same host. Recommended:
-  ```bash
-  uv tool install cli-agent-orchestrator
-  ```
-  Alternatives: `uvx --from git+https://github.com/awslabs/cli-agent-orchestrator.git@main cao`, or `pip install cli-agent-orchestrator`.
+- CAO installed on the same host with the `cao` binary on `PATH` — see [Installation](../../README.md#installation) in the root README.
 - OpenClaw installed and configured per its [setup docs](https://docs.openclaw.ai/start/wizard), with the OpenClaw agent's skills configuration pointing at this repo's `skills/cao-session-management/` directory. Refer to OpenClaw's documentation for the exact loader syntax.
 
 ### Start a Session

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -326,6 +326,86 @@ T=33s:  Supervisor receives all results, combines with template
 T=33s:  Present final report
 ```
 
+## Managing CAO Sessions via OpenClaw
+
+[OpenClaw](https://github.com/openclaw-ai/openclaw) ships a `cao-session-management` skill that lets an OpenClaw agent drive CAO sessions on your behalf from any connected chat channel (Telegram, Discord, etc.) or the local TUI. The skill wraps the `cao` CLI; the agent translates plain-language requests into the right command. Use this when you want to start, monitor, instruct, or shut down sessions without sitting at a terminal.
+
+### Prerequisites
+
+- OpenClaw installed and configured (`openclaw setup`).
+- CAO installed on the same host (`uvx --from git+https://github.com/awslabs/cli-agent-orchestrator.git@main cao` or `pip install cli-agent-orchestrator`).
+- Verify the skill is available:
+
+```bash
+openclaw skills | grep cao-session-management
+```
+
+The skill must show `✓ ready`.
+
+### Start a Session
+
+Ask OpenClaw to launch a session. The agent runs:
+
+```bash
+cao launch --agents <profile> --headless --yolo \
+  --session-name <name> --working-directory '<absolute-path>' "<task>"
+```
+
+Required flags when launched from an agent:
+- `--headless` so cao does not try to attach tmux interactively.
+- `--yolo` to skip confirmation prompts that would stall a non-interactive launch.
+- `--working-directory` must be an absolute path, single-quoted to block shell expansion of `~` or `$VARS` before the value reaches cao. A wrong path silently breaks the session.
+
+The launched session name is automatically prefixed with `cao-` (e.g. `--session-name triage` becomes `cao-triage`). All later commands use the prefixed form.
+
+Example chat instruction:
+> "Launch a CAO session called `triage` using the `analysis_supervisor` profile in `/home/me/data` to analyze datasets A, B, and C."
+
+### Check Session Status
+
+```bash
+cao session list                                  # active sessions
+cao session status cao-<name>                     # conductor status + last response
+cao session status cao-<name> --workers           # include worker terminals
+cao session status cao-<name> --terminal <id>     # drill into one terminal
+cao session status cao-<name> --json              # machine-readable; use to extract terminal IDs
+```
+
+Worker states reported include `IDLE`, `BUSY`, and `COMPLETED`. The JSON form is the reliable way to retrieve terminal IDs needed for direct sends.
+
+### Send Follow-Up Instructions
+
+```bash
+cao session send cao-<name> "<message>"                          # sync, waits for conductor to finish
+cao session send cao-<name> "<message>" --timeout N              # wait up to N seconds
+cao session send cao-<name> "<message>" --async                  # fire-and-forget
+cao session send cao-<name> "<message>" --terminal <worker-id>   # bypass conductor
+```
+
+Prefer routing through the conductor so it keeps full state of what was asked and answered. Bypass it only to unblock a stuck worker or to ask follow-ups of an `assign`-spawned worker that stays alive after completing its first task.
+
+### Stop a Session
+
+```bash
+cao shutdown --session cao-<name>
+```
+
+Gracefully shuts down the conductor and all worker terminals for one session and cleans up tmux records.
+
+### Kill All Sessions
+
+```bash
+cao shutdown --all
+```
+
+Tears down every active CAO session on the host. Use when sessions are orphaned, before a host reboot, or to reset state after a misconfigured launch.
+
+### Common Pitfalls
+
+- **Wrong `--working-directory`**: agents run but cannot find files; the only recovery is `cao shutdown --session ...` and relaunch with the correct path.
+- **Stuck conductor**: usually means a worker stopped responding. Run `cao session status cao-<name> --workers`, inspect the worker, and either prompt it to continue or ask it to resend results. Do not re-delegate work that may still be running.
+- **Prefix mismatch**: `launch` takes the un-prefixed name; `status`, `send`, and `shutdown --session` take the `cao-`-prefixed name.
+
 ## E2E Testing
 
 The `data_analyst` and `report_generator` profiles from this directory are used in the E2E test suite to validate assign and handoff flows across all providers (codex, claude_code, kiro_cli, kimi_cli, gemini_cli).

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -330,6 +330,8 @@ T=33s:  Present final report
 
 The `cao-session-management` skill ships in this repo at [`skills/cao-session-management/SKILL.md`](../../skills/cao-session-management/SKILL.md). Point an [OpenClaw](https://github.com/openclaw/openclaw) agent at it and the agent can drive CAO sessions on your behalf from any connected chat channel (Telegram, Discord, etc.) or the local TUI — translating plain-language requests into the right `cao` CLI invocations. Use this when you want to start, monitor, instruct, or shut down sessions without sitting at a terminal.
 
+> The basic commands shown below are an OpenClaw-flavored walkthrough. For the full command reference (all flags, status semantics, common mistakes), see [`skills/cao-session-management/SKILL.md`](../../skills/cao-session-management/SKILL.md). Related background: [docs/working-directory.md](../../docs/working-directory.md), [docs/terminal-lifecycle.md](../../docs/terminal-lifecycle.md), [docs/flows.md](../../docs/flows.md).
+
 ### Prerequisites
 
 - CAO installed on the same host with the `cao` binary on `PATH` — see [Installation](../../README.md#installation) in the root README.

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -343,13 +343,13 @@ Ask OpenClaw to launch a session. The agent runs:
 
 ```bash
 cao launch --agents <profile> --headless --yolo \
-  --session-name <name> --working-directory '<absolute-path>' "<task>"
+  --session-name <name> --working-directory <absolute-path> "<task>"
 ```
 
 Required flags when launched from an agent:
 - `--headless` so cao does not try to attach tmux interactively.
 - `--yolo` to skip confirmation prompts that would stall a non-interactive launch.
-- `--working-directory` must be absolute (cao rejects relative paths after canonicalization). `~` is fine — cao expands it server-side, so values like `~/projects/foo` work. Cao does **not** expand `$VARS`, so let the shell expand them (e.g. `"$HOME/projects/foo"`) or pass a fully resolved path. A wrong path silently breaks the session.
+- `--working-directory` should be an absolute path. Cao canonicalizes it (`abspath` + `realpath`), so a relative value silently resolves against the server's CWD — almost never what you want. Cao **does** expand `~` server-side (`~/projects/foo` works); it does **not** expand `$VARS`. If you need shell-style expansion, let the shell do it before the value reaches cao (use double quotes: `--working-directory "$HOME/projects/foo"`) or pre-resolve to a fully expanded absolute path. A wrong path silently breaks the session.
 
 The launched session name is automatically prefixed with `cao-` (e.g. `--session-name triage` becomes `cao-triage`). All later commands use the prefixed form.
 

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -328,7 +328,7 @@ T=33s:  Present final report
 
 ## Managing CAO Sessions via OpenClaw
 
-[OpenClaw](https://github.com/openclaw-ai/openclaw) ships a `cao-session-management` skill that lets an OpenClaw agent drive CAO sessions on your behalf from any connected chat channel (Telegram, Discord, etc.) or the local TUI. The skill wraps the `cao` CLI; the agent translates plain-language requests into the right command. Use this when you want to start, monitor, instruct, or shut down sessions without sitting at a terminal.
+[OpenClaw](https://github.com/openclaw/openclaw) ships a `cao-session-management` skill that lets an OpenClaw agent drive CAO sessions on your behalf from any connected chat channel (Telegram, Discord, etc.) or the local TUI. The skill wraps the `cao` CLI; the agent translates plain-language requests into the right command. Use this when you want to start, monitor, instruct, or shut down sessions without sitting at a terminal.
 
 ### Prerequisites
 

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -328,19 +328,16 @@ T=33s:  Present final report
 
 ## Managing CAO Sessions via OpenClaw
 
-[OpenClaw](https://github.com/openclaw/openclaw) ships a `cao-session-management` skill that lets an OpenClaw agent drive CAO sessions on your behalf from any connected chat channel (Telegram, Discord, etc.) or the local TUI. The skill wraps the `cao` CLI; the agent translates plain-language requests into the right command. Use this when you want to start, monitor, instruct, or shut down sessions without sitting at a terminal.
+The `cao-session-management` skill ships in this repo at [`skills/cao-session-management/SKILL.md`](../../skills/cao-session-management/SKILL.md). Point an [OpenClaw](https://github.com/openclaw/openclaw) agent at it and the agent can drive CAO sessions on your behalf from any connected chat channel (Telegram, Discord, etc.) or the local TUI — translating plain-language requests into the right `cao` CLI invocations. Use this when you want to start, monitor, instruct, or shut down sessions without sitting at a terminal.
 
 ### Prerequisites
 
-- OpenClaw installed and configured (`openclaw setup`).
-- CAO installed on the same host (`uvx --from git+https://github.com/awslabs/cli-agent-orchestrator.git@main cao` or `pip install cli-agent-orchestrator`).
-- Verify the skill is available:
-
-```bash
-openclaw skills | grep cao-session-management
-```
-
-The skill must show `✓ ready`.
+- CAO installed on the same host. Recommended:
+  ```bash
+  uv tool install cli-agent-orchestrator
+  ```
+  Alternatives: `uvx --from git+https://github.com/awslabs/cli-agent-orchestrator.git@main cao`, or `pip install cli-agent-orchestrator`.
+- OpenClaw installed and configured per its [setup docs](https://docs.openclaw.ai/start/wizard), with the OpenClaw agent's skills configuration pointing at this repo's `skills/cao-session-management/` directory. Refer to OpenClaw's documentation for the exact loader syntax.
 
 ### Start a Session
 
@@ -354,7 +351,7 @@ cao launch --agents <profile> --headless --yolo \
 Required flags when launched from an agent:
 - `--headless` so cao does not try to attach tmux interactively.
 - `--yolo` to skip confirmation prompts that would stall a non-interactive launch.
-- `--working-directory` must be an absolute path, single-quoted to block shell expansion of `~` or `$VARS` before the value reaches cao. A wrong path silently breaks the session.
+- `--working-directory` must be absolute (cao rejects relative paths after canonicalization). `~` is fine — cao expands it server-side, so values like `~/projects/foo` work. Cao does **not** expand `$VARS`, so let the shell expand them (e.g. `"$HOME/projects/foo"`) or pass a fully resolved path. A wrong path silently breaks the session.
 
 The launched session name is automatically prefixed with `cao-` (e.g. `--session-name triage` becomes `cao-triage`). All later commands use the prefixed form.
 
@@ -371,16 +368,18 @@ cao session status cao-<name> --terminal <id>     # drill into one terminal
 cao session status cao-<name> --json              # machine-readable; use to extract terminal IDs
 ```
 
-Worker states reported include `IDLE`, `BUSY`, and `COMPLETED`. The JSON form is the reliable way to retrieve terminal IDs needed for direct sends.
+Worker states are lowercase: `idle`, `processing`, `completed`, `waiting_user_answer`, `error`. The JSON form is the reliable way to retrieve terminal IDs needed for direct sends.
 
 ### Send Follow-Up Instructions
 
 ```bash
-cao session send cao-<name> "<message>"                          # sync, waits for conductor to finish
-cao session send cao-<name> "<message>" --timeout N              # wait up to N seconds
+cao session send cao-<name> "<message>"                          # sync, waits up to 300s (default)
+cao session send cao-<name> "<message>" --timeout N              # override timeout to N seconds
 cao session send cao-<name> "<message>" --async                  # fire-and-forget
 cao session send cao-<name> "<message>" --terminal <worker-id>   # bypass conductor
 ```
+
+If the timeout expires the agent is still running — re-check with `cao session status` later.
 
 Prefer routing through the conductor so it keeps full state of what was asked and answered. Bypass it only to unblock a stuck worker or to ask follow-ups of an `assign`-spawned worker that stays alive after completing its first task.
 

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -356,6 +356,8 @@ The launched session name is automatically prefixed with `cao-` (e.g. `--session
 Example chat instruction:
 > "Launch a CAO session called `triage` using the `analysis_supervisor` profile in `/home/me/data` to analyze datasets A, B, and C."
 
+> Full `cao launch` reference: [Session Management CLI](../../README.md#session-management-cli) and [`SKILL.md`](../../skills/cao-session-management/SKILL.md). Working-directory semantics: [docs/working-directory.md](../../docs/working-directory.md).
+
 ### Check Session Status
 
 ```bash
@@ -367,6 +369,8 @@ cao session status cao-<name> --json              # machine-readable; use to ext
 ```
 
 Worker states are lowercase: `idle`, `processing`, `completed`, `waiting_user_answer`, `error`. The JSON form is the reliable way to retrieve terminal IDs needed for direct sends.
+
+> Full status reference and state semantics: [`SKILL.md`](../../skills/cao-session-management/SKILL.md). Terminal state machine: [docs/terminal-lifecycle.md](../../docs/terminal-lifecycle.md).
 
 ### Send Follow-Up Instructions
 
@@ -380,6 +384,8 @@ cao session send cao-<name> "<message>" --terminal <worker-id>   # bypass conduc
 If the timeout expires the agent is still running — re-check with `cao session status` later.
 
 Prefer routing through the conductor so it keeps full state of what was asked and answered. Bypass it only to unblock a stuck worker or to ask follow-ups of an `assign`-spawned worker that stays alive after completing its first task.
+
+> Full `cao session send` reference and conductor/worker routing rules: [`SKILL.md`](../../skills/cao-session-management/SKILL.md).
 
 ### Stop a Session
 
@@ -396,6 +402,8 @@ cao shutdown --all
 ```
 
 Tears down every active CAO session on the host. Use when sessions are orphaned, before a host reboot, or to reset state after a misconfigured launch.
+
+> Full shutdown semantics and cleanup behavior (snapshots, restore): [docs/terminal-lifecycle.md](../../docs/terminal-lifecycle.md).
 
 ### Common Pitfalls
 


### PR DESCRIPTION
## Summary

Documents how to drive CAO sessions through an [OpenClaw](https://github.com/openclaw/openclaw) agent using the [`cao-session-management` skill](skills/cao-session-management/SKILL.md) that already ships in this repo. Until now there was no end-user documentation showing how to wire CAO up to an external agent harness.

- Adds an **OpenClaw Integration** section to the root `README.md` linking to the skill and the detailed guide.
- Adds a **Managing CAO Sessions via OpenClaw** section to `examples/assign/README.md` covering prerequisites, launch, status, send, shutdown, and common pitfalls.

## Why

OpenClaw can shell out to arbitrary CLIs, but several CAO behaviors are easy to get wrong on first contact and produce silent failures:

- The auto-prepended `cao-` session-name prefix (`launch` takes the un-prefixed name; `status` / `send` / `shutdown --session` take the prefixed form).
- The requirement to pass `--headless --yolo` for non-interactive launches.
- Single-quoting `--working-directory` to block premature shell expansion of `~` / `$VARS` — and the fact that cao itself does not expand `~` either, so the caller has to resolve it.
- The mismatch between sync-default `cao session send` (300s timeout) and `--async` / `--timeout N`.
- How to recover from a stuck conductor without re-delegating in-flight work.

Documenting these in one place reduces the failure surface for anyone wiring OpenClaw (or any other shell-driven harness) to CAO for the first time.

## What's documented

- **Prerequisites** — install path (`uv tool install cli-agent-orchestrator`), OpenClaw setup pointer, and the location of the `cao-session-management/` skill folder for OpenClaw's loader.
- **Start a Session** — `cao launch` invocation, required flags, working-directory quoting + `~`-expansion caveat, and `cao-` prefix behavior.
- **Check Session Status** — `cao session list` / `status` variants and when to use `--json` for terminal-ID extraction.
- **Send Follow-Up Instructions** — sync (300s default) vs `--timeout N` vs `--async`; conductor vs direct-to-worker routing.
- **Stop / Kill** — `cao shutdown --session <name>` vs `--all`.
- **Common Pitfalls** — wrong `--working-directory`, stuck conductor, prefix mismatch.

## Verification

- Every CLI command/flag was cross-checked against `cao --help`, `cao launch --help`, `cao session --help`, `cao session send --help`, and `cao shutdown --help` on `main`.
- The auto-prepended `cao-` prefix is verified at `src/cli_agent_orchestrator/services/terminal_service.py:125-127`.
- The `cao session send` 300s default is pinned at `src/cli_agent_orchestrator/cli/commands/session.py:16`.
- `--working-directory` is passed through verbatim (no server-side `~` expansion) — confirmed in `src/cli_agent_orchestrator/services/terminal_service.py:134`.

## Test plan

- [ ] Walk through the Start → Status → Send → Shutdown sequence with a real OpenClaw agent against a test CAO session.
- [ ] Verify the "Stuck conductor" recovery procedure on a real stuck session.
- [ ] Render both modified README files (GitHub markdown preview) and confirm internal links resolve.

## Out of scope

- The OpenClaw side (loader configuration, channel adapters) — covered in OpenClaw's own docs.
- New CAO functionality — this PR is documentation only.
