### PR TITLE
fix(inbox): mark messages DELIVERED before send_input to stop double delivery

### DIFF
--- a/src/cli_agent_orchestrator/services/inbox_service.py
+++ b/src/cli_agent_orchestrator/services/inbox_service.py
@@ -124,6 +124,13 @@ def check_and_send_pending_messages(
     # synchronous handoff/assign paths bypass the inbox and pass their own
     # orchestration_type directly to send_input().
     try:
+        # Mark DELIVERED before sending. send_input() types into the tmux pane,
+        # which writes to the terminal log file and re-triggers the watchdog's
+        # on_modified handler. If the status were still PENDING at that point,
+        # the re-entrant check would find the message and deliver it a second
+        # time. Updating the status first closes that race window. On failure
+        # the except block resets the status to FAILED.
+        update_message_status(message.id, MessageStatus.DELIVERED)
         if registry is None:
             terminal_service.send_input(terminal_id, message.message)
         else:
@@ -134,7 +141,6 @@ def check_and_send_pending_messages(
                 sender_id=message.sender_id,
                 orchestration_type=OrchestrationType.SEND_MESSAGE,
             )
-        update_message_status(message.id, MessageStatus.DELIVERED)
         logger.info(f"Delivered message {message.id} to terminal {terminal_id}")
         return True
     except Exception as e:

--- a/test/services/test_inbox_service.py
+++ b/test/services/test_inbox_service.py
@@ -172,7 +172,47 @@ class TestCheckAndSendPendingMessages:
         with pytest.raises(Exception, match="Send failed"):
             check_and_send_pending_messages("test-terminal")
 
-        mock_update_status.assert_called_once_with(1, MessageStatus.FAILED)
+        # Status is optimistically set to DELIVERED before send_input, then
+        # reset to FAILED when the send raises.
+        mock_update_status.assert_has_calls(
+            [
+                call(1, MessageStatus.DELIVERED),
+                call(1, MessageStatus.FAILED),
+            ]
+        )
+        assert mock_update_status.call_count == 2
+
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_marks_delivered_before_send_input(
+        self, mock_get_messages, mock_provider_manager, mock_terminal_service, mock_update_status
+    ):
+        """Regression test for the double-delivery race (GH #164).
+
+        send_input() writes to the terminal log, which re-triggers the
+        watchdog. The message must already be marked DELIVERED by then, so the
+        status update has to happen before send_input is called.
+        """
+        mock_message = MagicMock()
+        mock_message.id = 1
+        mock_message.message = "test message"
+        mock_get_messages.return_value = [mock_message]
+        mock_provider = MagicMock()
+        mock_provider.get_status.return_value = TerminalStatus.IDLE
+        mock_provider_manager.get_provider.return_value = mock_provider
+
+        order = []
+        mock_update_status.side_effect = lambda *args, **kwargs: order.append(("update", args))
+        mock_terminal_service.send_input.side_effect = lambda *args, **kwargs: order.append(
+            ("send", args)
+        )
+
+        check_and_send_pending_messages("test-terminal")
+
+        assert order[0] == ("update", (1, MessageStatus.DELIVERED))
+        assert order[1][0] == "send"
 
 
 class TestEagerInboxDelivery:


### PR DESCRIPTION
## Summary
Fixes #164. Inbox messages were delivered twice to the receiving terminal, corrupting agent input streams in multi-agent `assign` + `send_message` flows.

## Root cause
`check_and_send_pending_messages()` set the message status to `DELIVERED` only *after* calling `terminal_service.send_input()`. `send_input()` types into the tmux pane, which writes to the terminal log file and re-triggers the watchdog `on_modified` handler. That re-entrant delivery check still saw the message as `PENDING` and delivered it a second time.

## Fix
Move the `update_message_status(..., DELIVERED)` call ahead of `send_input()` so the watchdog re-fire finds no pending message. The failure path still resets the status to `FAILED` if `send_input()` raises.

## Tests
- Added a regression test asserting `DELIVERED` is recorded before `send_input()`.
- Updated the failure-path test for the new ordering (`DELIVERED` then `FAILED`).
- Full unit suite passes locally (`pytest test/ --ignore=test/e2e -m "not integration"`), along with `black --check` and `isort --check-only`.