### PR TITLE
feat(launch): forward env vars to supervisor and child agents

### DIFF
--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -30,6 +30,28 @@ cao shutdown --session <session-name>
 
 ![Tmux Window Selector](./assets/tmux_all_windows.png)
 
+## Forwarding env vars to spawned agents
+
+By default, only a tight allowlist of env vars (`HOME`, `PATH`, `SHELL`, plus `CAO_*` / `KIRO_*` / `MISE_*` / `AWS_*` prefixes) reaches agents spawned inside tmux. The filter keeps the `tmux new-session -e` argv under the kernel limit and prevents nested-session loops when CAO itself runs inside a provider.
+
+To forward additional vars to **the supervisor and every worker spawned later in the same session** (via `assign` / `handoff` / the web UI), pass `--env KEY=VALUE` to `cao launch`:
+
+```bash
+cao launch --agents code_supervisor \
+  --env MNEMOSYNE_DIR=/root/mnemosyne \
+  --env ISAAC_CHANNEL=room:engineering
+```
+
+The flag is repeatable. Values travel in the request body, not the URL, so secrets do not land in cao-server's HTTP access log.
+
+Rejected at the CLI boundary:
+
+- Keys matching `CLAUDE` / `CODEX_` / `__MISE_` (reserved for provider auth — the 6 `CLAUDE_CODE_USE_*` / `CLAUDE_CODE_SKIP_*` auth flags are explicitly allowlisted).
+- Keys outside `[A-Za-z_][A-Za-z0-9_]*` (non-POSIX names break the shell).
+- Values ≥ 2048 bytes (per-var cap that keeps the tmux argv under the kernel limit — see PR #246).
+
+Forwarded vars are held in process memory on cao-server and dropped when the session is deleted; restarting cao-server wipes them.
+
 ## Notes
 
 - CAO session names are automatically prefixed with `cao-`. Use the prefixed name (e.g. `cao-my-task`) when referencing a session in `tmux attach`, `cao session send`, or `cao shutdown`.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -14,7 +14,16 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated, Dict, List, Optional, cast
 
-from fastapi import FastAPI, HTTPException, Query, Request, WebSocket, WebSocketDisconnect, status
+from fastapi import (
+    Body,
+    FastAPI,
+    HTTPException,
+    Query,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from pydantic import BaseModel, Field, field_validator
@@ -406,8 +415,15 @@ async def create_session(
     session_name: Optional[str] = None,
     working_directory: Optional[str] = None,
     allowed_tools: Optional[str] = None,
+    env_vars: Optional[Dict[str, str]] = Body(default=None, embed=True),
 ) -> Terminal:
-    """Create a new session with exactly one terminal."""
+    """Create a new session with exactly one terminal.
+
+    ``env_vars`` (request body, optional) is the operator-forwarded env map
+    from ``cao launch --env``. It travels in the JSON body — not the query
+    string — so values potentially containing secrets do not land in
+    cao-server's HTTP access log. See issue #248.
+    """
     try:
         # Parse comma-separated allowed_tools string into list
         allowed_tools_list = allowed_tools.split(",") if allowed_tools else None
@@ -419,6 +435,7 @@ async def create_session(
             working_directory=working_directory,
             allowed_tools=allowed_tools_list,
             registry=get_plugin_registry(request),
+            env_vars=env_vars,
         )
         return result
 

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -28,6 +28,60 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     "opencode_cli",
 }
 
+# Validation constraints for ``--env`` forwarded vars (mirrored server-side
+# in ``TmuxClient._merge_extra_env``). See issue #248.
+_FORWARDED_ENV_BLOCKED_PREFIXES = ("CLAUDE", "CODEX_", "__MISE_")
+_FORWARDED_ENV_PREFIX_ALLOWLIST = frozenset(
+    {
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+        "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+    }
+)
+_FORWARDED_ENV_MAX_VALUE_BYTES = 2048
+
+
+def _parse_env_pairs(pairs):
+    """Parse repeated ``KEY=VALUE`` entries into a dict, validating each.
+
+    Mirrors the constraints applied to inherited env in TmuxClient so a
+    forwarded var that would be silently dropped server-side is rejected at
+    the CLI boundary with a clear error message instead.
+    """
+    result: dict[str, str] = {}
+    for raw in pairs:
+        if "=" not in raw:
+            raise click.ClickException(
+                f"--env expects KEY=VALUE (got {raw!r}); did you forget the '='?"
+            )
+        key, value = raw.split("=", 1)
+        # POSIX env names: leading letter/underscore, then alnum/underscore.
+        # Stricter than ``str.isidentifier`` only in that it forbids non-ASCII.
+        if (
+            not key
+            or not (key[0].isalpha() or key[0] == "_")
+            or not all(c.isalnum() or c == "_" for c in key)
+            or not key.isascii()
+        ):
+            raise click.ClickException(f"--env key must match [A-Za-z_][A-Za-z0-9_]* (got {key!r})")
+        if key not in _FORWARDED_ENV_PREFIX_ALLOWLIST and any(
+            key.startswith(p) for p in _FORWARDED_ENV_BLOCKED_PREFIXES
+        ):
+            raise click.ClickException(
+                f"--env key {key!r} uses a blocked prefix "
+                f"({', '.join(_FORWARDED_ENV_BLOCKED_PREFIXES)}) reserved for provider env"
+            )
+        if len(value.encode("utf-8")) >= _FORWARDED_ENV_MAX_VALUE_BYTES:
+            raise click.ClickException(
+                f"--env value for {key!r} exceeds {_FORWARDED_ENV_MAX_VALUE_BYTES} bytes "
+                "(tmux argv limit, PR #246)"
+            )
+        result[key] = value
+    return result
+
 
 @click.command()
 @click.argument("message", required=False, default=None)
@@ -66,6 +120,16 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     default=None,
     help="Working directory for the session (default: current directory)",
 )
+@click.option(
+    "--env",
+    "env_pairs",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Forward an env var to the supervisor AND every worker spawned later "
+    "in the same session. Repeatable. Values travel in the request body, not "
+    "the URL. Blocked prefixes (CLAUDE/CODEX_/__MISE_) and >=2048-byte values "
+    "are rejected. See issue #248.",
+)
 def launch(
     message,
     agents,
@@ -77,11 +141,13 @@ def launch(
     auto_approve,
     yolo,
     working_directory,
+    env_pairs,
 ):
     """Launch cao session with specified agent profile."""
     try:
         display_dir = working_directory or os.path.realpath(os.getcwd())
         explicit_provider = provider is not None  # True only when --provider was passed
+        forwarded_env = _parse_env_pairs(env_pairs) if env_pairs else {}
 
         # Resolve allowedTools: --yolo > --allowed-tools CLI > profile/role defaults
         from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
@@ -202,7 +268,14 @@ def launch(
             # Pass as comma-separated string for query param
             params["allowed_tools"] = ",".join(resolved_allowed_tools)
 
-        response = requests.post(url, params=params)
+        # Forwarded env vars travel in the JSON body so values (which may
+        # contain secrets) don't end up in cao-server's HTTP access log.
+        # See issue #248.
+        post_kwargs: dict = {"params": params}
+        if forwarded_env:
+            post_kwargs["json"] = {"env_vars": forwarded_env}
+
+        response = requests.post(url, **post_kwargs)
         response.raise_for_status()
 
         terminal = response.json()

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -114,32 +114,70 @@ class TmuxClient:
 
         return real_path
 
+    # Provider env vars that would cause "nested session" errors when CAO
+    # itself runs inside a provider (e.g. Claude Code), unless explicitly
+    # allow-listed for provider authentication (Bedrock, Vertex AI, Foundry).
+    # Applied to BOTH inherited env and operator-supplied --env vars so a
+    # forwarded ``CLAUDE_CODE_*`` cannot reintroduce nesting.
+    _BLOCKED_ENV_PREFIXES = ("CLAUDE", "CODEX_", "__MISE_")
+    _BLOCKED_PREFIX_ALLOWLIST = frozenset(
+        {
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "CLAUDE_CODE_USE_FOUNDRY",
+            "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+            "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+            "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+        }
+    )
+    # Per-var value cap (PR #246) — keeps the full tmux ``new-session -e`` /
+    # ``new-window -e`` argv under the kernel argv limit on busy hosts.
+    _MAX_ENV_VALUE_BYTES = 2048
+
+    @classmethod
+    def _is_blocked_env_key(cls, key: str) -> bool:
+        """Return True if ``key`` matches a blocked prefix and isn't allowlisted."""
+        if key in cls._BLOCKED_PREFIX_ALLOWLIST:
+            return False
+        return any(key.startswith(p) for p in cls._BLOCKED_ENV_PREFIXES)
+
+    @classmethod
+    def _merge_extra_env(
+        cls, environment: Dict[str, str], extra_env: Optional[Dict[str, str]]
+    ) -> None:
+        """Merge operator-supplied env vars into ``environment`` in place.
+
+        Mirrors the safety constraints applied to inherited env (blocked
+        prefixes, 2048-byte value cap) so a malformed --env entry cannot
+        slip past the validation that runs at the CLI boundary.
+        """
+        if not extra_env:
+            return
+        for key, value in extra_env.items():
+            if cls._is_blocked_env_key(key):
+                logger.warning("Dropping forwarded env var with blocked prefix: %s", key)
+                continue
+            if len(value.encode("utf-8")) >= cls._MAX_ENV_VALUE_BYTES:
+                logger.warning(
+                    "Dropping forwarded env var %s — value exceeds %d bytes",
+                    key,
+                    cls._MAX_ENV_VALUE_BYTES,
+                )
+                continue
+            environment[key] = value
+
     def create_session(
         self,
         session_name: str,
         window_name: str,
         terminal_id: str,
         working_directory: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
     ) -> str:
         """Create detached tmux session with initial window and return window name."""
         try:
             working_directory = self._resolve_and_validate_working_directory(working_directory)
 
-            # Filter out provider env vars that would cause "nested session"
-            # errors when CAO itself runs inside a provider (e.g. Claude Code).
-            # Preserve CLAUDE_CODE_USE_* and CLAUDE_CODE_SKIP_* vars needed
-            # for provider authentication (Bedrock, Vertex AI, Foundry).
-            # Also filter vars with very long values and __MISE_ internal vars
-            # to avoid tmux "command too long" errors in large environments.
-            blocked_prefixes = ("CLAUDE", "CODEX_", "__MISE_")
-            allowed_vars = {
-                "CLAUDE_CODE_USE_BEDROCK",
-                "CLAUDE_CODE_USE_VERTEX",
-                "CLAUDE_CODE_USE_FOUNDRY",
-                "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
-                "CLAUDE_CODE_SKIP_VERTEX_AUTH",
-                "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
-            }
             # Only pass essential env vars to avoid tmux "command too long"
             essential_keys = {
                 "HOME",
@@ -160,14 +198,19 @@ class TmuxClient:
                 for k, v in os.environ.items()
                 if (
                     k in essential_keys
-                    or k in allowed_vars
+                    or k in self._BLOCKED_PREFIX_ALLOWLIST
                     or (
-                        not any(k.startswith(p) for p in blocked_prefixes)
+                        not self._is_blocked_env_key(k)
                         and k.startswith(("CAO_", "KIRO_", "MISE_", "AWS_"))
-                        and len(v.encode("utf-8")) < 2048
+                        and len(v.encode("utf-8")) < self._MAX_ENV_VALUE_BYTES
                     )
                 )
             }
+            # Operator-forwarded vars (from ``cao launch --env``) merge AFTER
+            # the inherited slice and override on key collision, so an
+            # explicit ``--env AWS_REGION=us-west-2`` wins over the inherited
+            # value. See issue #248.
+            self._merge_extra_env(environment, extra_env)
             environment["CAO_TERMINAL_ID"] = terminal_id
 
             # Explicit 220x50 pane size avoids the default 80x24 that tmux
@@ -204,8 +247,14 @@ class TmuxClient:
         terminal_id: str,
         working_directory: Optional[str] = None,
         window_shell: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
     ) -> str:
-        """Create window in session and return window name."""
+        """Create window in session and return window name.
+
+        ``extra_env`` carries operator-forwarded vars from
+        ``cao launch --env`` so workers spawned via ``assign`` / ``handoff`` /
+        the web UI inherit the same context as the supervisor. See issue #248.
+        """
         try:
             working_directory = self._resolve_and_validate_working_directory(working_directory)
 
@@ -213,10 +262,14 @@ class TmuxClient:
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
+            window_env: dict[str, str] = {}
+            self._merge_extra_env(window_env, extra_env)
+            window_env["CAO_TERMINAL_ID"] = terminal_id
+
             kwargs: dict = {
                 "window_name": window_name,
                 "start_directory": working_directory,
-                "environment": {"CAO_TERMINAL_ID": terminal_id},
+                "environment": window_env,
             }
             if window_shell:
                 kwargs["window_shell"] = window_shell

--- a/src/cli_agent_orchestrator/services/session_env.py
+++ b/src/cli_agent_orchestrator/services/session_env.py
@@ -1,0 +1,41 @@
+"""In-memory store for per-session forwarded environment variables.
+
+``cao launch --env KEY=VALUE`` lets operators forward arbitrary env vars to
+the supervisor terminal. Those vars must also reach workers spawned later in
+the same session via ``assign`` / ``handoff`` / the web UI — otherwise the
+supervisor's children would not see ``MNEMOSYNE_DIR`` and the like. This
+module persists the mapping for the session lifetime so ``create_window``
+calls can pick it up. See issue #248.
+
+The store is process-local: cao-server holds it, restarts wipe it. There is
+no schema migration and no on-disk format.
+"""
+
+import threading
+
+_session_forwarded_env: dict[str, dict[str, str]] = {}
+_lock = threading.Lock()
+
+
+def set_session_env(session_name: str, env_vars: dict[str, str]) -> None:
+    """Register the forwarded env vars for ``session_name``.
+
+    Overwrites any prior mapping. Passing an empty dict clears it.
+    """
+    with _lock:
+        if env_vars:
+            _session_forwarded_env[session_name] = dict(env_vars)
+        else:
+            _session_forwarded_env.pop(session_name, None)
+
+
+def get_session_env(session_name: str) -> dict[str, str]:
+    """Return the forwarded env vars for ``session_name`` (empty dict if none)."""
+    with _lock:
+        return dict(_session_forwarded_env.get(session_name, {}))
+
+
+def clear_session_env(session_name: str) -> None:
+    """Drop the mapping for ``session_name``. Called on session teardown."""
+    with _lock:
+        _session_forwarded_env.pop(session_name, None)

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -36,6 +36,7 @@ from cli_agent_orchestrator.plugins import (
 )
 from cli_agent_orchestrator.providers.manager import provider_manager
 from cli_agent_orchestrator.services.plugin_dispatch import dispatch_plugin_event
+from cli_agent_orchestrator.services.session_env import clear_session_env
 from cli_agent_orchestrator.services.terminal_service import create_terminal
 from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
 
@@ -49,8 +50,14 @@ def create_session(
     working_directory: str | None = None,
     allowed_tools: list[str] | None = None,
     registry: PluginRegistry | None = None,
+    env_vars: dict[str, str] | None = None,
 ) -> Terminal:
-    """Create a new session by creating its initial terminal."""
+    """Create a new session by creating its initial terminal.
+
+    ``env_vars`` are operator-forwarded env vars from ``cao launch --env``.
+    They are persisted on the session record so every worker spawned later
+    in the same session inherits them. See issue #248.
+    """
     if provider is None:
         resolved_provider = resolve_provider(agent_profile, fallback_provider="kiro_cli")
     else:
@@ -64,6 +71,7 @@ def create_session(
         working_directory=working_directory,
         allowed_tools=allowed_tools,
         registry=registry,
+        env_vars=env_vars,
     )
     dispatch_plugin_event(
         registry,
@@ -131,6 +139,10 @@ def delete_session(session_name: str, registry: PluginRegistry | None = None) ->
 
         # Delete terminal metadata
         delete_terminals_by_session(session_name)
+
+        # Drop the per-session forwarded-env mapping (issue #248). Safe
+        # even when no vars were forwarded — the helper is a no-op then.
+        clear_session_env(session_name)
 
         result["deleted"].append(session_name)
         logger.info(f"Deleted session: {session_name}")

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -44,7 +44,11 @@ from cli_agent_orchestrator.plugins import (
 from cli_agent_orchestrator.providers.manager import provider_manager
 from cli_agent_orchestrator.services.memory_service import MemoryService
 from cli_agent_orchestrator.services.plugin_dispatch import dispatch_plugin_event
-from cli_agent_orchestrator.services.session_env import get_session_env, set_session_env
+from cli_agent_orchestrator.services.session_env import (
+    clear_session_env,
+    get_session_env,
+    set_session_env,
+)
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.skills import build_skill_catalog
 from cli_agent_orchestrator.utils.terminal import (
@@ -167,11 +171,9 @@ def create_terminal(
             if tmux_client.session_exists(session_name):
                 raise ValueError(f"Session '{session_name}' already exists")
 
-            # Persist forwarded env BEFORE the tmux call so even an early
-            # failure leaves the session record consistent with what gets
-            # cleared on delete_session.
-            if env_vars:
-                set_session_env(session_name, env_vars)
+            # Wipe any stale mapping a prior aborted lifecycle for this name
+            # may have left behind, so a no-env relaunch can't inherit them.
+            clear_session_env(session_name)
 
             # Create new tmux session with initial window
             tmux_client.create_session(
@@ -182,6 +184,12 @@ def create_terminal(
                 extra_env=env_vars,
             )
             session_created = True  # only set after successful creation
+
+            # Persist forwarded env only after the tmux session actually
+            # exists; the failure path below clears it if a later step
+            # tears the session back down.
+            if env_vars:
+                set_session_env(session_name, env_vars)
         else:
             # Add window to existing session
             if not tmux_client.session_exists(session_name):
@@ -292,6 +300,10 @@ def create_terminal(
                 tmux_client.kill_session(session_name)
             except:
                 pass  # Ignore cleanup errors
+            # Session is gone, drop any forwarded env we stashed for it so
+            # secrets don't linger in memory or bleed into a future reuse
+            # of the same name.
+            clear_session_env(session_name)
         raise
 
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -44,6 +44,7 @@ from cli_agent_orchestrator.plugins import (
 from cli_agent_orchestrator.providers.manager import provider_manager
 from cli_agent_orchestrator.services.memory_service import MemoryService
 from cli_agent_orchestrator.services.plugin_dispatch import dispatch_plugin_event
+from cli_agent_orchestrator.services.session_env import get_session_env, set_session_env
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.skills import build_skill_catalog
 from cli_agent_orchestrator.utils.terminal import (
@@ -115,6 +116,7 @@ def create_terminal(
     working_directory: Optional[str] = None,
     allowed_tools: Optional[list[str]] = None,
     registry: PluginRegistry | None = None,
+    env_vars: Optional[dict[str, str]] = None,
 ) -> Terminal:
     """Create a new terminal with an initialized CLI agent.
 
@@ -131,6 +133,12 @@ def create_terminal(
         session_name: Optional custom session name. If not provided, auto-generated.
         new_session: If True, creates a new tmux session. If False, adds to existing.
         working_directory: Optional working directory for the terminal shell
+        env_vars: Operator-forwarded env vars (``cao launch --env``). On
+            ``new_session=True``, these are stored on the session record and
+            inherited by every worker spawned later in the same session. On
+            ``new_session=False``, the persisted session vars are merged in
+            automatically; the explicit ``env_vars`` argument is ignored to
+            keep the per-session view consistent. See issue #248.
 
     Returns:
         Terminal object with all metadata populated
@@ -159,15 +167,31 @@ def create_terminal(
             if tmux_client.session_exists(session_name):
                 raise ValueError(f"Session '{session_name}' already exists")
 
+            # Persist forwarded env BEFORE the tmux call so even an early
+            # failure leaves the session record consistent with what gets
+            # cleared on delete_session.
+            if env_vars:
+                set_session_env(session_name, env_vars)
+
             # Create new tmux session with initial window
-            tmux_client.create_session(session_name, window_name, terminal_id, working_directory)
+            tmux_client.create_session(
+                session_name,
+                window_name,
+                terminal_id,
+                working_directory,
+                extra_env=env_vars,
+            )
             session_created = True  # only set after successful creation
         else:
             # Add window to existing session
             if not tmux_client.session_exists(session_name):
                 raise ValueError(f"Session '{session_name}' not found")
             window_name = tmux_client.create_window(
-                session_name, window_name, terminal_id, working_directory
+                session_name,
+                window_name,
+                terminal_id,
+                working_directory,
+                extra_env=get_session_env(session_name),
             )
 
         # Step 3: Persist terminal metadata to database

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -262,6 +262,7 @@ class TestCreateSession:
             working_directory=None,
             allowed_tools=None,
             registry=ANY,
+            env_vars=None,
         )
 
     def test_create_session_with_session_name(self, client):

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from cli_agent_orchestrator.cli.commands.launch import launch
+from cli_agent_orchestrator.cli.commands.launch import _parse_env_pairs, launch
 
 
 def test_launch_passes_cwd_by_default():
@@ -734,3 +734,146 @@ def test_launch_yolo_falls_back_to_default_when_profile_lacks_provider():
         # The kiro_cli-specific yolo warning IS expected here because the
         # profile didn't override and the fallback is kiro_cli.
         assert "kiro_cli will launch in --legacy-ui mode" in result.output
+
+
+# ── --env forwarded env vars (issue #248) ────────────────────────────
+
+
+class TestParseEnvPairs:
+    """``_parse_env_pairs`` validates --env at the CLI boundary so a value
+    that would be silently dropped server-side is rejected up front."""
+
+    def test_valid_pairs_parsed(self):
+        assert _parse_env_pairs(["FOO=bar", "AWS_REGION=us-west-2"]) == {
+            "FOO": "bar",
+            "AWS_REGION": "us-west-2",
+        }
+
+    def test_value_with_equals_preserved(self):
+        # Split on first '=' only — values may legitimately contain '='.
+        assert _parse_env_pairs(["URL=https://x?a=1&b=2"]) == {"URL": "https://x?a=1&b=2"}
+
+    def test_empty_value_allowed(self):
+        assert _parse_env_pairs(["EMPTY="]) == {"EMPTY": ""}
+
+    @pytest.mark.parametrize("bad", ["NO_EQUALS", "", "=value_with_no_key"])
+    def test_invalid_format_rejected(self, bad):
+        import click as _click
+
+        with pytest.raises(_click.ClickException):
+            _parse_env_pairs([bad])
+
+    @pytest.mark.parametrize("key", ["1FOO", "FÖÖ", "BAD-KEY", "WITH SPACE"])
+    def test_bad_key_rejected(self, key):
+        import click as _click
+
+        with pytest.raises(_click.ClickException, match="--env key must match"):
+            _parse_env_pairs([f"{key}=x"])
+
+    @pytest.mark.parametrize("blocked", ["CLAUDE_SECRET=x", "CODEX_TOKEN=x", "__MISE_X=y"])
+    def test_blocked_prefix_rejected(self, blocked):
+        import click as _click
+
+        with pytest.raises(_click.ClickException, match="blocked prefix"):
+            _parse_env_pairs([blocked])
+
+    def test_allowlisted_claude_auth_var_passes(self):
+        # The 6 CLAUDE_CODE_USE_* / SKIP_* auth vars are explicitly allowed
+        # through despite matching the CLAUDE prefix — same allowlist as
+        # TmuxClient inherits at the server boundary.
+        assert _parse_env_pairs(["CLAUDE_CODE_USE_BEDROCK=1"]) == {"CLAUDE_CODE_USE_BEDROCK": "1"}
+
+    def test_value_at_cap_rejected(self):
+        import click as _click
+
+        with pytest.raises(_click.ClickException, match="exceeds 2048 bytes"):
+            _parse_env_pairs(["BIG=" + ("x" * 2048)])
+
+    def test_value_under_cap_accepted(self):
+        assert _parse_env_pairs(["SMALL=" + ("x" * 2047)]) == {"SMALL": "x" * 2047}
+
+
+def test_launch_forwards_env_in_json_body_not_url():
+    """``--env`` values travel in the request body so secrets do not leak
+    into cao-server's HTTP access log. Issue #248."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--yolo",
+                "--env",
+                "MNEMOSYNE_DIR=/root/mnemosyne",
+                "--env",
+                "ISAAC_CHANNEL=room:engineering",
+            ],
+        )
+
+        assert result.exit_code == 0
+        kwargs = mock_post.call_args.kwargs
+        # env vars must NOT appear in query params
+        assert "env_vars" not in kwargs["params"]
+        assert "MNEMOSYNE_DIR" not in kwargs["params"]
+        # env vars travel under the embedded ``env_vars`` body key
+        assert kwargs["json"] == {
+            "env_vars": {
+                "MNEMOSYNE_DIR": "/root/mnemosyne",
+                "ISAAC_CHANNEL": "room:engineering",
+            }
+        }
+
+
+def test_launch_without_env_omits_request_body():
+    """A launch with no --env must not send a JSON body — preserves
+    backward compatibility with callers that ignore an unexpected body."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
+
+        assert result.exit_code == 0
+        assert "json" not in mock_post.call_args.kwargs
+
+
+def test_launch_rejects_blocked_env_prefix_before_calling_api():
+    """A blocked --env prefix must fail at the CLI boundary, before any
+    POST is issued — operator gets an actionable error instead of a
+    silent server-side drop."""
+    runner = CliRunner()
+
+    with patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post:
+        result = runner.invoke(
+            launch,
+            ["--agents", "test-agent", "--yolo", "--env", "CLAUDE_SESSION_ID=abc"],
+        )
+
+        assert result.exit_code != 0
+        assert "blocked prefix" in result.output
+        mock_post.assert_not_called()

--- a/test/clients/test_tmux_merge_extra_env.py
+++ b/test/clients/test_tmux_merge_extra_env.py
@@ -1,0 +1,66 @@
+"""Tests for TmuxClient._merge_extra_env (issue #248).
+
+Server-side defensive validation that mirrors the CLI's --env parser. CLI
+already rejects bad entries up front; this layer is the safety net for
+callers that bypass the CLI (cao-mcp-server, direct HTTP).
+"""
+
+from cli_agent_orchestrator.clients.tmux import TmuxClient
+
+
+def test_merge_with_none_is_noop():
+    env = {"HOME": "/home/u"}
+    TmuxClient._merge_extra_env(env, None)
+    assert env == {"HOME": "/home/u"}
+
+
+def test_merge_with_empty_dict_is_noop():
+    env = {"HOME": "/home/u"}
+    TmuxClient._merge_extra_env(env, {})
+    assert env == {"HOME": "/home/u"}
+
+
+def test_merge_adds_user_supplied_keys():
+    env = {"HOME": "/home/u"}
+    TmuxClient._merge_extra_env(env, {"MNEMOSYNE_DIR": "/root/mn", "X": "y"})
+    assert env["MNEMOSYNE_DIR"] == "/root/mn"
+    assert env["X"] == "y"
+
+
+def test_merge_overrides_inherited_value():
+    """An explicit --env entry wins over the inherited value on key collision."""
+    env = {"AWS_REGION": "us-east-1"}
+    TmuxClient._merge_extra_env(env, {"AWS_REGION": "us-west-2"})
+    assert env["AWS_REGION"] == "us-west-2"
+
+
+def test_merge_drops_blocked_prefix(caplog):
+    env: dict[str, str] = {}
+    TmuxClient._merge_extra_env(env, {"CLAUDE_SECRET": "x", "OK": "y"})
+    assert "CLAUDE_SECRET" not in env
+    assert env["OK"] == "y"
+
+
+def test_merge_keeps_allowlisted_claude_auth_var():
+    env: dict[str, str] = {}
+    TmuxClient._merge_extra_env(env, {"CLAUDE_CODE_USE_BEDROCK": "1"})
+    assert env["CLAUDE_CODE_USE_BEDROCK"] == "1"
+
+
+def test_merge_drops_value_at_or_above_cap():
+    env: dict[str, str] = {}
+    TmuxClient._merge_extra_env(env, {"BIG": "x" * 2048, "SMALL": "x" * 2047})
+    assert "BIG" not in env
+    assert env["SMALL"] == "x" * 2047
+
+
+def test_is_blocked_env_key_classification():
+    assert TmuxClient._is_blocked_env_key("CLAUDE_SESSION_ID") is True
+    assert TmuxClient._is_blocked_env_key("CODEX_TOKEN") is True
+    assert TmuxClient._is_blocked_env_key("__MISE_WATCH") is True
+    # Allowlisted overrides match-by-prefix.
+    assert TmuxClient._is_blocked_env_key("CLAUDE_CODE_USE_BEDROCK") is False
+    assert TmuxClient._is_blocked_env_key("CLAUDE_CODE_SKIP_FOUNDRY_AUTH") is False
+    # Unrelated keys aren't blocked.
+    assert TmuxClient._is_blocked_env_key("AWS_REGION") is False
+    assert TmuxClient._is_blocked_env_key("MNEMOSYNE_DIR") is False

--- a/test/clients/test_tmux_merge_extra_env.py
+++ b/test/clients/test_tmux_merge_extra_env.py
@@ -58,7 +58,8 @@ def test_is_blocked_env_key_classification():
     assert TmuxClient._is_blocked_env_key("CLAUDE_SESSION_ID") is True
     assert TmuxClient._is_blocked_env_key("CODEX_TOKEN") is True
     assert TmuxClient._is_blocked_env_key("__MISE_WATCH") is True
-    # Allowlisted overrides match-by-prefix.
+    # Allowlist matches the full key, not a prefix — only the exact entries
+    # in _BLOCKED_PREFIX_ALLOWLIST are exempted from the blocked prefixes.
     assert TmuxClient._is_blocked_env_key("CLAUDE_CODE_USE_BEDROCK") is False
     assert TmuxClient._is_blocked_env_key("CLAUDE_CODE_SKIP_FOUNDRY_AUTH") is False
     # Unrelated keys aren't blocked.

--- a/test/services/test_session_env.py
+++ b/test/services/test_session_env.py
@@ -1,0 +1,56 @@
+"""Tests for the per-session forwarded-env store (issue #248)."""
+
+from cli_agent_orchestrator.services.session_env import (
+    clear_session_env,
+    get_session_env,
+    set_session_env,
+)
+
+
+def test_get_returns_empty_dict_for_unknown_session():
+    assert get_session_env("cao-unknown-xyz") == {}
+
+
+def test_set_and_get_roundtrip():
+    set_session_env("cao-roundtrip", {"FOO": "bar", "BAZ": "qux"})
+    try:
+        assert get_session_env("cao-roundtrip") == {"FOO": "bar", "BAZ": "qux"}
+    finally:
+        clear_session_env("cao-roundtrip")
+
+
+def test_get_returns_a_copy_not_the_internal_dict():
+    """Caller mutation of the returned dict must not leak into the store."""
+    set_session_env("cao-copy", {"K": "v"})
+    try:
+        got = get_session_env("cao-copy")
+        got["K"] = "tampered"
+        got["NEW"] = "x"
+        assert get_session_env("cao-copy") == {"K": "v"}
+    finally:
+        clear_session_env("cao-copy")
+
+
+def test_set_with_empty_dict_clears_mapping():
+    """Passing an empty dict drops the entry — avoids two ways to say "none"."""
+    set_session_env("cao-empty", {"X": "1"})
+    set_session_env("cao-empty", {})
+    assert get_session_env("cao-empty") == {}
+
+
+def test_clear_is_idempotent():
+    clear_session_env("cao-never-set")  # must not raise
+    set_session_env("cao-clear", {"X": "1"})
+    clear_session_env("cao-clear")
+    clear_session_env("cao-clear")  # second call — still must not raise
+    assert get_session_env("cao-clear") == {}
+
+
+def test_overwrite_replaces_previous_mapping():
+    """A second set fully replaces the prior mapping (not merge)."""
+    set_session_env("cao-overwrite", {"A": "1", "B": "2"})
+    set_session_env("cao-overwrite", {"C": "3"})
+    try:
+        assert get_session_env("cao-overwrite") == {"C": "3"}
+    finally:
+        clear_session_env("cao-overwrite")


### PR DESCRIPTION
Fixes #248.

## Summary

- `cao launch --env KEY=VALUE` (repeatable) now forwards to both the supervisor terminal AND every worker spawned later in the same session via `assign` / `handoff` / the web UI.
- Validation runs at the CLI boundary (POSIX-name keys, blocked prefixes `CLAUDE`/`CODEX_`/`__MISE_` with the six `CLAUDE_CODE_USE_*` / `CLAUDE_CODE_SKIP_*` auth flags allowlisted, 2048-byte value cap) so a bad entry fails fast instead of getting silently dropped server-side.
- Values travel in the JSON body of `POST /sessions`, not the URL — keeps anything resembling a secret out of cao-server's HTTP access log.

## Why this matters

The strict tmux env allowlist from #246 keeps the `tmux new-session -e` argv under the kernel limit but also drops anything outside `CAO_/KIRO_/MISE_/AWS_` prefixes. Operators reported that arbitrary deployment context they wanted on their agents (e.g. `MNEMOSYNE_DIR`, `ISAAC_CHANNEL=room:engineering`) was silently disappearing. `--env` is the explicit opt-out for that allowlist on a per-session basis.

The naive approach — only honour `--env` on the first agent — would have broken the multi-agent case where a supervisor's `assign`-spawned analysts still need the same context. This PR persists the mapping on a per-session in-memory record so `create_window` picks it up on every spawn automatically.

## Architecture

- `services/session_env.py` — small thread-safe in-memory store (`set` / `get` / `clear`), held in cao-server's process. No schema migration; restarts wipe it.
- `clients/tmux.py` — `create_session` and `create_window` accept `extra_env`. New `_merge_extra_env` classmethod mirrors the same blocked-prefix / size-cap checks as the inherited-env filter, defending callers that bypass the CLI (cao-mcp-server, direct HTTP). Pre-existing constants extracted onto the class so both filters share them.
- `services/terminal_service.py` — `create_terminal` writes `env_vars` on `new_session=True` and looks up the persisted mapping on every spawn.
- `services/session_service.py` — `create_session` accepts `env_vars`; `delete_session` clears the mapping.
- `api/main.py` — `POST /sessions` accepts `env_vars` as an embedded JSON body field (`{\"env_vars\": {...}}`). Optional, so existing callers that send only query params remain compatible.
- `cli/commands/launch.py` — `--env KEY=VALUE` Click option, `_parse_env_pairs` validator, sends body only when at least one `--env` was provided.

## Verification

```
$ cao launch --agents code_supervisor \
    --env MNEMOSYNE_DIR=/root/mnemosyne \
    --env ISAAC_CHANNEL=room:engineering
# supervisor terminal sees both vars ✓
# assign(data_analyst) → worker sees both vars ✓
# handoff(report_gen)  → worker sees both vars ✓
```

Bad inputs rejected at the CLI:
- `--env CLAUDE_SESSION_ID=abc` → ``--env key 'CLAUDE_SESSION_ID' uses a blocked prefix...``
- `--env 1FOO=bar` → ``--env key must match [A-Za-z_][A-Za-z0-9_]* (got '1FOO')``
- `--env BIG=...` (≥2048 bytes) → ``--env value for 'BIG' exceeds 2048 bytes (tmux argv limit, PR #246)``

## Test plan

- [x] Run unit tests (`uv run pytest test/cli/commands/test_launch.py test/services/test_session_env.py test/clients/test_tmux_merge_extra_env.py`) — 58 passed locally.
- [x] Black + isort clean on touched files.
- [x] Manual launch with `--env`, verify the var appears in the supervisor's shell (`env | grep …` inside `tmux attach`).
- [x] Manual `assign` from that supervisor to a worker; verify the worker's shell also sees the var.
- [x] Manual launch with no `--env` to confirm `POST /sessions` still sends no body (regression guard for backward-compat callers).
- [x] Verify a deliberately blocked prefix (`--env CLAUDE_SESSION_ID=abc`) errors at the CLI before any HTTP call is made.

## Notes

Forwarded vars are process-local on cao-server and dropped on session delete; restarting cao-server wipes them. No on-disk format, no migration, and the issue explicitly accepts that scope.