### PR TITLE
fix(mcp): reject send_message when receiver_id equals sender (#24)

### DIFF
--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -672,6 +672,23 @@ else:
 def _send_message_impl(receiver_id: str, message: str) -> Dict[str, Any]:
     """Implementation of send_message logic."""
     try:
+        # Guard against the worker sending a message to itself (issue #24).
+        # Worker agents sometimes confuse their own CAO_TERMINAL_ID with the
+        # supervisor's and end up queueing a message into their own inbox,
+        # which never reaches the supervisor. Reject that here so the worker
+        # gets a clear error and can pick the correct receiver_id instead.
+        own_terminal_id = os.environ.get("CAO_TERMINAL_ID")
+        if own_terminal_id and receiver_id == own_terminal_id:
+            return {
+                "success": False,
+                "error": (
+                    f"receiver_id ({receiver_id}) is this terminal's own CAO_TERMINAL_ID. "
+                    "send_message cannot deliver to the sender. The callback terminal ID of "
+                    "the supervisor that assigned this task is in the task message — use "
+                    "that as receiver_id instead."
+                ),
+            }
+
         # Auto-inject sender terminal ID suffix when enabled
         if ENABLE_SENDER_ID_INJECTION:
             sender_id = os.environ.get("CAO_TERMINAL_ID", "unknown")

--- a/test/mcp_server/test_send_message.py
+++ b/test/mcp_server/test_send_message.py
@@ -4,6 +4,55 @@ import os
 from unittest.mock import patch
 
 
+class TestSendMessageSelfSendGuard:
+    """Tests for the self-send guard added for issue #24.
+
+    A worker agent occasionally calls send_message with its own
+    CAO_TERMINAL_ID as the receiver, which silently delivers the result
+    into its own inbox instead of the supervisor's. The guard turns that
+    into an explicit error so the worker can pick the correct receiver.
+    """
+
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_send_message_rejects_self_send(self, mock_inbox):
+        """Sending to the caller's own CAO_TERMINAL_ID should be rejected."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            result = _send_message_impl("worker-abc", "Done!")
+
+        assert result["success"] is False
+        assert "worker-abc" in result["error"]
+        assert "own CAO_TERMINAL_ID" in result["error"]
+        mock_inbox.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_send_message_allows_distinct_receiver(self, mock_inbox):
+        """Sending to a different terminal should still go through."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_inbox.return_value = {"success": True}
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            _send_message_impl("supervisor-xyz", "Done!")
+
+        mock_inbox.assert_called_once()
+        assert mock_inbox.call_args[0][0] == "supervisor-xyz"
+
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_send_message_no_guard_when_cao_terminal_id_unset(self, mock_inbox):
+        """Without CAO_TERMINAL_ID the guard is inert — _send_to_inbox runs
+        and surfaces its own error path."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_inbox.return_value = {"success": True}
+
+        with patch.dict(os.environ, {}, clear=True):
+            _send_message_impl("any-receiver", "Hello")
+
+        mock_inbox.assert_called_once()
+
+
 class TestSendMessageSenderIdInjection:
     """Tests for sender ID injection in _send_message_impl."""
 


### PR DESCRIPTION
## Summary
Fixes #24. Worker agents occasionally call `send_message` with their own `CAO_TERMINAL_ID` as the receiver, silently queueing the completion result into their own inbox instead of the supervisor's. The supervisor then never receives the callback.

This adds a server-side guard in `_send_message_impl`: when `receiver_id == os.environ["CAO_TERMINAL_ID"]`, the call is rejected with an error that explains the mistake and points the worker at the callback terminal ID embedded in the assigned task message.

- Single check, runs before the optional sender-ID injection path
- Inert when `CAO_TERMINAL_ID` is unset (no environment, no false-positive)
- Existing `cao-worker-protocols` skill already documents the rule; this just enforces it

## Test plan
- [x] New `TestSendMessageSelfSendGuard` covers: self-send rejected, distinct receiver still goes through, guard inert without `CAO_TERMINAL_ID`
- [x] `test/mcp_server/test_send_message.py` — 7/7 passing
- [x] Full suite (excluding e2e which need a live server) — **1874 passed, 17 skipped, 0 failures attributable to this change**. The 3 `test_q_cli_integration` failures observed on the slim Python image disappear once `tmux` is installed in the container, confirming they are pre-existing environment dependencies unrelated to this change.