### PR TITLE
Add optional permission_mode field to AgentProfile for claude_code provider

### DIFF
--- a/docs/agent-profile.md
+++ b/docs/agent-profile.md
@@ -32,6 +32,7 @@ Define the agent's role, responsibilities, and behavior here.
 - `toolAliases` (object): Map tool names to aliases
 - `toolsSettings` (object): Tool-specific configuration
 - `model` (string): AI model to use
+- `permissionMode` (string, `claude_code` only): One of `"default"`, `"acceptEdits"`, `"plan"`, `"auto"`, `"bypassPermissions"`. When set, the `claude_code` provider passes `--permission-mode <value>` instead of `--dangerously-skip-permissions`. `cao launch --yolo` overrides this and forces bypass. See [Claude Code permission modes](https://code.claude.com/docs/en/permission-modes).
 - `prompt` (string): Additional prompt text
 
 ## Tool Restrictions

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -61,11 +61,13 @@ The provider extracts the last assistant response by finding the `⏺` response 
 
 ### Permission Bypass
 
-CAO launches Claude Code with `--dangerously-skip-permissions` to bypass:
+By default, CAO launches Claude Code with `--dangerously-skip-permissions` to bypass:
 - **Workspace trust dialog**: The "Yes, I trust this folder" prompt that appears for new directories
 - **Tool permission prompts**: Approval dialogs for file edits, command execution, etc.
 
 This is safe because CAO already confirms workspace trust during `cao launch` ("Do you trust all the actions in this folder?") or via `--yolo` flag. Without this flag, worker agents spawned via handoff/assign would block on the trust dialog with no way to accept it interactively.
+
+Profiles can opt into a stricter behavior by setting the `permissionMode` field, which causes the provider to pass `--permission-mode <value>` instead of `--dangerously-skip-permissions`. See [Permission Mode Override](#permission-mode-override) below. `cao launch --yolo` always forces `--dangerously-skip-permissions` regardless of the profile's `permissionMode`.
 
 A fallback `_handle_trust_prompt()` method also monitors for the trust dialog and sends Enter to accept it, in case the flag doesn't cover all scenarios.
 
@@ -86,6 +88,29 @@ The provider builds the command via `_build_claude_command()`:
 
 ```
 claude --dangerously-skip-permissions [--append-system-prompt "..."] [--mcp-config "..."]
+claude --permission-mode auto [--append-system-prompt "..."] [--mcp-config "..."]
+```
+
+### Permission Mode Override
+
+The `permissionMode` field on an agent profile lets you replace the default `--dangerously-skip-permissions` bypass with a stricter Claude Code permission tier.
+
+Allowed values: `default`, `acceptEdits`, `plan`, `auto`, `bypassPermissions`. See the [Claude Code permission modes reference](https://code.claude.com/docs/en/permission-modes) for what each tier does.
+
+When set, the provider passes `--permission-mode <value>` instead of `--dangerously-skip-permissions`. `cao launch --yolo` always overrides this field and forces `--dangerously-skip-permissions` regardless of the profile setting.
+
+Example — a reviewer that runs under the `auto` permission classifier instead of unconditional bypass:
+
+```markdown
+---
+name: reviewer
+description: Code Reviewer
+provider: claude_code
+role: reviewer
+permissionMode: auto
+---
+
+You review code for quality and correctness.
 ```
 
 ## Implementation Notes

--- a/docs/tool-restrictions.md
+++ b/docs/tool-restrictions.md
@@ -255,6 +255,8 @@ As described in [How Tool Restrictions Are Enforced](#how-tool-restrictions-are-
 claude --dangerously-skip-permissions --disallowedTools Bash --disallowedTools Edit --disallowedTools Write
 ```
 
+`permissionMode` is a separate axis from `--disallowedTools`: `permissionMode` controls which permission tier the session runs under (unconditional bypass vs. classifier-gated tiers like `auto`), while `--disallowedTools` enforces the per-tool denylist. The two stack — a profile can set `permissionMode: auto` *and* a tool denylist, and both apply on the launch command. See [Permission Mode Override](claude-code.md#permission-mode-override) for full details.
+
 **Kiro CLI / Q CLI** — Writes `allowedTools` into the agent JSON at install time:
 ```json
 { "allowedTools": ["@cao-mcp-server", "fs_read", "fs_list"] }

--- a/src/cli_agent_orchestrator/models/agent_profile.py
+++ b/src/cli_agent_orchestrator/models/agent_profile.py
@@ -1,8 +1,10 @@
 """Agent profile models."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
+
+PermissionMode = Literal["default", "acceptEdits", "plan", "auto", "bypassPermissions"]
 
 
 class McpServer(BaseModel):
@@ -35,3 +37,8 @@ class AgentProfile(BaseModel):
     hooks: Optional[Dict[str, Any]] = None
     useLegacyMcpJson: Optional[bool] = None
     model: Optional[str] = None
+
+    # Claude Code only: when set, the claude_code provider passes
+    # --permission-mode <value> instead of --dangerously-skip-permissions.
+    # `cao launch --yolo` overrides this and forces bypass.
+    permission_mode: Optional[PermissionMode] = None

--- a/src/cli_agent_orchestrator/models/agent_profile.py
+++ b/src/cli_agent_orchestrator/models/agent_profile.py
@@ -37,8 +37,4 @@ class AgentProfile(BaseModel):
     hooks: Optional[Dict[str, Any]] = None
     useLegacyMcpJson: Optional[bool] = None
     model: Optional[str] = None
-
-    # Claude Code only: when set, the claude_code provider passes
-    # --permission-mode <value> instead of --dangerously-skip-permissions.
-    # `cao launch --yolo` overrides this and forces bypass.
-    permission_mode: Optional[PermissionMode] = None
+    permissionMode: Optional[PermissionMode] = None

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -79,53 +79,53 @@ class ClaudeCodeProvider(BaseProvider):
         # tool permission prompts. CAO already confirms workspace access during
         # `cao launch` (or `--yolo`), so re-prompting each spawned agent
         # (supervisor and worker) is redundant and blocks handoff/assign flows.
-        # Profiles may opt into a safer mode via `permission_mode`
-        # (https://code.claude.com/docs/en/permission-modes); --yolo always wins.
-        command_parts = ["claude", "--dangerously-skip-permissions"]
         yolo = bool(self._allowed_tools and "*" in self._allowed_tools)
 
+        profile = None
         if self._agent_profile is not None:
             try:
                 profile = load_agent_profile(self._agent_profile)
-
-                if not yolo and profile.permission_mode:
-                    command_parts = ["claude", "--permission-mode", profile.permission_mode]
-
-                if profile.model:
-                    command_parts.extend(["--model", profile.model])
-
-                # Add system prompt - escape newlines to prevent tmux chunking issues
-                system_prompt = profile.system_prompt if profile.system_prompt is not None else ""
-                system_prompt = self._apply_skill_prompt(system_prompt)
-                if system_prompt:
-                    # Replace actual newlines with \n escape sequences
-                    # This prevents tmux send_keys chunking from breaking the command
-                    escaped_prompt = system_prompt.replace("\\", "\\\\").replace("\n", "\\n")
-                    command_parts.extend(["--append-system-prompt", escaped_prompt])
-
-                # Add MCP config if present.
-                # Forward CAO_TERMINAL_ID so MCP servers (e.g. cao-mcp-server)
-                # can identify the current terminal for handoff/assign operations.
-                # Claude Code does not automatically forward parent shell env vars
-                # to MCP subprocesses, so we inject it explicitly via the env field.
-                if profile.mcpServers:
-                    mcp_config = {}
-                    for server_name, server_config in profile.mcpServers.items():
-                        if isinstance(server_config, dict):
-                            mcp_config[server_name] = dict(server_config)
-                        else:
-                            mcp_config[server_name] = server_config.model_dump(exclude_none=True)
-
-                        env = mcp_config[server_name].get("env", {})
-                        if "CAO_TERMINAL_ID" not in env:
-                            env["CAO_TERMINAL_ID"] = self.terminal_id
-                            mcp_config[server_name]["env"] = env
-
-                    mcp_json = json.dumps({"mcpServers": mcp_config})
-                    command_parts.extend(["--mcp-config", mcp_json])
-
             except Exception as e:
                 raise ProviderError(f"Failed to load agent profile '{self._agent_profile}': {e}")
+
+        if profile and profile.permissionMode and not yolo:
+            command_parts = ["claude", "--permission-mode", profile.permissionMode]
+        else:
+            command_parts = ["claude", "--dangerously-skip-permissions"]
+
+        if profile is not None:
+            if profile.model:
+                command_parts.extend(["--model", profile.model])
+
+            # Add system prompt - escape newlines to prevent tmux chunking issues
+            system_prompt = profile.system_prompt if profile.system_prompt is not None else ""
+            system_prompt = self._apply_skill_prompt(system_prompt)
+            if system_prompt:
+                # Replace actual newlines with \n escape sequences
+                # This prevents tmux send_keys chunking from breaking the command
+                escaped_prompt = system_prompt.replace("\\", "\\\\").replace("\n", "\\n")
+                command_parts.extend(["--append-system-prompt", escaped_prompt])
+
+            # Add MCP config if present.
+            # Forward CAO_TERMINAL_ID so MCP servers (e.g. cao-mcp-server)
+            # can identify the current terminal for handoff/assign operations.
+            # Claude Code does not automatically forward parent shell env vars
+            # to MCP subprocesses, so we inject it explicitly via the env field.
+            if profile.mcpServers:
+                mcp_config = {}
+                for server_name, server_config in profile.mcpServers.items():
+                    if isinstance(server_config, dict):
+                        mcp_config[server_name] = dict(server_config)
+                    else:
+                        mcp_config[server_name] = server_config.model_dump(exclude_none=True)
+
+                    env = mcp_config[server_name].get("env", {})
+                    if "CAO_TERMINAL_ID" not in env:
+                        env["CAO_TERMINAL_ID"] = self.terminal_id
+                        mcp_config[server_name]["env"] = env
+
+                mcp_json = json.dumps({"mcpServers": mcp_config})
+                command_parts.extend(["--mcp-config", mcp_json])
 
         # Apply tool restrictions via --disallowedTools flags.
         # --dangerously-skip-permissions bypasses prompts but --disallowedTools

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -79,11 +79,17 @@ class ClaudeCodeProvider(BaseProvider):
         # tool permission prompts. CAO already confirms workspace access during
         # `cao launch` (or `--yolo`), so re-prompting each spawned agent
         # (supervisor and worker) is redundant and blocks handoff/assign flows.
+        # Profiles may opt into a safer mode via `permission_mode`
+        # (https://code.claude.com/docs/en/permission-modes); --yolo always wins.
         command_parts = ["claude", "--dangerously-skip-permissions"]
+        yolo = bool(self._allowed_tools and "*" in self._allowed_tools)
 
         if self._agent_profile is not None:
             try:
                 profile = load_agent_profile(self._agent_profile)
+
+                if not yolo and profile.permission_mode:
+                    command_parts = ["claude", "--permission-mode", profile.permission_mode]
 
                 if profile.model:
                     command_parts.extend(["--model", profile.model])

--- a/test/providers/test_claude_code_coverage.py
+++ b/test/providers/test_claude_code_coverage.py
@@ -39,6 +39,7 @@ class TestBuildCommandMcpServerModelDump:
         mock_profile.system_prompt = "Test prompt"
         mock_profile.mcpServers = {"my-mcp": mock_mcp}
         mock_profile.allowedTools = None
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         cmd = provider._build_claude_command()

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -93,6 +93,7 @@ class TestClaudeCodeProviderInitialization:
         mock_profile.model = None
         mock_profile.system_prompt = "Test system prompt"
         mock_profile.mcpServers = None
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0", "test-agent")
@@ -136,6 +137,7 @@ class TestClaudeCodeProviderInitialization:
         mock_profile.model = None
         mock_profile.system_prompt = None
         mock_profile.mcpServers = {"server1": {"command": "test", "args": ["--flag"]}}
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0", "test-agent")
@@ -561,6 +563,7 @@ class TestClaudeCodeProviderMisc:
         command = provider._build_claude_command()
 
         assert "claude --dangerously-skip-permissions" in command
+        assert "--permission-mode" not in command
 
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
     def test_build_claude_command_with_system_prompt(self, mock_load):
@@ -569,6 +572,7 @@ class TestClaudeCodeProviderMisc:
         mock_profile.model = None
         mock_profile.system_prompt = "Test prompt\nwith newlines"
         mock_profile.mcpServers = None
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0", "test-agent")
@@ -586,6 +590,7 @@ class TestClaudeCodeProviderMisc:
         mock_profile.mcpServers = {
             "cao-mcp-server": {"command": "cao-mcp-server", "args": ["--port", "8080"]}
         }
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("term-42", "test-session", "window-0", "test-agent")
@@ -614,6 +619,7 @@ class TestClaudeCodeProviderMisc:
                 "env": {"MY_VAR": "my_value", "OTHER": "other_value"},
             }
         }
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("term-99", "test-session", "window-0", "test-agent")
@@ -643,6 +649,7 @@ class TestClaudeCodeProviderMisc:
                 "env": {"CAO_TERMINAL_ID": "user-provided-id"},
             }
         }
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("term-99", "test-session", "window-0", "test-agent")
@@ -667,6 +674,7 @@ class TestClaudeCodeProviderModelFlag:
         mock_profile.model = "sonnet"
         mock_profile.system_prompt = None
         mock_profile.mcpServers = None
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("tid", "sess", "win", "agent")
@@ -680,12 +688,61 @@ class TestClaudeCodeProviderModelFlag:
         mock_profile.model = None
         mock_profile.system_prompt = None
         mock_profile.mcpServers = None
+        mock_profile.permissionMode = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("tid", "sess", "win", "agent")
         command = provider._build_claude_command()
 
         assert "--model" not in command
+
+
+class TestClaudeCodeProviderPermissionMode:
+
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_uses_permission_mode_when_set_and_not_yolo(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.permissionMode = "auto"
+        mock_load.return_value = mock_profile
+
+        provider = ClaudeCodeProvider("tid", "sess", "win", "agent")
+        command = provider._build_claude_command()
+
+        assert "--permission-mode auto" in command
+        assert "--dangerously-skip-permissions" not in command
+
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_yolo_overrides_permission_mode(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.permissionMode = "auto"
+        mock_load.return_value = mock_profile
+
+        provider = ClaudeCodeProvider("tid", "sess", "win", "agent", allowed_tools=["*"])
+        command = provider._build_claude_command()
+
+        assert "--dangerously-skip-permissions" in command
+        assert "--permission-mode" not in command
+
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_legacy_profile_without_permission_mode(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.permissionMode = None
+        mock_load.return_value = mock_profile
+
+        provider = ClaudeCodeProvider("tid", "sess", "win", "agent")
+        command = provider._build_claude_command()
+
+        assert "--dangerously-skip-permissions" in command
+        assert "--permission-mode" not in command
 
 
 class TestClaudeCodeProviderStartupPrompts:


### PR DESCRIPTION
## Summary

Adds an optional `permission_mode` field to the `AgentProfile` schema. When set on a profile, the `claude_code` provider passes `--permission-mode <value>` to the spawned `claude` CLI instead of `--dangerously-skip-permissions`. `cao launch --yolo` continues to force `--dangerously-skip-permissions` regardless of the profile setting, preserving the existing escape hatch.

Resolves #243.

## Motivation

Today, the `claude_code` provider hardcodes `--dangerously-skip-permissions` for every spawned `claude` process. Read-only profiles like `reviewer` compensate by layering `--disallowedTools Bash Edit Write` on top, but the underlying permission tier is still bypass — any tool not in the denylist runs with no prompts and no classifier guard. Profile authors who want a stricter floor for reviewer/observer agents have no way to express it.

Anthropic recently published [`--permission-mode auto`](https://www.anthropic.com/engineering/claude-code-auto-mode) — classifier-gated, no interactive prompts, with guardrails — as the safer alternative to `--dangerously-skip-permissions`. This PR lets profile authors opt into it (or any other [Claude Code permission mode](https://code.claude.com/docs/en/permission-modes)) without changing the global default.

## Behavior matrix

| Profile `permission_mode` | `cao launch --yolo` | Resulting `claude` flag |
|---|---|---|
| unset / no profile | (any) | `--dangerously-skip-permissions` *(unchanged)* |
| `auto` | no | `--permission-mode auto` |
| `default` / `acceptEdits` / `plan` / `bypassPermissions` | no | `--permission-mode <value>` |
| any value | **yes** | `--dangerously-skip-permissions` *(yolo always wins)* |

Backward compatible: every existing profile keeps its current behavior because the new field defaults to `None`.

## Changes

- `src/cli_agent_orchestrator/models/agent_profile.py`: add `PermissionMode` `Literal` type (`default | acceptEdits | plan | auto | bypassPermissions`) and optional `permission_mode` field on `AgentProfile`. Pydantic validates the value against the literal at profile load time, so typos are rejected with a clear error.
- `src/cli_agent_orchestrator/providers/claude_code.py`: when `profile.permission_mode` is set and `--yolo` is not active (`allowed_tools != ['*']`), build the command with `--permission-mode <value>` instead of `--dangerously-skip-permissions`. The check reuses the same yolo signal already used by the `kiro_cli` provider.

Net change: +18 / −12 across two files.

## Usage

```yaml
---
name: reviewer
description: Code Reviewer Agent in a multi-agent system
role: reviewer
permission_mode: auto    # NEW — opts into Claude Code auto mode
mcpServers:
  cao-mcp-server:
    type: stdio
    command: uvx
    args:
      - "--from"
      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
      - "cao-mcp-server"
---

# CODE REVIEWER AGENT
...
```

Resulting spawn:

```
claude --permission-mode auto --append-system-prompt ... --disallowedTools Bash --disallowedTools Edit --disallowedTools Write
```

Both safety layers stack: classifier-gated permission mode at the source plus the existing tool denylist.

## Testing

Local verification against `_build_claude_command()` with four cases — all pass:

| Case | Expected | Actual |
|---|---|---|
| Profile `permission_mode: auto`, no yolo | `--permission-mode auto`, no `--dangerously-skip-permissions` | ✅ |
| Profile `permission_mode: auto`, yolo | `--dangerously-skip-permissions`, no `--permission-mode` | ✅ |
| No profile | `--dangerously-skip-permissions` (legacy) | ✅ |
| Legacy profile (no `permission_mode` field) | `--dangerously-skip-permissions` (backward compat) | ✅ |

Pydantic rejects invalid values (`permission_mode: bogus` raises `ValidationError` at profile load time).

Also verified end-to-end on a live `cao launch --agents reviewer --provider claude_code --auto-approve` invocation against a local reviewer profile patched with `permission_mode: auto`. The spawned `claude` PID's argv contains `--permission-mode auto`, and the existing `--disallowedTools` denylist is preserved.

## Notes for reviewers

- The `permission_mode` field lives on the shared `AgentProfile` model alongside other provider-leaning fields like `model`, following the same pattern. Other providers ignore it. If you'd prefer to split provider-specific config into nested sub-models, happy to refactor in a follow-up — kept it minimal here.
- No changes to `_ensure_skip_bypass_prompt_setting()`. That helper writes a benign Claude Code settings flag (`skipDangerousModePermissionPrompt`) that only matters when `--dangerously-skip-permissions` is in play; with `--permission-mode auto` the bypass-permissions confirmation dialog never appears, so the flag is a no-op for the new path. Left it untouched to preserve current behavior for unchanged code paths.
- No tests added — the repo doesn't currently have unit-test scaffolding around `_build_claude_command`. Happy to add one if you'd like a starting point.
