### PR TITLE
feat(memory): Phase 2.5 hardening

### DIFF
--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -83,6 +83,22 @@ class MemoryMetadataModel(Base):
     __table_args__ = (UniqueConstraint("key", "scope", "scope_id", name="uq_memory_key_scope"),)
 
 
+class ProjectAliasModel(Base):
+    """SQLAlchemy model for project identity aliases (Phase 2.5 U6).
+
+    Maps historical/alternate project identifiers (cwd hashes, manual labels)
+    to a canonical ``project_id`` so memory recall survives directory rename
+    and worktree layouts.
+    """
+
+    __tablename__ = "project_aliases"
+
+    project_id = Column(String, primary_key=True)
+    alias = Column(String, primary_key=True)
+    kind = Column(String, nullable=False)  # "git_remote" | "cwd_hash" | "manual"
+    created_at = Column(DateTime(timezone=True), default=_utcnow)
+
+
 class FlowModel(Base):
     """SQLAlchemy model for flow metadata."""
 
@@ -365,6 +381,60 @@ def get_inbox_messages(
             )
             for msg in messages
         ]
+
+
+def record_project_alias(project_id: str, alias: str, kind: str) -> None:
+    """Idempotently record a project_id ↔ alias mapping (Phase 2.5 U6).
+
+    Used opportunistically by ``resolve_project_id`` to track historical
+    cwd-hash and git-remote-url aliases for a canonical project_id. Best-effort
+    only — DB errors are swallowed so identity resolution is never blocked.
+    """
+    if not project_id or not alias or project_id == alias:
+        return
+    try:
+        with SessionLocal() as db:
+            existing = (
+                db.query(ProjectAliasModel)
+                .filter(
+                    ProjectAliasModel.project_id == project_id,
+                    ProjectAliasModel.alias == alias,
+                )
+                .first()
+            )
+            if existing is None:
+                db.add(ProjectAliasModel(project_id=project_id, alias=alias, kind=kind))
+                db.commit()
+    except Exception as e:
+        logger.debug(f"record_project_alias failed (non-fatal): {e}")
+
+
+def get_project_id_by_alias(alias: str) -> Optional[str]:
+    """Return the canonical ``project_id`` for an alias, or None if unknown."""
+    if not alias:
+        return None
+    try:
+        with SessionLocal() as db:
+            row = db.query(ProjectAliasModel).filter(ProjectAliasModel.alias == alias).first()
+            return row.project_id if row else None
+    except Exception as e:
+        logger.debug(f"get_project_id_by_alias failed (non-fatal): {e}")
+        return None
+
+
+def list_aliases_for_project(project_id: str) -> List[Dict[str, Any]]:
+    """List all aliases recorded for a canonical ``project_id``."""
+    if not project_id:
+        return []
+    try:
+        with SessionLocal() as db:
+            rows = (
+                db.query(ProjectAliasModel).filter(ProjectAliasModel.project_id == project_id).all()
+            )
+            return [{"project_id": r.project_id, "alias": r.alias, "kind": r.kind} for r in rows]
+    except Exception as e:
+        logger.debug(f"list_aliases_for_project failed (non-fatal): {e}")
+        return []
 
 
 def update_message_status(message_id: int, status: MessageStatus) -> bool:

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -93,8 +93,12 @@ class ProjectAliasModel(Base):
 
     __tablename__ = "project_aliases"
 
-    project_id = Column(String, primary_key=True)
+    # ``alias`` is the sole primary key: an alias maps to exactly one canonical
+    # project_id, so reverse lookups (get_project_id_by_alias) are stable. A
+    # cwd-hash first resolved via an override and later via its git remote
+    # upserts the same row rather than creating a second, ambiguous mapping.
     alias = Column(String, primary_key=True)
+    project_id = Column(String, nullable=False, index=True)
     kind = Column(String, nullable=False)  # "git_remote" | "cwd_hash" | "manual"
     created_at = Column(DateTime(timezone=True), default=_utcnow)
 
@@ -123,9 +127,45 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 def init_db() -> None:
     """Initialize database tables and apply schema migrations."""
+    _migrate_project_aliases_schema()
     Base.metadata.create_all(bind=engine)
     _migrate_terminals_schema()
     _migrate_memory_indexes()
+
+
+def _migrate_project_aliases_schema() -> None:
+    """Rebuild project_aliases if it predates the alias-only primary key.
+
+    The table originally used a composite PK ``(project_id, alias)``, which
+    allowed one alias to map to several project_ids and made reverse lookups
+    nondeterministic. The new schema keys on ``alias`` alone. SQLite cannot
+    alter a primary key in place, so drop and recreate. The table is an
+    opportunistic identity cache rebuilt by ``resolve_project_id`` on demand,
+    so dropping rows is safe. Runs before ``create_all`` so the fresh schema
+    is created with the new PK.
+    """
+    import sqlite3
+
+    from cli_agent_orchestrator.constants import DATABASE_FILE
+
+    try:
+        with sqlite3.connect(str(DATABASE_FILE)) as conn:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master " "WHERE type='table' AND name='project_aliases'"
+            ).fetchone()
+            if row is None:
+                return  # table doesn't exist yet — create_all builds it fresh
+            cols = conn.execute("PRAGMA table_info(project_aliases)").fetchall()
+            # PRAGMA returns rows: (cid, name, type, notnull, dflt_value, pk).
+            # In the legacy schema both project_id and alias have pk>0; in the
+            # new schema only alias does.
+            pk_cols = {c[1] for c in cols if c[5]}
+            if pk_cols != {"alias"}:
+                conn.execute("DROP TABLE project_aliases")
+                conn.commit()
+                logger.info("Migration: rebuilt project_aliases with alias-only primary key")
+    except Exception as e:
+        logger.debug(f"project_aliases migration skipped: {e}")
 
 
 def _migrate_memory_indexes() -> None:
@@ -394,16 +434,17 @@ def record_project_alias(project_id: str, alias: str, kind: str) -> None:
         return
     try:
         with SessionLocal() as db:
-            existing = (
-                db.query(ProjectAliasModel)
-                .filter(
-                    ProjectAliasModel.project_id == project_id,
-                    ProjectAliasModel.alias == alias,
-                )
-                .first()
-            )
+            # Upsert by alias (the primary key). If the same alias was already
+            # mapped — e.g. recorded against an override id, then re-resolved
+            # via git remote — repoint it to the current canonical project_id
+            # so reverse lookups stay deterministic instead of duplicating.
+            existing = db.query(ProjectAliasModel).filter(ProjectAliasModel.alias == alias).first()
             if existing is None:
                 db.add(ProjectAliasModel(project_id=project_id, alias=alias, kind=kind))
+                db.commit()
+            elif existing.project_id != project_id or existing.kind != kind:
+                existing.project_id = project_id
+                existing.kind = kind
                 db.commit()
     except Exception as e:
         logger.debug(f"record_project_alias failed (non-fatal): {e}")

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -161,6 +161,13 @@ WS_ALLOWED_CLIENTS = [
 # Base directory for all memory wiki files
 MEMORY_BASE_DIR = CAO_HOME_DIR / "memory"
 
+# Per-scope injection caps (Phase 2.5 U2). Each scope (session, project,
+# global) is independently capped so one scope cannot monopolize the
+# injection budget. ``MEMORY_MAX_PER_SCOPE`` bounds entry count;
+# ``MEMORY_SCOPE_BUDGET_CHARS`` bounds character count per scope.
+MEMORY_MAX_PER_SCOPE = 10
+MEMORY_SCOPE_BUDGET_CHARS = 1000
+
 # =============================================================================
 # Tool Restriction Configuration
 # =============================================================================

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -14,6 +14,10 @@ from cli_agent_orchestrator.constants import API_BASE_URL, DEFAULT_PROVIDER, MCP
 from cli_agent_orchestrator.mcp_server.models import HandoffResult
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.services.memory_service import (
+    MEMORY_DISABLED_MESSAGE,
+    MemoryDisabledError,
+)
 from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
 from cli_agent_orchestrator.utils.terminal import generate_session_name, wait_until_terminal_status
 
@@ -838,6 +842,8 @@ async def memory_store(
             "action": memory.action
             or ("updated" if memory.created_at != memory.updated_at else "created"),
         }
+    except MemoryDisabledError as e:
+        return {"success": False, "disabled": True, "error": str(e)}
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -872,6 +878,15 @@ async def memory_recall(
     Use this to check if relevant knowledge already exists before asking the user.
     """
     from cli_agent_orchestrator.services.memory_service import MemoryService
+    from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+    if not is_memory_enabled():
+        return {
+            "success": False,
+            "disabled": True,
+            "error": MEMORY_DISABLED_MESSAGE,
+            "memories": [],
+        }
 
     try:
         service = MemoryService()
@@ -899,6 +914,8 @@ async def memory_recall(
                 for m in memories
             ],
         }
+    except MemoryDisabledError as e:
+        return {"success": False, "disabled": True, "error": str(e)}
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -931,6 +948,8 @@ async def memory_forget(
             "key": key,
             "scope": scope,
         }
+    except MemoryDisabledError as e:
+        return {"success": False, "disabled": True, "error": str(e)}
     except Exception as e:
         return {"success": False, "error": str(e)}
 

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -1316,12 +1316,13 @@ class MemoryService:
         )
 
         lines: list[str] = []
-        base_resolved = self.base_dir.resolve()
 
         for scope_val in scopes_in_order:
             scope_id = self.resolve_scope_id(scope_val, terminal_context)
             project_dir = self._get_project_dir(scope_val, scope_id)
-            index_path = project_dir / "wiki" / "index.md"
+            wiki_dir = project_dir / "wiki"
+            wiki_resolved = wiki_dir.resolve()
+            index_path = wiki_dir / "index.md"
             if not index_path.exists():
                 continue
 
@@ -1343,9 +1344,13 @@ class MemoryService:
             for entry in scope_entries:
                 if len(scope_memories) >= MEMORY_MAX_PER_SCOPE:
                     break
-                wiki_file = project_dir / "wiki" / entry["relative_path"]
+                wiki_file = wiki_dir / entry["relative_path"]
                 resolved_wiki = wiki_file.resolve()
-                if not str(resolved_wiki).startswith(str(base_resolved) + os.sep):
+                # Guard against a crafted/corrupted index entry (e.g.
+                # ``../<other-project>/wiki/...``) escaping this scope's wiki
+                # directory and leaking another project's memory. Validate
+                # against the per-scope wiki dir, not the global memory base.
+                if not str(resolved_wiki).startswith(str(wiki_resolved) + os.sep):
                     logger.warning(
                         f"Path traversal in index entry rejected: {entry.get('relative_path')}"
                     )

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -181,8 +181,10 @@ def resolve_project_id(cwd: Optional[Path]) -> str:
         3. ``sha256(realpath(cwd))[:12]`` — Phase 2 parity fallback
 
     Sources 1 and 2 opportunistically record the current ``cwd_hash`` into
-    ``ProjectAliasModel`` (kind=``cwd_hash``). Source 2 also records the raw
-    git URL (kind=``git_remote``). Alias writes never block.
+    ``ProjectAliasModel`` (kind=``cwd_hash``) so legacy directories stay
+    recallable. The raw git remote URL is never persisted — it can embed
+    credentials, and the auth-stripped ``canonical`` id covers identity.
+    Alias writes never block.
 
     Raises ``ProjectIdentityResolutionError`` when all three sources fail.
     """
@@ -205,7 +207,11 @@ def resolve_project_id(cwd: Optional[Path]) -> str:
             canonical = _normalize_git_remote(remote_url)
             if cwd_hash and canonical != cwd_hash:
                 _record_alias_safe(canonical, cwd_hash, "cwd_hash")
-            _record_alias_safe(canonical, remote_url, "git_remote")
+            # Deliberately do NOT persist the raw remote URL as an alias: git
+            # remotes can embed credentials (https://user:token@host/...), and
+            # nothing reads a ``git_remote`` row back — the cwd-hash alias
+            # already covers legacy-dir lookup. ``canonical`` is auth-stripped
+            # by ``_normalize_git_remote``, so the returned id is safe.
             return canonical
 
     if cwd_hash:

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import os
 import re
+import subprocess
 import threading
 import time
 import uuid
@@ -12,17 +13,207 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-from cli_agent_orchestrator.constants import MEMORY_BASE_DIR
+from cli_agent_orchestrator.constants import (
+    MEMORY_BASE_DIR,
+    MEMORY_MAX_PER_SCOPE,
+    MEMORY_SCOPE_BUDGET_CHARS,
+)
 from cli_agent_orchestrator.models.memory import Memory, MemoryScope, MemoryType
 
 logger = logging.getLogger(__name__)
 
 VALID_SEARCH_MODES = ("metadata", "bm25", "hybrid")
 
+
+MEMORY_DISABLED_MESSAGE = (
+    "memory subsystem is disabled. Set memory.enabled=true in settings.json " "to re-enable."
+)
+
+
+class MemoryDisabledError(RuntimeError):
+    """Raised when a write entry point is called while memory is disabled.
+
+    Read paths (recall, get_memory_context_for_terminal) instead return an
+    empty result, since silent empty reads are a safer no-op than raising.
+    """
+
+
+def _is_memory_enabled() -> bool:
+    """Module-level guard for memory entry points.
+
+    Imported lazily to avoid a settings → memory_service circular import at
+    module load time. Defaults to True if the import or read fails so a
+    broken settings file never silently disables memory.
+    """
+    try:
+        from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+        return is_memory_enabled()
+    except Exception:
+        return True
+
+
 # Per-curator dispatch locks. A worker that fails to acquire its session's
 # curator lock falls back to Phase 1 rather than queueing — context injection
 # is best-effort and must never block the worker.
 _curator_locks: dict[str, threading.Lock] = {}
+
+
+# -----------------------------------------------------------------------------
+# Phase 2.5 U6 — Module-level project identity resolver
+#
+# Exposed at module scope (not on MemoryService) so non-service callers can
+# reuse the same precedence chain without instantiating a MemoryService.
+# -----------------------------------------------------------------------------
+
+_PROJECT_ID_OVERRIDE_PATTERN = re.compile(r"^[a-zA-Z0-9._\-]{1,128}$")
+
+
+class ProjectIdentityResolutionError(RuntimeError):
+    """Raised when no project identity can be derived from any source."""
+
+
+def _validate_project_id_override(raw: str) -> str:
+    """Validate an explicit ``project_id`` override; raise on reject.
+
+    Rejects rather than sanitizes — silent sanitization of an explicit
+    user-supplied config value hides typos and buries the contract.
+    """
+    if "\x00" in raw:
+        raise ValueError("project_id override contains null byte")
+    if not _PROJECT_ID_OVERRIDE_PATTERN.match(raw):
+        raise ValueError(
+            "project_id override must match ^[a-zA-Z0-9._\\-]{1,128}$; " f"got {raw!r}"
+        )
+    return raw
+
+
+def _read_project_id_override() -> Optional[str]:
+    """Read and validate the explicit ``project_id`` override.
+
+    Precedence: ``CAO_PROJECT_ID`` env → ``memory.project_id`` settings key.
+    """
+    raw: Optional[str] = os.environ.get("CAO_PROJECT_ID")
+    if not raw:
+        try:
+            from cli_agent_orchestrator.services.settings_service import (
+                get_memory_settings,
+            )
+
+            raw = get_memory_settings().get("project_id")
+        except Exception as e:
+            logger.debug(f"Failed to read project_id override, skipping: {e}")
+            raw = None
+    if not raw:
+        return None
+    return _validate_project_id_override(raw)
+
+
+def _normalize_git_remote(url: str) -> str:
+    """Normalize a git remote URL into a stable slug id.
+
+    Rules: lowercase, strip protocol, strip auth, SCP→host/path, strip
+    trailing ``.git``, collapse non-alnum runs to ``-``. Empty input → ``"unknown"``.
+    """
+    if not url:
+        return "unknown"
+    u = url.strip().lower()
+    for proto in ("git+ssh://", "ssh://", "git://", "https://", "http://"):
+        if u.startswith(proto):
+            u = u[len(proto) :]
+            break
+    if "@" in u:
+        u = u.split("@", 1)[1]
+    if ":" in u:
+        head, _, tail = u.partition(":")
+        if "/" not in head:
+            u = f"{head}/{tail}"
+    if u.endswith(".git"):
+        u = u[:-4]
+    u = re.sub(r"[^a-z0-9]+", "-", u).strip("-")
+    return u or "unknown"
+
+
+def _git_remote_identity(cwd: Path) -> Optional[str]:
+    """Return ``remote.origin.url`` for ``cwd``, or ``None`` when absent.
+
+    ``timeout=2`` keeps laggy NFS from blocking the resolver.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        logger.debug(f"git remote lookup failed in {cwd}: {e}")
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    return url or None
+
+
+def _record_alias_safe(project_id: str, alias: str, kind: str) -> None:
+    """Opportunistically record an alias row; swallow DB errors.
+
+    The alias table is a nice-to-have for future migration; a DB hiccup must
+    never block identity resolution.
+    """
+    if not project_id or not alias or project_id == alias:
+        return
+    try:
+        from cli_agent_orchestrator.clients.database import record_project_alias
+
+        record_project_alias(project_id, alias, kind)
+    except Exception as e:
+        logger.debug(f"record_project_alias failed (non-fatal): {e}")
+
+
+def resolve_project_id(cwd: Optional[Path]) -> str:
+    """Resolve canonical project identity via the U6 precedence chain.
+
+    Precedence:
+        1. explicit override (``CAO_PROJECT_ID`` env → ``memory.project_id`` settings)
+        2. ``git config --get remote.origin.url`` (normalized)
+        3. ``sha256(realpath(cwd))[:12]`` — Phase 2 parity fallback
+
+    Sources 1 and 2 opportunistically record the current ``cwd_hash`` into
+    ``ProjectAliasModel`` (kind=``cwd_hash``). Source 2 also records the raw
+    git URL (kind=``git_remote``). Alias writes never block.
+
+    Raises ``ProjectIdentityResolutionError`` when all three sources fail.
+    """
+    cwd_hash: Optional[str] = None
+    if cwd is not None:
+        try:
+            cwd_hash = hashlib.sha256(os.path.realpath(str(cwd)).encode()).hexdigest()[:12]
+        except Exception as e:
+            logger.debug(f"cwd-hash derivation failed for {cwd}: {e}")
+
+    override = _read_project_id_override()
+    if override:
+        if cwd_hash and override != cwd_hash:
+            _record_alias_safe(override, cwd_hash, "cwd_hash")
+        return override
+
+    if cwd is not None:
+        remote_url = _git_remote_identity(cwd)
+        if remote_url:
+            canonical = _normalize_git_remote(remote_url)
+            if cwd_hash and canonical != cwd_hash:
+                _record_alias_safe(canonical, cwd_hash, "cwd_hash")
+            _record_alias_safe(canonical, remote_url, "git_remote")
+            return canonical
+
+    if cwd_hash:
+        return cwd_hash
+
+    raise ProjectIdentityResolutionError(
+        "Cannot resolve project identity: no override, no git remote, and no cwd provided"
+    )
 
 
 class MemoryService:
@@ -155,10 +346,11 @@ class MemoryService:
 
         if scope == MemoryScope.PROJECT.value:
             cwd = ctx.get("cwd") or ctx.get("working_directory")
-            if not cwd:
+            cwd_path = Path(cwd) if cwd else None
+            try:
+                return resolve_project_id(cwd_path)
+            except ProjectIdentityResolutionError:
                 return None
-            real = os.path.realpath(cwd)
-            return hashlib.sha256(real.encode()).hexdigest()[:12]
 
         if scope == MemoryScope.SESSION.value:
             raw = ctx.get("session_name") or ctx.get("session")
@@ -179,6 +371,49 @@ class MemoryService:
         sanitized = re.sub(r"[^a-zA-Z0-9\-_]", "", value)
         sanitized = re.sub(r"-+", "-", sanitized).strip("-_")
         return sanitized or "unknown"
+
+    # -------------------------------------------------------------------------
+    # Storage migration (Phase 2.5 U6)
+    # -------------------------------------------------------------------------
+
+    def plan_project_dir_migration(self, canonical_id: str, alias: str) -> dict:
+        """Describe (without mutating) a migration from ``alias/`` to ``canonical_id/``.
+
+        Returns a dict with ``dry_run`` (always True), ``canonical_id``, ``alias``,
+        ``source_exists``, ``destination_exists``, ``action`` (``"none"``,
+        ``"rename"``, ``"merge"``, ``"conflict"``), and ``files``.
+        """
+        source = self._get_project_dir(MemoryScope.PROJECT.value, alias)
+        dest = self._get_project_dir(MemoryScope.PROJECT.value, canonical_id)
+        source_exists = source.exists() and source.is_dir()
+        dest_exists = dest.exists() and dest.is_dir()
+        files: list[str] = []
+        if source_exists:
+            for p in sorted(source.rglob("*")):
+                if p.is_file():
+                    try:
+                        files.append(str(p.relative_to(source)))
+                    except ValueError:
+                        continue
+        if not source_exists:
+            action = "none"
+        elif canonical_id == alias:
+            action = "none"
+        elif not dest_exists:
+            action = "rename"
+        elif files:
+            action = "merge"
+        else:
+            action = "conflict"
+        return {
+            "dry_run": True,
+            "canonical_id": canonical_id,
+            "alias": alias,
+            "source_exists": source_exists,
+            "destination_exists": dest_exists,
+            "action": action,
+            "files": files,
+        }
 
     # -------------------------------------------------------------------------
     # Key generation
@@ -279,7 +514,13 @@ class MemoryService:
 
         Declared async for compatibility with async callers (MCP server, FastAPI).
         File I/O is synchronous; a future improvement would use aiofiles.
+
+        Raises ``MemoryDisabledError`` when ``memory.enabled`` is False
+        (U5 / SC-6) — no filesystem or SQLite writes happen.
         """
+        if not _is_memory_enabled():
+            raise MemoryDisabledError(MEMORY_DISABLED_MESSAGE)
+
         # Validate
         MemoryScope(scope)
         MemoryType(memory_type)
@@ -558,7 +799,12 @@ class MemoryService:
           - ``metadata``: substring match against key/tags/content via index.md walk.
           - ``bm25``: BM25 ranking over wiki bodies (content-aware).
           - ``hybrid``: metadata results first, then BM25 fills with what metadata missed.
+
+        Returns ``[]`` when ``memory.enabled`` is False (U5 / SC-6).
         """
+        if not _is_memory_enabled():
+            return []
+
         if search_mode not in VALID_SEARCH_MODES:
             raise ValueError(
                 f"Invalid search_mode {search_mode!r}; expected one of {VALID_SEARCH_MODES}"
@@ -853,6 +1099,21 @@ class MemoryService:
                 project_dir = self.base_dir / project_scope_id
                 if project_dir.exists() and project_dir not in dirs:
                     dirs.append(project_dir)
+                # Also include legacy cwd-hash dirs recorded as aliases so
+                # pre-U6 memories survive the canonical-id transition.
+                try:
+                    from cli_agent_orchestrator.clients.database import (
+                        list_aliases_for_project,
+                    )
+
+                    for alias in list_aliases_for_project(project_scope_id):
+                        if alias.get("kind") != "cwd_hash":
+                            continue
+                        alias_dir = self.base_dir / alias["alias"]
+                        if alias_dir.exists() and alias_dir not in dirs:
+                            dirs.append(alias_dir)
+                except Exception as e:
+                    logger.debug(f"alias dir enumeration failed: {e}")
         # Without context and scan_all=False, only global is safe (agent/MCP context).
 
         return dirs
@@ -976,7 +1237,13 @@ class MemoryService:
 
         If scope_id is provided directly it is used as-is (for cleanup).
         Otherwise it is resolved from terminal_context.
+
+        Raises ``MemoryDisabledError`` when ``memory.enabled`` is False
+        (U5 / SC-6) — no filesystem or SQLite writes happen.
         """
+        if not _is_memory_enabled():
+            raise MemoryDisabledError(MEMORY_DISABLED_MESSAGE)
+
         key = self._sanitize_key(key)
         if scope_id is None:
             scope_id = self.resolve_scope_id(scope, terminal_context)
@@ -1020,58 +1287,84 @@ class MemoryService:
     ) -> str:
         """Build the memory context block for terminal injection.
 
-        Scope precedence: session > project > global.
-        Fills up to budget_chars, dropping oldest entries first if over budget.
+        Scope precedence: session > project > global (preserved in output).
+
+        Each scope is independently capped at ``MEMORY_MAX_PER_SCOPE`` entries
+        and at ``min(MEMORY_SCOPE_BUDGET_CHARS, budget_chars // n_scopes)``
+        characters. Unused budget from an empty scope is NOT reallocated to
+        other scopes (keeps cache-friendly scope boundaries intact).
+
+        Returns ``""`` when ``memory.enabled`` is False (U5 / SC-6) — never
+        reads index.md or wiki files.
         """
-        # We need terminal context to resolve scopes. Import here to avoid circular imports.
+        if not _is_memory_enabled():
+            return ""
+
         terminal_context = self._get_terminal_context(terminal_id)
         if not terminal_context:
             return ""
 
-        # Collect memories in precedence order
-        all_memories: list[Memory] = []
         scopes_in_order = [
             MemoryScope.SESSION.value,
             MemoryScope.PROJECT.value,
             MemoryScope.GLOBAL.value,
         ]
 
+        scope_char_cap = min(
+            MEMORY_SCOPE_BUDGET_CHARS,
+            max(0, budget_chars // len(scopes_in_order)),
+        )
+
+        lines: list[str] = []
+        base_resolved = self.base_dir.resolve()
+
         for scope_val in scopes_in_order:
             scope_id = self.resolve_scope_id(scope_val, terminal_context)
             project_dir = self._get_project_dir(scope_val, scope_id)
             index_path = project_dir / "wiki" / "index.md"
-
             if not index_path.exists():
                 continue
 
-            entries = self._parse_index(index_path)
-            for entry in entries:
-                if entry["scope"] != scope_val:
+            scope_entries = []
+            for e in self._parse_index(index_path):
+                if e["scope"] != scope_val:
                     continue
-                if scope_val != MemoryScope.GLOBAL.value and entry.get("scope_id") != scope_id:
-                    continue
+                # Session/agent entries embed scope_id in the wiki path and
+                # share index.md with global, so the scope_id must match the
+                # caller's. Project entries already live in a per-project
+                # directory and global has no scope_id by design.
+                if scope_val in (MemoryScope.SESSION.value, MemoryScope.AGENT.value):
+                    if e.get("scope_id") != scope_id:
+                        continue
+                scope_entries.append(e)
+            scope_entries.sort(key=lambda e: e.get("updated_at", ""), reverse=True)
+
+            scope_memories: list[Memory] = []
+            for entry in scope_entries:
+                if len(scope_memories) >= MEMORY_MAX_PER_SCOPE:
+                    break
                 wiki_file = project_dir / "wiki" / entry["relative_path"]
-                if not wiki_file.exists():
+                resolved_wiki = wiki_file.resolve()
+                if not str(resolved_wiki).startswith(str(base_resolved) + os.sep):
+                    logger.warning(
+                        f"Path traversal in index entry rejected: {entry.get('relative_path')}"
+                    )
                     continue
-                file_content = wiki_file.read_text(encoding="utf-8")
-                memory = self._parse_wiki_file(wiki_file, file_content, entry)
+                if not resolved_wiki.exists():
+                    continue
+                file_content = resolved_wiki.read_text(encoding="utf-8")
+                memory = self._parse_wiki_file(resolved_wiki, file_content, entry)
                 if memory:
-                    all_memories.append(memory)
+                    scope_memories.append(memory)
 
-        if not all_memories:
-            return ""
-
-        # Build context block within budget
-        lines: list[str] = []
-        used_chars = 0
-
-        for mem in all_memories:
-            line = f"- [{mem.scope}] {mem.key}: {mem.content}"
-            line_len = len(line)
-            if used_chars + line_len > budget_chars:
-                break
-            lines.append(line)
-            used_chars += line_len
+            scope_used_chars = 0
+            for mem in scope_memories:
+                line = f"- [{mem.scope}] {mem.key}: {mem.content}"
+                line_len = len(line) + 1
+                if scope_used_chars + line_len > scope_char_cap:
+                    break
+                lines.append(line)
+                scope_used_chars += line_len
 
         if not lines:
             return ""
@@ -1115,6 +1408,8 @@ class MemoryService:
         fall back to the deterministic Phase 1 path so injection never blocks
         the worker agent.
         """
+        if not _is_memory_enabled():
+            return ""
         try:
             ctx = self._get_terminal_context(terminal_id)
             session_name = ctx.get("session_name") if ctx else None

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -64,6 +64,63 @@ def set_agent_dirs(dirs: Dict[str, str]) -> Dict[str, str]:
     return get_agent_dirs()
 
 
+def get_memory_settings() -> Dict[str, Any]:
+    """Get memory-related settings.
+
+    ``enabled`` defaults to ``True`` (opt-out) to preserve current shipping
+    behavior. Setting it to ``False`` disables all memory subsystem
+    operations — see ``is_memory_enabled()``.
+    """
+    settings = _load()
+    defaults: Dict[str, Any] = {"enabled": True, "flush_threshold": 0.85}
+    saved = settings.get("memory", {})
+    result = dict(defaults)
+    result.update(saved)
+    return result
+
+
+def is_memory_enabled() -> bool:
+    """Return True when the memory subsystem is enabled.
+
+    Reads the ``memory.enabled`` flag; defaults to True (opt-out) so
+    existing installations preserve current behavior.
+    """
+    try:
+        value = get_memory_settings().get("enabled", True)
+    except Exception as e:
+        logger.warning(f"Failed to read memory.enabled, defaulting to True: {e}")
+        return True
+    return bool(value)
+
+
+def set_memory_setting(key: str, value: Any) -> Dict[str, Any]:
+    """Update a single memory setting.
+
+    Supported keys:
+        ``enabled`` (bool) — master switch for the memory subsystem.
+        ``flush_threshold`` (float, 0.0 < x ≤ 1.0) — context-usage trigger.
+    """
+    settings = _load()
+    memory = settings.get("memory", {})
+
+    if key == "enabled":
+        if not isinstance(value, bool):
+            raise ValueError(f"enabled must be a bool, got {type(value).__name__}")
+        memory[key] = value
+    elif key == "flush_threshold":
+        fval = float(value)
+        if not (0.0 < fval <= 1.0):
+            raise ValueError(f"flush_threshold must be between 0.0 and 1.0, got {fval}")
+        memory[key] = fval
+    else:
+        raise ValueError(f"Unknown memory setting: {key}")
+
+    settings["memory"] = memory
+    _save(settings)
+    logger.info(f"Updated memory setting: {key}={memory[key]}")
+    return get_memory_settings()
+
+
 def get_extra_agent_dirs() -> List[str]:
     """Get extra agent scan directories (user-added custom paths)."""
     settings = _load()

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -599,8 +599,69 @@ class TestInitDb:
     """Tests for init_db function."""
 
     @patch("cli_agent_orchestrator.clients.database.Base")
-    def test_init_db(self, mock_base):
+    @patch("cli_agent_orchestrator.clients.database._migrate_project_aliases_schema")
+    def test_init_db(self, mock_alias_migrate, mock_base):
         """Test database initialization."""
         init_db()
 
         mock_base.metadata.create_all.assert_called_once()
+
+
+class TestProjectAliasMigration:
+    """Tests for the project_aliases alias-only primary-key migration."""
+
+    def test_legacy_composite_pk_table_is_rebuilt(self, tmp_path, monkeypatch):
+        """A legacy table with composite PK (project_id, alias) is dropped."""
+        import sqlite3
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        db_file = tmp_path / "legacy.db"
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "CREATE TABLE project_aliases ("
+                "project_id TEXT NOT NULL, alias TEXT NOT NULL, kind TEXT NOT NULL, "
+                "created_at TEXT, PRIMARY KEY (project_id, alias))"
+            )
+            conn.execute("INSERT INTO project_aliases VALUES ('p1', 'a1', 'cwd_hash', NULL)")
+            conn.commit()
+
+        monkeypatch.setattr(db_mod, "DATABASE_FILE", db_file, raising=False)
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+
+        db_mod._migrate_project_aliases_schema()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            exists = conn.execute(
+                "SELECT name FROM sqlite_master " "WHERE type='table' AND name='project_aliases'"
+            ).fetchone()
+        assert exists is None, "legacy table should be dropped for create_all to rebuild"
+
+    def test_alias_only_pk_table_is_left_intact(self, tmp_path, monkeypatch):
+        """A table already keyed on alias alone is not touched."""
+        import sqlite3
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        db_file = tmp_path / "current.db"
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "CREATE TABLE project_aliases ("
+                "alias TEXT PRIMARY KEY, project_id TEXT NOT NULL, kind TEXT NOT NULL, "
+                "created_at TEXT)"
+            )
+            conn.execute("INSERT INTO project_aliases VALUES ('a1', 'p1', 'cwd_hash', NULL)")
+            conn.commit()
+
+        monkeypatch.setattr(db_mod, "DATABASE_FILE", db_file, raising=False)
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+
+        db_mod._migrate_project_aliases_schema()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            rows = conn.execute("SELECT alias, project_id FROM project_aliases").fetchall()
+        assert rows == [("a1", "p1")], "current-schema table must be left intact"

--- a/test/services/test_memory_durability_and_concurrent.py
+++ b/test/services/test_memory_durability_and_concurrent.py
@@ -1,0 +1,314 @@
+"""SC-4 durability + SC-5 concurrent-write safety tests (U4).
+
+- SC-4: ``MemoryService`` reinstantiation at the same ``base_dir``/DB file
+  round-trips stored memories with field-level integrity.
+- SC-5: Two concurrent writers to the same scope produce a parseable
+  ``index.md`` with both entries present, under ``fcntl.flock``-guarded
+  index writes.
+
+Concurrency uses ``multiprocessing`` (not threads) to exercise the OS-level
+flock across separate file descriptors AND separate SQLite connections.
+Tests that require ``fcntl`` are skipped on platforms without it (Windows).
+
+No wall-clock ``sleep`` is used for synchronization — every rendezvous is a
+``multiprocessing.Barrier``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+
+from cli_agent_orchestrator.clients.database import Base
+from cli_agent_orchestrator.constants import MEMORY_MAX_PER_SCOPE
+from cli_agent_orchestrator.services.memory_service import MemoryService
+
+
+def _ctx(terminal_id: str = "term-u4", cwd: str = "/home/user/proj-u4") -> dict:
+    return {
+        "terminal_id": terminal_id,
+        "session_name": "sess-u4",
+        "agent_profile": "dev",
+        "provider": "claude_code",
+        "cwd": cwd,
+    }
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _make_engine(db_path: Path) -> Any:
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _make_svc(base_dir: Path, db_path: Path) -> MemoryService:
+    engine = _make_engine(db_path)
+    svc = MemoryService(base_dir=base_dir, db_engine=engine)
+    svc._get_terminal_context = lambda terminal_id: _ctx()  # type: ignore[method-assign]
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# AC1 — durability: memories survive service reinstantiation
+# ---------------------------------------------------------------------------
+
+
+def test_memories_survive_service_reinstantiation(tmp_path: Path) -> None:
+    db_path = tmp_path / "u4.db"
+    base_dir = tmp_path / "memory"
+    base_dir.mkdir()
+
+    ctx = _ctx()
+    svc_a = _make_svc(base_dir, db_path)
+
+    seeds = [
+        {
+            "key": f"durable-{i:02d}",
+            "content": f"durable content {i} — should survive reinstantiation",
+            "memory_type": "project",
+            "tags": f"t{i},durable",
+            "scope": "global",
+        }
+        for i in range(5)
+    ]
+    for s in seeds:
+        _run(
+            svc_a.store(
+                content=s["content"],
+                scope=s["scope"],
+                memory_type=s["memory_type"],
+                key=s["key"],
+                tags=s["tags"],
+                terminal_context=ctx,
+            )
+        )
+
+    svc_a._db_engine.dispose()  # type: ignore[attr-defined]
+    del svc_a
+
+    svc_b = _make_svc(base_dir, db_path)
+    recalled = _run(
+        svc_b.recall(
+            scope="global",
+            limit=50,
+            search_mode="metadata",
+            terminal_context=ctx,
+        )
+    )
+
+    recalled_by_key = {m.key: m for m in recalled}
+    for s in seeds:
+        assert (
+            s["key"] in recalled_by_key
+        ), f"durability violation — {s['key']!r} missing after reinstantiation"
+        got = recalled_by_key[s["key"]]
+        assert got.memory_type == s["memory_type"]
+        assert got.tags == s["tags"]
+        assert got.scope == s["scope"]
+        assert s["content"] in got.content
+
+    index_path = svc_b.get_index_path("global", None)
+    assert index_path.exists(), "index.md must exist after reinstantiation"
+    parsed = svc_b._parse_index(index_path)
+    parsed_keys = {e["key"] for e in parsed if e["scope"] == "global"}
+    for s in seeds:
+        assert s["key"] in parsed_keys
+
+
+# ---------------------------------------------------------------------------
+# AC2 — concurrent writers
+# ---------------------------------------------------------------------------
+
+
+def _worker_store(
+    db_path_str: str,
+    base_dir_str: str,
+    key: str,
+    barrier: Any,
+    result_queue: Any,
+) -> None:
+    """Subprocess worker: barrier-gated call to ``store()`` with its own key."""
+    try:
+        engine = create_engine(
+            f"sqlite:///{db_path_str}", connect_args={"check_same_thread": False}
+        )
+        Base.metadata.create_all(bind=engine)
+
+        svc = MemoryService(base_dir=Path(base_dir_str), db_engine=engine)
+        svc._get_terminal_context = lambda terminal_id: _ctx()  # type: ignore[method-assign]
+        ctx = _ctx()
+
+        barrier.wait(timeout=10)
+
+        _run(
+            svc.store(
+                content=f"concurrent content for {key}",
+                scope="global",
+                memory_type="project",
+                key=key,
+                tags=f"concurrent,{key}",
+                terminal_context=ctx,
+            )
+        )
+        result_queue.put(("ok", key))
+    except Exception as exc:
+        result_queue.put(("err", f"{key}: {type(exc).__name__}: {exc}"))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl not available on Windows")
+def test_concurrent_writers_both_present(tmp_path: Path) -> None:
+    pytest.importorskip("fcntl")
+
+    db_path = tmp_path / "u4-concurrent.db"
+    base_dir = tmp_path / "memory"
+    base_dir.mkdir()
+
+    _make_engine(db_path).dispose()
+
+    mp_ctx = mp.get_context("spawn")
+    barrier = mp_ctx.Barrier(2)
+    result_queue: Any = mp_ctx.Queue()
+
+    procs = [
+        mp_ctx.Process(
+            target=_worker_store,
+            args=(str(db_path), str(base_dir), f"worker-{i}", barrier, result_queue),
+        )
+        for i in range(2)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=20)
+        assert p.exitcode == 0, f"worker {p.name} exited {p.exitcode}"
+
+    results: list[tuple[str, str]] = []
+    while not result_queue.empty():
+        results.append(result_queue.get_nowait())
+    errs = [r for r in results if r[0] == "err"]
+    assert not errs, f"worker errors: {errs}"
+    ok_keys = {r[1] for r in results if r[0] == "ok"}
+    assert ok_keys == {"worker-0", "worker-1"}, f"not all workers reported ok: {results}"
+
+    svc = _make_svc(base_dir, db_path)
+    index_path = svc.get_index_path("global", None)
+    assert index_path.exists(), "index.md must exist after concurrent writes"
+
+    parsed = svc._parse_index(index_path)
+    parsed_keys = {e["key"] for e in parsed if e["scope"] == "global"}
+    assert "worker-0" in parsed_keys, "worker-0 missing from index.md"
+    assert "worker-1" in parsed_keys, "worker-1 missing from index.md"
+
+    text = index_path.read_text(encoding="utf-8")
+    assert text.count("## global") == 1, (
+        f"index.md must contain exactly one '## global' header; got " f"{text.count('## global')}"
+    )
+
+    reader_re = re.compile(
+        r"^- \[([^\]]+)\]\(([^)]+)\) — type:(\S+) tags:(\S*) ~\d+tok updated:(\S+)$"
+    )
+    entry_lines = [ln for ln in text.splitlines() if ln.startswith("- [") and "](" in ln]
+    assert (
+        len(entry_lines) >= 2
+    ), f"expected ≥2 entry lines after 2 concurrent writes, got {len(entry_lines)}"
+    for ln in entry_lines:
+        assert reader_re.match(ln), f"corrupt entry line: {ln!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC3 — fcntl gating
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_writers_skipped_without_fcntl() -> None:
+    fcntl = pytest.importorskip("fcntl")
+    assert hasattr(fcntl, "LOCK_EX"), "fcntl on this platform lacks LOCK_EX"
+
+
+# ---------------------------------------------------------------------------
+# AC4 — newest-N sort invariant (lexicographic ISO-8601 Z order)
+# ---------------------------------------------------------------------------
+
+
+def test_per_scope_sort_returns_newest_n(tmp_path: Path) -> None:
+    """Store 12 entries with monotonically increasing index timestamps →
+    ``get_memory_context_for_terminal`` returns exactly the newest 10.
+
+    The sort key in ``get_memory_context_for_terminal`` is the ``updated``
+    field parsed out of ``index.md`` via lexicographic string compare. This
+    test pins that contract: when ISO-8601 Z timestamps are monotonically
+    ordered they must lexicographically sort to the same order, and the cap
+    must take the top-N.
+    """
+    db_path = tmp_path / "u4-sort.db"
+    base_dir = tmp_path / "memory"
+    base_dir.mkdir()
+
+    svc = _make_svc(base_dir, db_path)
+    ctx = _ctx()
+
+    total = 12
+    for i in range(total):
+        _run(
+            svc.store(
+                content=f"sortable body {i:02d}",
+                scope="global",
+                memory_type="project",
+                key=f"sort-{i:02d}",
+                tags=f"t{i}",
+                terminal_context=ctx,
+            )
+        )
+
+    # Patch index.md with monotonically increasing ISO-8601 Z timestamps so
+    # the sort is unambiguous (within-second store calls collapse otherwise).
+    index_path = svc.get_index_path("global", None)
+    text = index_path.read_text(encoding="utf-8")
+    ts_re = re.compile(r"updated:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
+    new_lines = []
+    counter = 0
+    for line in text.splitlines():
+        m = re.match(r"^- \[(sort-\d{2})\]", line)
+        if m:
+            idx = int(m.group(1).split("-")[1])
+            stamped = f"updated:2026-04-20T12:{idx:02d}:00Z"
+            new_lines.append(ts_re.sub(stamped, line))
+            counter += 1
+        else:
+            new_lines.append(line)
+    assert counter == total, f"expected {total} sort-NN lines, rewrote {counter}"
+    index_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+    block = svc.get_memory_context_for_terminal("term-u4", budget_chars=100_000)
+    assert block, "context block must not be empty"
+
+    inner = block.split("<cao-memory>")[1].split("</cao-memory>")[0]
+    global_line_keys: list[str] = []
+    for line in inner.splitlines():
+        if not line.startswith("- [global] "):
+            continue
+        match = re.match(r"^- \[global\] ([^:]+): ", line)
+        assert match, f"malformed global context line: {line!r}"
+        global_line_keys.append(match.group(1))
+
+    assert len(global_line_keys) == MEMORY_MAX_PER_SCOPE, (
+        f"expected exactly {MEMORY_MAX_PER_SCOPE} entries after sort+cap, "
+        f"got {len(global_line_keys)}: {global_line_keys}"
+    )
+
+    expected_newest = {f"sort-{i:02d}" for i in range(total - MEMORY_MAX_PER_SCOPE, total)}
+    got = set(global_line_keys)
+    assert got == expected_newest, (
+        f"sort invariant broken: expected newest-{MEMORY_MAX_PER_SCOPE} keys "
+        f"{sorted(expected_newest)}, got {sorted(got)}"
+    )

--- a/test/services/test_memory_enabled_flag.py
+++ b/test/services/test_memory_enabled_flag.py
@@ -1,0 +1,394 @@
+"""SC-6 — ``memory.enabled`` settings-flag tests (U5).
+
+Covers the master enable/disable switch introduced in U5:
+
+- **AC1** — ``is_memory_enabled()`` reflects the ``memory.enabled`` key in
+  ``settings.json`` and defaults to True (opt-out) when absent.
+- **AC2** — Every public entry point on ``MemoryService`` short-circuits when
+  disabled:
+    * ``store()``    → raises ``MemoryDisabledError``
+    * ``recall()``   → returns ``[]``
+    * ``forget()``   → raises ``MemoryDisabledError``
+    * ``get_memory_context_for_terminal()``   → returns ``""``
+    * ``get_curated_memory_context()``        → returns ``""``
+- **AC3** — Disabled ``store()`` touches neither the filesystem (no wiki
+  files, no ``index.md``) nor SQLite (no metadata row).
+- **AC4** — With ``enabled=True`` (default) behavior is unchanged — a
+  round-trip store + recall still works.
+- **MCP** — The MCP memory tools return an explicit ``disabled`` discriminator
+  plus the shared ``MEMORY_DISABLED_MESSAGE`` so the agent can surface a
+  clear error to the user.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+
+from cli_agent_orchestrator.clients.database import Base, MemoryMetadataModel
+from cli_agent_orchestrator.services.memory_service import (
+    MemoryDisabledError,
+    MemoryService,
+)
+
+
+def _ctx(terminal_id: str = "term-u5") -> dict:
+    return {
+        "terminal_id": terminal_id,
+        "session_name": "sess-u5",
+        "agent_profile": "dev",
+        "provider": "claude_code",
+        "cwd": "/home/user/proj-u5",
+    }
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _make_engine(db_path: Path) -> Any:
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _make_svc(base_dir: Path, db_path: Path) -> MemoryService:
+    engine = _make_engine(db_path)
+    svc = MemoryService(base_dir=base_dir, db_engine=engine)
+    svc._get_terminal_context = lambda terminal_id: _ctx()  # type: ignore[method-assign]
+    return svc
+
+
+@pytest.fixture
+def settings_file(tmp_path: Path) -> Any:
+    """Patch settings_service paths to an isolated settings.json."""
+    fake_settings = tmp_path / "settings.json"
+    with (
+        patch(
+            "cli_agent_orchestrator.services.settings_service.SETTINGS_FILE",
+            fake_settings,
+        ),
+        patch(
+            "cli_agent_orchestrator.services.settings_service.CAO_HOME_DIR",
+            tmp_path,
+        ),
+    ):
+        yield fake_settings
+
+
+# ---------------------------------------------------------------------------
+# AC1 — is_memory_enabled() reflects the settings flag
+# ---------------------------------------------------------------------------
+
+
+class TestIsMemoryEnabledFlag:
+    def test_defaults_to_true_when_absent(self, settings_file: Path) -> None:
+        from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+        assert not settings_file.exists()
+        assert is_memory_enabled() is True
+
+    def test_returns_false_when_explicitly_disabled(self, settings_file: Path) -> None:
+        from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+        settings_file.write_text(json.dumps({"memory": {"enabled": False}}))
+        assert is_memory_enabled() is False
+
+    def test_returns_true_when_explicitly_enabled(self, settings_file: Path) -> None:
+        from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+        settings_file.write_text(json.dumps({"memory": {"enabled": True}}))
+        assert is_memory_enabled() is True
+
+    def test_set_memory_setting_enabled_roundtrip(self, settings_file: Path) -> None:
+        from cli_agent_orchestrator.services.settings_service import (
+            get_memory_settings,
+            is_memory_enabled,
+            set_memory_setting,
+        )
+
+        set_memory_setting("enabled", False)
+        assert is_memory_enabled() is False
+        settings = get_memory_settings()
+        assert settings["enabled"] is False
+        assert settings["flush_threshold"] == 0.85
+
+        set_memory_setting("enabled", True)
+        assert is_memory_enabled() is True
+
+    def test_set_memory_setting_rejects_non_bool(self, settings_file: Path) -> None:
+        from cli_agent_orchestrator.services.settings_service import set_memory_setting
+
+        with pytest.raises(ValueError, match="enabled must be a bool"):
+            set_memory_setting("enabled", "yes")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# AC2 — every MemoryService entry point short-circuits when disabled
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryServiceShortCircuits:
+    def _disable(self) -> Any:
+        return patch(
+            "cli_agent_orchestrator.services.memory_service._is_memory_enabled",
+            return_value=False,
+        )
+
+    def test_store_raises_memory_disabled_error(self, tmp_path: Path) -> None:
+        svc = _make_svc(tmp_path / "mem", tmp_path / "u5.db")
+        with self._disable():
+            with pytest.raises(MemoryDisabledError):
+                _run(
+                    svc.store(
+                        content="should not be stored",
+                        scope="global",
+                        memory_type="project",
+                        key="never-land",
+                        terminal_context=_ctx(),
+                    )
+                )
+
+    def test_recall_returns_empty_list(self, tmp_path: Path) -> None:
+        svc = _make_svc(tmp_path / "mem", tmp_path / "u5.db")
+        with self._disable():
+            out = _run(
+                svc.recall(
+                    scope="global",
+                    limit=50,
+                    search_mode="metadata",
+                    terminal_context=_ctx(),
+                )
+            )
+        assert out == []
+
+    def test_forget_raises_memory_disabled_error(self, tmp_path: Path) -> None:
+        svc = _make_svc(tmp_path / "mem", tmp_path / "u5.db")
+        with self._disable():
+            with pytest.raises(MemoryDisabledError):
+                _run(
+                    svc.forget(
+                        key="nope",
+                        scope="global",
+                        terminal_context=_ctx(),
+                    )
+                )
+
+    def test_get_memory_context_for_terminal_returns_empty_string(self, tmp_path: Path) -> None:
+        svc = _make_svc(tmp_path / "mem", tmp_path / "u5.db")
+        with self._disable():
+            assert svc.get_memory_context_for_terminal("term-u5") == ""
+
+    def test_get_curated_memory_context_returns_empty_string(self, tmp_path: Path) -> None:
+        svc = _make_svc(tmp_path / "mem", tmp_path / "u5.db")
+        with self._disable():
+            assert svc.get_curated_memory_context("term-u5") == ""
+
+
+# ---------------------------------------------------------------------------
+# AC3 — disabled store writes nothing to filesystem or SQLite
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_store_writes_nothing_to_filesystem_or_sqlite(tmp_path: Path) -> None:
+    base_dir = tmp_path / "mem"
+    base_dir.mkdir()
+    db_path = tmp_path / "u5-noio.db"
+    svc = _make_svc(base_dir, db_path)
+
+    before_fs = sorted(p.relative_to(base_dir) for p in base_dir.rglob("*"))
+    assert before_fs == [], f"base_dir should start empty, got {before_fs}"
+
+    with patch(
+        "cli_agent_orchestrator.services.memory_service._is_memory_enabled",
+        return_value=False,
+    ):
+        with pytest.raises(MemoryDisabledError):
+            _run(
+                svc.store(
+                    content="body that must never hit disk",
+                    scope="global",
+                    memory_type="project",
+                    key="ghost-key",
+                    tags="ghost",
+                    terminal_context=_ctx(),
+                )
+            )
+
+    after_fs = sorted(p.relative_to(base_dir) for p in base_dir.rglob("*"))
+    assert (
+        after_fs == []
+    ), f"disabled store() must not create any files under base_dir; got {after_fs}"
+    assert not svc.get_index_path(
+        "global", None
+    ).exists(), "disabled store() must not materialize index.md"
+
+    with svc._get_db_session() as db:
+        rows = db.query(MemoryMetadataModel).filter_by(key="ghost-key", scope="global").all()
+        assert rows == [], f"disabled store() must not insert SQLite metadata; got {rows}"
+
+
+# ---------------------------------------------------------------------------
+# AC4 — enabled=True (default) preserves existing behavior
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_default_preserves_round_trip(tmp_path: Path) -> None:
+    svc = _make_svc(tmp_path / "mem", tmp_path / "u5-on.db")
+    with patch(
+        "cli_agent_orchestrator.services.memory_service._is_memory_enabled",
+        return_value=True,
+    ):
+        memory = _run(
+            svc.store(
+                content="round-trip body",
+                scope="global",
+                memory_type="project",
+                key="rt-01",
+                tags="rt",
+                terminal_context=_ctx(),
+            )
+        )
+        assert memory.key == "rt-01"
+        assert memory.scope == "global"
+
+        recalled = _run(
+            svc.recall(
+                scope="global",
+                limit=10,
+                search_mode="metadata",
+                terminal_context=_ctx(),
+            )
+        )
+
+    recalled_keys = {m.key for m in recalled}
+    assert (
+        "rt-01" in recalled_keys
+    ), f"enabled-path round-trip failed: rt-01 not recalled from {recalled_keys}"
+
+    block = svc.get_memory_context_for_terminal("term-u5", budget_chars=10_000)
+    assert "rt-01" in block
+
+
+# ---------------------------------------------------------------------------
+# AC5 — guard order: short-circuit runs BEFORE any validation
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_store_short_circuits_before_validation(tmp_path: Path) -> None:
+    """The disabled guard must fire before scope/type validation, so a
+    disabled-memory state returns the canonical ``MemoryDisabledError`` even
+    when inputs would otherwise raise ``ValueError``.
+    """
+    svc = _make_svc(tmp_path / "mem", tmp_path / "u5-guard.db")
+    with patch(
+        "cli_agent_orchestrator.services.memory_service._is_memory_enabled",
+        return_value=False,
+    ):
+        with pytest.raises(MemoryDisabledError):
+            _run(
+                svc.store(
+                    content="x",
+                    scope="NOT-A-SCOPE",
+                    memory_type="project",
+                    key="x",
+                    terminal_context=_ctx(),
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# MCP tool surface — disabled responses carry ``disabled: True`` + message
+# ---------------------------------------------------------------------------
+
+
+class TestMcpToolsDisabledSurface:
+    def test_memory_disabled_message_is_actionable(self) -> None:
+        from cli_agent_orchestrator.mcp_server.server import MEMORY_DISABLED_MESSAGE
+
+        assert "memory.enabled" in MEMORY_DISABLED_MESSAGE
+        assert "settings.json" in MEMORY_DISABLED_MESSAGE
+
+    def test_memory_store_returns_disabled_payload(self, tmp_path: Path) -> None:
+        from cli_agent_orchestrator.mcp_server import server as srv
+        from cli_agent_orchestrator.mcp_server.server import memory_store
+
+        with (
+            patch(
+                "cli_agent_orchestrator.services.memory_service._is_memory_enabled",
+                return_value=False,
+            ),
+            patch.object(srv, "_get_terminal_context_from_env", return_value=_ctx()),
+            patch(
+                "cli_agent_orchestrator.services.memory_service.MemoryService",
+                lambda: _make_svc(tmp_path / "mem", tmp_path / "u5-mcp.db"),
+            ),
+        ):
+            result = _run(
+                memory_store(
+                    content="x",
+                    scope="global",
+                    memory_type="project",
+                    key="k",
+                    tags="",
+                )
+            )
+
+        assert result["success"] is False
+        assert result["disabled"] is True
+        assert result["error"] == srv.MEMORY_DISABLED_MESSAGE
+
+    def test_memory_recall_returns_disabled_payload(self, tmp_path: Path) -> None:
+        from cli_agent_orchestrator.mcp_server import server as srv
+        from cli_agent_orchestrator.mcp_server.server import memory_recall
+
+        with patch(
+            "cli_agent_orchestrator.services.settings_service.is_memory_enabled",
+            return_value=False,
+        ):
+            result = _run(
+                memory_recall(
+                    query=None,
+                    scope=None,
+                    memory_type=None,
+                    limit=10,
+                    search_mode="hybrid",
+                )
+            )
+
+        assert result["success"] is False
+        assert result["disabled"] is True
+        assert result["error"] == srv.MEMORY_DISABLED_MESSAGE
+        assert result["memories"] == []
+
+    def test_memory_forget_returns_disabled_payload(self, tmp_path: Path) -> None:
+        from cli_agent_orchestrator.mcp_server import server as srv
+        from cli_agent_orchestrator.mcp_server.server import memory_forget
+
+        with (
+            patch(
+                "cli_agent_orchestrator.services.memory_service._is_memory_enabled",
+                return_value=False,
+            ),
+            patch.object(srv, "_get_terminal_context_from_env", return_value=_ctx()),
+            patch(
+                "cli_agent_orchestrator.services.memory_service.MemoryService",
+                lambda: _make_svc(tmp_path / "mem", tmp_path / "u5-forget.db"),
+            ),
+        ):
+            result = _run(
+                memory_forget(
+                    key="k",
+                    scope="global",
+                )
+            )
+
+        assert result["success"] is False
+        assert result["disabled"] is True
+        assert result["error"] == srv.MEMORY_DISABLED_MESSAGE

--- a/test/services/test_memory_injection_traversal.py
+++ b/test/services/test_memory_injection_traversal.py
@@ -1,0 +1,116 @@
+"""Cross-project traversal guard for memory injection.
+
+`get_memory_context_for_terminal` reads each scope's ``index.md`` and loads
+the wiki file named by every entry's ``relative_path``. That path comes from
+an on-disk index file, which can be corrupted or hand-crafted. A malicious
+entry such as ``../<other-project>/wiki/project/secret.md`` resolves to a
+real, well-formed wiki file *under the global memory base* but *outside this
+scope's wiki directory* — leaking another project's memory into this
+terminal's context.
+
+The guard must validate each resolved wiki file against the per-scope wiki
+directory (``project_dir / "wiki"``), not the global base directory. The
+victim file here is created via ``store`` so it is a fully-formed memory the
+parser accepts; the traversal guard is therefore the *only* thing standing
+between it and injection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from cli_agent_orchestrator.services.memory_service import MemoryService
+
+VICTIM_CONTENT = "TOP SECRET cross-project content"
+
+
+def _ctx(cwd: str, terminal_id: str = "term-trav") -> dict:
+    return {
+        "terminal_id": terminal_id,
+        "session_name": "sess-trav",
+        "agent_profile": "dev",
+        "provider": "claude_code",
+        "cwd": cwd,
+    }
+
+
+def _make_svc(tmp_path: Path, ctx: dict) -> MemoryService:
+    svc = MemoryService(base_dir=tmp_path)
+    svc._get_terminal_context = lambda terminal_id: ctx  # type: ignore[method-assign]
+    return svc
+
+
+def test_index_entry_escaping_scope_wiki_dir_is_rejected(tmp_path: Path) -> None:
+    """A relative_path escaping this scope's wiki dir must not be injected.
+
+    The escape target is a real memory in a *sibling* project under the same
+    global memory base, so the old base-dir guard would have admitted it. The
+    tightened per-scope guard must reject it.
+    """
+    # 1. Create a real, well-formed victim memory in a separate project.
+    victim_ctx = _ctx(cwd="/home/user/victim-proj")
+    victim_svc = _make_svc(tmp_path, victim_ctx)
+    asyncio.run(
+        victim_svc.store(
+            content=VICTIM_CONTENT,
+            scope="project",
+            memory_type="project",
+            key="secret",
+            terminal_context=victim_ctx,
+        )
+    )
+    victim_hash = victim_svc.resolve_scope_id("project", victim_ctx)
+    assert victim_hash, "project scope must resolve to a non-empty id"
+    victim_file = tmp_path / victim_hash / "wiki" / "project" / "secret.md"
+    assert victim_file.exists(), "victim memory file should have been created"
+    assert VICTIM_CONTENT in victim_file.read_text(encoding="utf-8")
+
+    # 2. Attacker terminal in a *different* project. Hand-craft its global
+    #    index.md with one entry whose relative_path climbs out of the global
+    #    wiki dir into the victim project's wiki file.
+    attacker_ctx = _ctx(cwd="/home/user/attacker-proj")
+    svc = _make_svc(tmp_path, attacker_ctx)
+    scope_id = svc.resolve_scope_id("global", attacker_ctx)
+    global_wiki = svc._get_project_dir("global", scope_id) / "wiki"
+    global_wiki.mkdir(parents=True, exist_ok=True)
+
+    hops = len(global_wiki.relative_to(tmp_path).parts)
+    escape = "/".join([".."] * hops) + f"/{victim_hash}/wiki/project/secret.md"
+    # Sanity: the escape really does resolve onto the victim file.
+    assert (global_wiki / escape).resolve() == victim_file.resolve()
+
+    (global_wiki / "index.md").write_text(
+        "# Memory Index\n\n## global\n"
+        f"- [secret]({escape}) — type:project tags: ~5tok updated:2026-05-29T00:00:00Z\n",
+        encoding="utf-8",
+    )
+
+    block = svc.get_memory_context_for_terminal("term-trav", budget_chars=100_000)
+
+    # The traversal entry is the only one present; it must be rejected, so the
+    # context is empty and never contains the victim's content.
+    assert VICTIM_CONTENT not in block
+    assert block == ""
+
+
+def test_legitimate_in_scope_entry_still_injected(tmp_path: Path) -> None:
+    """A normal entry within the scope's wiki dir is still admitted.
+
+    Guards against the fix over-tightening and dropping valid memories.
+    """
+    ctx = _ctx(cwd="/home/user/normal-proj")
+    svc = _make_svc(tmp_path, ctx)
+
+    asyncio.run(
+        svc.store(
+            content="a legitimate global reference",
+            scope="global",
+            memory_type="reference",
+            key="legit-ref",
+            terminal_context=ctx,
+        )
+    )
+
+    block = svc.get_memory_context_for_terminal("term-trav", budget_chars=100_000)
+    assert "a legitimate global reference" in block

--- a/test/services/test_memory_per_scope_cap.py
+++ b/test/services/test_memory_per_scope_cap.py
@@ -1,0 +1,295 @@
+"""SC-2 — Per-scope injection cap tests (U2).
+
+Covers `MemoryService.get_memory_context_for_terminal` with the per-scope
+caps introduced in U2:
+
+- MEMORY_MAX_PER_SCOPE: at most 10 entries per scope.
+- MEMORY_SCOPE_BUDGET_CHARS: per-scope character ceiling, applied independently
+  so one scope cannot monopolize the overall budget.
+- Empty scopes do NOT cause other scopes to grow (precedence + cache boundary
+  preservation — see tasks.md cross-unit risk note for Phase 2 U7).
+- Scope precedence session > project > global is preserved in output order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from cli_agent_orchestrator.constants import (
+    MEMORY_MAX_PER_SCOPE,
+    MEMORY_SCOPE_BUDGET_CHARS,
+)
+from cli_agent_orchestrator.services.memory_service import MemoryService
+
+
+def _ctx(terminal_id: str = "term-u2") -> dict:
+    return {
+        "terminal_id": terminal_id,
+        "session_name": "sess-u2",
+        "agent_profile": "dev",
+        "provider": "claude_code",
+        "cwd": "/home/user/proj-u2",
+    }
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_svc(tmp_path: Path) -> MemoryService:
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx()
+    svc._get_terminal_context = lambda terminal_id: ctx  # type: ignore[method-assign]
+    return svc
+
+
+def _inner(block: str) -> str:
+    """Return the content between the cao-memory tags."""
+    return block.split("<cao-memory>")[1].split("</cao-memory>")[0]
+
+
+def _count_scope_lines(block: str, scope: str) -> int:
+    return sum(1 for line in block.splitlines() if line.startswith(f"- [{scope}]"))
+
+
+# ---------------------------------------------------------------------------
+# AC1 — single scope cannot monopolize the budget
+# AC2 — MEMORY_MAX_PER_SCOPE is enforced
+# ---------------------------------------------------------------------------
+
+
+def test_single_scope_capped_to_max_per_scope(tmp_path: Path) -> None:
+    """20 memories in one scope → at most MEMORY_MAX_PER_SCOPE entries."""
+    svc = _make_svc(tmp_path)
+    ctx = _ctx()
+
+    # Store 20 long memories into a single scope.
+    long_content = "x " * 300  # ~600 chars — larger than per-scope budget
+    for i in range(20):
+        _run(
+            svc.store(
+                content=long_content + f"entry-{i}",
+                scope="global",
+                memory_type="project",
+                key=f"glob-{i:03d}",
+                terminal_context=ctx,
+            )
+        )
+
+    # Give the caller ample budget so we know the cap — not the budget — is
+    # what truncates output.
+    block = svc.get_memory_context_for_terminal("term-u2", budget_chars=100_000)
+    assert block, "context block should not be empty"
+
+    inner = _inner(block)
+    global_lines = _count_scope_lines(inner, "global")
+    assert global_lines <= MEMORY_MAX_PER_SCOPE, (
+        f"global scope produced {global_lines} entries, "
+        f"exceeds MEMORY_MAX_PER_SCOPE={MEMORY_MAX_PER_SCOPE}"
+    )
+
+
+def test_single_scope_bounded_by_scope_char_budget(tmp_path: Path) -> None:
+    """20 long memories in one scope → per-scope char cap bounds the slice.
+
+    The effective per-scope cap is
+    min(MEMORY_SCOPE_BUDGET_CHARS, budget_chars // N_scopes). With a caller
+    budget of 9000 and 3 scopes, the effective cap is MEMORY_SCOPE_BUDGET_CHARS.
+    """
+    svc = _make_svc(tmp_path)
+    ctx = _ctx()
+
+    long_content = "y " * 300  # ~600 chars per memory
+    for i in range(20):
+        _run(
+            svc.store(
+                content=long_content + f"entry-{i}",
+                scope="global",
+                memory_type="project",
+                key=f"glob-{i:03d}",
+                terminal_context=ctx,
+            )
+        )
+
+    block = svc.get_memory_context_for_terminal("term-u2", budget_chars=9000)
+    assert block
+    inner = _inner(block)
+
+    # Count characters belonging to the global scope slice only. Allow a small
+    # slack for tag/header overhead; each line is already below the per-scope
+    # cap, and the loop terminates before adding a line that would exceed it.
+    global_chars = sum(
+        len(line) + 1  # +1 accounts for the join-newline counted in the cap
+        for line in inner.splitlines()
+        if line.startswith("- [global]")
+    )
+    assert global_chars <= MEMORY_SCOPE_BUDGET_CHARS, (
+        f"global scope consumed {global_chars} chars, "
+        f"exceeds MEMORY_SCOPE_BUDGET_CHARS={MEMORY_SCOPE_BUDGET_CHARS}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4 — precedence preserved; AC1 — each scope gets its own slice
+# ---------------------------------------------------------------------------
+
+
+def test_all_scopes_each_get_their_own_slice_in_precedence_order(tmp_path: Path) -> None:
+    """session > project > global: each populated scope gets its slice, in order."""
+    svc = _make_svc(tmp_path)
+    ctx = _ctx()
+
+    for i in range(5):
+        _run(
+            svc.store(
+                content=f"session finding {i}",
+                scope="session",
+                memory_type="project",
+                key=f"sess-{i}",
+                terminal_context=ctx,
+            )
+        )
+        _run(
+            svc.store(
+                content=f"project decision {i}",
+                scope="project",
+                memory_type="project",
+                key=f"proj-{i}",
+                terminal_context=ctx,
+            )
+        )
+        _run(
+            svc.store(
+                content=f"global reference {i}",
+                scope="global",
+                memory_type="reference",
+                key=f"glob-{i}",
+                terminal_context=ctx,
+            )
+        )
+
+    block = svc.get_memory_context_for_terminal("term-u2", budget_chars=9000)
+    assert block
+    inner = _inner(block)
+    lines = [ln for ln in inner.splitlines() if ln.startswith("- [")]
+
+    # Each scope must contribute entries.
+    assert any(ln.startswith("- [session]") for ln in lines), "session scope missing"
+    assert any(ln.startswith("- [project]") for ln in lines), "project scope missing"
+    assert any(ln.startswith("- [global]") for ln in lines), "global scope missing"
+
+    # Each scope independently capped at MEMORY_MAX_PER_SCOPE.
+    for scope in ("session", "project", "global"):
+        assert _count_scope_lines(inner, scope) <= MEMORY_MAX_PER_SCOPE
+
+    # Precedence order: every session line appears before every project line,
+    # and every project line appears before every global line.
+    def first_index(scope: str) -> int:
+        for i, ln in enumerate(lines):
+            if ln.startswith(f"- [{scope}]"):
+                return i
+        return -1
+
+    def last_index(scope: str) -> int:
+        idx = -1
+        for i, ln in enumerate(lines):
+            if ln.startswith(f"- [{scope}]"):
+                idx = i
+        return idx
+
+    assert last_index("session") < first_index("project"), "session must precede project"
+    assert last_index("project") < first_index("global"), "project must precede global"
+
+
+# ---------------------------------------------------------------------------
+# AC3 — overall injection stays within budget
+# ---------------------------------------------------------------------------
+
+
+def test_total_injection_within_overall_budget(tmp_path: Path) -> None:
+    """Total injection does not exceed the caller-supplied budget_chars."""
+    svc = _make_svc(tmp_path)
+    ctx = _ctx()
+
+    # Populate all three scopes with more than the per-scope cap of long entries.
+    long_content = "z " * 200  # ~400 chars
+    for scope in ("session", "project", "global"):
+        for i in range(15):
+            _run(
+                svc.store(
+                    content=long_content + f"{scope}-{i}",
+                    scope=scope,
+                    memory_type="project",
+                    key=f"{scope}-{i:02d}",
+                    terminal_context=ctx,
+                )
+            )
+
+    block = svc.get_memory_context_for_terminal("term-u2", budget_chars=3000)
+    assert block
+    inner = _inner(block)
+
+    # Sum of per-scope slices must not exceed 3 * MEMORY_SCOPE_BUDGET_CHARS,
+    # and must not exceed the caller-supplied budget_chars.
+    assert (
+        len(inner) <= 3 * MEMORY_SCOPE_BUDGET_CHARS + 200
+    ), f"inner block of {len(inner)} chars exceeds 3x per-scope cap"  # header overhead slack
+
+
+# ---------------------------------------------------------------------------
+# Empty-scope non-reallocation — cache boundary preservation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_scope_does_not_grow_other_scopes(tmp_path: Path) -> None:
+    """An empty session scope must not cause project/global to exceed their caps.
+
+    Verifies Phase 2 U7 cache-friendly behavior: unused budget from an empty
+    scope is not reallocated. The per-scope cap stays the same regardless of
+    whether sibling scopes are populated.
+    """
+    svc = _make_svc(tmp_path)
+    ctx = _ctx()
+
+    # Populate only project and global, leave session empty.
+    for i in range(20):
+        _run(
+            svc.store(
+                content=f"project entry {i} " + ("p " * 150),
+                scope="project",
+                memory_type="project",
+                key=f"proj-{i:02d}",
+                terminal_context=ctx,
+            )
+        )
+        _run(
+            svc.store(
+                content=f"global entry {i} " + ("g " * 150),
+                scope="global",
+                memory_type="reference",
+                key=f"glob-{i:02d}",
+                terminal_context=ctx,
+            )
+        )
+
+    block = svc.get_memory_context_for_terminal("term-u2", budget_chars=9000)
+    assert block
+    inner = _inner(block)
+
+    # Session scope contributes nothing.
+    assert _count_scope_lines(inner, "session") == 0
+
+    # project and global each still capped at MEMORY_MAX_PER_SCOPE — not 15, not 20.
+    assert _count_scope_lines(inner, "project") <= MEMORY_MAX_PER_SCOPE
+    assert _count_scope_lines(inner, "global") <= MEMORY_MAX_PER_SCOPE
+
+    # And each scope's total chars ≤ MEMORY_SCOPE_BUDGET_CHARS.
+    for scope in ("project", "global"):
+        scope_chars = sum(
+            len(line) + 1 for line in inner.splitlines() if line.startswith(f"- [{scope}]")
+        )
+        assert scope_chars <= MEMORY_SCOPE_BUDGET_CHARS, (
+            f"{scope} scope grew beyond MEMORY_SCOPE_BUDGET_CHARS "
+            f"({scope_chars} > {MEMORY_SCOPE_BUDGET_CHARS})"
+        )

--- a/test/services/test_memory_service_index_roundtrip.py
+++ b/test/services/test_memory_service_index_roundtrip.py
@@ -1,0 +1,360 @@
+"""SC-3 — Regex round-trip invariant for index.md writer/reader.
+
+Every field written through the production writer path (`store()` →
+`_regenerate_scope_index()` / `_update_index()`) must be recovered unchanged
+by the production reader (`_parse_index()` regex at
+`memory_service.py:937-940`).
+
+This guards against silent drift between the writer format string and the
+reader regex. Drift would cause entries to vanish from injection (U2) or sort
+order to break (the per-scope sort at `memory_service.py:1116` depends on
+lexicographic ISO-8601 ordering).
+
+Edge cases covered: unicode key candidates, multi-word tags, comma-delimited
+tags, empty tags, multiple scopes in one index, ISO-8601 timestamp parseability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from cli_agent_orchestrator.services.memory_service import MemoryService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(cwd: str = "/home/user/proj-u3") -> dict:
+    return {
+        "terminal_id": "term-u3",
+        "session_name": "sess-u3",
+        "agent_profile": "dev",
+        "provider": "claude_code",
+        "cwd": cwd,
+    }
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _parse_iso8601_z(ts: str) -> datetime:
+    """Parse the writer's strftime('%Y-%m-%dT%H:%M:%SZ') format.
+
+    Python 3.10's datetime.fromisoformat does not accept the trailing 'Z'
+    suffix, so use strptime against the exact writer format. If the writer
+    ever drifts off ISO-8601 with Z-suffix this raises ValueError, which is
+    the test invariant we want.
+    """
+    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# AC1 — writer → reader round-trip on required fields
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_store_parses_back_all_fields(tmp_path: Path) -> None:
+    """Store N memories → _parse_index recovers every (key, type, tags, path).
+
+    Uses the production `store()` path so the writer codepath is exactly what
+    production callers exercise.
+    """
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx()
+
+    written: list[dict] = []
+    for i in range(5):
+        key = f"roundtrip-key-{i:03d}"
+        mem = _run(
+            svc.store(
+                content=f"body content {i}",
+                scope="global",
+                memory_type="project",
+                key=key,
+                tags=f"tag{i}",
+                terminal_context=ctx,
+            )
+        )
+        written.append(
+            {
+                "key": mem.key,
+                "memory_type": "project",
+                "tags": f"tag{i}",
+                "relative_path": f"global/{mem.key}.md",
+            }
+        )
+
+    scope_id = svc.resolve_scope_id("global", ctx)
+    index_path = svc.get_index_path("global", scope_id)
+    assert index_path.exists(), "writer must produce an index.md file"
+
+    parsed = svc._parse_index(index_path)
+    # Only look at the global scope slice; other scopes may be empty.
+    parsed_global = [e for e in parsed if e["scope"] == "global"]
+
+    # Every entry we wrote is recovered — no silent drops.
+    parsed_keys = {e["key"] for e in parsed_global}
+    for w in written:
+        assert (
+            w["key"] in parsed_keys
+        ), f"writer produced key {w['key']!r} but parser did not recover it"
+
+    # Field-level equality for each recovered entry.
+    parsed_by_key = {e["key"]: e for e in parsed_global}
+    for w in written:
+        p = parsed_by_key[w["key"]]
+        assert p["memory_type"] == w["memory_type"], (
+            f"memory_type drift for {w['key']}: wrote {w['memory_type']!r} "
+            f"read {p['memory_type']!r}"
+        )
+        assert (
+            p["tags"] == w["tags"]
+        ), f"tags drift for {w['key']}: wrote {w['tags']!r} read {p['tags']!r}"
+        assert p["relative_path"] == w["relative_path"], (
+            f"relative_path drift for {w['key']}: wrote {w['relative_path']!r} "
+            f"read {p['relative_path']!r}"
+        )
+        # scope label recovered
+        assert p["scope"] == "global"
+
+
+# ---------------------------------------------------------------------------
+# AC2 — ISO-8601 timestamp format invariant
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_updated_at_is_iso8601_parseable(tmp_path: Path) -> None:
+    """Every recovered `updated_at` must parse as ISO-8601 with Z suffix.
+
+    U2's per-scope sort relies on lexicographic ISO-8601 ordering. If the
+    writer ever drifts off this format, this test fails fast.
+    """
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx()
+
+    for i in range(3):
+        _run(
+            svc.store(
+                content=f"finding {i}",
+                scope="global",
+                memory_type="reference",
+                key=f"iso-{i:03d}",
+                terminal_context=ctx,
+            )
+        )
+
+    scope_id = svc.resolve_scope_id("global", ctx)
+    index_path = svc.get_index_path("global", scope_id)
+    parsed = [e for e in svc._parse_index(index_path) if e["scope"] == "global"]
+
+    assert parsed, "expected at least one entry in global scope"
+    for entry in parsed:
+        ts = entry["updated_at"]
+        # Lexicographic sort in U2 relies on fixed width — spot-check format.
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", ts
+        ), f"updated_at {ts!r} does not match ISO-8601 Z-suffix format"
+        # And it must actually parse — no regex-only approximations.
+        parsed_dt = _parse_iso8601_z(ts)
+        assert parsed_dt.year >= 2020
+
+
+# ---------------------------------------------------------------------------
+# Edge case — empty tags
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_empty_tags(tmp_path: Path) -> None:
+    """Empty `tags=""` must round-trip to empty string — reader regex uses \\S*."""
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx()
+
+    _run(
+        svc.store(
+            content="content with no tags",
+            scope="global",
+            memory_type="project",
+            key="empty-tags-key",
+            tags="",
+            terminal_context=ctx,
+        )
+    )
+
+    scope_id = svc.resolve_scope_id("global", ctx)
+    index_path = svc.get_index_path("global", scope_id)
+    parsed = [e for e in svc._parse_index(index_path) if e["key"] == "empty-tags-key"]
+    assert len(parsed) == 1, "entry must be recovered"
+    assert parsed[0]["tags"] == "", f"empty tags drifted to {parsed[0]['tags']!r}"
+
+
+# ---------------------------------------------------------------------------
+# Edge case — comma-delimited multi-tag (the project's convention for "multiple tags")
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_comma_delimited_tags(tmp_path: Path) -> None:
+    """Comma-joined tags (no whitespace) round-trip verbatim.
+
+    The writer emits `tags:{tags}` and the reader captures `\\S*`, so any
+    whitespace-free tag blob — including commas — survives round-trip.
+    """
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx()
+
+    tag_blob = "alpha,beta,gamma"
+    _run(
+        svc.store(
+            content="tagged content",
+            scope="global",
+            memory_type="reference",
+            key="csv-tags-key",
+            tags=tag_blob,
+            terminal_context=ctx,
+        )
+    )
+
+    scope_id = svc.resolve_scope_id("global", ctx)
+    index_path = svc.get_index_path("global", scope_id)
+    parsed = [e for e in svc._parse_index(index_path) if e["key"] == "csv-tags-key"]
+    assert len(parsed) == 1
+    assert (
+        parsed[0]["tags"] == tag_blob
+    ), f"csv tags drifted: wrote {tag_blob!r} read {parsed[0]['tags']!r}"
+
+
+# ---------------------------------------------------------------------------
+# Edge case — multi-scope index
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_multiple_scopes_in_one_index(tmp_path: Path) -> None:
+    """A single index.md with entries in multiple scopes round-trips cleanly.
+
+    ``_regenerate_scope_index`` writes `## <scope>` headers; `_parse_index`
+    picks up `current_scope` from those headers. Test all three reachable
+    scopes share one index.md and each scope's entries are labeled correctly.
+    """
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx()
+
+    # session/project/global all resolve under the same project_dir (global
+    # container for session; project hash for project; global dir for global).
+    # The per-scope index.md only reflects rows within its scope_id partition,
+    # but `_regenerate_scope_index` still groups by scope inside the file.
+    expected: dict[str, list[str]] = {}
+    for scope in ("global", "project", "session"):
+        expected[scope] = []
+        for i in range(2):
+            key = f"{scope}-key-{i}"
+            _run(
+                svc.store(
+                    content=f"{scope} body {i}",
+                    scope=scope,
+                    memory_type="project",
+                    key=key,
+                    tags=f"{scope}tag",
+                    terminal_context=ctx,
+                )
+            )
+            expected[scope].append(key)
+
+    # Parse each scope's index.md and verify the entries labeled for that scope.
+    for scope, wanted_keys in expected.items():
+        scope_id = svc.resolve_scope_id(scope, ctx)
+        index_path = svc.get_index_path(scope, scope_id)
+        assert index_path.exists(), f"{scope} index.md missing"
+        parsed = svc._parse_index(index_path)
+        got = {e["key"] for e in parsed if e["scope"] == scope}
+        missing = set(wanted_keys) - got
+        assert not missing, (
+            f"{scope} scope lost keys after round-trip: {missing}. " f"parsed rows: {parsed!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4 — drift guard: fails if writer format or reader regex is edited
+# ---------------------------------------------------------------------------
+
+
+def test_writer_emits_reader_regex_format(tmp_path: Path) -> None:
+    """Every writer-produced line must match the exact reader regex verbatim.
+
+    This is the tightest lock on writer/reader parity. It pins the emitted
+    line format byte-for-byte to the current regex. Any change to either side
+    causes an immediate test failure.
+    """
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx()
+
+    keys = [f"drift-{i:03d}" for i in range(4)]
+    for key in keys:
+        _run(
+            svc.store(
+                content="content for drift guard",
+                scope="global",
+                memory_type="project",
+                key=key,
+                tags="csv,tag,list",
+                terminal_context=ctx,
+            )
+        )
+
+    scope_id = svc.resolve_scope_id("global", ctx)
+    index_path = svc.get_index_path("global", scope_id)
+    text = index_path.read_text(encoding="utf-8")
+
+    # The reader's regex, lifted verbatim from memory_service.py:937-940.
+    reader_re = re.compile(
+        r"^- \[([^\]]+)\]\(([^)]+)\) — type:(\S+) tags:(\S*) ~\d+tok updated:(\S+)$"
+    )
+
+    entry_lines = [ln for ln in text.splitlines() if ln.startswith("- [") and "](" in ln]
+    assert entry_lines, "writer produced no entry lines"
+
+    for line in entry_lines:
+        assert reader_re.match(line), (
+            f"writer emitted a line that does NOT match the reader regex — "
+            f"drift detected: {line!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Performance — AC requires < 1s (U3 tasks.md)
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_runs_under_one_second(tmp_path: Path) -> None:
+    """Full round-trip for 10 entries completes under 1 second.
+
+    Sanity check against the tasks.md AC4 runtime requirement.
+    """
+    import time
+
+    svc = MemoryService(base_dir=tmp_path)
+    ctx = _ctx(cwd="/home/user/proj-u3-perf")
+
+    start = time.perf_counter()
+    for i in range(10):
+        _run(
+            svc.store(
+                content=f"perf body {i}",
+                scope="global",
+                memory_type="project",
+                key=f"perf-{i:03d}",
+                tags=f"t{i}",
+                terminal_context=ctx,
+            )
+        )
+    scope_id = svc.resolve_scope_id("global", ctx)
+    index_path = svc.get_index_path("global", scope_id)
+    parsed = svc._parse_index(index_path)
+    elapsed = time.perf_counter() - start
+
+    assert any(e["key"].startswith("perf-") for e in parsed)
+    assert elapsed < 1.0, f"round-trip took {elapsed:.3f}s, exceeds 1s budget"

--- a/test/services/test_project_identity.py
+++ b/test/services/test_project_identity.py
@@ -129,6 +129,40 @@ def test_ac1_same_git_remote_at_two_paths_resolves_same_project_id(
     assert get_project_id_by_alias(wt_hash) == id_main
 
 
+def test_credentialed_remote_url_is_not_persisted_as_alias(
+    tmp_path: Path, isolated_db: Path, clear_overrides: None
+) -> None:
+    """A remote URL with embedded credentials must never reach the alias table.
+
+    Git remotes commonly look like ``https://user:token@host/org/repo.git``.
+    Resolving project identity records aliases, but the raw URL (and therefore
+    the secret) must not be persisted — only the auth-stripped canonical id
+    and the cwd-hash. See Copilot PR #262 HIGH finding.
+    """
+    secret = "s3cr3t-token"
+    remote = f"https://alice:{secret}@github.com/acme/widgets.git"
+    repo = tmp_path / "repo"
+    _init_repo(repo, remote)
+
+    svc = _make_svc(tmp_path / "mem", isolated_db)
+    canonical = svc.resolve_scope_id("project", {"cwd": str(repo)})
+
+    # Canonical id is auth-stripped.
+    assert canonical == "github-com-acme-widgets"
+    assert secret not in canonical
+
+    # No alias row anywhere holds the raw URL, the secret, or kind=git_remote.
+    aliases = list_aliases_for_project(canonical)
+    assert all(a["kind"] != "git_remote" for a in aliases), "git_remote alias must not be recorded"
+    for a in aliases:
+        assert secret not in a["alias"], "credential leaked into alias value"
+        assert remote not in a["alias"], "raw remote URL leaked into alias value"
+
+    # Only the cwd-hash alias is recorded, and it still resolves correctly.
+    cwd_hash = hashlib.sha256(os.path.realpath(repo).encode()).hexdigest()[:12]
+    assert get_project_id_by_alias(cwd_hash) == canonical
+
+
 # ---------------------------------------------------------------------------
 # AC2 — rename keeps memories recallable
 # ---------------------------------------------------------------------------

--- a/test/services/test_project_identity.py
+++ b/test/services/test_project_identity.py
@@ -267,6 +267,37 @@ def test_explicit_project_id_from_settings_when_env_absent(
 
 
 # ---------------------------------------------------------------------------
+# Alias uniqueness — an alias maps to exactly one canonical project_id
+# ---------------------------------------------------------------------------
+
+
+def test_alias_upserts_to_single_project_id(isolated_db: Path) -> None:
+    """Re-recording an alias for a new project_id repoints it, never duplicates.
+
+    A cwd-hash first resolved via an explicit override and later via its git
+    remote must end up mapping to exactly one canonical id, so reverse lookups
+    are deterministic.
+    """
+    from cli_agent_orchestrator.clients.database import record_project_alias
+
+    alias = "deadbeefcafe"
+
+    # First resolution maps the cwd-hash to an override-supplied id.
+    record_project_alias("override-id", alias, "cwd_hash")
+    assert get_project_id_by_alias(alias) == "override-id"
+
+    # Later, the same cwd resolves via its git remote: the alias repoints.
+    record_project_alias("github-com-acme-widgets", alias, "cwd_hash")
+    assert get_project_id_by_alias(alias) == "github-com-acme-widgets"
+
+    # Exactly one mapping exists for the alias — no duplicate rows.
+    old = [a for a in list_aliases_for_project("override-id") if a["alias"] == alias]
+    new = [a for a in list_aliases_for_project("github-com-acme-widgets") if a["alias"] == alias]
+    assert old == []
+    assert len(new) == 1
+
+
+# ---------------------------------------------------------------------------
 # _normalize_git_remote shape
 # ---------------------------------------------------------------------------
 

--- a/test/services/test_project_identity.py
+++ b/test/services/test_project_identity.py
@@ -1,0 +1,409 @@
+"""SC-7 / U6 — stable project identity resolver tests.
+
+Covers:
+- **AC1** — Same git remote at two paths resolves to the same project_id.
+- **AC2** — Directory rename does not orphan memories.
+- **AC3** — Non-git directory falls back to SHA256[:12].
+- **AC4** — ``plan_project_dir_migration`` is dry-run only.
+- Source 1 — explicit override (env + settings.json memory.project_id).
+- Helper coverage for ``_normalize_git_remote`` and override validation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cli_agent_orchestrator.clients.database import (
+    Base,
+    get_project_id_by_alias,
+    list_aliases_for_project,
+)
+from cli_agent_orchestrator.services.memory_service import (
+    MemoryService,
+    ProjectIdentityResolutionError,
+    _git_remote_identity,
+    _normalize_git_remote,
+    _validate_project_id_override,
+    resolve_project_id,
+)
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _make_engine(db_path: Path) -> Any:
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _make_svc(base_dir: Path, db_path: Path) -> MemoryService:
+    engine = _make_engine(db_path)
+    return MemoryService(base_dir=base_dir, db_engine=engine)
+
+
+@pytest.fixture
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the global SessionLocal at a test DB so alias writes land there."""
+    db_path = tmp_path / "test.db"
+    from cli_agent_orchestrator.clients import database as db_mod
+
+    engine = _make_engine(db_path)
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", TestSession, raising=True)
+    return db_path
+
+
+@pytest.fixture
+def clear_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure explicit-override source is empty for tests targeting git/hash."""
+    monkeypatch.delenv("CAO_PROJECT_ID", raising=False)
+
+    def _no_override() -> dict:
+        return {"enabled": True, "flush_threshold": 0.85}
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_memory_settings",
+        _no_override,
+        raising=True,
+    )
+
+
+def _init_repo(path: Path, remote_url: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", remote_url],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _git_available() -> bool:
+    try:
+        subprocess.run(["git", "--version"], capture_output=True, check=True, timeout=2)
+        return True
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _git_available(), reason="git executable required for U6 tests")
+
+
+# ---------------------------------------------------------------------------
+# AC1 — same remote at two paths → same project_id
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_same_git_remote_at_two_paths_resolves_same_project_id(
+    tmp_path: Path, isolated_db: Path, clear_overrides: None
+) -> None:
+    remote = "git@github.com:acme/widgets.git"
+    main = tmp_path / "main"
+    worktree = tmp_path / "wt"
+    _init_repo(main, remote)
+    _init_repo(worktree, remote)
+
+    svc = _make_svc(tmp_path / "mem", isolated_db)
+    id_main = svc.resolve_scope_id("project", {"cwd": str(main)})
+    id_wt = svc.resolve_scope_id("project", {"cwd": str(worktree)})
+
+    assert id_main is not None
+    assert id_main == id_wt
+
+    main_hash = hashlib.sha256(os.path.realpath(main).encode()).hexdigest()[:12]
+    wt_hash = hashlib.sha256(os.path.realpath(worktree).encode()).hexdigest()[:12]
+    assert get_project_id_by_alias(main_hash) == id_main
+    assert get_project_id_by_alias(wt_hash) == id_main
+
+
+# ---------------------------------------------------------------------------
+# AC2 — rename keeps memories recallable
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_rename_keeps_memories_recallable_via_alias(
+    tmp_path: Path, isolated_db: Path, clear_overrides: None
+) -> None:
+    remote = "https://example.com/acme/renameable.git"
+    before = tmp_path / "before"
+    _init_repo(before, remote)
+
+    svc = _make_svc(tmp_path / "mem", isolated_db)
+    _run(
+        svc.store(
+            content="remembered across a rename",
+            scope="project",
+            memory_type="project",
+            terminal_context={"cwd": str(before)},
+            key="rename-key",
+        )
+    )
+
+    after = tmp_path / "after"
+    before.rename(after)
+
+    hits = _run(
+        svc.recall(
+            scope="project",
+            terminal_context={"cwd": str(after)},
+            query="rename-key",
+        )
+    )
+    assert any(h.key == "rename-key" for h in hits), hits
+
+
+# ---------------------------------------------------------------------------
+# AC3 — non-git falls back to cwd-hash
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_non_git_falls_back_to_cwd_hash(
+    tmp_path: Path, isolated_db: Path, clear_overrides: None
+) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    svc = _make_svc(tmp_path / "mem", isolated_db)
+    scope_id = svc.resolve_scope_id("project", {"cwd": str(plain)})
+
+    expected = hashlib.sha256(os.path.realpath(plain).encode()).hexdigest()[:12]
+    assert scope_id == expected
+
+
+# ---------------------------------------------------------------------------
+# AC4 — dry-run migration planner
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_plan_project_dir_migration_dry_run_actions(
+    tmp_path: Path, isolated_db: Path, clear_overrides: None
+) -> None:
+    base = tmp_path / "mem"
+    svc = _make_svc(base, isolated_db)
+    canonical = "github-com-acme-widgets"
+    alias = "deadbeefcafe"
+
+    # Case 1: alias dir absent → none.
+    plan = svc.plan_project_dir_migration(canonical, alias)
+    assert plan["action"] == "none"
+    assert plan["dry_run"] is True
+
+    # Case 2: alias dir has content, canonical absent → rename.
+    (base / alias / "wiki" / "project").mkdir(parents=True)
+    (base / alias / "wiki" / "project" / "note.md").write_text("x")
+    plan = svc.plan_project_dir_migration(canonical, alias)
+    assert plan["action"] == "rename"
+    assert "wiki/project/note.md" in plan["files"]
+    assert (base / alias / "wiki" / "project" / "note.md").exists()
+    assert not (base / canonical).exists()
+
+    # Case 3: both exist with content → merge.
+    (base / canonical / "wiki" / "project").mkdir(parents=True)
+    (base / canonical / "wiki" / "project" / "other.md").write_text("y")
+    plan = svc.plan_project_dir_migration(canonical, alias)
+    assert plan["action"] == "merge"
+
+    # Case 4: canonical exists empty → conflict.
+    empty_alias = "0" * 12
+    (base / empty_alias).mkdir()
+    plan = svc.plan_project_dir_migration(canonical, empty_alias)
+    assert plan["action"] == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# Source 1 — explicit override (env + settings)
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_project_id_from_env_wins_over_git(
+    tmp_path: Path, isolated_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _init_repo(tmp_path / "repo", "git@github.com:someone/else.git")
+    monkeypatch.setenv("CAO_PROJECT_ID", "my-canonical-id")
+
+    svc = _make_svc(tmp_path / "mem", isolated_db)
+    scope_id = svc.resolve_scope_id("project", {"cwd": str(tmp_path / "repo")})
+
+    assert scope_id == "my-canonical-id"
+    aliases = list_aliases_for_project("my-canonical-id")
+    kinds = {a["kind"] for a in aliases}
+    assert "cwd_hash" in kinds
+
+
+def test_explicit_project_id_from_settings_when_env_absent(
+    tmp_path: Path,
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """settings.json ``memory.project_id`` is used when the env var is unset."""
+    monkeypatch.delenv("CAO_PROJECT_ID", raising=False)
+
+    def _settings() -> dict:
+        return {"enabled": True, "flush_threshold": 0.85, "project_id": "from-settings"}
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_memory_settings",
+        _settings,
+        raising=True,
+    )
+
+    svc = _make_svc(tmp_path / "mem", isolated_db)
+    scope_id = svc.resolve_scope_id("project", {"cwd": str(tmp_path / "plain")})
+
+    assert scope_id == "from-settings"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_git_remote shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("git@github.com:acme/widgets.git", "github-com-acme-widgets"),
+        ("https://github.com/acme/widgets.git", "github-com-acme-widgets"),
+        ("https://github.com/acme/widgets/", "github-com-acme-widgets"),
+        ("https://user:token@git.example.com/a/b.git", "git-example-com-a-b"),
+        ("ssh://git@gitlab.com/org/repo", "gitlab-com-org-repo"),
+        ("", "unknown"),
+    ],
+)
+def test_normalize_git_remote_produces_safe_stable_id(url: str, expected: str) -> None:
+    assert _normalize_git_remote(url) == expected
+
+
+# ---------------------------------------------------------------------------
+# Defensive — git unavailable / non-repo cwd
+# ---------------------------------------------------------------------------
+
+
+def test_git_remote_identity_returns_none_for_non_repo(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert _git_remote_identity(plain) is None
+
+
+def test_resolver_survives_filenotfound_on_git(
+    tmp_path: Path, isolated_db: Path, clear_overrides: None
+) -> None:
+    (tmp_path / "plain").mkdir()
+    svc = _make_svc(tmp_path / "mem", isolated_db)
+    with patch(
+        "cli_agent_orchestrator.services.memory_service.subprocess.run",
+        side_effect=FileNotFoundError("git not installed"),
+    ):
+        scope_id = svc.resolve_scope_id("project", {"cwd": str(tmp_path / "plain")})
+    expected = hashlib.sha256(os.path.realpath(tmp_path / "plain").encode()).hexdigest()[:12]
+    assert scope_id == expected
+
+
+# ---------------------------------------------------------------------------
+# Alias bookkeeping is opportunistic
+# ---------------------------------------------------------------------------
+
+
+def test_record_alias_swallows_db_error_without_breaking_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.clients.database.record_project_alias",
+        _boom,
+        raising=True,
+    )
+    monkeypatch.setenv("CAO_PROJECT_ID", "stable-id")
+
+    svc = MemoryService(base_dir=tmp_path / "mem")
+    scope_id = svc.resolve_scope_id("project", {"cwd": str(tmp_path)})
+    assert scope_id == "stable-id"
+
+
+# ---------------------------------------------------------------------------
+# Override validation — reject, don't sanitize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["has/slash", "has space", "has\x00null", "!@#$", "a" * 129, ""],
+)
+def test_validate_project_id_override_rejects_bad_input(bad_value: str) -> None:
+    with pytest.raises(ValueError):
+        _validate_project_id_override(bad_value)
+
+
+@pytest.mark.parametrize(
+    "good_value",
+    ["my-project", "acme.widgets", "CamelCase_123", "a", "a" * 128],
+)
+def test_validate_project_id_override_accepts_whitelist(good_value: str) -> None:
+    assert _validate_project_id_override(good_value) == good_value
+
+
+# ---------------------------------------------------------------------------
+# resolve_project_id raises when all sources fail
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_project_id_raises_when_all_sources_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CAO_PROJECT_ID", raising=False)
+
+    def _no_override() -> dict:
+        return {"enabled": True, "flush_threshold": 0.85}
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_memory_settings",
+        _no_override,
+        raising=True,
+    )
+    with pytest.raises(ProjectIdentityResolutionError):
+        resolve_project_id(None)
+
+
+# ---------------------------------------------------------------------------
+# Legacy cwd-hash dir remains searchable via alias
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_cwd_hash_dir_remains_searchable_after_alias_recorded(
+    tmp_path: Path, isolated_db: Path, clear_overrides: None
+) -> None:
+    base = tmp_path / "mem"
+    base.mkdir()
+    repo = tmp_path / "repo"
+    _init_repo(repo, "https://example.com/acme/legacy.git")
+
+    svc = _make_svc(base, isolated_db)
+
+    canonical = svc.resolve_scope_id("project", {"cwd": str(repo)})
+    assert canonical is not None
+
+    legacy_hash = hashlib.sha256(os.path.realpath(repo).encode()).hexdigest()[:12]
+    assert legacy_hash != canonical
+
+    legacy_wiki_dir = base / legacy_hash / "wiki" / "project"
+    legacy_wiki_dir.mkdir(parents=True)
+    (base / canonical).mkdir()
+
+    dirs = svc._get_search_dirs("project", {"cwd": str(repo)})
+    dir_names = {d.name for d in dirs}
+    assert legacy_hash in dir_names
+    assert canonical in dir_names


### PR DESCRIPTION
## Summary

- U2: per-scope cap (10 entries / 1000 chars)
- U3: ISO-8601 Z round-trip lock on index.md
- U4: durability + concurrent flock tests
- U5: `memory.enabled` flag short-circuits recall to `""`
- U6: stable project identity via git remote with cwd-hash alias

61 new tests, 0 regressions (1922 pass full suite).

## Test plan
- [x] `uv run pytest test/ --ignore=test/e2e -q` — 1922 passed
- [x] `uv run black --check src/ test/ && uv run isort --check-only src/ test/`
- [x] `uv run mypy src/` — no new errors