### PR TITLE
docs: add external tool integration guide for CAO skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Add `--async` to return immediately without waiting for completion.
 
 For the command reference and the agent-facing skill, see the [Session Management skill](skills/cao-session-management/SKILL.md).
 
-Because `cao session` is just shell commands, any AI assistant that supports shell-callable skills should be able to drive CAO this way — e.g. Claude Code, Kiro CLI, [OpenClaw](https://github.com/openclaw/openclaw), or [Hermes Agent](https://github.com/NousResearch/hermes-agent).
+Because `cao session` is just shell commands, any AI assistant that supports shell-callable skills should be able to drive CAO this way — e.g. Claude Code, Kiro CLI, [OpenClaw](https://github.com/openclaw/openclaw), or [Hermes Agent](https://github.com/NousResearch/hermes-agent). See [docs/external-tool-integration.md](docs/external-tool-integration.md) for integrating CAO session management into external tools.
 
 ### CAO Ops MCP Server
 
@@ -348,7 +348,7 @@ cao skills remove my-coding-standards
 
 Skills are delivered to providers automatically (native `skill://` resources for Kiro CLI; runtime prompt injection for Claude Code / Codex / Gemini / Kimi; baked-in `.agent.md` for Copilot).
 
-For the full reference — authoring, loading, delivery mechanics — see [docs/skills.md](docs/skills.md).
+For the full reference — authoring, loading, delivery mechanics — see [docs/skills.md](docs/skills.md). For integrating with OpenClaw or other external tools, see [docs/external-tool-integration.md](docs/external-tool-integration.md).
 
 ### Plugins
 

--- a/docs/external-tool-integration.md
+++ b/docs/external-tool-integration.md
@@ -1,0 +1,75 @@
+# External Tool Integration
+
+CAO skills follow the universal [SKILL.md](https://github.com/anthropics/skills) format. Any LLM harness that reads this format can consume CAO skills directly — no conversion needed.
+
+Any tool that loads SKILL.md files can consume these skills — [OpenClaw](https://github.com/openclaw/openclaw) is used as the example below, but the same approach works for any compatible harness.
+
+## What This Enables
+
+By adding the `cao-session-management` skill to an external tool, the agent in that tool can orchestrate CAO sessions via shell commands — launching supervisor agents, sending tasks, and collecting results without leaving its own chat loop.
+
+The agent can:
+
+- **Launch a CAO session** with a specific agent profile and initial task
+- **Send work synchronously** — block until the CAO agent completes and return results inline
+- **Send work asynchronously** — fire a task and continue, check back later for status
+- **Monitor sessions** — list active sessions, check worker status, retrieve output
+- **Shut down sessions** — clean up when done
+
+This turns any SKILL.md-compatible tool into an orchestration client for CAO's multi-agent system.
+
+## Prerequisites
+
+- CAO installed and initialized (`cao init`)
+- `cao-server` running (`cao-server`)
+- Target tool installed with a writable skill directory
+- Shared filesystem (symlinks require both on the same machine)
+
+## Setup
+
+### Option A: Symlink (recommended)
+
+```bash
+# Replace TARGET_SKILLS with your tool's skill directory
+TARGET_SKILLS=~/.openclaw/workspace/skills   # OpenClaw example
+mkdir -p "$TARGET_SKILLS"
+
+# Symlink the session management skill
+ln -sf ~/.aws/cli-agent-orchestrator/skills/cao-session-management \
+       "$TARGET_SKILLS/cao-session-management"
+```
+
+Symlinks stay in sync with CAO upgrades automatically.
+
+### Option B: Point your tool at CAO's skill directory
+
+Some tools can load skills from additional directories without copying or symlinking. For OpenClaw, add CAO's skill store as an extra skill root in `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  skills: {
+    load: {
+      extraDirs: ["~/.aws/cli-agent-orchestrator/skills"]
+    }
+  }
+}
+```
+
+This makes all CAO skills visible to OpenClaw agents with zero file operations.
+
+### Option C: Ask the agent to install it
+
+If the external tool's agent has filesystem access, tell it to install the skill directly:
+
+> Install the skill from ~/.aws/cli-agent-orchestrator/skills/cao-session-management into your skills directory
+
+The agent will read the SKILL.md, copy the folder into its own workspace, and make it available for future sessions.
+
+## Scope
+
+This gives the external agent **knowledge** of how to drive CAO via `cao session` shell commands. It does not add CAO as a live MCP server — the agent invokes shell commands, not MCP tools. If direct MCP access is needed, add `cao-ops-mcp-server` to the target tool's MCP configuration instead.
+
+## Related
+
+- [Skills reference](skills.md) — authoring, CLI commands, provider delivery
+- [Control Planes](control-planes.md) — choosing between CLI, MCP, and Web UI surfaces


### PR DESCRIPTION
 ## Summary

  - Adds `docs/openclaw.md` — guide for sharing CAO's `cao-session-management` skill with external LLM harnesses via symlink
  - Cross-references from README (Session Management CLI and Skills sections)

  ## Motivation

  CAO skills use the universal SKILL.md format. External tools like OpenClaw, Cursor, Strands SDK, and Microsoft Agent Framework can consume these skills directly. With the
  `cao-session-management` skill symlinked into their skill directory, agents in those tools can orchestrate CAO sessions (launch, send sync/async work, monitor, shutdown) via
  shell commands — without adding CAO as an MCP server dependency.

  ## Changes

  - `docs/openclaw.md` — new doc: prerequisites, setup (symlink command), scope clarification
  - `README.md` — two one-sentence cross-references to the new doc

  ## Test plan

  - [ ] Verify `docs/openclaw.md` renders correctly on GitHub
  - [ ] Verify README anchor links resolve to the new doc