### PR TITLE
fix(api): default TERM to xterm-256color for tmux PTY attach

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -208,6 +208,29 @@ def get_plugin_registry(request: Request) -> PluginRegistry:
     return cast(PluginRegistry, request.app.state.plugin_registry)
 
 
+# Values that indicate ``TERM`` is effectively unusable and must be overridden
+# rather than inherited by the tmux attach subprocess. ``dumb`` is the common
+# fallback that containers and devcontainers ship with when no real terminal
+# is attached. Empty string and missing key behave the same way.
+_UNUSABLE_TERM_VALUES = frozenset({"", "dumb"})
+_DEFAULT_PTY_TERM = "xterm-256color"
+
+
+def _build_pty_env() -> Dict[str, str]:
+    """Build the env handed to the tmux PTY attach subprocess.
+
+    Copies the parent process environment so cao-server's normal config
+    (PATH, HOME, AWS_*, etc.) reaches tmux, and forces ``TERM`` to a usable
+    value when the inherited one would break terminal rendering. Explicit
+    non-dumb ``TERM`` values from the operator are preserved verbatim. See
+    issue #150.
+    """
+    env = os.environ.copy()
+    if env.get("TERM", "") in _UNUSABLE_TERM_VALUES:
+        env["TERM"] = _DEFAULT_PTY_TERM
+    return env
+
+
 app = FastAPI(
     title="CLI Agent Orchestrator",
     description="Simplified CLI Agent Orchestrator API",
@@ -772,7 +795,13 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
     winsize = struct.pack("HHHH", 24, 80, 0, 0)
     fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, winsize)
 
-    # Start tmux attach inside the PTY
+    # Start tmux attach inside the PTY.
+    # Container/devcontainer environments often leave TERM unset or set to
+    # ``dumb``, which strips colours, breaks cursor positioning and corrupts
+    # the Ink-based TUIs that agent CLIs render. Force a sane default so the
+    # browser-side xterm.js renderer sees the escape sequences it expects.
+    # Any explicit non-dumb TERM the operator set is preserved.
+    pty_env = _build_pty_env()
     proc = subprocess.Popen(
         ["tmux", "-u", "attach-session", "-t", f"{session_name}:{window_name}"],
         stdin=slave_fd,
@@ -780,6 +809,7 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
         stderr=slave_fd,
         close_fds=True,
         preexec_fn=os.setsid,
+        env=pty_env,
     )
     os.close(slave_fd)
 

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -1,6 +1,7 @@
 """Tests for terminal-related API endpoints including working directory and exit."""
 
-from unittest.mock import ANY, MagicMock, patch
+from typing import Dict
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -408,6 +409,119 @@ class TestWebSocketLocalhostRestriction:
         with pytest.raises(Exception):
             with client.websocket_connect("/terminals/abcd1234/ws"):
                 pass
+
+
+class TestBuildPtyEnv:
+    """Tests for the tmux PTY attach environment builder (issue #150).
+
+    The helper is responsible for ensuring the tmux ``attach-session``
+    subprocess sees a usable ``TERM`` value. Container environments
+    routinely ship with ``TERM`` unset or set to ``dumb``, which breaks
+    xterm.js rendering on the browser side.
+    """
+
+    def _build(self, env_overrides):
+        """Run ``_build_pty_env`` under a controlled os.environ."""
+        from cli_agent_orchestrator.api.main import _build_pty_env
+
+        with patch.dict("os.environ", env_overrides, clear=True):
+            return _build_pty_env()
+
+    def test_unset_term_is_defaulted(self):
+        env = self._build({"HOME": "/root", "PATH": "/usr/bin"})
+        assert env["TERM"] == "xterm-256color"
+
+    def test_empty_string_term_is_defaulted(self):
+        env = self._build({"TERM": "", "HOME": "/root"})
+        assert env["TERM"] == "xterm-256color"
+
+    def test_dumb_term_is_overridden(self):
+        # The whole point of issue #150 — Docker's TERM=dumb is unusable.
+        env = self._build({"TERM": "dumb", "HOME": "/root"})
+        assert env["TERM"] == "xterm-256color"
+
+    def test_explicit_xterm_term_is_preserved(self):
+        env = self._build({"TERM": "xterm-256color", "HOME": "/root"})
+        assert env["TERM"] == "xterm-256color"
+
+    def test_custom_term_is_preserved(self):
+        # Operators that explicitly pick a different terminfo entry should
+        # see their choice respected — only unset/empty/dumb gets overridden.
+        env = self._build({"TERM": "screen-256color", "HOME": "/root"})
+        assert env["TERM"] == "screen-256color"
+
+    def test_other_env_vars_are_inherited(self):
+        env = self._build(
+            {
+                "HOME": "/home/cao",
+                "PATH": "/opt/cao/bin",
+                "AWS_REGION": "us-west-2",
+                "CAO_TERMINAL_ID": "abcd1234",
+            }
+        )
+        # The whole parent env must reach the subprocess so tmux can find its
+        # config and the agent CLIs can locate their credentials.
+        assert env["HOME"] == "/home/cao"
+        assert env["PATH"] == "/opt/cao/bin"
+        assert env["AWS_REGION"] == "us-west-2"
+        assert env["CAO_TERMINAL_ID"] == "abcd1234"
+
+
+class TestWebSocketSubprocessTerm:
+    """Wiring guard: ensure ``terminal_ws`` actually hands the PTY env
+    (with the corrected ``TERM``) to the tmux attach subprocess. Catches
+    a regression where the helper exists but never gets called from the
+    endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_subprocess_popen_receives_corrected_term(self):
+        """When the parent process has TERM=dumb, the tmux attach Popen call
+        must receive ``env`` with ``TERM=xterm-256color`` instead of inheriting
+        the broken value.
+
+        We let Popen raise immediately after capture so the endpoint stops
+        before touching the real PTY/asyncio loop.
+        """
+        from cli_agent_orchestrator.api import main as main_module
+
+        ws = MagicMock()
+        ws.client = MagicMock(host="127.0.0.1")
+        ws.accept = AsyncMock()
+        ws.close = AsyncMock()
+
+        captured: Dict[str, object] = {}
+
+        def capture_and_stop(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            raise _StopHere("captured Popen args")
+
+        with (
+            patch.dict("os.environ", {"TERM": "dumb", "HOME": "/root"}, clear=True),
+            patch.object(
+                main_module,
+                "get_terminal_metadata",
+                return_value={"tmux_session": "cao-s", "tmux_window": "w"},
+            ),
+            patch.object(main_module.subprocess, "Popen", side_effect=capture_and_stop),
+            patch.object(main_module.pty, "openpty", return_value=(100, 101)),
+            patch.object(main_module.fcntl, "ioctl"),
+            patch.object(main_module.fcntl, "fcntl"),
+            patch.object(main_module.os, "close"),
+        ):
+            with pytest.raises(_StopHere):
+                await main_module.terminal_ws(ws, "abcd1234")
+
+        passed_env = captured["kwargs"].get("env")  # type: ignore[union-attr]
+        assert passed_env is not None, (
+            "tmux Popen must receive env=; without it the subprocess inherits "
+            "the parent's broken TERM (issue #150)"
+        )
+        assert passed_env["TERM"] == "xterm-256color"
+
+
+class _StopHere(Exception):
+    """Sentinel raised by the wiring test once Popen args are captured."""
 
 
 class TestCrossProviderResolution:


### PR DESCRIPTION
## Summary

The WebSocket PTY attach endpoint in `cao-server` calls `subprocess.Popen(["tmux", "-u", "attach-session", ...])` without an `env=` argument, so the tmux child inherits the parent process environment as-is. Inside Docker and devcontainers `TERM` is routinely unset or set to `dumb`, and that value flows straight through to the agent CLI's TUI renderer. The result is broken colours, garbled cursor positioning, and corrupted Ink output in the browser.

This PR adds a small `_build_pty_env()` helper that copies the parent environment and rewrites `TERM` to `xterm-256color` when the inherited value is unset, empty, or `dumb`. Explicit non-dumb values (e.g. `screen-256color`) are preserved.

## Why this isn't #249

[PR #249](https://github.com/awslabs/cli-agent-orchestrator/pull/249) attempted the same fix but was closed. It used `pty_env.setdefault("TERM", "xterm-256color")`, which only rewrites the **unset** case — `TERM=dumb` (the value the issue title explicitly calls out) still flowed through unchanged. It also shipped no tests, and Codecov flagged 0% patch coverage on the two changed lines.

This PR:

- Treats `unset`, empty string, and `"dumb"` as equally unusable values that must be overridden. Anything else operator-set is preserved.
- Pulls the env-building logic into a named helper so it can be unit-tested without standing up a real WebSocket / PTY / tmux server.
- Ships 7 tests:
  - 5 helper cases (unset → defaulted, empty → defaulted, `dumb` → overridden, `xterm-256color` → preserved, `screen-256color` → preserved, all other env vars inherited unchanged).
  - 1 wiring guard that patches `subprocess.Popen` and asserts the endpoint actually hands the corrected env in — catches the regression of "helper exists but never gets called".

## Changes

- `src/cli_agent_orchestrator/api/main.py` — new `_build_pty_env()` helper near the existing module-level helpers, plus the one-line wiring change at the `terminal_ws` Popen call to pass `env=_build_pty_env()`.
- `test/api/test_terminals.py` — new `TestBuildPtyEnv` (6 tests) and `TestWebSocketSubprocessTerm` (1 wiring test).

## Test plan

- [x] `uv run pytest test/api/test_terminals.py::TestBuildPtyEnv test/api/test_terminals.py::TestWebSocketSubprocessTerm -v` — 7/7 pass.
- [x] Full unit suite — `uv run pytest test/ --ignore=test/e2e -m "not integration"` — 1713 passed, 1 skipped on Python 3.10, 3.11, and 3.12 (the CI matrix).
- [x] `uv run black --check src/ test/` — clean.
- [x] `uv run isort --check-only src/ test/` — clean.
- [x] `uv run mypy src/cli_agent_orchestrator/api/main.py` — clean (no new findings on the changed module).

Closes #150.
