### PR TITLE
Add optional codexProfile field to AgentProfile for codex provider

### DIFF
--- a/docs/codex-cli.md
+++ b/docs/codex-cli.md
@@ -101,13 +101,13 @@ The Codex provider automatically adds these flags for tmux compatibility:
 - `--no-alt-screen`: Runs Codex in inline mode so output stays in normal scrollback, making `tmux capture-pane` reliable
 - `--disable shell_snapshot`: Prevents TTY input conflicts (SIGTTIN) caused by the shell_snapshot subprocess inheriting stdin in tmux
 
-By default, CAO also passes `--yolo` (alias for `--dangerously-bypass-approvals-and-sandbox`) because CAO agents run in non-interactive tmux sessions where approval prompts block handoff/assign flows. Profiles can opt out via `codexProfile`; see [Custom Codex Profile](#custom-codex-profile). `cao launch --yolo` always forces `--yolo` regardless of the profile setting.
+By default, CAO also passes `--yolo` (alias for `--dangerously-bypass-approvals-and-sandbox`) because CAO agents run in non-interactive tmux sessions where approval prompts block handoff/assign flows. Profiles can opt out via `codexProfile`; see [Custom Codex Profile](#custom-codex-profile). Any unrestricted allowed-tools configuration (`allowedTools: ["*"]`, `--allowed-tools '*'`, or `cao launch --yolo`) forces `--yolo` regardless of the profile setting.
 
 ### Custom Codex Profile
 
-The `codexProfile` field on an agent profile names a `[profiles.<name>]` block in your `~/.codex/config.toml`. When set, CAO drops `--yolo` and passes `--profile <name>` instead, letting the user's named profile govern sandbox and approval behavior. `cao launch --yolo` overrides this field and always forces `--yolo`.
+The `codexProfile` field on an agent profile names a `[profiles.<name>]` block in your `~/.codex/config.toml`. When set, CAO drops `--yolo` and passes `--profile <name>` instead, letting the user's named profile govern sandbox and approval behavior. Unrestricted allowed tools (`allowedTools: ["*"]`, `--allowed-tools '*'`, or `cao launch --yolo`) override this field and always force `--yolo`.
 
-**Important — non-interactive only**: CAO's status detector cannot interact with Codex's current boxed approval UI (`Command Approval Required / [a] Accept / [d] Decline`). Any `codexProfile` you reference MUST resolve to a non-interactive permission tier, or CAO sessions will time out waiting for input nothing can deliver. Safe shapes:
+**Important — non-interactive only**: CAO's status detector cannot interact with Codex's current boxed approval UI (`Command Approval Required / [a] Accept / [d] Decline`). Any `codexProfile` you reference MUST resolve to a non-interactive permission tier, or CAO sessions will time out waiting for input that nothing can deliver. Safe shapes:
 
 - **Read-only / audit agents**: `approval_policy = "never"` + `sandbox_mode = "read-only"` — write/network/escape attempts fail closed and return errors to the model.
 - **Write-permitted agents**: `approval_policy = "never"` + `sandbox_mode = "workspace-write"` — writes inside the workspace proceed; sandbox escapes fail closed.

--- a/docs/codex-cli.md
+++ b/docs/codex-cli.md
@@ -101,6 +101,42 @@ The Codex provider automatically adds these flags for tmux compatibility:
 - `--no-alt-screen`: Runs Codex in inline mode so output stays in normal scrollback, making `tmux capture-pane` reliable
 - `--disable shell_snapshot`: Prevents TTY input conflicts (SIGTTIN) caused by the shell_snapshot subprocess inheriting stdin in tmux
 
+By default, CAO also passes `--yolo` (alias for `--dangerously-bypass-approvals-and-sandbox`) because CAO agents run in non-interactive tmux sessions where approval prompts block handoff/assign flows. Profiles can opt out via `codexProfile`; see [Custom Codex Profile](#custom-codex-profile). `cao launch --yolo` always forces `--yolo` regardless of the profile setting.
+
+### Custom Codex Profile
+
+The `codexProfile` field on an agent profile names a `[profiles.<name>]` block in your `~/.codex/config.toml`. When set, CAO drops `--yolo` and passes `--profile <name>` instead, letting the user's named profile govern sandbox and approval behavior. `cao launch --yolo` overrides this field and always forces `--yolo`.
+
+**Important — non-interactive only**: CAO's status detector cannot interact with Codex's current boxed approval UI (`Command Approval Required / [a] Accept / [d] Decline`). Any `codexProfile` you reference MUST resolve to a non-interactive permission tier, or CAO sessions will time out waiting for input nothing can deliver. Safe shapes:
+
+- **Read-only / audit agents**: `approval_policy = "never"` + `sandbox_mode = "read-only"` — write/network/escape attempts fail closed and return errors to the model.
+- **Write-permitted agents**: `approval_policy = "never"` + `sandbox_mode = "workspace-write"` — writes inside the workspace proceed; sandbox escapes fail closed.
+- **Smart Approvals (classifier-gated)**: `approval_policy = "on-request"` + `sandbox_mode = "workspace-write"` + `approvals_reviewer = "auto_review"` — the auto-review classifier decides escalations; denials fail closed without prompting.
+
+Avoid `approval_policy = "untrusted"` or `approval_policy = "on-request"` without `approvals_reviewer = "auto_review"` — those tiers prompt the user, which CAO cannot answer.
+
+Example — a reviewer that runs under Codex's read-only sandbox:
+
+```markdown
+---
+name: reviewer
+description: Code Reviewer
+provider: codex
+role: reviewer
+codexProfile: cao_reviewer
+---
+
+You review code for quality and correctness.
+```
+
+Matching `~/.codex/config.toml`:
+
+```toml
+[profiles.cao_reviewer]
+sandbox_mode = "read-only"
+approval_policy = "never"
+```
+
 ## Workflows
 
 ### 1. Interactive single-agent task

--- a/src/cli_agent_orchestrator/models/agent_profile.py
+++ b/src/cli_agent_orchestrator/models/agent_profile.py
@@ -39,8 +39,9 @@ class AgentProfile(BaseModel):
     model: Optional[str] = None
     permissionMode: Optional[PermissionMode] = None
 
-    # Codex-only. Names a [profiles.<name>] block in ~/.codex/config.toml;
-    # passed as --profile <name> instead of --yolo. min_length=1 prevents
-    # an explicit empty string from silently degrading to --yolo, since
-    # this is a permission-floor knob.
+    # Codex-only. Names a [profiles.<name>] block in ~/.codex/config.toml.
+    # Used as --profile <name> when yolo mode is not active; unrestricted
+    # allowed tools still force --yolo. min_length=1 prevents an explicit
+    # empty string from silently degrading to --yolo, since this is a
+    # permission-floor knob.
     codexProfile: Optional[str] = Field(default=None, min_length=1)

--- a/src/cli_agent_orchestrator/models/agent_profile.py
+++ b/src/cli_agent_orchestrator/models/agent_profile.py
@@ -38,3 +38,9 @@ class AgentProfile(BaseModel):
     useLegacyMcpJson: Optional[bool] = None
     model: Optional[str] = None
     permissionMode: Optional[PermissionMode] = None
+
+    # Codex-only. Names a [profiles.<name>] block in ~/.codex/config.toml;
+    # passed as --profile <name> instead of --yolo. min_length=1 prevents
+    # an explicit empty string from silently degrading to --yolo, since
+    # this is a permission-floor knob.
+    codexProfile: Optional[str] = Field(default=None, min_length=1)

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -137,7 +137,9 @@ class CodexProvider(BaseProvider):
         # is the default because CAO runs codex non-interactively in tmux
         # where approval prompts would block handoff/assign. Profiles can
         # opt out via `codexProfile` (names a [profiles.<name>] block in
-        # ~/.codex/config.toml); `cao launch --yolo` always wins.
+        # ~/.codex/config.toml), unless unrestricted allowed tools are enabled.
+        # In practice, allowed_tools containing "*" is treated as yolo mode
+        # and overrides codexProfile in the same way as an explicit yolo launch.
         yolo = bool(self._allowed_tools and "*" in self._allowed_tools)
 
         profile = None

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -133,82 +133,89 @@ class CodexProvider(BaseProvider):
         Returns properly escaped shell command string that can be safely sent via tmux.
         Uses codex's -c developer_instructions flag to inject agent system prompts.
         """
-        # --yolo (alias for --dangerously-bypass-approvals-and-sandbox):
-        # bypass approval prompts and sandboxing. CAO agents run in
-        # non-interactive tmux sessions where interactive approval prompts
-        # block handoff/assign flows. This mirrors Claude Code's
-        # --dangerously-skip-permissions and Gemini CLI's --yolo flags.
-        command_parts = ["codex", "--yolo", "--no-alt-screen", "--disable", "shell_snapshot"]
+        # --yolo (alias for --dangerously-bypass-approvals-and-sandbox)
+        # is the default because CAO runs codex non-interactively in tmux
+        # where approval prompts would block handoff/assign. Profiles can
+        # opt out via `codexProfile` (names a [profiles.<name>] block in
+        # ~/.codex/config.toml); `cao launch --yolo` always wins.
+        yolo = bool(self._allowed_tools and "*" in self._allowed_tools)
 
+        profile = None
         if self._agent_profile is not None:
             try:
                 profile = load_agent_profile(self._agent_profile)
-
-                if profile.model:
-                    command_parts.extend(["--model", profile.model])
-
-                system_prompt = profile.system_prompt if profile.system_prompt is not None else ""
-                system_prompt = self._apply_skill_prompt(system_prompt)
-
-                # Prepend security constraints for soft enforcement (Codex has no
-                # native tool restriction mechanism). Only applied when tool
-                # restrictions are active (not unrestricted "*").
-                if self._allowed_tools and "*" not in self._allowed_tools:
-                    from cli_agent_orchestrator.constants import SECURITY_PROMPT
-
-                    tools_list = ", ".join(self._allowed_tools)
-                    tool_constraint = f"\nYou only have access to these tools: {tools_list}\n"
-                    system_prompt = SECURITY_PROMPT + tool_constraint + system_prompt
-
-                if system_prompt:
-                    # Codex accepts developer_instructions via -c config override.
-                    # This is injected as a developer role message before AGENTS.md content.
-                    # Escape backslashes, double quotes, and newlines for TOML basic string.
-                    # Newlines must become literal \n to prevent tmux send_keys from
-                    # splitting the command across multiple lines.
-                    escaped_prompt = (
-                        system_prompt.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
-                    )
-                    command_parts.extend(["-c", f'developer_instructions="{escaped_prompt}"'])
-
-                # Add MCP servers via -c config overrides (per-session, no global config changes).
-                # Each server field is set via dotted path: mcp_servers.<name>.<field>=<value>
-                if profile.mcpServers:
-                    for server_name, server_config in profile.mcpServers.items():
-                        prefix = f"mcp_servers.{server_name}"
-                        if isinstance(server_config, dict):
-                            cfg = server_config
-                        else:
-                            cfg = server_config.model_dump(exclude_none=True)
-                        if "command" in cfg:
-                            command_parts.extend(["-c", f'{prefix}.command="{cfg["command"]}"'])
-                        if "args" in cfg:
-                            args_toml = "[" + ", ".join(f'"{a}"' for a in cfg["args"]) + "]"
-                            command_parts.extend(["-c", f"{prefix}.args={args_toml}"])
-                        if "env" in cfg and cfg["env"]:
-                            for env_key, env_val in cfg["env"].items():
-                                command_parts.extend(["-c", f'{prefix}.env.{env_key}="{env_val}"'])
-                        # Forward CAO_TERMINAL_ID so MCP servers (e.g. cao-mcp-server)
-                        # can identify the current session for handoff/assign operations.
-                        # Codex does not forward env vars to MCP subprocesses by default;
-                        # env_vars lists names to inherit from the parent shell environment.
-                        env_vars = cfg.get("env_vars", [])
-                        if "CAO_TERMINAL_ID" not in env_vars:
-                            env_vars = list(env_vars) + ["CAO_TERMINAL_ID"]
-                        env_vars_toml = "[" + ", ".join(f'"{v}"' for v in env_vars) + "]"
-                        command_parts.extend(["-c", f"{prefix}.env_vars={env_vars_toml}"])
-                        # Set a generous tool timeout for MCP calls like handoff, which
-                        # create a new terminal, initialize the provider, send a message,
-                        # wait for the agent to complete, and extract the output.
-                        # Codex defaults to 60s which is too short for multi-step operations.
-                        # Value MUST be a TOML float (600.0, not 600) because Codex
-                        # deserializes tool_timeout_sec via Option<f64>; a TOML integer
-                        # is silently rejected and falls back to the 60s default.
-                        if "tool_timeout_sec" not in cfg:
-                            command_parts.extend(["-c", f"{prefix}.tool_timeout_sec=600.0"])
-
             except Exception as e:
                 raise ProviderError(f"Failed to load agent profile '{self._agent_profile}': {e}")
+
+        if profile and profile.codexProfile and not yolo:
+            command_parts = ["codex", "--profile", profile.codexProfile]
+        else:
+            command_parts = ["codex", "--yolo"]
+        command_parts.extend(["--no-alt-screen", "--disable", "shell_snapshot"])
+
+        if profile is not None:
+            if profile.model:
+                command_parts.extend(["--model", profile.model])
+
+            system_prompt = profile.system_prompt if profile.system_prompt is not None else ""
+            system_prompt = self._apply_skill_prompt(system_prompt)
+
+            # Prepend security constraints for soft enforcement (Codex has no
+            # native tool restriction mechanism). Only applied when tool
+            # restrictions are active (not unrestricted "*").
+            if self._allowed_tools and "*" not in self._allowed_tools:
+                from cli_agent_orchestrator.constants import SECURITY_PROMPT
+
+                tools_list = ", ".join(self._allowed_tools)
+                tool_constraint = f"\nYou only have access to these tools: {tools_list}\n"
+                system_prompt = SECURITY_PROMPT + tool_constraint + system_prompt
+
+            if system_prompt:
+                # Codex accepts developer_instructions via -c config override.
+                # This is injected as a developer role message before AGENTS.md content.
+                # Escape backslashes, double quotes, and newlines for TOML basic string.
+                # Newlines must become literal \n to prevent tmux send_keys from
+                # splitting the command across multiple lines.
+                escaped_prompt = (
+                    system_prompt.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+                )
+                command_parts.extend(["-c", f'developer_instructions="{escaped_prompt}"'])
+
+            # Add MCP servers via -c config overrides (per-session, no global config changes).
+            # Each server field is set via dotted path: mcp_servers.<name>.<field>=<value>
+            if profile.mcpServers:
+                for server_name, server_config in profile.mcpServers.items():
+                    prefix = f"mcp_servers.{server_name}"
+                    if isinstance(server_config, dict):
+                        cfg = server_config
+                    else:
+                        cfg = server_config.model_dump(exclude_none=True)
+                    if "command" in cfg:
+                        command_parts.extend(["-c", f'{prefix}.command="{cfg["command"]}"'])
+                    if "args" in cfg:
+                        args_toml = "[" + ", ".join(f'"{a}"' for a in cfg["args"]) + "]"
+                        command_parts.extend(["-c", f"{prefix}.args={args_toml}"])
+                    if "env" in cfg and cfg["env"]:
+                        for env_key, env_val in cfg["env"].items():
+                            command_parts.extend(["-c", f'{prefix}.env.{env_key}="{env_val}"'])
+                    # Forward CAO_TERMINAL_ID so MCP servers (e.g. cao-mcp-server)
+                    # can identify the current session for handoff/assign operations.
+                    # Codex does not forward env vars to MCP subprocesses by default;
+                    # env_vars lists names to inherit from the parent shell environment.
+                    env_vars = cfg.get("env_vars", [])
+                    if "CAO_TERMINAL_ID" not in env_vars:
+                        env_vars = list(env_vars) + ["CAO_TERMINAL_ID"]
+                    env_vars_toml = "[" + ", ".join(f'"{v}"' for v in env_vars) + "]"
+                    command_parts.extend(["-c", f"{prefix}.env_vars={env_vars_toml}"])
+                    # Set a generous tool timeout for MCP calls like handoff, which
+                    # create a new terminal, initialize the provider, send a message,
+                    # wait for the agent to complete, and extract the output.
+                    # Codex defaults to 60s which is too short for multi-step operations.
+                    # Value MUST be a TOML float (600.0, not 600) because Codex
+                    # deserializes tool_timeout_sec via Option<f64>; a TOML integer
+                    # is silently rejected and falls back to the 60s default.
+                    if "tool_timeout_sec" not in cfg:
+                        command_parts.extend(["-c", f"{prefix}.tool_timeout_sec=600.0"])
 
         return shlex.join(command_parts)
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -315,6 +315,58 @@ class TestCodexProviderModelFlag:
         assert "--model" not in command
 
 
+class TestCodexBuildCommandExtra:
+    """Coverage for branches inside ``_build_codex_command`` that the
+    pre-existing fixtures didn't exercise."""
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_security_prompt_prepended_when_tools_restricted(self, mock_load):
+        # When ``allowed_tools`` is a restricted set (no "*"), the provider
+        # prepends SECURITY_PROMPT plus a "You only have access to these
+        # tools:" hint to the developer_instructions payload.
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = "Original system prompt."
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider(
+            "tid", "sess", "win", "agent", allowed_tools=["fs_read", "fs_list"]
+        )
+        command = provider._build_codex_command()
+
+        assert "You only have access to these tools: fs_read, fs_list" in command
+        assert "Original system prompt." in command
+        # SECURITY_PROMPT lives in constants; assert on a stable substring
+        # rather than importing the constant into the test fixture.
+        assert "NEVER" in command  # "NEVER read/output: ~/.aws/credentials..."
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_mcp_server_accepts_model_instance(self, mock_load):
+        # mcpServers values may arrive as McpServer model instances (not
+        # dicts) when loaded via Pydantic; the provider falls back to
+        # ``model_dump(exclude_none=True)`` for that path.
+        from cli_agent_orchestrator.models.agent_profile import McpServer
+
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = ""
+        mock_profile.mcpServers = {
+            "model-server": McpServer(command="node", args=["server.js"]),
+        }
+        mock_profile.codexProfile = None
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        command = provider._build_codex_command()
+
+        assert "mcp_servers.model-server.command=" in command
+        assert "node" in command
+        assert "mcp_servers.model-server.args=" in command
+        assert "server.js" in command
+
+
 class TestCodexProviderCodexProfile:
     """Tests that profile.codexProfile swaps --yolo for codex's --profile <name>."""
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -378,6 +378,7 @@ class TestCodexProviderCodexProfile:
         assert "--yolo" in command
         assert "--profile" not in command
 
+
 class TestCodexProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.codex.tmux_client")
     def test_get_status_idle(self, mock_tmux):

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -76,6 +76,7 @@ class TestCodexBuildCommand:
         mock_profile.model = None
         mock_profile.system_prompt = "You are a supervisor."
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider(
@@ -98,6 +99,7 @@ class TestCodexBuildCommand:
         mock_profile.model = None
         mock_profile.system_prompt = "You are a code supervisor agent."
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "code_supervisor")
@@ -115,6 +117,7 @@ class TestCodexBuildCommand:
         mock_profile.model = None
         mock_profile.system_prompt = 'Use "double quotes" carefully.'
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
@@ -128,6 +131,7 @@ class TestCodexBuildCommand:
         mock_profile.model = None
         mock_profile.system_prompt = "Line one.\nLine two.\n\n## Section\n- Item"
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
@@ -150,6 +154,7 @@ class TestCodexBuildCommand:
                 "args": ["--from", "git+https://example.com/repo.git@main", "cao-mcp-server"],
             }
         }
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "code_supervisor")
@@ -177,6 +182,7 @@ class TestCodexBuildCommand:
                 "env": {"API_KEY": "secret123"},
             }
         }
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
@@ -201,6 +207,7 @@ class TestCodexBuildCommand:
                 "env_vars": ["HOME", "PATH"],
             }
         }
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
@@ -217,6 +224,7 @@ class TestCodexBuildCommand:
         mock_profile.model = None
         mock_profile.system_prompt = ""
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "empty_agent")
@@ -231,6 +239,7 @@ class TestCodexBuildCommand:
         mock_profile.model = None
         mock_profile.system_prompt = None
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "none_agent")
@@ -261,6 +270,7 @@ class TestCodexBuildCommand:
         mock_profile.model = None
         mock_profile.system_prompt = "You are a supervisor."
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "code_supervisor")
@@ -282,6 +292,7 @@ class TestCodexProviderModelFlag:
         mock_profile.model = "gpt-5"
         mock_profile.system_prompt = None
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load.return_value = mock_profile
 
         provider = CodexProvider("tid", "sess", "win", "agent")
@@ -295,6 +306,7 @@ class TestCodexProviderModelFlag:
         mock_profile.model = None
         mock_profile.system_prompt = None
         mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
         mock_load.return_value = mock_profile
 
         provider = CodexProvider("tid", "sess", "win", "agent")
@@ -302,6 +314,69 @@ class TestCodexProviderModelFlag:
 
         assert "--model" not in command
 
+
+class TestCodexProviderCodexProfile:
+    """Tests that profile.codexProfile swaps --yolo for codex's --profile <name>."""
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_codex_profile_replaces_yolo(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = "cao_reviewer"
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        command = provider._build_codex_command()
+
+        assert "--profile cao_reviewer" in command
+        assert "--yolo" not in command
+        # Tmux-compat flags still required regardless of permission tier
+        assert "--no-alt-screen" in command
+        assert "--disable shell_snapshot" in command
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_codex_profile_composes_with_mcp_overrides(self, mock_load):
+        # Regression guard: --profile <name> must still be followed by the
+        # -c mcp_servers... overrides CAO injects, so handoff/assign keep
+        # working when an agent profile opts into a named codex profile.
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = {
+            "cao-mcp-server": {
+                "command": "uvx",
+                "args": ["--from", "git+https://example.com/repo.git@main", "cao-mcp-server"],
+            }
+        }
+        mock_profile.codexProfile = "cao_reviewer"
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        command = provider._build_codex_command()
+
+        assert "--profile cao_reviewer" in command
+        assert "--yolo" not in command
+        # Existing MCP wiring still applies
+        assert "mcp_servers.cao-mcp-server.command=" in command
+        assert "mcp_servers.cao-mcp-server.tool_timeout_sec=600.0" in command
+        assert "CAO_TERMINAL_ID" in command
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_yolo_overrides_codex_profile(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = "cao_reviewer"
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent", allowed_tools=["*"])
+        command = provider._build_codex_command()
+
+        assert "--yolo" in command
+        assert "--profile" not in command
 
 class TestCodexProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.codex.tmux_client")


### PR DESCRIPTION
## Summary

Adds an optional `codexProfile` field to `AgentProfile`. When set, the `codex` provider drops `--yolo` and passes `--profile <name>` instead, letting the user's `[profiles.<name>]` block in `~/.codex/config.toml` govern `sandbox_mode` / `approval_policy` / `approvals_reviewer`. `cao launch --yolo` continues to force `--yolo` regardless of the profile setting, preserving the existing escape hatch. Legacy profiles with no `codexProfile` keep emitting `codex --yolo --no-alt-screen --disable shell_snapshot` exactly as before.

Companion to #244 (`permissionMode` for claude_code).

## Motivation

Today, the `codex` provider hardcodes `--yolo` (alias for `--dangerously-bypass-approvals-and-sandbox`) for every spawned `codex` process. This mirrors the original claude_code default and is necessary so non-interactive tmux sessions don't deadlock on approval prompts, but it means profile authors have no way to express a stricter permission floor for reviewer/observer agents — every codex spawn runs with sandbox bypassed and zero approvals.

Codex 0.132 has a richer permission model than Claude Code (two-axis `sandbox_mode` + `approval_policy`, plus the stable Smart Approvals classifier `approvals_reviewer = "auto_review"`), and that model is fully expressible via codex's own `~/.codex/config.toml` named profiles. The cleanest move is to *point* at that mechanism rather than re-invent a parallel permission vocabulary inside CAO:

- For `claude_code`, #244 added an enumerated `permissionMode: Literal[...]` because Claude Code's permission tiers don't have a config-file equivalent — they only exist as `--permission-mode <value>` CLI flag values.
- For `codex`, the equivalent control is already a named profile (`codex --profile <name>` + `[profiles.<name>]` in `config.toml`). CAO doesn't need to re-encode codex's sandbox/approval matrix — it just needs to stop overriding the user's named profile with `--yolo`.

So `codexProfile` is a single optional string. The field's value is the name of a codex profile the user has authored. CAO does not interpret the value.

## Behavior matrix

| Profile `codexProfile` | `cao launch --yolo` | Resulting `codex` flag |
|---|---|---|
| unset / no profile | (any) | `--yolo` *(unchanged)* |
| `"cao_reviewer"` (or any non-empty string) | no | `--profile cao_reviewer` |
| any value | **yes** | `--yolo` *(yolo always wins)* |
| `""` (explicit empty string) | (any) | **rejected at profile load** — Pydantic `ValidationError` |

Backward compatible: every existing profile keeps its current behavior because the new field defaults to `None`.

The empty-string rejection is intentional. This is a permission-floor knob; a typo in profile YAML (`codexProfile: ""`) should not silently fall through to `--yolo`. `Field(default=None, min_length=1)` makes that case a load-time error with a clear Pydantic message.

## Changes

- `src/cli_agent_orchestrator/models/agent_profile.py`: add optional `codexProfile: Optional[str] = Field(default=None, min_length=1)` to `AgentProfile`.
- `src/cli_agent_orchestrator/providers/codex.py`: when `profile.codexProfile` is set and `--yolo` is not active (`allowed_tools != ["*"]`), build the command with `["codex", "--profile", profile.codexProfile]` instead of `["codex", "--yolo"]`. Tmux-compat flags (`--no-alt-screen --disable shell_snapshot`) and the existing `-c developer_instructions` / `-c mcp_servers...` overrides still apply in both branches. The yolo check reuses the same signal used by `claude_code` post-#244.
- `test/providers/test_codex_provider_unit.py`: new `TestCodexProviderCodexProfile` class with three tests (replaces-yolo, yolo-overrides, composes-with-mcp-overrides). `codexProfile = None` added to the 11 pre-existing fixture sites to prevent MagicMock's truthy auto-attribute from triggering the new branch.
- `docs/codex-cli.md`: add a "Custom Codex Profile" section under Configuration, plus a one-line note in "Launch Flags" linking to it. The new section documents the field, the precedence rule, the non-interactive constraint (see "Notes for reviewers" below), and a YAML + matching `config.toml` example.

Net change: +195 / -71 across four files.

## Usage

```yaml
---
name: reviewer
description: Code Reviewer
provider: codex
role: reviewer
codexProfile: cao_reviewer
---

You review code for quality and correctness.
```

Matching `~/.codex/config.toml`:

```toml
[profiles.cao_reviewer]
sandbox_mode = "read-only"
approval_policy = "never"
```

Resulting spawn:

```
codex --profile cao_reviewer --no-alt-screen --disable shell_snapshot \
  -c developer_instructions="..." \
  -c mcp_servers.cao-mcp-server.command="uvx" \
  ...
```

The user can then express any sandbox/approval combination codex supports without CAO needing to know about it.

## Testing

Local verification against `_build_codex_command()` with the canonical case matrix — all pass:

| Case | Expected | Actual |
|---|---|---|
| No profile | `codex --yolo --no-alt-screen --disable shell_snapshot` *(legacy)* | ✅ |
| Legacy profile (no `codexProfile`) | `codex --yolo --no-alt-screen --disable shell_snapshot` | ✅ |
| `codexProfile: "cao_reviewer"`, no yolo | `codex --profile cao_reviewer --no-alt-screen ...` | ✅ |
| `codexProfile: "cao_dev"` + yolo (`allowed_tools=["*"]`) | `codex --yolo ...` *(yolo wins)* | ✅ |
| `codexProfile: "cao_x"` + `mcpServers` set | `codex --profile cao_x ...` + `-c mcp_servers.X.command=...` + `-c mcp_servers.X.tool_timeout_sec=600.0` | ✅ |

Pydantic rejects empty string at load time (`Field(default=None, min_length=1)` → `ValidationError: String should have at least 1 character`).

All 72 codex + 62 claude_code unit tests pass.

End-to-end smoke test on a live `cao launch --provider codex --agents <profile-with-codexProfile-set>` invocation confirmed the spawned codex argv:

```
codex --profile cao_smoke_test --no-alt-screen --disable shell_snapshot -c ...
```

`--yolo` absent, `--profile cao_smoke_test` present, all existing `-c` overrides (developer_instructions, mcp_servers, tool_timeout_sec=600.0, CAO_TERMINAL_ID env_vars) preserved.

## Notes for reviewers

- **Why a string field instead of a `Literal` enum like `permissionMode`?** Codex has a mature config system with rich tier expression already (sandbox_mode × approval_policy × approvals_reviewer, plus per-tier sub-config like `[sandbox_workspace_write]`). Enumerating a CAO-side subset would either (a) leak codex's vocabulary into CAO's `AgentProfile` model and require updates whenever codex grows a new tier, or (b) fudge codex's two-axis matrix into a flat enum and lose fidelity. Pointing at codex's named profiles avoids both. CAO doesn't decide *what* the permission tier means; codex's config does.

- **Asymmetry with `permissionMode`.** `permissionMode` (unprefixed) is implicitly claude_code-only; `codexProfile` is explicitly codex-only. The asymmetry reflects the underlying mechanisms: Claude Code exposes permissions only as CLI flag values, codex exposes them via named config blocks. Naming each field after its target mechanism feels more honest than forcing both into the same shape.

- **Non-interactive constraint.** CAO's existing status detector (`WAITING_PROMPT_PATTERN` in `codex.py:46`) only matches the older `Approve...y/n` UI; it does *not* match codex 0.132's boxed `Command Approval Required / [a] Accept / [d] Decline`. The docs explicitly warn that any `codexProfile` you reference MUST resolve to a non-interactive tier (`approval_policy = "never"`, or `approvals_reviewer = "auto_review"` which fails closed without prompting). The patch doesn't introduce this limitation — `--yolo` was hiding it before — but the new field surfaces it to profile authors for the first time. Updating the regex / fixtures to detect the modern approval UI feels like a separate change.

- **Known limitation (out of scope for this PR).** If `codexProfile` names a profile that does not exist in `~/.codex/config.toml`, codex fails fast with `Error: config profile 'X' not found`, but CAO's `wait_until_status` keeps polling through ERROR for the full 60s `initialize()` timeout before surfacing the failure. This is existing CAO behavior in `utils/terminal.py:73`, not specific to this patch — but typing a wrong profile name is now a possible new failure mode. Worth a follow-up to bail out on ERROR status during init; happy to do that as a separate PR if maintainers prefer.

- **No changes to `_handle_trust_prompt()`.** The workspace trust prompt handler runs regardless of the permission tier — it's gating directory trust, not approvals. Left untouched.

- **MCP overrides compose with `--profile`.** Verified via the `test_codex_profile_composes_with_mcp_overrides` test: when both `codexProfile` and `mcpServers` are set, the argv contains `--profile <name>` followed by `-c mcp_servers.<name>.command=...` (and `tool_timeout_sec=600.0`, and the `CAO_TERMINAL_ID` `env_vars`). This is the most regression-prone path (handoff/assign depend on it), so it gets its own dedicated test.
