### PR TITLE
fix(launch): resolve profile.provider regardless of yolo/allowed-tools branch

### DIFF
--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -106,20 +106,25 @@ def launch(
                 resolved_allowed_tools = resolve_allowed_tools(
                     profile.allowedTools, profile.role, mcp_server_names
                 )
-                # Honour profile.provider when --provider not explicitly passed
-                if provider is None:
-                    from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
-
-                    provider = resolve_provider(agents, DEFAULT_PROVIDER)
             except (FileNotFoundError, RuntimeError):
                 # Profile not found — use developer defaults (backward compatible)
                 no_role_set = True
                 resolved_allowed_tools = resolve_allowed_tools(None, None, None)
 
-        # Fall back to DEFAULT_PROVIDER when --provider was not given and
-        # profile resolution didn't set it (yolo, --allowed-tools, or missing profile)
+        # Honour profile.provider whenever the user did not pass --provider
+        # explicitly. This runs regardless of which permission-resolution
+        # branch above fired — provider selection ("which CLI runs this
+        # agent?") is orthogonal to tool restrictions ("what is the agent
+        # allowed to do?"). Previously this lookup lived inside the ``else``
+        # branch and ``--yolo`` / ``--allowed-tools`` silently bypassed the
+        # profile's ``provider:`` field, breaking heterogeneous-panel
+        # workflows. See issue #239. ``resolve_provider`` falls back to
+        # ``DEFAULT_PROVIDER`` when the profile is missing or has no
+        # ``provider`` key, so the trailing fallback is no longer needed.
         if provider is None:
-            provider = DEFAULT_PROVIDER
+            from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
+
+            provider = resolve_provider(agents, DEFAULT_PROVIDER)
 
         # Validate provider
         if provider not in PROVIDERS:

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -596,3 +596,141 @@ def test_launch_honors_profile_provider_when_flag_not_given():
         params = mock_post.call_args.kwargs["params"]
         # provider is NOT sent — server-side resolution handles it
         assert "provider" not in params
+
+
+def test_launch_yolo_still_resolves_profile_provider():
+    """--yolo must not swallow ``provider:`` in the agent profile frontmatter.
+
+    Regression guard for #239: ``resolve_provider`` previously lived inside
+    the ``else`` branch of the permission-resolution conditional and never
+    fired when ``--yolo`` took the first branch, breaking heterogeneous-
+    panelist workflows where each agent profile pins a specific CLI.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch(
+            "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
+            return_value="claude_code",
+        ) as mock_resolve,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        result = runner.invoke(launch, ["--agents", "codex_panelist", "--yolo"])
+
+        assert result.exit_code == 0
+        # Provider resolution must run even on the --yolo branch.
+        mock_resolve.assert_called_once_with("codex_panelist", "kiro_cli")
+        # The kiro_cli-specific yolo warning text must NOT appear, because
+        # the profile's provider ("claude_code") was honoured.
+        assert "kiro_cli will launch in --legacy-ui mode" not in result.output
+
+
+def test_launch_allowed_tools_still_resolves_profile_provider():
+    """--allowed-tools must also not swallow ``provider:`` in the profile."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch(
+            "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
+            return_value="gemini_cli",
+        ) as mock_resolve,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "gemini_panelist",
+                "--allowed-tools",
+                "fs_read",
+                "--headless",
+            ],
+            input="y\n",
+        )
+
+        assert result.exit_code == 0
+        mock_resolve.assert_called_once_with("gemini_panelist", "kiro_cli")
+        # Local prompts must reflect the resolved provider, not the default.
+        assert "launching on gemini_cli" in result.output
+
+
+def test_launch_explicit_provider_skips_profile_resolution():
+    """An explicit --provider flag wins over the profile's provider field.
+
+    ``resolve_provider`` should not be invoked at all when the operator names
+    a provider on the command line.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.utils.agent_profiles.resolve_provider") as mock_resolve,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        result = runner.invoke(
+            launch,
+            ["--agents", "codex_panelist", "--yolo", "--provider", "claude_code"],
+        )
+
+        assert result.exit_code == 0
+        mock_resolve.assert_not_called()
+        # Explicit provider IS sent to the API in this path.
+        params = mock_post.call_args.kwargs["params"]
+        assert params["provider"] == "claude_code"
+
+
+def test_launch_yolo_falls_back_to_default_when_profile_lacks_provider():
+    """When the profile has no ``provider`` key, ``--yolo`` falls back to
+    DEFAULT_PROVIDER. ``resolve_provider`` handles this by returning the
+    fallback it was given, so the trailing local fallback is unnecessary."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch(
+            "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
+            return_value="kiro_cli",  # fallback returned because profile has no provider
+        ),
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
+
+        assert result.exit_code == 0
+        # The kiro_cli-specific yolo warning IS expected here because the
+        # profile didn't override and the fallback is kiro_cli.
+        assert "kiro_cli will launch in --legacy-ui mode" in result.output


### PR DESCRIPTION
## Summary

`resolve_provider()` lived inside the `else` branch of the permission-resolution conditional in `launch.py`, so it never ran when `--yolo` or `--allowed-tools` took the first two branches. In those paths the agent profile's `provider:` frontmatter field was silently dropped and the supervisor fell back to `DEFAULT_PROVIDER` for local prompts and warnings — even when the profile explicitly pinned a different CLI.

That breaks heterogeneous-panelist workflows. The issue author (panel-of-experts setup with one CLI per panelist) reported every panelist routing to `kiro_cli` regardless of profile.

## Why this is the right fix

Provider selection ("which CLI runs this agent?") is **orthogonal** to tool-restriction selection ("what is the agent allowed to do?"). The two should not share a conditional. The issue author traced the bug to `launch.py:95-125` and proposed lifting the `if provider is None: resolve_provider(...)` block out of the `else` branch — this PR is exactly that change.

Because `resolve_provider()` already falls back to its second argument (DEFAULT_PROVIDER) when the profile is missing or lacks a `provider:` field, the trailing `if provider is None: provider = DEFAULT_PROVIDER` line is now redundant and removed.

## Changes

- `src/cli_agent_orchestrator/cli/commands/launch.py`
  - Removed the conditionally-firing `resolve_provider` call from inside the `else` branch (~5 lines)
  - Added an unconditional `if provider is None: resolve_provider(...)` block that runs after permission resolution, with a comment explaining why it's outside the conditional
  - Removed the redundant trailing `DEFAULT_PROVIDER` fallback (now handled inside `resolve_provider`)
- `test/cli/commands/test_launch.py` — 4 new regression tests in addition to the pre-existing `test_launch_honors_profile_provider_when_flag_not_given`:
  - `test_launch_yolo_still_resolves_profile_provider` — the headline case
  - `test_launch_allowed_tools_still_resolves_profile_provider` — same bug, `--allowed-tools` path
  - `test_launch_explicit_provider_skips_profile_resolution` — `--provider` still wins
  - `test_launch_yolo_falls_back_to_default_when_profile_lacks_provider` — fallback still works

## PR #196 behavior table addition

| Scenario | Before | After |
|---|---|---|
| Profile has `provider:`, `--yolo` passed | `DEFAULT_PROVIDER` | `profile.provider` |
| Profile has `provider:`, `--allowed-tools X` passed | `DEFAULT_PROVIDER` | `profile.provider` |
| Profile has `provider:`, `--provider Y` passed | `Y` | `Y` (unchanged) |
| Profile has no `provider:`, `--yolo` passed | `DEFAULT_PROVIDER` | `DEFAULT_PROVIDER` (unchanged) |

## Test plan

- [x] `uv run pytest test/cli/commands/test_launch.py -v` — 25/25 pass (4 new + 1 pre-existing for this code path).
- [x] Full unit suite — `uv run pytest test/ --ignore=test/e2e -m "not integration"` — 1724 passed, 1 skipped on Python 3.10, 3.11, 3.12.
- [x] `uv run black --check src/ test/` — clean.
- [x] `uv run isort --check-only src/ test/` — clean.
- [x] `uv run mypy src/cli_agent_orchestrator/cli/commands/launch.py` — no new findings on the changed module (the pre-existing `types-requests` stub warning is unchanged from main).

Closes #239.
