### PR TITLE
fix(ci): stop TestPyPI squats breaking the release smoke test

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -82,11 +82,26 @@ jobs:
       - name: Install from TestPyPI (retry while index propagates)
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          # Install in two steps so TestPyPI never participates in dependency
+          # resolution. TestPyPI is a public sandbox full of squatted/junk
+          # packages — e.g. a bogus "FASTAPI 1.0" whose version outranks the
+          # real fastapi. With TestPyPI as a resolution index, pip picks the
+          # squat and the build fails. So: pull only our package from TestPyPI
+          # with --no-deps, then resolve every dependency from real PyPI alone.
           for attempt in 1 2 3 4 5 6; do
+            # Chain both installs with && so an attempt only succeeds when BOTH
+            # the TestPyPI fetch and the PyPI dependency resolution pass. If the
+            # second install were inside the if-body, its failure would be
+            # masked by the following unconditional exit 0 and a release with a
+            # broken dependency would slip through the smoke test. Re-running the
+            # first install on a retry is cheap (--no-deps, and pip caches it).
             if pip install \
-                --index-url https://test.pypi.org/simple/ \
-                --extra-index-url https://pypi.org/simple/ \
-                "cli-agent-orchestrator==${VERSION}"; then
+                  --index-url https://test.pypi.org/simple/ \
+                  --no-deps \
+                  "cli-agent-orchestrator==${VERSION}" \
+               && pip install \
+                  --index-url https://pypi.org/simple/ \
+                  "cli-agent-orchestrator==${VERSION}"; then
               exit 0
             fi
             echo "Attempt ${attempt} failed; sleeping 15s before retry..."


### PR DESCRIPTION
## Problem

The 2.2.0 release failed at the **Install from TestPyPI and verify entry points** stage:

```
Collecting fastapi>=0.104.0 (from cli-agent-orchestrator==2.2.0)
  Downloading FASTAPI-1.0.tar.gz (2.5 kB)
  ...
  FileNotFoundError: [Errno 2] No such file or directory: 'DESCRIPTION.txt'
```

The package itself built and uploaded fine. The failure was in the smoke test's dependency resolution: the install used `--index-url test.pypi.org --extra-index-url pypi.org`, which lets pip aggregate candidates from **both** indexes and pick the highest version. A squatted **`FASTAPI 1.0`** on TestPyPI (a 2.5 kB junk sdist) outranks the real fastapi (~0.118), so pip selected it and its broken `setup.py` blew up. Classic TestPyPI dependency-confusion.

## Fix

Two-step install so TestPyPI never participates in dependency resolution:
1. `pip install --index-url test.pypi.org --no-deps cli-agent-orchestrator==$VERSION` — fetch only our package
2. `pip install --index-url pypi.org cli-agent-orchestrator==$VERSION` — resolve all deps from real PyPI (package already satisfied)

Both are `&&`-chained inside the retry `if` so the attempt succeeds only when **both** pass — previously, with step 2 in the if-body followed by an unconditional `exit 0`, a step-2 failure would have been masked and a broken release could slip through.

## Verification (local, against live indexes + real 2.2.0 on TestPyPI)

- Reproduced the original `FASTAPI 1.0` / `DESCRIPTION.txt` failure with the old flags ✅
- Ran the **exact** new step (extracted verbatim from the YAML) end-to-end → exit 0; installed real `fastapi 0.136.3`, no squat ✅
- `cao --help`, `cao-server --help`, `cao-mcp-server --help` → all exit 0 ✅
- Control-flow simulated in bash: (ok,ok)→0, (ok,fail)→1, (fail,*)→1 ✅