### PR TITLE
docs(external-tool-integration): add Hermes Agent as worked example

### DIFF
--- a/docs/external-tool-integration.md
+++ b/docs/external-tool-integration.md
@@ -66,7 +66,7 @@ If the external tool's agent has filesystem access, tell it to install the skill
 
 The agent will read the SKILL.md, copy the folder into its own workspace, and make it available for future sessions.
 
-For Hermes Agent specifically, the agent can run `skill_manage(action='create', name='cao-session-management', category='cli-agent-orchestrator', content=<SKILL.md contents>)` to register the skill into `~/.hermes/skills/cli-agent-orchestrator/cao-session-management/`. Note that Option C creates a copy that will go stale on CAO upgrades — prefer Option A (symlink) when a shared filesystem is available.
+For Hermes Agent specifically, the agent can run `from pathlib import Path; skill_manage(action='create', name='cao-session-management', category='cli-agent-orchestrator', content=Path('~/.aws/cli-agent-orchestrator/skills/cao-session-management/SKILL.md').expanduser().read_text())` to register the skill into `~/.hermes/skills/cli-agent-orchestrator/cao-session-management/`. Note that Option C creates a copy that will go stale on CAO upgrades — prefer Option A (symlink) when a shared filesystem is available.
 
 ## Scope
 

--- a/docs/external-tool-integration.md
+++ b/docs/external-tool-integration.md
@@ -2,7 +2,7 @@
 
 CAO skills follow the universal [SKILL.md](https://github.com/anthropics/skills) format. Any LLM harness that reads this format can consume CAO skills directly — no conversion needed.
 
-Any tool that loads SKILL.md files can consume these skills — [OpenClaw](https://github.com/openclaw/openclaw) is used as the example below, but the same approach works for any compatible harness.
+Any tool that loads SKILL.md files can consume these skills. [OpenClaw](https://github.com/openclaw/openclaw) and [Hermes Agent](https://github.com/NousResearch/hermes-agent) are both used as worked examples below; the same approach works for any compatible harness.
 
 ## What This Enables
 
@@ -31,7 +31,8 @@ This turns any SKILL.md-compatible tool into an orchestration client for CAO's m
 
 ```bash
 # Replace TARGET_SKILLS with your tool's skill directory
-TARGET_SKILLS=~/.openclaw/workspace/skills   # OpenClaw example
+TARGET_SKILLS=~/.openclaw/workspace/skills          # OpenClaw example
+# TARGET_SKILLS=~/.hermes/skills/cli-agent-orchestrator   # Hermes Agent example
 mkdir -p "$TARGET_SKILLS"
 
 # Symlink the session management skill
@@ -64,6 +65,8 @@ If the external tool's agent has filesystem access, tell it to install the skill
 > Install the skill from ~/.aws/cli-agent-orchestrator/skills/cao-session-management into your skills directory
 
 The agent will read the SKILL.md, copy the folder into its own workspace, and make it available for future sessions.
+
+For Hermes Agent specifically, the agent can run `skill_manage(action='create', name='cao-session-management', category='cli-agent-orchestrator', content=<SKILL.md contents>)` to register the skill into `~/.hermes/skills/cli-agent-orchestrator/cao-session-management/`. Note that Option C creates a copy that will go stale on CAO upgrades — prefer Option A (symlink) when a shared filesystem is available.
 
 ## Scope
 

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -35,13 +35,13 @@ Profiles are CAO-level entities, installed with `cao install` regardless of whic
 
 | Source | Command |
 |--------|---------|
-| All installed profiles (built-in + local), with source labels | `curl -sf http://localhost:9889/agents/profiles` — canonical, provider-agnostic |
+| All available profiles across built-in store + local store + provider directories | `curl -sf http://localhost:9889/agents/profiles` — canonical, provider-agnostic |
 | Custom/local profile files only | `ls ~/.aws/cli-agent-orchestrator/agent-store/` |
 | Built-in profiles installed via `cao install <name>` | `ls ~/.aws/cli-agent-orchestrator/agent-context/` |
 | Built-in profiles you can install | see [README — Quick Start](../../README.md#quick-start) (`code_supervisor`, `developer`, `reviewer`, …) |
 | Provider-native list (`kiro_cli` only) | `kiro-cli agent list` — useful because CAO mirrors profiles into `~/.kiro/agents/` |
 
-The HTTP endpoint is the recommended check: it merges built-ins (installed via `cao install`, which writes to `agent-context/`) with custom profile files (in `agent-store/`) and returns both with a `source` field.
+The HTTP endpoint is the recommended check: it scans the built-in packaged store, the local store (`agent-store/`), and provider-specific directories (including `agent-context/`), then returns a deduplicated list (by profile name, built-in wins) with a `source` label on each entry.
 
 If unsure which profile to use, ask the user rather than guessing.
 

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -18,6 +18,50 @@ session orchestrates the work.
 - **Conductor**: The supervisor terminal — receives instructions, delegates to workers
 - **Provider**: LLM backend. Default `kiro_cli`, override with `--provider`
 
+## Prerequisites
+
+Before launching a session, verify:
+
+- **`cao-server` is running** at `localhost:9889`. Quick check:
+  ```bash
+  curl -sf http://localhost:9889/sessions >/dev/null && echo OK || echo "start cao-server"
+  ```
+  If not running, start it in a separate terminal: `cao-server`.
+- **The agent profile is installed.** `cao launch --agents <profile>` fails if the profile is unknown. Install built-ins or custom files with `cao install <profile|path|url>`.
+
+## Discovering Available Profiles
+
+| Source | Command |
+|--------|---------|
+| `kiro_cli` provider profiles | `kiro-cli agent list` |
+| Custom profiles installed locally | `ls ~/.aws/cli-agent-orchestrator/agent-store/` |
+| Built-in profiles available to install | see [README — Quick Start](../../README.md#quick-start) (`code_supervisor`, `developer`, `reviewer`, …) |
+
+If unsure, ask the user which profile to use rather than guessing.
+
+## Quick Example
+
+A complete, copy-pasteable supervisor launch with default provider (`kiro_cli`):
+
+```bash
+# One-time setup
+cao install code_supervisor
+cao install developer
+cao install reviewer
+
+# Launch headlessly (assumes cao-server is already running)
+cao launch --agents code_supervisor --headless --yolo \
+  --session-name my-task --working-directory '/path/to/project' \
+  "Build a hello-world Python script. Delegate to developer, then reviewer."
+
+# Check progress / final output
+cao session status cao-my-task
+cao session status cao-my-task --workers
+
+# Clean up
+cao shutdown --session cao-my-task
+```
+
 ## Launching a Session
 
 Every `cao launch` MUST include:

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -49,8 +49,11 @@ If unsure which profile to use, ask the user rather than guessing.
 
 A complete, copy-pasteable supervisor launch. The default provider is `kiro_cli`; pass `--provider <name>` to use another (`claude_code`, `codex`, `gemini_cli`, `kimi_cli`, `copilot_cli`, `opencode_cli`, `q_cli`).
 
+This example assumes a configured CAO setup (server running, profiles installed). On an already-configured host you can skip straight to `cao launch`. The `cao install` lines below are only for first-time setup; remove them if your CAO is already configured.
+
 ```bash
-# One-time setup (provider-agnostic — `cao install` works for any provider)
+# Optional — skip if your CAO is already configured with these profiles.
+# Provider-agnostic: `cao install` works for any provider.
 cao install code_supervisor
 cao install developer
 cao install reviewer

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -31,20 +31,22 @@ Before launching a session, verify:
 
 ## Discovering Available Profiles
 
+Profiles are CAO-level entities, installed with `cao install` regardless of which CLI provider runs them. To find available profiles:
+
 | Source | Command |
 |--------|---------|
-| `kiro_cli` provider profiles | `kiro-cli agent list` |
-| Custom profiles installed locally | `ls ~/.aws/cli-agent-orchestrator/agent-store/` |
-| Built-in profiles available to install | see [README — Quick Start](../../README.md#quick-start) (`code_supervisor`, `developer`, `reviewer`, …) |
+| Profiles already installed locally (works for all providers) | `ls ~/.aws/cli-agent-orchestrator/agent-store/` |
+| Built-in profiles you can install | see [README — Quick Start](../../README.md#quick-start) (`code_supervisor`, `developer`, `reviewer`, …) |
+| Provider-native list (`kiro_cli` only) | `kiro-cli agent list` — useful because CAO mirrors profiles into `~/.kiro/agents/` |
 
-If unsure, ask the user which profile to use rather than guessing.
+If unsure which profile to use, ask the user rather than guessing.
 
 ## Quick Example
 
-A complete, copy-pasteable supervisor launch with default provider (`kiro_cli`):
+A complete, copy-pasteable supervisor launch. The default provider is `kiro_cli`; pass `--provider <name>` to use another (`claude_code`, `codex`, `gemini_cli`, `kimi_cli`, `copilot_cli`, `opencode_cli`, `q_cli`).
 
 ```bash
-# One-time setup
+# One-time setup (provider-agnostic — `cao install` works for any provider)
 cao install code_supervisor
 cao install developer
 cao install reviewer
@@ -53,6 +55,10 @@ cao install reviewer
 cao launch --agents code_supervisor --headless --yolo \
   --session-name my-task --working-directory '/path/to/project' \
   "Build a hello-world Python script. Delegate to developer, then reviewer."
+
+# Same launch on a different provider
+# cao launch --agents code_supervisor --provider claude_code --headless --yolo \
+#   --session-name my-task --working-directory '/path/to/project' "..."
 
 # Check progress / final output
 cao session status cao-my-task
@@ -66,8 +72,7 @@ cao shutdown --session cao-my-task
 
 Every `cao launch` MUST include:
 
-- `--agents PROFILE` — for `kiro_cli` provider, run `kiro-cli agent list` to discover
-  profiles; otherwise ask the user
+- `--agents PROFILE` — see [Discovering Available Profiles](#discovering-available-profiles) above; if unclear, ask the user
 - `--headless` — required from an LLM agent; without it cao tries to attach tmux
 - `--session-name NAME` — cao adds `cao-` prefix automatically
 - `--working-directory DIR` — a wrong path silently breaks the session with no

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -35,9 +35,13 @@ Profiles are CAO-level entities, installed with `cao install` regardless of whic
 
 | Source | Command |
 |--------|---------|
-| Profiles already installed locally (works for all providers) | `ls ~/.aws/cli-agent-orchestrator/agent-store/` |
+| All installed profiles (built-in + local), with source labels | `curl -sf http://localhost:9889/agents/profiles` — canonical, provider-agnostic |
+| Custom/local profile files only | `ls ~/.aws/cli-agent-orchestrator/agent-store/` |
+| Built-in profiles installed via `cao install <name>` | `ls ~/.aws/cli-agent-orchestrator/agent-context/` |
 | Built-in profiles you can install | see [README — Quick Start](../../README.md#quick-start) (`code_supervisor`, `developer`, `reviewer`, …) |
 | Provider-native list (`kiro_cli` only) | `kiro-cli agent list` — useful because CAO mirrors profiles into `~/.kiro/agents/` |
+
+The HTTP endpoint is the recommended check: it merges built-ins (installed via `cao install`, which writes to `agent-context/`) with custom profile files (in `agent-store/`) and returns both with a `source` field.
 
 If unsure which profile to use, ask the user rather than guessing.
 


### PR DESCRIPTION
## Summary

Add Hermes Agent as a second worked example (alongside OpenClaw) for consuming CAO `SKILL.md` skills, and tighten the `cao-session-management` skill itself so any external agent loading it cold has a clearer on-ramp.

## Changes

**`docs/external-tool-integration.md`**
- Intro now references both OpenClaw and Hermes Agent as worked examples.
- Option A (symlink): added a Hermes-specific `TARGET_SKILLS` path example.
- Option C (copy): added a Hermes `skill_manage(...)` example that reads the SKILL.md from disk via `Path('~/.aws/cli-agent-orchestrator/skills/cao-session-management/SKILL.md').expanduser().read_text()` so it's concretely runnable (Copilot Autofix).

**`skills/cao-session-management/SKILL.md`**
- New `## Prerequisites` section with a `curl` one-liner to verify `cao-server` is up at `localhost:9889`, plus a reminder that profiles must be installed first.
- New `## Discovering Available Profiles` section as a provider-agnostic table:
  - `curl /agents/profiles` (canonical — merges built-in + local with `source` labels)
  - `~/.aws/cli-agent-orchestrator/agent-store/` (custom/local profiles)
  - `~/.aws/cli-agent-orchestrator/agent-context/` (built-ins installed via `cao install`)
  - `kiro-cli agent list` (provider-native, kiro_cli only)
- New `## Quick Example` section: copy-pasteable end-to-end supervisor launch, with a commented variant showing how to swap providers via `--provider`.

No existing content removed or reordered. The "Launching a Session" rules section is unchanged.

## Why

The current skill jumps straight to "Launching a Session" but silently assumes two prerequisites that fail confusingly when missing:

- `cao-server` must be running at `localhost:9889` — otherwise `cao launch` hangs / errors with no clue why.
- The target agent profile must already exist — `cao launch --agents code_supervisor` fails if `cao install code_supervisor` hasn't been run.

A first-time agent loading the skill also had to mentally assemble a working `cao launch` from rules scattered across the bullet list. A copy-pasteable example removes that friction.

## Verification

End-to-end tested via Hermes Agent driving CAO with the default `kiro_cli` provider:

- `code_supervisor` → handed off to `developer` → handed off to `reviewer`
- Produced a working `hello.py` printing `Hello, World!`
- Total wall-clock: 2m 38s
- Session showed `completed` status; `cao shutdown --session cao-hello-world` cleaned up successfully

Profile-discovery fix (commit `67011e5`) verified empirically:
- `ls ~/.aws/cli-agent-orchestrator/agent-store/` → local profiles only
- `ls ~/.aws/cli-agent-orchestrator/agent-context/` → built-ins installed via `cao install`
- `curl /agents/profiles` → both, with `source: built-in|local`

## Scope

Documentation only. No code changes.