### PR TITLE
fix(api): make network allowlists configurable via env vars

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -84,3 +84,35 @@ Add additional directories that are scanned for agent profiles across all provid
 | `POST` | `/settings/extra-agent-dirs` | Set extra custom directories |
 
 See [api.md](api.md) for the full API reference.
+
+## Server Network Settings
+
+`cao-server` is a local-only service by default. The host header, CORS, and
+WebSocket client allowlists ship locked down to loopback. Three env vars let
+operators extend each list when running CAO behind a reverse proxy or inside a
+container — see issues [#149](https://github.com/awslabs/cli-agent-orchestrator/issues/149)
+and [#151](https://github.com/awslabs/cli-agent-orchestrator/issues/151).
+
+All three accept a comma-separated list and **extend** (not replace) the built-in
+defaults, so loopback access is preserved even when the env var is set:
+
+| Env var | Extends | Use case |
+|---|---|---|
+| `CAO_ALLOWED_HOSTS` | `ALLOWED_HOSTS` (Host header allowlist used by `TrustedHostMiddleware`) | Fronting cao-server with a reverse proxy at a hostname other than `localhost` / `127.0.0.1`. |
+| `CAO_CORS_ORIGINS` | `CORS_ORIGINS` (browser origins permitted by CORS) | Serving the web UI from a non-default port, or from another origin (e.g. a custom dashboard). |
+| `CAO_WS_ALLOWED_CLIENTS` | `WS_ALLOWED_CLIENTS` (client IPs permitted to attach to the PTY WebSocket) | Running `cao-server` inside Docker where the host browser arrives via a bridge IP (e.g. `172.17.0.1`). |
+
+Example — running `cao-server` in a container that accepts WebSocket attaches
+from the Docker bridge:
+
+```bash
+CAO_ALLOWED_HOSTS=cao.local \
+CAO_CORS_ORIGINS=http://cao.local:8080 \
+CAO_WS_ALLOWED_CLIENTS=172.17.0.1 \
+  uv tool run cao-server --host 0.0.0.0
+```
+
+> **Security note:** the WebSocket PTY endpoint is unauthenticated. Only add
+> client IPs you actually trust to `CAO_WS_ALLOWED_CLIENTS` — anyone who can
+> reach the listener at one of those IPs gets full PTY access to running
+> agent terminals.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -36,6 +36,7 @@ from cli_agent_orchestrator.constants import (
     SERVER_PORT,
     SERVER_VERSION,
     TERMINAL_LOG_DIR,
+    WS_ALLOWED_CLIENTS,
 )
 from cli_agent_orchestrator.models.flow import Flow
 from cli_agent_orchestrator.models.inbox import MessageStatus, OrchestrationType
@@ -772,10 +773,13 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
     It is intended for localhost-only use. Do NOT expose the server to
     untrusted networks (e.g. --host 0.0.0.0) without adding authentication.
     """
-    # Reject connections from non-loopback clients
+    # Reject connections from clients outside the configured allowlist.
+    # Defaults to loopback; operators running cao-server inside a container can
+    # extend the allowlist with the ``CAO_WS_ALLOWED_CLIENTS`` env var so the
+    # host browser (reaching the container via a bridge IP) can attach.
     client_host = websocket.client.host if websocket.client else None
-    if client_host not in (None, "127.0.0.1", "::1", "localhost"):
-        await websocket.close(code=4003, reason="WebSocket access is restricted to localhost")
+    if client_host is not None and client_host not in WS_ALLOWED_CLIENTS:
+        await websocket.close(code=4003, reason="WebSocket access is restricted to allowed clients")
         return
 
     await websocket.accept()

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -110,24 +110,47 @@ SERVER_VERSION = "0.1.0"
 
 API_BASE_URL = f"http://{SERVER_HOST}:{SERVER_PORT}"
 
-# CORS allowed origins for web-based clients
+
+# Operators can extend network allowlists via the env vars handled below.
+# Same comma-separated pattern as ``CAO_PROFILE_ALLOWED_HOSTS`` in install_service.
+def _split_env_list(name: str) -> list[str]:
+    """Parse a comma-separated env var into a stripped, non-empty entry list."""
+    value = os.environ.get(name, "")
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+# CORS allowed origins for web-based clients.
+# Defaults cover the Vite dev server and a common production port.
+# Operators serving the UI on a custom port (or from a different origin) can
+# extend the list with the ``CAO_CORS_ORIGINS`` env var (comma-separated).
 CORS_ORIGINS = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
-]
+] + _split_env_list("CAO_CORS_ORIGINS")
 
-# Allowed Host headers for DNS rebinding protection (CVE mitigation)
-# Only localhost connections permitted - CAO is a local-only service
-# These hosts are validated by TrustedHostMiddleware to prevent DNS rebinding attacks
-# Note: IPv6 (::1) is not included as CAO is accessed via IPv4 localhost in practice
-# Future extension point: To allow additional hosts, add --allowed-hosts CLI flag
-# or CAO_ALLOWED_HOSTS env var (comma-separated) that modifies this list
+# Allowed Host headers for DNS rebinding protection (CVE mitigation).
+# Defaults: localhost-only, matching CAO's local-only service design.
+# Validated by TrustedHostMiddleware to prevent DNS rebinding attacks.
+# Operators fronting cao-server with a reverse proxy or running it inside a
+# container can extend the list via ``CAO_ALLOWED_HOSTS`` (comma-separated).
 ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
-]
+] + _split_env_list("CAO_ALLOWED_HOSTS")
+
+# Allowed client IPs/hostnames for the WebSocket PTY attach endpoint.
+# Defaults: loopback-only. The WebSocket endpoint provides unauthenticated PTY
+# access, so this list is deliberately tight.
+# Operators running cao-server inside a container (e.g. Docker, where the host
+# browser connects via a bridge IP like 172.17.0.1) can extend the list with
+# ``CAO_WS_ALLOWED_CLIENTS`` (comma-separated). See issue #149.
+WS_ALLOWED_CLIENTS = [
+    "127.0.0.1",
+    "::1",
+    "localhost",
+] + _split_env_list("CAO_WS_ALLOWED_CLIENTS")
 
 # =============================================================================
 # Memory System Configuration

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -410,6 +410,64 @@ class TestWebSocketLocalhostRestriction:
             with client.websocket_connect("/terminals/abcd1234/ws"):
                 pass
 
+    @pytest.mark.asyncio
+    async def test_websocket_endpoint_admits_client_in_allowlist(self):
+        """Direct-call unit test: a client whose host is in WS_ALLOWED_CLIENTS
+        passes the allowlist gate and reaches the next step (terminal lookup).
+
+        Driving the coroutine directly with a mock ``WebSocket`` lets us
+        observe the exact ``close`` calls without fighting the TestClient's
+        opaque mapping of post-accept closes to HTTP 400 denials.
+        """
+        from cli_agent_orchestrator.api.main import terminal_ws
+
+        ws = MagicMock()
+        ws.client = MagicMock(host="172.17.0.1")  # Docker bridge IP, simulating issue #149
+        ws.accept = AsyncMock()
+        ws.close = AsyncMock()
+
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.WS_ALLOWED_CLIENTS",
+                ["127.0.0.1", "::1", "localhost", "172.17.0.1"],
+            ),
+            patch(
+                "cli_agent_orchestrator.api.main.get_terminal_metadata",
+                return_value=None,
+            ),
+        ):
+            await terminal_ws(ws, "abcd1234")
+
+        # Allowlist let it through → accept happened.
+        ws.accept.assert_awaited_once()
+        # Terminal lookup returned None → close with 4004 (not 4003).
+        ws.close.assert_awaited_once()
+        kwargs = ws.close.call_args.kwargs
+        assert kwargs.get("code") == 4004
+
+    @pytest.mark.asyncio
+    async def test_websocket_endpoint_rejects_client_outside_allowlist(self):
+        """Direct-call unit test: a client whose host is not in the allowlist
+        is closed with policy code 4003 before any accept happens."""
+        from cli_agent_orchestrator.api.main import terminal_ws
+
+        ws = MagicMock()
+        ws.client = MagicMock(host="10.0.0.5")
+        ws.accept = AsyncMock()
+        ws.close = AsyncMock()
+
+        with patch(
+            "cli_agent_orchestrator.api.main.WS_ALLOWED_CLIENTS",
+            ["127.0.0.1", "::1", "localhost"],
+        ):
+            await terminal_ws(ws, "abcd1234")
+
+        # Rejected before accept.
+        ws.accept.assert_not_called()
+        ws.close.assert_awaited_once()
+        kwargs = ws.close.call_args.kwargs
+        assert kwargs.get("code") == 4003
+
 
 class TestBuildPtyEnv:
     """Tests for the tmux PTY attach environment builder (issue #150).

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -81,6 +81,71 @@ class TestCorsOrigins:
         assert "http://127.0.0.1:3000" in CORS_ORIGINS
 
 
+class TestNetworkAllowlistEnvOverrides:
+    """Tests for env-var-driven extensions of the network allowlists (issues #149, #151).
+
+    Each override extends the built-in defaults rather than replacing them, so an
+    operator can add a Docker bridge IP or a custom origin without locking
+    themselves out of loopback access.
+    """
+
+    def _reload_constants(self, env_overrides):
+        import importlib
+        import os
+
+        env_copy = os.environ.copy()
+        # Strip any pre-set network override vars so the test starts from the
+        # documented defaults, then layer the overrides under test on top.
+        for key in ("CAO_CORS_ORIGINS", "CAO_ALLOWED_HOSTS", "CAO_WS_ALLOWED_CLIENTS"):
+            env_copy.pop(key, None)
+        env_copy.update(env_overrides)
+        with patch.dict("os.environ", env_copy, clear=True):
+            import cli_agent_orchestrator.constants as constants_module
+
+            importlib.reload(constants_module)
+            return constants_module
+
+    def test_cao_cors_origins_extends_defaults(self):
+        mod = self._reload_constants(
+            {"CAO_CORS_ORIGINS": "http://app.local,http://example.test:9000"}
+        )
+        assert "http://localhost:5173" in mod.CORS_ORIGINS
+        assert "http://app.local" in mod.CORS_ORIGINS
+        assert "http://example.test:9000" in mod.CORS_ORIGINS
+
+    def test_cao_allowed_hosts_extends_defaults(self):
+        mod = self._reload_constants({"CAO_ALLOWED_HOSTS": "cao.internal,proxy.example.com"})
+        assert "localhost" in mod.ALLOWED_HOSTS
+        assert "127.0.0.1" in mod.ALLOWED_HOSTS
+        assert "cao.internal" in mod.ALLOWED_HOSTS
+        assert "proxy.example.com" in mod.ALLOWED_HOSTS
+
+    def test_cao_ws_allowed_clients_extends_defaults(self):
+        mod = self._reload_constants({"CAO_WS_ALLOWED_CLIENTS": "172.17.0.1, 192.168.1.5"})
+        assert "127.0.0.1" in mod.WS_ALLOWED_CLIENTS
+        assert "::1" in mod.WS_ALLOWED_CLIENTS
+        assert "172.17.0.1" in mod.WS_ALLOWED_CLIENTS
+        # Leading whitespace stripped
+        assert "192.168.1.5" in mod.WS_ALLOWED_CLIENTS
+
+    def test_overrides_skip_empty_segments(self):
+        mod = self._reload_constants({"CAO_WS_ALLOWED_CLIENTS": ",,172.17.0.1,, ,"})
+        assert "" not in mod.WS_ALLOWED_CLIENTS
+        assert "172.17.0.1" in mod.WS_ALLOWED_CLIENTS
+
+    def test_defaults_when_env_not_set(self):
+        mod = self._reload_constants({})
+        # Defaults intact, no extras.
+        assert mod.WS_ALLOWED_CLIENTS == ["127.0.0.1", "::1", "localhost"]
+        assert mod.ALLOWED_HOSTS == ["localhost", "127.0.0.1"]
+        assert mod.CORS_ORIGINS == [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ]
+
+
 class TestCaoHomeDir:
     """Tests for CAO home directory constants."""
 


### PR DESCRIPTION
## Summary

`cao-server` ships with three hardcoded loopback-only allowlists:

- `ALLOWED_HOSTS` — Host header allowlist for `TrustedHostMiddleware`
- `CORS_ORIGINS` — browser origins permitted by CORS
- The WebSocket PTY `client_host` check in `terminal_ws`

That posture is correct for the default install. It breaks two real workflows that the linked issues describe:

- **#149** — running `cao-server` inside a container with `--host 0.0.0.0`. The host browser connects via a Docker bridge IP (e.g. `172.17.0.1`), which fails the hardcoded loopback check on the WebSocket endpoint, so the web UI cannot attach to any terminal.
- **#151** — serving the UI from a non-default port or a custom origin. The hardcoded `CORS_ORIGINS` list rejects the browser's `Origin` header.

The `constants.py` block above `ALLOWED_HOSTS` already documented this as a "future extension point" mentioning `CAO_ALLOWED_HOSTS` — this PR wires that up and adds matching CORS and WebSocket overrides.

## Changes

- `constants.py` — new `_split_env_list()` helper. `ALLOWED_HOSTS`, `CORS_ORIGINS`, and a new `WS_ALLOWED_CLIENTS` constant now extend their built-in defaults with comma-separated entries from `CAO_ALLOWED_HOSTS`, `CAO_CORS_ORIGINS`, and `CAO_WS_ALLOWED_CLIENTS` respectively.
- `api/main.py` — the WebSocket `terminal_ws` endpoint reads `WS_ALLOWED_CLIENTS` instead of its inline tuple. The close reason is generalised from "restricted to localhost" to "restricted to allowed clients".
- `docs/settings.md` — new **Server Network Settings** section documenting the three env vars, with an example for the Docker scenario and a security note about the unauthenticated WebSocket endpoint.

The override pattern matches the existing `CAO_PROFILE_ALLOWED_HOSTS` extension in `install_service._allowed_download_hosts()`, so contributors familiar with that path will recognise it.

## Security posture

- **Defaults are unchanged.** An operator that does not set any of the three env vars sees the same loopback-only behavior as before.
- **Extends, never replaces.** Setting `CAO_WS_ALLOWED_CLIENTS=172.17.0.1` keeps `127.0.0.1`, `::1`, and `localhost` allowed. This is intentional — replace-semantics (as in `_allowed_download_hosts()`) is easy to misuse by locking out loopback.
- The WebSocket endpoint remains **unauthenticated**, so the docs section calls out that the env var should only list IPs the operator actually trusts.

## Test plan

- [x] `uv run pytest test/test_constants.py test/api/test_terminals.py -v` — 54/54 pass, including 5 new env-var-override tests and 2 new direct-call WebSocket allowlist tests.
- [x] Full unit suite — `uv run pytest test/ --ignore=test/e2e -m "not integration"` — 1713 passed, 1 skipped on Python 3.10, 3.11, and 3.12 (the CI matrix).
- [x] `uv run black --check src/ test/` — clean.
- [x] `uv run isort --check-only src/ test/` — clean.
- [x] `uv run mypy src/cli_agent_orchestrator/constants.py src/cli_agent_orchestrator/api/main.py` — clean (no new findings on the changed modules).

The new WebSocket tests intentionally bypass `TestClient.websocket_connect` and call the endpoint coroutine directly with an `AsyncMock` websocket. Starlette's `TestClient` maps both pre-accept and post-accept close into the same `WebSocketDenialResponse`, so it cannot distinguish a 4003 allowlist rejection from a 4004 metadata-not-found close after accept. Driving the coroutine directly keeps the assertion precise: `accept` is called or not, and `close.code` is exactly 4003 or 4004. The existing `test_websocket_rejects_non_loopback` integration test (which only asserts that *some* exception fires) is left in place as a smoke test.

Closes #149.
Partially addresses #151 (the WebSocket and CORS gaps).
