### PR TITLE
feat(herdr): add herdr terminal backend with event-driven inbox delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ cao shutdown --session cao-my-session   # shut down a specific session
 
 All agent sessions run in tmux — you can `tmux attach -t <session-name>` to watch agents in real time. For the full list of tmux shortcuts and the interactive window selector, see [docs/tmux.md](docs/tmux.md).
 
+CAO also supports [herdr](https://herdr.dev/) as an experimental alternative backend. herdr is agent-aware, so it replaces tmux output polling with real-time status events. For setup and configuration, see [docs/herdr.md](docs/herdr.md).
+
 ## Web UI
 
 CAO ships a bundled web dashboard for managing agents, terminals, and flows from the browser. The pre-built UI is packaged inside the wheel, so there is nothing extra to install — just start the server:

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -54,7 +54,7 @@ Optionally specify the herdr session name (defaults to `"cao"`):
 Start the CAO server the same way as with tmux -- no additional flags needed:
 
 ```bash
-uv run cao-server
+cao-server
 ```
 
 CAO detects the backend from `config.json` and connects to herdr automatically.
@@ -135,6 +135,6 @@ herdr must be running before the CAO server starts. If you see socket errors:
 
 1. Confirm herdr is running: `herdr --session cao workspace list`
 2. If not running, start it: `herdr --session cao`
-3. Restart the CAO server: `uv run cao-server`
+3. Restart the CAO server: `cao-server`
 
 The default socket path is derived from the session name. If you use a non-default `herdr_session`, ensure herdr was started with the matching `--session` flag.

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -19,7 +19,9 @@ Choose herdr if you want lower-latency inter-agent messaging and native agent li
 ## Prerequisites
 
 1. **herdr installed** and available on `$PATH`. See [herdr.dev](https://herdr.dev/) for installation instructions.
-2. **herdr server running** before starting the CAO server. Start it with:
+2. **herdr server** for the configured session. CAO starts it automatically if
+   the session socket is absent, so pre-starting is optional. To start (or
+   attach to) it yourself:
 
 ```bash
 herdr                        # default session name

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -51,13 +51,22 @@ Optionally specify the herdr session name (defaults to `"cao"`):
 
 ## Launching
 
-Start the CAO server the same way as with tmux -- no additional flags needed:
+With `terminal_backend` set in `config.json`, start the server the same way as
+with tmux -- CAO detects the backend and connects to herdr automatically:
 
 ```bash
 cao-server
 ```
 
-CAO detects the backend from `config.json` and connects to herdr automatically.
+To select herdr without editing `config.json`, pass `--terminal`:
+
+```bash
+cao-server --terminal herdr
+```
+
+The `--terminal` flag (`tmux` or `herdr`) overrides `terminal_backend` from
+`config.json` for that run. The `herdr_session` name, if set, is still read from
+`config.json`.
 
 ## Viewing and Attaching
 

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -1,0 +1,138 @@
+# herdr Backend
+
+CAO's default backend is [tmux](tmux.md). For agentic workloads, CAO also supports [herdr](https://herdr.dev/) -- a terminal-native agent runtime and multiplexer designed specifically for AI coding agents.
+
+The key difference: tmux has no concept of "agent state," so CAO must poll terminal output and match regex patterns to detect when an agent is idle. herdr exposes a Unix socket API that emits real-time status events (`working`, `idle`, `done`, `blocked`). This eliminates polling entirely and enables instant inbox delivery.
+
+## tmux vs herdr
+
+| | tmux | herdr |
+|---|---|---|
+| Status detection | Poll `capture-pane` output + regex matching | Native socket events (`idle`, `done`, `blocked`) |
+| Inbox delivery | Watchdog polls every 5s, delivers on idle pattern | Event-driven: delivers immediately on status change |
+| Session identity | Inferred from pane content | Tracked natively per pane |
+| Attach to agents | `tmux attach -t <session>` | `herdr attach` or herdr TUI |
+| Maturity | Stable, well-tested default | Experimental |
+
+Choose herdr if you want lower-latency inter-agent messaging and native agent lifecycle tracking. Choose tmux if you want the stable, battle-tested default.
+
+## Prerequisites
+
+1. **herdr installed** and available on `$PATH`. See [herdr.dev](https://herdr.dev/) for installation instructions.
+2. **herdr server running** before starting the CAO server. Start it with:
+
+```bash
+herdr                        # default session name
+herdr --session cao          # explicit session name (recommended)
+```
+
+## Configuration
+
+Set `terminal_backend` in `~/.aws/cli-agent-orchestrator/config.json`:
+
+```json
+{
+  "terminal_backend": "herdr"
+}
+```
+
+Optionally specify the herdr session name (defaults to `"cao"`):
+
+```json
+{
+  "terminal_backend": "herdr",
+  "herdr_session": "my-session"
+}
+```
+
+> **Note:** This goes in `config.json`, not `settings.json`. See [settings.md](settings.md) for the distinction between the two files.
+
+## Launching
+
+Start the CAO server the same way as with tmux -- no additional flags needed:
+
+```bash
+uv run cao-server
+```
+
+CAO detects the backend from `config.json` and connects to herdr automatically.
+
+## Viewing and Attaching
+
+```bash
+# List active CAO sessions
+cao session list
+
+# Attach to the herdr TUI (shows all workspaces and tabs)
+herdr --session cao
+
+# Attach to a specific CAO session
+cao session attach <session-name>
+```
+
+## How It Works
+
+CAO maps its concepts to herdr primitives:
+
+| CAO concept | herdr primitive |
+|---|---|
+| Session (e.g. `cao-my-task`) | Workspace (labeled with session name) |
+| Terminal / window (e.g. `conductor-a1b2`) | Tab within workspace (labeled with window name) |
+
+### Event-driven inbox delivery
+
+`HerdrInboxService` connects to the herdr Unix socket at startup and subscribes to `pane.agent_status_changed` events for each managed pane. When a pane transitions to `idle` or `done`, pending inbox messages are delivered immediately.
+
+### Startup and reconnect behavior
+
+On server start (or reconnect after socket disconnect):
+
+1. **Startup cleanup** -- cross-checks all DB terminal records against live herdr tabs. Removes ghost records left by prior server runs that exited uncleanly.
+2. **Reconnect reconcile** -- prunes stale pane subscriptions from the in-memory map and re-subscribes only to panes that are still alive.
+3. **Lifecycle events** -- subscribes to `pane.closed` and `workspace.closed` events for real-time cleanup when agents exit or sessions end.
+
+The socket connection uses exponential backoff (1s to 30s) on disconnect.
+
+## Switching Back to tmux
+
+Remove `terminal_backend` from `config.json`, or set it explicitly:
+
+```json
+{
+  "terminal_backend": "tmux"
+}
+```
+
+Restart the CAO server. Existing herdr sessions are unaffected (they remain running in herdr). New sessions will be created in tmux.
+
+## Troubleshooting
+
+### `cao session list` shows no sessions after server restart
+
+Ghost DB records from a prior run were cleaned up. This is expected. Restart the server and check the log for:
+
+```
+Startup DB cleanup: removed N ghost terminal(s)
+```
+
+If sessions are genuinely running in herdr, they will be re-discovered on the next `cao launch`.
+
+### Session visible in herdr but not in CAO
+
+The CAO server may be connected to the wrong herdr session. Verify `herdr_session` in `config.json` matches the session herdr is running under:
+
+```bash
+# Check which session herdr is using
+herdr workspace list                        # default session
+herdr --session cao workspace list          # named session
+```
+
+### Socket connection errors in CAO logs
+
+herdr must be running before the CAO server starts. If you see socket errors:
+
+1. Confirm herdr is running: `herdr --session cao workspace list`
+2. If not running, start it: `herdr --session cao`
+3. Restart the CAO server: `uv run cao-server`
+
+The default socket path is derived from the session name. If you use a non-default `herdr_session`, ensure herdr was started with the matching `--session` flag.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -338,7 +338,20 @@ app.add_middleware(
 
 @app.get("/health")
 async def health_check():
-    return {"status": "ok", "service": "cli-agent-orchestrator"}
+    import shutil
+
+    def _probe(binary: str) -> str:
+        return "ok" if shutil.which(binary) else "unavailable"
+
+    return {
+        "status": "ok",
+        "service": "cli-agent-orchestrator",
+        "components": {
+            "cao": "ok",
+            "herdr": _probe("herdr"),
+            "claude": _probe("claude"),
+        },
+    }
 
 
 @app.get("/agents/profiles")

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -31,6 +31,7 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from pydantic import BaseModel, Field, field_validator
 from watchdog.observers.polling import PollingObserver
 
+from cli_agent_orchestrator.backends import TerminalNotFoundError
 from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import (
@@ -682,6 +683,8 @@ async def get_terminal(terminal_id: TerminalId) -> Terminal:
         terminal = terminal_service.get_terminal(terminal_id)
         return Terminal(**terminal)
     except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except TerminalNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:
         raise HTTPException(

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -1269,6 +1269,13 @@ def main():
     )
     parser.add_argument("--host", type=str, default=None, help="Server host")
     parser.add_argument("--port", type=int, default=None, help="Server port")
+    parser.add_argument(
+        "--terminal",
+        type=str,
+        choices=["tmux", "herdr"],
+        default=None,
+        help="Terminal backend to use, overriding terminal_backend in config.json",
+    )
     args = parser.parse_args()
 
     if args.agents_dir:
@@ -1277,6 +1284,16 @@ def main():
 
         constants.KIRO_AGENTS_DIR = Path(args.agents_dir)
         logger.info(f"Using agents directory: {args.agents_dir}")
+
+    # Resolve the backend before the server starts so the lifespan (and every
+    # get_backend() consumer) sees the CLI-selected backend. Without --terminal,
+    # the singleton stays lazy and BackendFactory reads config.json on first use.
+    if args.terminal:
+        from cli_agent_orchestrator.backends.factory import BackendFactory
+        from cli_agent_orchestrator.backends.registry import set_backend
+
+        set_backend(BackendFactory.create(backend_override=args.terminal))
+        logger.info(f"Terminal backend overridden via --terminal: {args.terminal}")
 
     host = args.host or SERVER_HOST
     port = args.port or SERVER_PORT

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -31,6 +31,8 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from pydantic import BaseModel, Field, field_validator
 from watchdog.observers.polling import PollingObserver
 
+from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import (
     create_inbox_message,
     get_inbox_messages,
@@ -66,7 +68,12 @@ from cli_agent_orchestrator.services.cleanup_service import (
     cleanup_expired_memories,
     cleanup_old_data,
 )
-from cli_agent_orchestrator.services.inbox_service import LogFileHandler
+from cli_agent_orchestrator.services.herdr_inbox_registry import set_herdr_inbox_service
+from cli_agent_orchestrator.services.herdr_inbox_service import HerdrInboxService
+from cli_agent_orchestrator.services.inbox_service import (
+    LogFileHandler,
+    check_and_send_pending_messages,
+)
 from cli_agent_orchestrator.services.install_service import InstallResult, install_agent
 from cli_agent_orchestrator.services.terminal_service import OutputMode, TerminalInputBlockedError
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile, resolve_provider
@@ -211,18 +218,44 @@ async def lifespan(app: FastAPI):
     # messages the immediate and watchdog paths missed (issue #131).
     inbox_reconcile_task = asyncio.create_task(inbox_reconciliation_daemon(registry))
 
-    # Start inbox watcher
-    inbox_observer = PollingObserver(timeout=INBOX_POLLING_INTERVAL)
-    inbox_observer.schedule(LogFileHandler(registry), str(TERMINAL_LOG_DIR), recursive=False)
-    inbox_observer.start()
-    logger.info("Inbox watcher started (PollingObserver)")
+    # Start inbox watcher — herdr uses socket events, tmux uses file polling
+    herdr_inbox_task: Optional[asyncio.Task] = None
+    inbox_observer: Optional[PollingObserver] = None
+
+    backend = get_backend()
+    if isinstance(backend, HerdrBackend):
+
+        def deliver_inbox(terminal_id: str) -> None:
+            check_and_send_pending_messages(terminal_id, registry=registry)
+
+        svc = HerdrInboxService(
+            herdr_session=backend.herdr_session,
+            delivery_callback=deliver_inbox,
+        )
+        set_herdr_inbox_service(svc)
+        herdr_inbox_task = asyncio.create_task(svc.start())
+        logger.info("Herdr inbox service started")
+    else:
+        inbox_observer = PollingObserver(timeout=INBOX_POLLING_INTERVAL)
+        inbox_observer.schedule(LogFileHandler(registry), str(TERMINAL_LOG_DIR), recursive=False)
+        inbox_observer.start()
+        logger.info("Inbox watcher started (PollingObserver)")
 
     yield
 
-    # Stop inbox observer
-    inbox_observer.stop()
-    inbox_observer.join()
-    logger.info("Inbox watcher stopped")
+    # Stop inbox watcher
+    if herdr_inbox_task is not None:
+        herdr_inbox_task.cancel()
+        try:
+            await herdr_inbox_task
+        except asyncio.CancelledError:
+            pass
+        set_herdr_inbox_service(None)
+        logger.info("Herdr inbox service stopped")
+    elif inbox_observer is not None:
+        inbox_observer.stop()
+        inbox_observer.join()
+        logger.info("Inbox watcher stopped")
 
     # Cancel daemon on shutdown
     daemon_task.cancel()

--- a/src/cli_agent_orchestrator/backends/__init__.py
+++ b/src/cli_agent_orchestrator/backends/__init__.py
@@ -1,0 +1,21 @@
+"""Terminal backend abstraction layer.
+
+This package provides the TerminalBackend ABC and concrete implementations
+(TmuxBackend, HerdrBackend) that decouple CAO core services from any
+specific terminal multiplexer.
+"""
+
+from cli_agent_orchestrator.backends.base import (
+    TerminalBackend,
+    TerminalBackendError,
+    TerminalNotFoundError,
+)
+from cli_agent_orchestrator.backends.factory import BackendFactory, ConfigurationError
+
+__all__ = [
+    "BackendFactory",
+    "ConfigurationError",
+    "TerminalBackend",
+    "TerminalBackendError",
+    "TerminalNotFoundError",
+]

--- a/src/cli_agent_orchestrator/backends/base.py
+++ b/src/cli_agent_orchestrator/backends/base.py
@@ -291,13 +291,9 @@ class TerminalBackend(ABC):
         Raises:
             NotImplementedError: If backend does not support pane ID resolution
         """
-        raise NotImplementedError(
-            f"{type(self).__name__} does not support get_pane_id()"
-        )
+        raise NotImplementedError(f"{type(self).__name__} does not support get_pane_id()")
 
-    def get_native_status(
-        self, session_name: str, window_name: str
-    ) -> Optional[TerminalStatus]:
+    def get_native_status(self, session_name: str, window_name: str) -> Optional[TerminalStatus]:
         """Query native agent status if the backend has agent awareness.
 
         Returns None if unsupported — caller falls back to pane content parsing.

--- a/src/cli_agent_orchestrator/backends/base.py
+++ b/src/cli_agent_orchestrator/backends/base.py
@@ -1,0 +1,305 @@
+"""Terminal backend abstract base class.
+
+Defines the contract that all terminal backends (tmux, herdr, etc.) must satisfy.
+Core services depend only on this ABC, never on a concrete backend directly.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+
+class TerminalBackendError(Exception):
+    """Base exception for terminal backend operations."""
+
+    pass
+
+
+class TerminalNotFoundError(TerminalBackendError):
+    """Raised when a terminal/pane cannot be found or resolved."""
+
+    def __init__(self, terminal_id: str, message: Optional[str] = None):
+        self.terminal_id = terminal_id
+        super().__init__(message or f"Terminal not found: {terminal_id}")
+
+
+class TerminalBackend(ABC):
+    """Abstract base class defining the terminal backend contract.
+
+    All terminal operations CAO requires are declared here. Concrete backends
+    (TmuxBackend, HerdrBackend) implement these methods using their respective
+    multiplexer APIs.
+    """
+
+    # --- Session lifecycle ---
+
+    @abstractmethod
+    def create_session(
+        self,
+        session_name: str,
+        window_name: str,
+        terminal_id: str,
+        working_directory: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Create a new terminal session with an initial window.
+
+        Args:
+            session_name: Name for the session (e.g., "cao-my-project")
+            window_name: Name for the initial window/tab
+            terminal_id: Unique terminal identifier to inject into the environment
+            working_directory: Optional starting directory
+
+        Returns:
+            The actual window name assigned by the backend
+
+        Raises:
+            TerminalBackendError: If session creation fails
+            ValueError: If working_directory is invalid
+        """
+        ...
+
+    @abstractmethod
+    def session_exists(self, session_name: str) -> bool:
+        """Check if a session exists.
+
+        Args:
+            session_name: Session name to check
+
+        Returns:
+            True if the session exists
+        """
+        ...
+
+    @abstractmethod
+    def list_sessions(self) -> List[Dict[str, str]]:
+        """List all sessions managed by this backend.
+
+        Returns:
+            List of dicts with keys: id, name, status
+        """
+        ...
+
+    @abstractmethod
+    def kill_session(self, session_name: str) -> bool:
+        """Kill/destroy a session.
+
+        Args:
+            session_name: Session to kill
+
+        Returns:
+            True if session was killed, False if not found
+        """
+        ...
+
+    # --- Window/tab lifecycle ---
+
+    @abstractmethod
+    def create_window(
+        self,
+        session_name: str,
+        window_name: str,
+        terminal_id: str,
+        working_directory: Optional[str] = None,
+        window_shell: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Create a new window/tab in an existing session.
+
+        Args:
+            session_name: Session to add the window to
+            window_name: Name for the new window
+            terminal_id: Unique terminal identifier to inject into the environment
+            working_directory: Optional starting directory
+            window_shell: Optional shell command to run instead of default shell
+
+        Returns:
+            The actual window name assigned by the backend
+
+        Raises:
+            TerminalBackendError: If window creation fails
+            ValueError: If session not found or working_directory is invalid
+        """
+        ...
+
+    @abstractmethod
+    def kill_window(self, session_name: str, window_name: str) -> bool:
+        """Kill a specific window within a session.
+
+        Args:
+            session_name: Session containing the window
+            window_name: Window to kill
+
+        Returns:
+            True if window was killed, False if not found
+        """
+        ...
+
+    # --- Input ---
+
+    @abstractmethod
+    def send_keys(
+        self,
+        session_name: str,
+        window_name: str,
+        keys: str,
+        enter_count: int = 1,
+        force_bracketed_paste: bool = False,
+    ) -> None:
+        """Send text input to a window.
+
+        Args:
+            session_name: Target session
+            window_name: Target window
+            keys: Text to send
+            enter_count: Number of Enter keys to send after the text
+            force_bracketed_paste: If True, wrap in bracketed paste sequences
+        """
+        ...
+
+    @abstractmethod
+    def send_special_key(self, session_name: str, window_name: str, key: str) -> None:
+        """Send a special key (e.g., C-c, C-d, Enter) to a window.
+
+        Unlike send_keys(), this sends the key as a control/special key name
+        and does not append a carriage return.
+
+        Args:
+            session_name: Target session
+            window_name: Target window
+            key: Key name (e.g., "C-d", "C-c", "Escape", "Enter", "")
+        """
+        ...
+
+    # --- Output ---
+
+    @abstractmethod
+    def get_history(
+        self,
+        session_name: str,
+        window_name: str,
+        tail_lines: Optional[int] = None,
+        strip_escapes: bool = False,
+        full_history: bool = False,
+    ) -> str:
+        """Get terminal output/history from a window.
+
+        Args:
+            session_name: Target session
+            window_name: Target window
+            tail_lines: Number of lines from the end (None = backend default)
+            strip_escapes: If True, strip ANSI escape sequences
+            full_history: If True, capture entire scrollback
+
+        Returns:
+            Terminal output as a string
+        """
+        ...
+
+    @abstractmethod
+    def get_pane_working_directory(self, session_name: str, window_name: str) -> Optional[str]:
+        """Get the current working directory of a pane.
+
+        Args:
+            session_name: Target session
+            window_name: Target window
+
+        Returns:
+            Working directory path, or None if unavailable
+        """
+        ...
+
+    @abstractmethod
+    def get_pane_current_command(self, session_name: str, window_name: str) -> Optional[str]:
+        """Get the current foreground command running in a pane.
+
+        Args:
+            session_name: Target session
+            window_name: Target window
+
+        Returns:
+            Command name, or None if unavailable
+        """
+        ...
+
+    # --- Attach ---
+
+    @abstractmethod
+    def attach_session(self, session_name: str) -> None:
+        """Attach to a session (for interactive use).
+
+        Args:
+            session_name: Session to attach to
+        """
+        ...
+
+    # --- Pipe-pane (logging) ---
+
+    @abstractmethod
+    def pipe_pane(self, session_name: str, window_name: str, file_path: str) -> None:
+        """Start piping pane output to a file.
+
+        For backends that don't support pipe-pane (e.g., herdr), this is a no-op
+        since inbox delivery uses a different mechanism.
+
+        Args:
+            session_name: Target session
+            window_name: Target window
+            file_path: Absolute path to the log file
+        """
+        ...
+
+    @abstractmethod
+    def stop_pipe_pane(self, session_name: str, window_name: str) -> None:
+        """Stop piping pane output.
+
+        For backends that don't support pipe-pane, this is a no-op.
+
+        Args:
+            session_name: Target session
+            window_name: Target window
+        """
+        ...
+
+    # --- Capability queries ---
+
+    def supports_event_inbox(self) -> bool:
+        """Whether this backend uses event-based inbox delivery (e.g., socket events).
+
+        When True, terminals should be registered with an event-based inbox service
+        instead of using pipe-pane file watching.
+
+        Default is False (pipe-pane based delivery).
+        """
+        return False
+
+    def get_pane_id(self, terminal_id: str, session_name: str = "", window_name: str = "") -> str:
+        """Resolve terminal_id to backend-specific pane identifier.
+
+        Only meaningful for backends that use event-based inbox delivery.
+        Default raises NotImplementedError.
+
+        Args:
+            terminal_id: CAO terminal identifier
+            session_name: Optional session name for window-based fallback lookup
+            window_name: Optional window name for window-based fallback lookup
+
+        Returns:
+            Backend-specific pane identifier
+
+        Raises:
+            NotImplementedError: If backend does not support pane ID resolution
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support get_pane_id()"
+        )
+
+    def get_native_status(
+        self, session_name: str, window_name: str
+    ) -> Optional[TerminalStatus]:
+        """Query native agent status if the backend has agent awareness.
+
+        Returns None if unsupported — caller falls back to pane content parsing.
+        """
+        return None

--- a/src/cli_agent_orchestrator/backends/factory.py
+++ b/src/cli_agent_orchestrator/backends/factory.py
@@ -1,0 +1,71 @@
+"""BackendFactory — constructs the configured TerminalBackend at startup.
+
+Reads `terminal_backend` from ~/.aws/cli-agent-orchestrator/config.json.
+Default is "tmux". "herdr" is opt-in and experimental.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from cli_agent_orchestrator.backends.base import TerminalBackend
+
+logger = logging.getLogger(__name__)
+
+# Default config path for CAO
+_CONFIG_PATH = Path.home() / ".aws" / "cli-agent-orchestrator" / "config.json"
+
+
+class ConfigurationError(Exception):
+    """Raised when the backend configuration is invalid."""
+
+    pass
+
+
+class BackendFactory:
+    """Factory that reads config and returns the appropriate backend instance."""
+
+    @staticmethod
+    def create(config_path: Optional[Path] = None) -> TerminalBackend:
+        """Create a TerminalBackend based on configuration.
+
+        Args:
+            config_path: Optional override for config file path (for testing)
+
+        Returns:
+            A configured TerminalBackend instance
+
+        Raises:
+            ConfigurationError: If terminal_backend value is unrecognized
+        """
+        path = config_path or _CONFIG_PATH
+        backend_name = "tmux"  # default
+
+        config = {}
+        if path.exists():
+            try:
+                with open(path, "r") as f:
+                    config = json.load(f)
+                backend_name = config.get("terminal_backend", "tmux")
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"Failed to read config from {path}: {e}; using default 'tmux'")
+
+        if backend_name == "tmux":
+            from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend
+
+            return TmuxBackend()
+        elif backend_name == "herdr":
+            from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
+
+            herdr_session = config.get("herdr_session", "cao")
+            logger.info(
+                "[EXPERIMENTAL] terminal_backend='herdr' is experimental. "
+                "Report issues at https://github.com/awslabs/cli-agent-orchestrator/issues"
+            )
+            return HerdrBackend(herdr_session=herdr_session)
+        else:
+            raise ConfigurationError(
+                f"Unknown terminal_backend: '{backend_name}'. "
+                f"Valid options are: 'tmux', 'herdr' [EXPERIMENTAL]"
+            )

--- a/src/cli_agent_orchestrator/backends/factory.py
+++ b/src/cli_agent_orchestrator/backends/factory.py
@@ -27,11 +27,17 @@ class BackendFactory:
     """Factory that reads config and returns the appropriate backend instance."""
 
     @staticmethod
-    def create(config_path: Optional[Path] = None) -> TerminalBackend:
+    def create(
+        config_path: Optional[Path] = None, backend_override: Optional[str] = None
+    ) -> TerminalBackend:
         """Create a TerminalBackend based on configuration.
 
         Args:
             config_path: Optional override for config file path (for testing)
+            backend_override: Explicit backend name that takes precedence over
+                the config file (e.g. from ``cao-server --terminal herdr``).
+                When provided, ``terminal_backend`` in config.json is ignored,
+                though other keys (such as ``herdr_session``) are still read.
 
         Returns:
             A configured TerminalBackend instance
@@ -50,6 +56,10 @@ class BackendFactory:
                 backend_name = config.get("terminal_backend", "tmux")
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"Failed to read config from {path}: {e}; using default 'tmux'")
+
+        # An explicit override (CLI flag) wins over the config file value.
+        if backend_override:
+            backend_name = backend_override
 
         if backend_name == "tmux":
             from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -82,13 +82,10 @@ class HerdrBackend(TerminalBackend):
         """
         cmd = ["herdr", "--session", self._herdr_session] + args
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=30
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
             if check and result.returncode != 0:
                 raise TerminalBackendError(
-                    f"herdr command failed: {' '.join(cmd)}\n"
-                    f"stderr: {result.stderr.strip()}"
+                    f"herdr command failed: {' '.join(cmd)}\n" f"stderr: {result.stderr.strip()}"
                 )
             return result
         except subprocess.TimeoutExpired as e:
@@ -169,9 +166,7 @@ class HerdrBackend(TerminalBackend):
             data = self._parse_herdr_json(result.stdout)
             workspaces = data.get("workspaces", []) if isinstance(data, dict) else data
         except json.JSONDecodeError as e:
-            raise TerminalBackendError(
-                f"Failed to parse herdr workspace list output: {e}"
-            ) from e
+            raise TerminalBackendError(f"Failed to parse herdr workspace list output: {e}") from e
 
         for ws in workspaces:
             if ws.get("label") == session_name:
@@ -311,9 +306,7 @@ class HerdrBackend(TerminalBackend):
             try:
                 self._run_herdr(["pane", "run", new_pane_id, window_shell])
             except TerminalBackendError as e:
-                logger.warning(
-                    f"create_window: pane run failed for {new_pane_id} (non-fatal): {e}"
-                )
+                logger.warning(f"create_window: pane run failed for {new_pane_id} (non-fatal): {e}")
 
         logger.info(f"Created herdr tab in workspace {session_name}")
         return window_name
@@ -323,9 +316,7 @@ class HerdrBackend(TerminalBackend):
         try:
             pane_id = self._resolve_pane_id_from_window(session_name, window_name)
         except TerminalBackendError:
-            logger.warning(
-                f"kill_window: could not resolve pane for {session_name}:{window_name}"
-            )
+            logger.warning(f"kill_window: could not resolve pane for {session_name}:{window_name}")
             return False
 
         result = self._run_herdr(["pane", "close", pane_id], check=False)
@@ -482,9 +473,7 @@ class HerdrBackend(TerminalBackend):
         """Herdr uses socket events for inbox delivery."""
         return True
 
-    def get_native_status(
-        self, session_name: str, window_name: str
-    ) -> Optional[TerminalStatus]:
+    def get_native_status(self, session_name: str, window_name: str) -> Optional[TerminalStatus]:
         """Query herdr's native agent_status for a pane.
 
         Uses herdr pane get to read the agent_status field directly, avoiding
@@ -633,7 +622,10 @@ class HerdrBackend(TerminalBackend):
             return None
 
     def _inject_env_vars(
-        self, session_name: str, window_name: str, terminal_id: str,
+        self,
+        session_name: str,
+        window_name: str,
+        terminal_id: str,
         pane_id: Optional[str] = None,
     ) -> None:
         """Inject CAO_TERMINAL_ID and CAO_SESSION_NAME into the specified pane.

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -13,6 +13,7 @@ Design decisions:
 import json
 import logging
 import os
+import shlex
 import subprocess
 import time
 from pathlib import Path
@@ -219,7 +220,9 @@ class HerdrBackend(TerminalBackend):
 
         # Inject CAO env vars into the initial pane so agents and cao info can
         # identify the terminal/session (mirrors TmuxClient env injection).
-        self._inject_env_vars(session_name, window_name, terminal_id, pane_id=new_pane_id)
+        self._inject_env_vars(
+            session_name, window_name, terminal_id, pane_id=new_pane_id, extra_env=extra_env
+        )
 
         logger.info(f"Created herdr workspace: {session_name} in {working_directory}")
         return window_name
@@ -298,7 +301,9 @@ class HerdrBackend(TerminalBackend):
         new_pane_id = self._parse_new_pane_id(result.stdout)
 
         # Inject CAO env vars using the known pane_id (no list scan needed)
-        self._inject_env_vars(session_name, window_name, terminal_id, pane_id=new_pane_id)
+        self._inject_env_vars(
+            session_name, window_name, terminal_id, pane_id=new_pane_id, extra_env=extra_env
+        )
 
         if window_shell is not None and new_pane_id is not None:
             # Wait for shell startup before sending the initial command.
@@ -633,11 +638,15 @@ class HerdrBackend(TerminalBackend):
         window_name: str,
         terminal_id: str,
         pane_id: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
     ) -> None:
-        """Inject CAO_TERMINAL_ID and CAO_SESSION_NAME into the specified pane.
+        """Inject CAO env vars (and operator-forwarded vars) into the pane.
 
         Called after create_session/create_window to export env vars into the
         pane's shell so agents and `cao info` can identify the terminal/session.
+        Operator-supplied ``extra_env`` (from ``cao launch --env``) is forwarded
+        too, filtered with the same rules TmuxClient applies to its ``-e`` argv
+        so the launch-env contract behaves identically across backends.
 
         Args:
             session_name: CAO session name
@@ -645,6 +654,7 @@ class HerdrBackend(TerminalBackend):
             terminal_id: Terminal identifier to inject
             pane_id: Pane ID from the create response. If None, falls back to
                 pane list scan (less reliable under concurrency).
+            extra_env: Operator-forwarded env vars from ``cao launch --env``.
         """
         try:
             # Use provided pane_id if available (from create response)
@@ -665,15 +675,51 @@ class HerdrBackend(TerminalBackend):
             if target_pane_id:
                 # Cache the mapping
                 self._pane_cache[terminal_id] = (target_pane_id, time.time())
-                # Send env export command
-                env_cmd = (
-                    f"export CAO_TERMINAL_ID={terminal_id}; "
-                    f"export CAO_SESSION_NAME={session_name}"
-                )
+                # Build export command: CAO identity vars first, then any
+                # operator-forwarded vars. terminal_id/session_name come from
+                # CAO internals (safe); extra_env values are operator-supplied,
+                # so quote them to keep the shell export injection-safe.
+                exports = [
+                    f"export CAO_TERMINAL_ID={terminal_id}",
+                    f"export CAO_SESSION_NAME={session_name}",
+                ]
+                exports.extend(self._build_extra_env_exports(extra_env))
+                env_cmd = "; ".join(exports)
                 self._run_herdr(["pane", "send-text", target_pane_id, env_cmd])
                 self._run_herdr(["pane", "send-keys", target_pane_id, "Enter"])
         except (TerminalBackendError, json.JSONDecodeError, KeyError) as e:
             logger.warning(f"Failed to inject env vars for {terminal_id}: {e}")
+
+    @staticmethod
+    def _build_extra_env_exports(extra_env: Optional[Dict[str, str]]) -> List[str]:
+        """Return shell ``export`` statements for operator-forwarded env vars.
+
+        Applies the same safety filtering TmuxClient uses for its ``-e`` argv
+        (blocked provider prefixes, per-value byte cap) so ``cao launch --env``
+        forwards the same set of vars under herdr as under tmux. Values are
+        shell-quoted because herdr injects via ``pane send-text`` (a shell
+        command line), unlike tmux's exec-style ``-e KEY=VALUE`` argv.
+        """
+        if not extra_env:
+            return []
+
+        # Reuse the tmux filtering policy so the two backends cannot drift.
+        from cli_agent_orchestrator.clients.tmux import TmuxClient
+
+        exports: List[str] = []
+        for key, value in extra_env.items():
+            if TmuxClient._is_blocked_env_key(key):
+                logger.warning("Dropping forwarded env var with blocked prefix: %s", key)
+                continue
+            if len(value.encode("utf-8")) >= TmuxClient._MAX_ENV_VALUE_BYTES:
+                logger.warning(
+                    "Dropping forwarded env var %s -- value exceeds %d bytes",
+                    key,
+                    TmuxClient._MAX_ENV_VALUE_BYTES,
+                )
+                continue
+            exports.append(f"export {key}={shlex.quote(value)}")
+        return exports
 
     def _resolve_tab_id(self, session_name: str, workspace_id: str, window_name: str) -> str:
         """Resolve window_name to its herdr tab_id in the given workspace.

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -63,6 +63,11 @@ class HerdrBackend(TerminalBackend):
         self._window_to_terminal: Dict[str, str] = {}
         self._ensure_session_running()
 
+    @property
+    def herdr_session(self) -> str:
+        """The herdr session name this backend operates in."""
+        return self._herdr_session
+
     def _run_herdr(self, args: List[str], check: bool = True) -> subprocess.CompletedProcess:
         """Run a herdr CLI command and return the result.
 

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -1,0 +1,784 @@
+"""HerdrBackend — TerminalBackend implementation using the herdr CLI.
+
+Herdr is a Rust-based terminal multiplexer with native agent-awareness.
+This backend maps CAO operations to herdr CLI commands.
+
+Design decisions:
+- One herdr session, workspaces per CAO session (labeled cao-<name>)
+- terminal_id is the stable identifier; pane_id is resolved before each operation
+- Resolution cache with 5s TTL reduces redundant herdr pane list calls
+- CAO_TERMINAL_ID and CAO_SESSION_NAME injected via command prefix
+"""
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from cli_agent_orchestrator.backends.base import (
+    TerminalBackend,
+    TerminalBackendError,
+    TerminalNotFoundError,
+)
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL for pane_id resolution (seconds).
+# Used by _resolve_pane_id() (inbox service path, herdr-native terminal_ids).
+# Not used by _resolve_pane_id_from_window() which skips TTL for active terminals.
+_PANE_CACHE_TTL = 5.0
+
+
+class HerdrBackend(TerminalBackend):
+    """TerminalBackend implementation using herdr CLI commands.
+
+    Maps CAO concepts to herdr:
+    - CAO session → herdr workspace (labeled cao-<name>)
+    - CAO terminal/window → herdr tab within workspace
+    - terminal_id → stable identifier stored in CAO DB
+    - pane_id → compact ID resolved via herdr pane list before each operation
+    """
+
+    def __init__(self, send_delay_ms: int = 0, herdr_session: str = "cao") -> None:
+        """Initialize HerdrBackend.
+
+        Args:
+            send_delay_ms: Milliseconds to sleep between send-text and send-keys Enter.
+                Configurable per-provider for bracketed paste timing.
+            herdr_session: Name of the herdr session CAO operates in.
+                Maps to ``herdr --session <name>``. Defaults to ``"cao"`` so CAO
+                runs isolated from the user's personal herdr session.
+        """
+        self._send_delay_ms = send_delay_ms
+        self._herdr_session = herdr_session
+        # Resolution cache: terminal_id → (pane_id, timestamp)
+        self._pane_cache: Dict[str, tuple[str, float]] = {}
+        # Workspace cache: session_name → (workspace_id, timestamp)
+        self._workspace_cache: Dict[str, tuple[str, float]] = {}
+        # Window name → terminal_id mapping (populated at create_session/create_window)
+        self._window_to_terminal: Dict[str, str] = {}
+        self._ensure_session_running()
+
+    def _run_herdr(self, args: List[str], check: bool = True) -> subprocess.CompletedProcess:
+        """Run a herdr CLI command and return the result.
+
+        Args:
+            args: Command arguments (without 'herdr' prefix)
+            check: If True, raise TerminalBackendError on non-zero exit
+
+        Returns:
+            CompletedProcess result
+
+        Raises:
+            TerminalBackendError: If check=True and command fails
+        """
+        cmd = ["herdr", "--session", self._herdr_session] + args
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=30
+            )
+            if check and result.returncode != 0:
+                raise TerminalBackendError(
+                    f"herdr command failed: {' '.join(cmd)}\n"
+                    f"stderr: {result.stderr.strip()}"
+                )
+            return result
+        except subprocess.TimeoutExpired as e:
+            raise TerminalBackendError(f"herdr command timed out: {' '.join(cmd)}") from e
+        except FileNotFoundError as e:
+            raise TerminalBackendError(
+                "herdr CLI not found. Install herdr to use terminal_backend='herdr'."
+            ) from e
+
+    def _parse_herdr_json(self, stdout: str) -> dict:
+        """Parse herdr CLI JSON output, handling the envelope format.
+
+        Herdr wraps responses in {"id":..., "result": {...}} envelopes.
+        """
+        data = json.loads(stdout)
+        if isinstance(data, dict) and "result" in data:
+            return data["result"]
+        return data
+
+    def _resolve_pane_id(self, terminal_id: str) -> str:
+        """Resolve terminal_id to current compact pane_id.
+
+        Uses a cache with 5s TTL to reduce redundant herdr pane list calls.
+
+        Args:
+            terminal_id: Stable terminal identifier
+
+        Returns:
+            Current compact pane_id
+
+        Raises:
+            TerminalNotFoundError: If terminal_id not found in pane list
+        """
+        # Check cache
+        if terminal_id in self._pane_cache:
+            pane_id, cached_at = self._pane_cache[terminal_id]
+            if time.time() - cached_at < _PANE_CACHE_TTL:
+                return pane_id
+
+        # Resolve via herdr pane list
+        result = self._run_herdr(["pane", "list"])
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            panes = data.get("panes", []) if isinstance(data, dict) else data
+        except json.JSONDecodeError as e:
+            raise TerminalBackendError(f"Failed to parse herdr pane list output: {e}") from e
+
+        for pane in panes:
+            if pane.get("terminal_id") == terminal_id:
+                pane_id = str(pane["pane_id"])
+                self._pane_cache[terminal_id] = (pane_id, time.time())
+                return pane_id
+
+        raise TerminalNotFoundError(terminal_id)
+
+    def _resolve_workspace_id(self, session_name: str) -> str:
+        """Resolve session_name (workspace label) to workspace ID.
+
+        Uses _workspace_cache with the same TTL as pane cache.
+
+        Args:
+            session_name: CAO session name (used as workspace label)
+
+        Returns:
+            Workspace ID
+
+        Raises:
+            TerminalBackendError: If workspace not found
+        """
+        # Check cache
+        if session_name in self._workspace_cache:
+            workspace_id, cached_at = self._workspace_cache[session_name]
+            if time.time() - cached_at < _PANE_CACHE_TTL:
+                return workspace_id
+
+        result = self._run_herdr(["workspace", "list"])
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            workspaces = data.get("workspaces", []) if isinstance(data, dict) else data
+        except json.JSONDecodeError as e:
+            raise TerminalBackendError(
+                f"Failed to parse herdr workspace list output: {e}"
+            ) from e
+
+        for ws in workspaces:
+            if ws.get("label") == session_name:
+                ws_id = str(ws["workspace_id"])
+                self._workspace_cache[session_name] = (ws_id, time.time())
+                return ws_id
+
+        raise TerminalBackendError(f"Workspace with label '{session_name}' not found")
+
+    # --- Session lifecycle ---
+
+    def create_session(
+        self,
+        session_name: str,
+        window_name: str,
+        terminal_id: str,
+        working_directory: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Create a herdr workspace (= CAO session) with an initial tab."""
+        import os
+
+        working_directory = working_directory or os.getcwd()
+
+        args = ["workspace", "create", "--label", session_name]
+        if working_directory:
+            args.extend(["--cwd", working_directory])
+
+        result = self._run_herdr(args)
+
+        # Parse workspace ID and root tab_id from output for cache
+        workspace_id = ""
+        root_tab_id = ""
+        try:
+            ws_data = self._parse_herdr_json(result.stdout)
+            root_pane = ws_data.get("root_pane", {})
+            workspace_id = str(root_pane.get("workspace_id", ""))
+            root_tab_id = str(root_pane.get("tab_id", ""))
+            if workspace_id:
+                self._workspace_cache[session_name] = (workspace_id, time.time())
+        except (json.JSONDecodeError, KeyError):
+            pass  # Non-fatal; we can resolve later
+
+        # Parse root pane_id from the create response for env injection
+        new_pane_id = self._parse_new_pane_id(result.stdout)
+
+        # Label the root tab so it shows the CAO window name in herdr TUI.
+        if root_tab_id:
+            self._run_herdr(["tab", "rename", root_tab_id, window_name], check=False)
+
+        # Inject CAO env vars into the initial pane so agents and cao info can
+        # identify the terminal/session (mirrors TmuxClient env injection).
+        self._inject_env_vars(session_name, window_name, terminal_id, pane_id=new_pane_id)
+
+        logger.info(f"Created herdr workspace: {session_name} in {working_directory}")
+        return window_name
+
+    def session_exists(self, session_name: str) -> bool:
+        """Check if a workspace with the given label exists."""
+        result = self._run_herdr(["workspace", "list"], check=False)
+        if result.returncode != 0:
+            return False
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            workspaces = data.get("workspaces", []) if isinstance(data, dict) else data
+            return any(ws.get("label") == session_name for ws in workspaces)
+        except (json.JSONDecodeError, KeyError):
+            return False
+
+    def list_sessions(self) -> List[Dict[str, str]]:
+        """List all herdr workspaces as sessions."""
+        result = self._run_herdr(["workspace", "list"], check=False)
+        if result.returncode != 0:
+            return []
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            workspaces = data.get("workspaces", []) if isinstance(data, dict) else data
+            return [
+                {
+                    "id": ws.get("label", str(ws.get("workspace_id", ""))),
+                    "name": ws.get("label", str(ws.get("workspace_id", ""))),
+                    "status": "active",
+                }
+                for ws in workspaces
+            ]
+        except (json.JSONDecodeError, KeyError):
+            return []
+
+    def kill_session(self, session_name: str) -> bool:
+        """Close a herdr workspace by workspace_id (herdr only accepts id, not --label)."""
+        try:
+            workspace_id = self._resolve_workspace_id(session_name)
+        except TerminalBackendError:
+            logger.warning(f"kill_session: workspace '{session_name}' not found")
+            return False
+        result = self._run_herdr(["workspace", "close", workspace_id], check=False)
+        if result.returncode == 0:
+            self._workspace_cache.pop(session_name, None)
+            # Clean up window→terminal mappings for this session
+            prefix = f"{session_name}:"
+            to_remove = [k for k in self._window_to_terminal if k.startswith(prefix)]
+            for k in to_remove:
+                self._window_to_terminal.pop(k, None)
+            logger.info(f"Killed herdr workspace: {session_name}")
+            return True
+        return False
+
+    # --- Window/tab lifecycle ---
+
+    def create_window(
+        self,
+        session_name: str,
+        window_name: str,
+        terminal_id: str,
+        working_directory: Optional[str] = None,
+        window_shell: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Create a new tab in the workspace."""
+        import os
+
+        working_directory = working_directory or os.getcwd()
+
+        # Resolve workspace ID
+        workspace_id = self._resolve_workspace_id(session_name)
+
+        args = ["tab", "create", "--workspace", workspace_id, "--label", window_name]
+        if working_directory:
+            args.extend(["--cwd", working_directory])
+
+        result = self._run_herdr(args)
+
+        # Parse the new pane_id directly from the create response
+        new_pane_id = self._parse_new_pane_id(result.stdout)
+
+        # Inject CAO env vars using the known pane_id (no list scan needed)
+        self._inject_env_vars(session_name, window_name, terminal_id, pane_id=new_pane_id)
+
+        if window_shell is not None and new_pane_id is not None:
+            # Wait for shell startup before sending the initial command.
+            time.sleep(0.5)
+            try:
+                self._run_herdr(["pane", "run", new_pane_id, window_shell])
+            except TerminalBackendError as e:
+                logger.warning(
+                    f"create_window: pane run failed for {new_pane_id} (non-fatal): {e}"
+                )
+
+        logger.info(f"Created herdr tab in workspace {session_name}")
+        return window_name
+
+    def kill_window(self, session_name: str, window_name: str) -> bool:
+        """Kill a pane by resolving session_name:window_name to its pane_id."""
+        try:
+            pane_id = self._resolve_pane_id_from_window(session_name, window_name)
+        except TerminalBackendError:
+            logger.warning(
+                f"kill_window: could not resolve pane for {session_name}:{window_name}"
+            )
+            return False
+
+        result = self._run_herdr(["pane", "close", pane_id], check=False)
+
+        # Clean up window→terminal mapping and inbox-service pane cache entry
+        key = f"{session_name}:{window_name}"
+        terminal_id = self._window_to_terminal.pop(key, None)
+        if terminal_id:
+            # Remove from _pane_cache so the inbox service path doesn't use a stale entry
+            self._pane_cache.pop(terminal_id, None)
+
+        if result.returncode == 0:
+            logger.info(f"Killed herdr pane {pane_id} for {session_name}:{window_name}")
+            return True
+        return False
+
+    # --- Input ---
+
+    def send_keys(
+        self,
+        session_name: str,
+        window_name: str,
+        keys: str,
+        enter_count: int = 1,
+        force_bracketed_paste: bool = False,
+    ) -> None:
+        """Send text to a pane via herdr pane send-text + send-keys Enter.
+
+        When force_bracketed_paste=True, wraps content in \\x1b[200~...\\x1b[201~
+        so Claude Code's Ink TUI treats it as a paste event rather than raw
+        keystrokes. Without this, multi-line prompts go into multi-line mode
+        and the final Enter adds a newline instead of submitting.
+        """
+        # Resolve pane_id from terminal_id stored in DB metadata
+        # The window_name is used as a lookup key in CAO's DB → terminal_id mapping
+        # For herdr, we need the terminal_id. The service layer passes session:window
+        # which maps to a terminal in the DB. We'll resolve via the pane list.
+        pane_id = self._resolve_pane_id_from_window(session_name, window_name)
+
+        # Wrap in bracketed paste sequences when requested.
+        # herdr pane send-text writes raw bytes to the pty, so escape sequences
+        # pass through to the running process unchanged — same behavior as tmux.
+        if force_bracketed_paste:
+            text = "\x1b[200~" + keys + "\x1b[201~"
+        else:
+            text = keys
+
+        self._run_herdr(["pane", "send-text", pane_id, text])
+
+        # Allow the TUI to process the pasted content before sending Enter.
+        # For bracketed paste, the TUI needs time to process the end sequence
+        # and enter multi-line mode; 2s is intentionally generous.
+        # For non-bracketed paste, use the configurable send_delay_ms.
+        if force_bracketed_paste:
+            time.sleep(2.0)
+        elif self._send_delay_ms > 0:
+            time.sleep(self._send_delay_ms / 1000.0)
+
+        # Send Enter key(s)
+        for _ in range(enter_count):
+            self._run_herdr(["pane", "send-keys", pane_id, "Enter"])
+
+    def send_special_key(self, session_name: str, window_name: str, key: str) -> None:
+        """Send a special key to a pane."""
+        pane_id = self._resolve_pane_id_from_window(session_name, window_name)
+
+        # Map key names
+        if not key or key.lower() == "enter":
+            self._run_herdr(["pane", "send-keys", pane_id, "Enter"])
+        elif key == "C-c":
+            self._run_herdr(["pane", "send-keys", pane_id, "C-c"])
+        elif key == "C-d":
+            self._run_herdr(["pane", "send-keys", pane_id, "C-d"])
+        else:
+            # Pass key name directly
+            self._run_herdr(["pane", "send-keys", pane_id, key])
+
+    # --- Output ---
+
+    def get_history(
+        self,
+        session_name: str,
+        window_name: str,
+        tail_lines: Optional[int] = None,
+        strip_escapes: bool = False,
+        full_history: bool = False,
+    ) -> str:
+        """Read pane output via herdr pane read."""
+        pane_id = self._resolve_pane_id_from_window(session_name, window_name)
+
+        args = ["pane", "read", pane_id]
+        if full_history:
+            pass  # no flags — returns full scrollback
+        elif tail_lines:
+            args.extend(["--source", "recent", "--lines", str(tail_lines)])
+        else:
+            args.extend(["--source", "recent", "--lines", "500"])
+
+        result = self._run_herdr(args, check=False)
+        if result.returncode != 0:
+            logger.warning(f"herdr pane read failed: {result.stderr}")
+            return ""
+        return result.stdout
+
+    def get_pane_working_directory(self, session_name: str, window_name: str) -> Optional[str]:
+        """Get pane CWD via herdr pane get."""
+        pane_id = self._resolve_pane_id_from_window(session_name, window_name)
+
+        result = self._run_herdr(["pane", "get", pane_id], check=False)
+        if result.returncode != 0:
+            return None
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            # pane get returns {"pane": {...}} inside result
+            pane_info = data.get("pane", data) if isinstance(data, dict) else data
+            return pane_info.get("cwd")
+        except (json.JSONDecodeError, AttributeError):
+            return None
+
+    def get_pane_current_command(self, session_name: str, window_name: str) -> Optional[str]:
+        """Get foreground process via herdr pane get."""
+        pane_id = self._resolve_pane_id_from_window(session_name, window_name)
+
+        result = self._run_herdr(["pane", "get", pane_id], check=False)
+        if result.returncode != 0:
+            return None
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            pane_info = data.get("pane", data) if isinstance(data, dict) else data
+            return pane_info.get("foreground_process")
+        except (json.JSONDecodeError, AttributeError):
+            return None
+
+    # --- Attach ---
+
+    def attach_session(self, session_name: str) -> None:
+        """Attach the user's terminal to the herdr UI, focused on the CAO workspace.
+
+        Strategy:
+        1. Focus the CAO workspace in the running herdr server (so the UI opens
+           on the right workspace).
+        2. Exec `herdr` to replace the current process with the full herdr TUI.
+
+        This mirrors how `tmux attach-session -t <session>` works — it opens
+        the multiplexer UI showing the requested session.
+        """
+        import os
+
+        workspace_id = self._resolve_workspace_id(session_name)
+
+        # Focus the workspace so herdr opens on it when we attach
+        self._run_herdr(["workspace", "focus", workspace_id], check=False)
+
+        # Replace current process with herdr TUI, targeting the CAO session.
+        # Equivalent to `tmux attach-session -t <session>`.
+        os.execvp("herdr", ["herdr", "--session", self._herdr_session])
+
+    # --- Capability overrides ---
+
+    def supports_event_inbox(self) -> bool:
+        """Herdr uses socket events for inbox delivery."""
+        return True
+
+    def get_native_status(
+        self, session_name: str, window_name: str
+    ) -> Optional[TerminalStatus]:
+        """Query herdr's native agent_status for a pane.
+
+        Uses herdr pane get to read the agent_status field directly, avoiding
+        pane content parsing entirely when herdr knows the agent state.
+
+        Mapping (all five herdr agent states):
+        - working  -> PROCESSING
+        - blocked  -> WAITING_USER_ANSWER
+        - done     -> COMPLETED
+        - idle     -> IDLE  (caller disambiguates IDLE vs COMPLETED via _task_dispatched)
+        - unknown  -> ERROR  (pane exists but no agent registered yet)
+
+        Returns None only on backend errors (command failure, parse error) so
+        the caller can fall through to buffer analysis as a last resort.
+        """
+        try:
+            pane_id = self._resolve_pane_id_from_window(session_name, window_name)
+        except TerminalBackendError:
+            return None
+
+        result = self._run_herdr(["pane", "get", pane_id], check=False)
+        if result.returncode != 0:
+            return None
+
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            pane_info = data.get("pane", data) if isinstance(data, dict) else data
+            agent_status = pane_info.get("agent_status", "unknown")
+        except (json.JSONDecodeError, AttributeError):
+            return None
+
+        if agent_status == "working":
+            return TerminalStatus.PROCESSING
+        if agent_status == "blocked":
+            return TerminalStatus.WAITING_USER_ANSWER
+        if agent_status == "done":
+            return TerminalStatus.COMPLETED
+        if agent_status == "idle":
+            return TerminalStatus.IDLE
+        # "unknown" and any unrecognized value
+        return TerminalStatus.ERROR
+
+    def get_pane_id(self, terminal_id: str, session_name: str = "", window_name: str = "") -> str:
+        """Resolve CAO terminal_id to herdr pane_id.
+
+        Prefers the _pane_cache (populated by _inject_env_vars at create time).
+        Falls back to _window_to_terminal + _resolve_pane_id if session/window given.
+
+        Args:
+            terminal_id: CAO UUID terminal identifier
+            session_name: Optional session name for window-based fallback lookup
+            window_name: Optional window name for window-based fallback lookup
+
+        Returns:
+            Current herdr compact pane_id
+
+        Raises:
+            TerminalNotFoundError: If pane cannot be resolved
+        """
+        # Fast path: pane_id was cached by _inject_env_vars
+        if terminal_id in self._pane_cache:
+            pane_id, cached_at = self._pane_cache[terminal_id]
+            if time.time() - cached_at < _PANE_CACHE_TTL:
+                return pane_id
+
+        # Fallback: resolve via window mapping if session/window provided
+        if session_name and window_name:
+            return self._resolve_pane_id_from_window(session_name, window_name)
+
+        raise TerminalNotFoundError(terminal_id)
+
+    # --- Pipe-pane (no-op for herdr) ---
+
+    def pipe_pane(self, session_name: str, window_name: str, file_path: str) -> None:
+        """No-op: herdr uses socket events for inbox delivery."""
+        logger.debug(f"pipe_pane is a no-op for herdr backend (session={session_name})")
+
+    def stop_pipe_pane(self, session_name: str, window_name: str) -> None:
+        """No-op: herdr uses socket events for inbox delivery."""
+        logger.debug(f"stop_pipe_pane is a no-op for herdr backend (session={session_name})")
+
+    # --- Internal helpers ---
+
+    def _session_socket_path(self) -> str:
+        """Return the herdr socket path for the configured session.
+
+        Mirrors HerdrInboxService._default_socket_path():
+        - ``"default"`` session: ``~/.config/herdr/herdr.sock``
+        - Named sessions:       ``~/.config/herdr/sessions/<name>/herdr.sock``
+        """
+        config_home = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+        if self._herdr_session == "default":
+            return f"{config_home}/herdr/herdr.sock"
+        return f"{config_home}/herdr/sessions/{self._herdr_session}/herdr.sock"
+
+    def _ensure_session_running(self) -> None:
+        """Start the herdr session server if its socket does not exist.
+
+        Checks for the session socket file. If absent, starts the server
+        headlessly and waits up to 5 seconds for the socket to appear.
+        Logs a warning if the socket never appears but does not raise —
+        the first actual herdr operation will produce a clear error.
+        """
+        socket_path = self._session_socket_path()
+        if os.path.exists(socket_path):
+            return
+
+        logger.info(
+            f"Herdr session '{self._herdr_session}' not running "
+            f"(socket {socket_path} absent) — starting server."
+        )
+        subprocess.Popen(
+            ["herdr", "--session", self._herdr_session, "server"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+        # Give herdr a moment to create the socket file before polling.
+        time.sleep(0.5)
+
+        # Poll up to 15 seconds for the socket to appear.
+        deadline = time.time() + 15.0
+        while time.time() < deadline:
+            if os.path.exists(socket_path):
+                logger.info(f"Herdr session '{self._herdr_session}' is ready.")
+                return
+            time.sleep(0.1)
+
+        logger.warning(
+            f"Herdr session '{self._herdr_session}' socket did not appear within 15s "
+            f"at {socket_path}. The first herdr operation will fail with a clear error."
+        )
+
+    def _parse_new_pane_id(self, stdout: str) -> Optional[str]:
+        """Extract the root pane_id from a workspace/tab create response.
+
+        Both 'herdr workspace create' and 'herdr tab create' return a
+        result.root_pane.pane_id field with the newly created pane's ID.
+        """
+        try:
+            data = self._parse_herdr_json(stdout)
+            return str(data["root_pane"]["pane_id"])
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return None
+
+    def _inject_env_vars(
+        self, session_name: str, window_name: str, terminal_id: str,
+        pane_id: Optional[str] = None,
+    ) -> None:
+        """Inject CAO_TERMINAL_ID and CAO_SESSION_NAME into the specified pane.
+
+        Called after create_session/create_window to export env vars into the
+        pane's shell so agents and `cao info` can identify the terminal/session.
+        Also records the window_name→terminal_id mapping for pane resolution.
+
+        Args:
+            session_name: CAO session name
+            window_name: Window name for the mapping
+            terminal_id: Terminal identifier to inject
+            pane_id: Pane ID from the create response. If None, falls back to
+                pane list scan (less reliable under concurrency).
+        """
+        # Record mapping for _resolve_pane_id_from_window
+        key = f"{session_name}:{window_name}"
+        self._window_to_terminal[key] = terminal_id
+
+        try:
+            # Use provided pane_id if available (from create response)
+            target_pane_id = pane_id
+            if not target_pane_id:
+                # Fallback: scan pane list for last pane in workspace
+                workspace_id = self._resolve_workspace_id(session_name)
+                result = self._run_herdr(["pane", "list"])
+                data = self._parse_herdr_json(result.stdout)
+                panes = data.get("panes", []) if isinstance(data, dict) else data
+                for p in panes:
+                    if p.get("workspace_id") == workspace_id:
+                        target_pane_id = str(p["pane_id"])
+
+            if target_pane_id:
+                # Cache the mapping
+                self._pane_cache[terminal_id] = (target_pane_id, time.time())
+                # Send env export command
+                env_cmd = (
+                    f"export CAO_TERMINAL_ID={terminal_id}; "
+                    f"export CAO_SESSION_NAME={session_name}"
+                )
+                self._run_herdr(["pane", "send-text", target_pane_id, env_cmd])
+                self._run_herdr(["pane", "send-keys", target_pane_id, "Enter"])
+        except (TerminalBackendError, json.JSONDecodeError, KeyError) as e:
+            logger.warning(f"Failed to inject env vars for {terminal_id}: {e}")
+
+    def _resolve_tab_id(self, session_name: str, workspace_id: str, window_name: str) -> str:
+        """Resolve window_name to its herdr tab_id in the given workspace.
+
+        Args:
+            session_name: CAO session name (used only in error messages)
+            workspace_id: Herdr workspace ID to search within
+            window_name: Tab label to match
+
+        Returns:
+            The tab_id of the matching tab
+
+        Raises:
+            TerminalBackendError: If no tab with label window_name exists in workspace_id
+        """
+        result = self._run_herdr(["tab", "list"])
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            tabs = data.get("tabs", []) if isinstance(data, dict) else data
+        except json.JSONDecodeError as e:
+            raise TerminalBackendError(f"Failed to parse herdr tab list: {e}") from e
+
+        for tab in tabs:
+            if tab.get("workspace_id") == workspace_id and tab.get("label") == window_name:
+                return str(tab["tab_id"])
+
+        raise TerminalBackendError(
+            f"No tab labeled '{window_name}' found in workspace '{session_name}'"
+        )
+
+    def _resolve_pane_id_from_window(self, session_name: str, window_name: str) -> str:
+        """Resolve a pane_id given session_name and window_name.
+
+        Always performs a fresh herdr tab list + pane list lookup. Pane IDs are
+        not stable across deletions — herdr renumbers remaining panes when any
+        pane in the workspace is removed. A cache would return stale IDs and
+        cause pane_not_found errors for live terminals.
+
+        When a window→terminal mapping exists (set at create time), uses tab_id
+        as the stable intermediary to find the exact pane. Falls back to the
+        first pane in the workspace when no mapping exists (e.g., legacy panes).
+        """
+        # Look up terminal_id from the window mapping
+        key = f"{session_name}:{window_name}"
+        terminal_id = self._window_to_terminal.get(key)
+
+        if terminal_id:
+            # Fresh resolution via tab_id as stable intermediary.
+            # workspace_id is cached with TTL and is stable — workspaces are
+            # never renumbered by pane deletions.
+            workspace_id = self._resolve_workspace_id(session_name)
+            tab_id = self._resolve_tab_id(session_name, workspace_id, window_name)
+
+            result = self._run_herdr(["pane", "list"])
+            try:
+                data = self._parse_herdr_json(result.stdout)
+                panes = data.get("panes", []) if isinstance(data, dict) else data
+            except json.JSONDecodeError as e:
+                raise TerminalBackendError(f"Failed to parse herdr pane list: {e}") from e
+
+            for pane in panes:
+                if pane.get("tab_id") == tab_id:
+                    return str(pane["pane_id"])
+
+            raise TerminalNotFoundError(terminal_id)
+
+        # Fallback: no mapping (e.g., legacy or externally created panes)
+        # Resolve workspace and return the first pane found
+        try:
+            workspace_id = self._resolve_workspace_id(session_name)
+        except TerminalBackendError:
+            raise TerminalBackendError(
+                f"No pane found for workspace '{session_name}' window '{window_name}'"
+            )
+
+        result = self._run_herdr(["pane", "list"])
+        try:
+            data = self._parse_herdr_json(result.stdout)
+            panes = data.get("panes", []) if isinstance(data, dict) else data
+        except json.JSONDecodeError as e:
+            raise TerminalBackendError(f"Failed to parse herdr pane list: {e}") from e
+
+        for pane in panes:
+            if pane.get("workspace_id") == workspace_id:
+                return str(pane["pane_id"])
+
+        raise TerminalBackendError(
+            f"No pane found for workspace '{session_name}' window '{window_name}'"
+        )
+
+    def invalidate_cache(self) -> None:
+        """Invalidate all cached pane_id mappings.
+
+        Called after herdr reconnection when pane_ids may have compacted.
+        """
+        self._pane_cache.clear()
+        self._workspace_cache.clear()

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -407,6 +407,12 @@ class HerdrBackend(TerminalBackend):
             args.extend(["--source", "recent", "--lines", str(tail_lines)])
         else:
             args.extend(["--source", "recent", "--lines", "500"])
+        # Honor strip_escapes via herdr's native --format text (strips ANSI).
+        # The TerminalBackend contract only requires that strip_escapes=True
+        # yields plain text; when False we leave the format unset and take
+        # herdr's default so existing provider output parsing is unchanged.
+        if strip_escapes:
+            args.extend(["--format", "text"])
 
         result = self._run_herdr(args, check=False)
         if result.returncode != 0:

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -28,8 +28,9 @@ from cli_agent_orchestrator.models.terminal import TerminalStatus
 logger = logging.getLogger(__name__)
 
 # Cache TTL for pane_id resolution (seconds).
-# Used by _resolve_pane_id() (inbox service path, herdr-native terminal_ids).
-# Not used by _resolve_pane_id_from_window() which skips TTL for active terminals.
+# Used by _resolve_pane_id() (inbox service path, herdr-native terminal_ids) and
+# _resolve_workspace_id(). _resolve_pane_id_from_window() never caches pane_ids —
+# herdr renumbers panes on deletion, so it resolves the pane fresh every call.
 _PANE_CACHE_TTL = 5.0
 
 
@@ -59,8 +60,6 @@ class HerdrBackend(TerminalBackend):
         self._pane_cache: Dict[str, tuple[str, float]] = {}
         # Workspace cache: session_name → (workspace_id, timestamp)
         self._workspace_cache: Dict[str, tuple[str, float]] = {}
-        # Window name → terminal_id mapping (populated at create_session/create_window)
-        self._window_to_terminal: Dict[str, str] = {}
         self._ensure_session_running()
 
     @property
@@ -271,11 +270,6 @@ class HerdrBackend(TerminalBackend):
         result = self._run_herdr(["workspace", "close", workspace_id], check=False)
         if result.returncode == 0:
             self._workspace_cache.pop(session_name, None)
-            # Clean up window→terminal mappings for this session
-            prefix = f"{session_name}:"
-            to_remove = [k for k in self._window_to_terminal if k.startswith(prefix)]
-            for k in to_remove:
-                self._window_to_terminal.pop(k, None)
             logger.info(f"Killed herdr workspace: {session_name}")
             return True
         return False
@@ -335,13 +329,6 @@ class HerdrBackend(TerminalBackend):
             return False
 
         result = self._run_herdr(["pane", "close", pane_id], check=False)
-
-        # Clean up window→terminal mapping and inbox-service pane cache entry
-        key = f"{session_name}:{window_name}"
-        terminal_id = self._window_to_terminal.pop(key, None)
-        if terminal_id:
-            # Remove from _pane_cache so the inbox service path doesn't use a stale entry
-            self._pane_cache.pop(terminal_id, None)
 
         if result.returncode == 0:
             logger.info(f"Killed herdr pane {pane_id} for {session_name}:{window_name}")
@@ -544,7 +531,8 @@ class HerdrBackend(TerminalBackend):
         """Resolve CAO terminal_id to herdr pane_id.
 
         Prefers the _pane_cache (populated by _inject_env_vars at create time).
-        Falls back to _window_to_terminal + _resolve_pane_id if session/window given.
+        Falls back to live label-based resolution (_resolve_workspace_id ->
+        _resolve_tab_id -> pane list) if session/window given.
 
         Args:
             terminal_id: CAO UUID terminal identifier
@@ -652,24 +640,22 @@ class HerdrBackend(TerminalBackend):
 
         Called after create_session/create_window to export env vars into the
         pane's shell so agents and `cao info` can identify the terminal/session.
-        Also records the window_name→terminal_id mapping for pane resolution.
 
         Args:
             session_name: CAO session name
-            window_name: Window name for the mapping
+            window_name: Window name (kept for signature symmetry / logging)
             terminal_id: Terminal identifier to inject
             pane_id: Pane ID from the create response. If None, falls back to
                 pane list scan (less reliable under concurrency).
         """
-        # Record mapping for _resolve_pane_id_from_window
-        key = f"{session_name}:{window_name}"
-        self._window_to_terminal[key] = terminal_id
-
         try:
             # Use provided pane_id if available (from create response)
             target_pane_id = pane_id
             if not target_pane_id:
-                # Fallback: scan pane list for last pane in workspace
+                # Fallback: scan pane list for last pane in workspace.
+                # NOTE: under concurrent creates in the same workspace this can
+                # pick the wrong (most-recent) pane. It only fires when the create
+                # response lacked a pane_id; the pane_id param is the primary path.
                 workspace_id = self._resolve_workspace_id(session_name)
                 result = self._run_herdr(["pane", "list"])
                 data = self._parse_herdr_json(result.stdout)
@@ -723,23 +709,22 @@ class HerdrBackend(TerminalBackend):
     def _resolve_pane_id_from_window(self, session_name: str, window_name: str) -> str:
         """Resolve a pane_id given session_name and window_name.
 
-        Always performs a fresh herdr tab list + pane list lookup. Pane IDs are
-        not stable across deletions — herdr renumbers remaining panes when any
-        pane in the workspace is removed. A cache would return stale IDs and
-        cause pane_not_found errors for live terminals.
+        Performs a fresh herdr workspace + tab + pane lookup on every call. Pane
+        IDs are not stable across deletions — herdr renumbers remaining panes
+        when any pane in the workspace is removed, so a cached pane_id would go
+        stale and cause pane_not_found errors for live terminals. workspace_id
+        resolution is cached with a short TTL inside _resolve_workspace_id as a
+        latency optimization; the chain is otherwise resolved live.
 
-        When a window→terminal mapping exists (set at create time), uses tab_id
-        as the stable intermediary to find the exact pane. Falls back to the
-        first pane in the workspace when no mapping exists (e.g., legacy panes).
+        Resolution chain: workspace_id (by label) → tab_id (by label within the
+        workspace) → the pane whose tab_id matches. There is no fallback: a tab
+        must exist for the window and a pane must exist for the tab.
+
+        Raises:
+            TerminalNotFoundError: If the workspace, tab, or pane cannot be
+                resolved for session_name:window_name.
         """
-        # Look up terminal_id from the window mapping
-        key = f"{session_name}:{window_name}"
-        terminal_id = self._window_to_terminal.get(key)
-
-        if terminal_id:
-            # Fresh resolution via tab_id as stable intermediary.
-            # workspace_id is cached with TTL and is stable — workspaces are
-            # never renumbered by pane deletions.
+        try:
             workspace_id = self._resolve_workspace_id(session_name)
             tab_id = self._resolve_tab_id(session_name, workspace_id, window_name)
 
@@ -749,36 +734,14 @@ class HerdrBackend(TerminalBackend):
                 panes = data.get("panes", []) if isinstance(data, dict) else data
             except json.JSONDecodeError as e:
                 raise TerminalBackendError(f"Failed to parse herdr pane list: {e}") from e
-
-            for pane in panes:
-                if pane.get("tab_id") == tab_id:
-                    return str(pane["pane_id"])
-
-            raise TerminalNotFoundError(terminal_id)
-
-        # Fallback: no mapping (e.g., legacy or externally created panes)
-        # Resolve workspace and return the first pane found
-        try:
-            workspace_id = self._resolve_workspace_id(session_name)
-        except TerminalBackendError:
-            raise TerminalBackendError(
-                f"No pane found for workspace '{session_name}' window '{window_name}'"
-            )
-
-        result = self._run_herdr(["pane", "list"])
-        try:
-            data = self._parse_herdr_json(result.stdout)
-            panes = data.get("panes", []) if isinstance(data, dict) else data
-        except json.JSONDecodeError as e:
-            raise TerminalBackendError(f"Failed to parse herdr pane list: {e}") from e
+        except TerminalBackendError as e:
+            raise TerminalNotFoundError(f"{session_name}:{window_name}") from e
 
         for pane in panes:
-            if pane.get("workspace_id") == workspace_id:
+            if pane.get("tab_id") == tab_id:
                 return str(pane["pane_id"])
 
-        raise TerminalBackendError(
-            f"No pane found for workspace '{session_name}' window '{window_name}'"
-        )
+        raise TerminalNotFoundError(f"{session_name}:{window_name}")
 
     def invalidate_cache(self) -> None:
         """Invalidate all cached pane_id mappings.

--- a/src/cli_agent_orchestrator/backends/registry.py
+++ b/src/cli_agent_orchestrator/backends/registry.py
@@ -1,0 +1,29 @@
+"""Backend registry — module-level backend singleton management.
+
+This module provides get_backend() and set_backend() as the central access point
+for the configured TerminalBackend. It has no dependencies on providers or services,
+breaking the circular import chain.
+"""
+
+from typing import Optional
+
+from cli_agent_orchestrator.backends.base import TerminalBackend
+
+# Module-level backend instance. Initialized lazily via get_backend().
+_backend: Optional[TerminalBackend] = None
+
+
+def get_backend() -> TerminalBackend:
+    """Return the configured terminal backend (lazy-initialized via BackendFactory)."""
+    global _backend
+    if _backend is None:
+        from cli_agent_orchestrator.backends.factory import BackendFactory
+
+        _backend = BackendFactory.create()
+    return _backend
+
+
+def set_backend(backend: TerminalBackend) -> None:
+    """Set the terminal backend (called at application startup)."""
+    global _backend
+    _backend = backend

--- a/src/cli_agent_orchestrator/backends/tmux_backend.py
+++ b/src/cli_agent_orchestrator/backends/tmux_backend.py
@@ -1,0 +1,133 @@
+"""TmuxBackend — concrete TerminalBackend implementation wrapping TmuxClient.
+
+This backend delegates all operations to the existing TmuxClient, preserving
+identical behavior for all callers. It serves as the default backend when
+no alternative is configured.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from cli_agent_orchestrator.backends.base import TerminalBackend, TerminalBackendError
+from cli_agent_orchestrator.clients.tmux import TmuxClient
+
+logger = logging.getLogger(__name__)
+
+
+class TmuxBackend(TerminalBackend):
+    """TerminalBackend implementation backed by tmux via TmuxClient."""
+
+    def __init__(self, client: Optional[TmuxClient] = None) -> None:
+        """Initialize with an optional TmuxClient (defaults to module singleton)."""
+        if client is None:
+            from cli_agent_orchestrator.clients.tmux import tmux_client
+
+            client = tmux_client
+        self._client = client
+
+    # --- Session lifecycle ---
+
+    def create_session(
+        self,
+        session_name: str,
+        window_name: str,
+        terminal_id: str,
+        working_directory: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+    ) -> str:
+        try:
+            return self._client.create_session(
+                session_name, window_name, terminal_id, working_directory, extra_env=extra_env
+            )
+        except Exception as e:
+            raise TerminalBackendError(f"Failed to create session '{session_name}': {e}") from e
+
+    def session_exists(self, session_name: str) -> bool:
+        return self._client.session_exists(session_name)
+
+    def list_sessions(self) -> List[Dict[str, str]]:
+        return self._client.list_sessions()
+
+    def kill_session(self, session_name: str) -> bool:
+        return self._client.kill_session(session_name)
+
+    # --- Window/tab lifecycle ---
+
+    def create_window(
+        self,
+        session_name: str,
+        window_name: str,
+        terminal_id: str,
+        working_directory: Optional[str] = None,
+        window_shell: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+    ) -> str:
+        try:
+            return self._client.create_window(
+                session_name, window_name, terminal_id, working_directory, window_shell,
+                extra_env=extra_env,
+            )
+        except Exception as e:
+            raise TerminalBackendError(
+                f"Failed to create window '{window_name}' in session '{session_name}': {e}"
+            ) from e
+
+    def kill_window(self, session_name: str, window_name: str) -> bool:
+        return self._client.kill_window(session_name, window_name)
+
+    # --- Input ---
+
+    def send_keys(
+        self,
+        session_name: str,
+        window_name: str,
+        keys: str,
+        enter_count: int = 1,
+        force_bracketed_paste: bool = False,
+    ) -> None:
+        self._client.send_keys(
+            session_name, window_name, keys, enter_count=enter_count,
+            force_bracketed_paste=force_bracketed_paste,
+        )
+
+    def send_special_key(self, session_name: str, window_name: str, key: str) -> None:
+        self._client.send_special_key(session_name, window_name, key)
+
+    # --- Output ---
+
+    def get_history(
+        self,
+        session_name: str,
+        window_name: str,
+        tail_lines: Optional[int] = None,
+        strip_escapes: bool = False,
+        full_history: bool = False,
+    ) -> str:
+        return self._client.get_history(
+            session_name, window_name,
+            tail_lines=tail_lines,
+            strip_escapes=strip_escapes,
+            full_history=full_history,
+        )
+
+    def get_pane_working_directory(self, session_name: str, window_name: str) -> Optional[str]:
+        return self._client.get_pane_working_directory(session_name, window_name)
+
+    def get_pane_current_command(self, session_name: str, window_name: str) -> Optional[str]:
+        return self._client.get_pane_current_command(session_name, window_name)
+
+    # --- Attach ---
+
+    def attach_session(self, session_name: str) -> None:
+        """Attach to tmux session via subprocess (replaces current process)."""
+        import subprocess
+
+        subprocess.run(["tmux", "attach-session", "-t", session_name], check=True)
+
+    # --- Pipe-pane ---
+
+    def pipe_pane(self, session_name: str, window_name: str, file_path: str) -> None:
+        self._client.pipe_pane(session_name, window_name, file_path)
+
+    def stop_pipe_pane(self, session_name: str, window_name: str) -> None:
+        self._client.stop_pipe_pane(session_name, window_name)

--- a/src/cli_agent_orchestrator/backends/tmux_backend.py
+++ b/src/cli_agent_orchestrator/backends/tmux_backend.py
@@ -64,7 +64,11 @@ class TmuxBackend(TerminalBackend):
     ) -> str:
         try:
             return self._client.create_window(
-                session_name, window_name, terminal_id, working_directory, window_shell,
+                session_name,
+                window_name,
+                terminal_id,
+                working_directory,
+                window_shell,
                 extra_env=extra_env,
             )
         except Exception as e:
@@ -86,7 +90,10 @@ class TmuxBackend(TerminalBackend):
         force_bracketed_paste: bool = False,
     ) -> None:
         self._client.send_keys(
-            session_name, window_name, keys, enter_count=enter_count,
+            session_name,
+            window_name,
+            keys,
+            enter_count=enter_count,
             force_bracketed_paste=force_bracketed_paste,
         )
 
@@ -104,7 +111,8 @@ class TmuxBackend(TerminalBackend):
         full_history: bool = False,
     ) -> str:
         return self._client.get_history(
-            session_name, window_name,
+            session_name,
+            window_name,
             tail_lines=tail_lines,
             strip_escapes=strip_escapes,
             full_history=full_history,

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -1,12 +1,12 @@
 """Launch command for CLI Agent Orchestrator CLI."""
 
 import os
-import subprocess
 import time
 
 import click
 import requests
 
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import (
     API_BASE_URL,
     DEFAULT_PROVIDER,
@@ -314,7 +314,7 @@ def launch(
                         fg="yellow",
                     )
                 )
-            subprocess.run(["tmux", "attach-session", "-t", terminal["session_name"]])
+            get_backend().attach_session(terminal["session_name"])
         elif message:
             ready = wait_until_terminal_status(
                 terminal["id"],

--- a/src/cli_agent_orchestrator/cli/commands/terminal.py
+++ b/src/cli_agent_orchestrator/cli/commands/terminal.py
@@ -6,7 +6,7 @@ import os
 import click
 import requests
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import API_BASE_URL, TERMINAL_LOG_DIR
 
 
@@ -62,7 +62,7 @@ def restore(terminal_id: str):
         window_shell = f"exec {login_shell} -l"
 
     try:
-        tmux_client.create_window(
+        get_backend().create_window(
             session_name,
             window_name,
             terminal_id,

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -393,8 +393,14 @@ def delete_terminals_by_session(tmux_session: str) -> int:
 
 
 def create_inbox_message(sender_id: str, receiver_id: str, message: str) -> InboxMessage:
-    """Create inbox message with status=MessageStatus.PENDING."""
+    """Create inbox message with status=MessageStatus.PENDING.
+
+    Raises:
+        ValueError: If the receiver terminal does not exist.
+    """
     with SessionLocal() as db:
+        if not db.query(TerminalModel).filter(TerminalModel.id == receiver_id).first():
+            raise ValueError(f"Terminal '{receiver_id}' not found")
         inbox_msg = InboxModel(
             sender_id=sender_id,
             receiver_id=receiver_id,

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -61,7 +61,7 @@ TERMINAL_LOG_DIR.mkdir(parents=True, exist_ok=True)
 INBOX_POLLING_INTERVAL = 5
 
 # Eager inbox delivery: when enabled, deliver queued messages to terminals in
-# PROCESSING or WAITING_USER_ANSWER state for providers that declare
+# PROCESSING state for providers that declare
 # accepts_input_while_processing=True. Eliminates latency between agent turns
 # for capable providers (e.g., Claude Code).
 EAGER_INBOX_DELIVERY = os.environ.get("CAO_EAGER_INBOX_DELIVERY", "false").lower() == "true"

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -136,8 +136,8 @@ class BaseProvider(ABC):
         """Whether this provider buffers pasted input during PROCESSING for next-turn pickup.
 
         When True AND CAO_EAGER_INBOX_DELIVERY is enabled, the inbox service will
-        deliver messages to this terminal even when its status is PROCESSING or
-        WAITING_USER_ANSWER, rather than waiting for IDLE/COMPLETED.
+        deliver messages to this terminal even when its status is PROCESSING,
+        rather than waiting for IDLE/COMPLETED.
 
         Override in subclasses for providers whose TUI buffers input at all times
         (e.g., Claude Code's Ink renderer).

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -8,8 +8,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.backends.registry import get_backend
+from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -68,7 +68,7 @@ class ClaudeCodeProvider(BaseProvider):
         self._initialized = False
         self._agent_profile = agent_profile
         self._task_dispatched = False
-        self._last_dispatch_time: float = 0.0   # set by mark_input_received()
+        self._last_dispatch_time: float = 0.0  # set by mark_input_received()
         self._done_first_detected: float = 0.0  # first time herdr reported "done" this cycle
         self._idle_first_detected: float = 0.0  # first time herdr reported "idle" post-dispatch
 
@@ -247,9 +247,7 @@ class ClaudeCodeProvider(BaseProvider):
             # 2) Handle workspace trust prompt
             if re.search(TRUST_PROMPT_PATTERN, clean_output):
                 logger.info("Workspace trust prompt detected, auto-accepting")
-                get_backend().send_special_key(
-                    self.session_name, self.window_name, "Enter"
-                )
+                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 return
 
             # 3) Claude Code fully started — no prompts needed
@@ -309,7 +307,11 @@ class ClaudeCodeProvider(BaseProvider):
             )
             if claude_started:
                 status = self.get_status()
-                if status in {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER}:
+                if status in {
+                    TerminalStatus.IDLE,
+                    TerminalStatus.COMPLETED,
+                    TerminalStatus.WAITING_USER_ANSWER,
+                }:
                     break
             time.sleep(1.0)
         else:
@@ -367,12 +369,14 @@ class ClaudeCodeProvider(BaseProvider):
                 if waited >= 10.0:
                     logger.debug(
                         "[get_status] terminal=%s -> COMPLETED (native done, %.1fs flush wait elapsed)",
-                        self.terminal_id, waited,
+                        self.terminal_id,
+                        waited,
                     )
                     return TerminalStatus.COMPLETED
                 logger.debug(
                     "[get_status] terminal=%s -> PROCESSING (native done, flush wait %.1fs/10s)",
-                    self.terminal_id, waited,
+                    self.terminal_id,
+                    waited,
                 )
                 return TerminalStatus.PROCESSING
             if native == TerminalStatus.IDLE and self._task_dispatched:
@@ -386,17 +390,20 @@ class ClaudeCodeProvider(BaseProvider):
                     if elapsed >= 300.0:
                         logger.warning(
                             "[get_status] terminal=%s -> COMPLETED (native idle, %.0fs since dispatch, giving up)",
-                            self.terminal_id, elapsed,
+                            self.terminal_id,
+                            elapsed,
                         )
                         return TerminalStatus.COMPLETED
                     logger.debug(
                         "[get_status] terminal=%s -> COMPLETED (native idle, %.1fs flush wait elapsed)",
-                        self.terminal_id, waited,
+                        self.terminal_id,
+                        waited,
                     )
                     return TerminalStatus.COMPLETED
                 logger.debug(
                     "[get_status] terminal=%s -> PROCESSING (native idle, flush wait %.1fs/10s)",
-                    self.terminal_id, waited,
+                    self.terminal_id,
+                    waited,
                 )
                 return TerminalStatus.PROCESSING
             if native == TerminalStatus.IDLE:
@@ -406,12 +413,12 @@ class ClaudeCodeProvider(BaseProvider):
                 )
                 return TerminalStatus.IDLE
             # COMPLETED (no task dispatched), WAITING_USER_ANSWER, ERROR -- return directly
-            logger.debug(
-                "[get_status] terminal=%s -> %s (native)", self.terminal_id, native.value
-            )
+            logger.debug("[get_status] terminal=%s -> %s (native)", self.terminal_id, native.value)
             return native
 
-        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(
+            self.session_name, self.window_name, tail_lines=tail_lines
+        )
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -4,13 +4,12 @@ import json
 import logging
 import re
 import shlex
-import subprocess
 import time
 from pathlib import Path
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
@@ -27,7 +26,7 @@ class ProviderError(Exception):
 
 # Regex patterns for Claude Code output analysis
 ANSI_CODE_PATTERN = r"\x1b\[[0-9;]*m"
-RESPONSE_PATTERN = r"⏺(?:\x1b\[[0-9;]*m)*\s+"  # Handle any ANSI codes between marker and text
+RESPONSE_PATTERN = r"[⏺●](?:\x1b\[[0-9;]*m)*\s+"  # ⏺ (U+23FA) old claude, ● (U+25CF) new claude
 # Match Claude Code processing spinners:
 # - Old format: "✽ Cooking… (esc to interrupt)" / "✶ Thinking… (esc to interrupt)"
 # - New format: "✽ Cooking… (6s · ↓ 174 tokens · thinking)"
@@ -68,6 +67,10 @@ class ClaudeCodeProvider(BaseProvider):
         super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
         self._initialized = False
         self._agent_profile = agent_profile
+        self._task_dispatched = False
+        self._last_dispatch_time: float = 0.0   # set by mark_input_received()
+        self._done_first_detected: float = 0.0  # first time herdr reported "done" this cycle
+        self._idle_first_detected: float = 0.0  # first time herdr reported "idle" post-dispatch
 
     def _build_claude_command(self) -> str:
         """Build Claude Code command with agent profile if provided.
@@ -220,7 +223,7 @@ class ClaudeCodeProvider(BaseProvider):
         start_time = time.time()
         bypass_accepted = False
         while time.time() - start_time < timeout:
-            output = tmux_client.get_history(self.session_name, self.window_name)
+            output = get_backend().get_history(self.session_name, self.window_name)
             if not output:
                 time.sleep(1.0)
                 continue
@@ -231,13 +234,12 @@ class ClaudeCodeProvider(BaseProvider):
             #    Only act once — the text stays in the buffer after dismissal.
             if not bypass_accepted and re.search(BYPASS_PROMPT_PATTERN, clean_output):
                 logger.info("Bypass permissions prompt detected, auto-accepting")
-                target = f"{self.session_name}:{self.window_name}"
-                # Send raw Down arrow escape sequence (-l for literal) to move
-                # cursor to "Yes, I accept", then Enter to confirm.
-                # tmux send-keys "Down" doesn't work with Claude's Ink TUI.
-                subprocess.run(["tmux", "send-keys", "-t", target, "-l", "\x1b[B"], check=False)
+                # Send Down arrow to move cursor to "Yes, I accept", then Enter.
+                get_backend().send_keys(
+                    self.session_name, self.window_name, "\x1b[B", enter_count=0
+                )
                 time.sleep(0.5)
-                subprocess.run(["tmux", "send-keys", "-t", target, "Enter"], check=False)
+                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 bypass_accepted = True
                 time.sleep(1.0)
                 continue  # Trust prompt may follow
@@ -245,17 +247,9 @@ class ClaudeCodeProvider(BaseProvider):
             # 2) Handle workspace trust prompt
             if re.search(TRUST_PROMPT_PATTERN, clean_output):
                 logger.info("Workspace trust prompt detected, auto-accepting")
-                session = tmux_client.server.sessions.get(session_name=self.session_name)
-                if session is None:
-                    time.sleep(1.0)
-                    continue
-                window = session.windows.get(window_name=self.window_name)
-                if window is None:
-                    time.sleep(1.0)
-                    continue
-                pane = window.active_pane
-                if pane:
-                    pane.send_keys("", enter=True)
+                get_backend().send_special_key(
+                    self.session_name, self.window_name, "Enter"
+                )
                 return
 
             # 3) Claude Code fully started — no prompts needed
@@ -272,7 +266,7 @@ class ClaudeCodeProvider(BaseProvider):
     def initialize(self) -> bool:
         """Initialize Claude Code provider by starting claude command."""
         # Wait for shell prompt to appear in the tmux window
-        if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+        if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         # Prevent bypass permissions dialog from appearing (settings-based fix).
@@ -286,10 +280,10 @@ class ClaudeCodeProvider(BaseProvider):
         # from Claude Code's own ❯ REPL prompt — they are visually identical
         # after ANSI stripping, so without a snapshot, status detection can
         # falsely return IDLE on the old shell prompt before claude even starts.
-        pre_launch_snapshot = tmux_client.get_history(self.session_name, self.window_name) or ""
+        pre_launch_snapshot = get_backend().get_history(self.session_name, self.window_name) or ""
 
         # Send Claude Code command using tmux client
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         # Handle startup prompts (bypass permissions + workspace trust)
         self._handle_startup_prompts(timeout=20.0)
@@ -303,7 +297,7 @@ class ClaudeCodeProvider(BaseProvider):
         # ❯ prompt triggers an immediate IDLE return before claude starts.
         deadline = time.time() + 30.0
         while time.time() < deadline:
-            current_output = tmux_client.get_history(self.session_name, self.window_name) or ""
+            current_output = get_backend().get_history(self.session_name, self.window_name) or ""
             new_content = current_output[len(pre_launch_snapshot) :]
             # Claude-specific startup markers that cannot come from the shell:
             # the ──────── separator, bypass/trust prompt text, or "Claude Code"
@@ -315,7 +309,7 @@ class ClaudeCodeProvider(BaseProvider):
             )
             if claude_started:
                 status = self.get_status()
-                if status in {TerminalStatus.IDLE, TerminalStatus.COMPLETED}:
+                if status in {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER}:
                     break
             time.sleep(1.0)
         else:
@@ -325,50 +319,104 @@ class ClaudeCodeProvider(BaseProvider):
         return True
 
     def get_status(self, tail_lines: Optional[int] = None) -> TerminalStatus:
-        """Get Claude Code status by analyzing terminal output.
+        """Get Claude Code status.
 
-        Uses a structural "thinking-before-separator" check as the primary
-        PROCESSING indicator, plus position-based fallbacks for edge cases.
+        Two detection paths:
 
-        Bug history:
-        1. Stale-spinner bug (#104): Old spinner lines persist in the tmux
-           scrollback after the agent returns to idle (Claude Code renders
-           inline, not alt-screen, inside a tmux pane). Position comparison
-           of last spinner vs last idle prompt catches this.
+        1. Native path (herdr backend): get_native_status() returns the full
+           herdr agent state as a TerminalStatus. When non-None, buffer reads are
+           skipped entirely. The only ambiguous case is IDLE -- herdr reports "idle"
+           both before any task has been dispatched and after a task completed when
+           the user focuses the tab (resetting "done" to "idle"). _task_dispatched
+           (set by mark_input_received() on first send_input()) disambiguates:
+           IDLE + _task_dispatched=True -> COMPLETED, otherwise -> IDLE.
 
-        2. Mid-tool-execution race (this issue): The ❯ input prompt is ALWAYS
-           rendered at the bottom of the tmux pane (last position in the
-           scrollback buffer). Position-based comparisons against ❯ are
-           therefore unreliable — last_idle.start() is always greater than
-           any other marker when anything has been typed/executed.
-
-        V3 fix (structural): Check whether any line containing … (U+2026,
-        the ellipsis used in all Claude Code thinking/spinner text) appears
-        immediately before the ──────── separator line. Claude Code draws
-        this separator between the active-execution area and the input prompt.
-        When the agent is thinking/processing:
-        "· Swirling… (thinking)\n\n──────────────────────\n❯ "
-        When idle or completed:
-        "some response text\n──────────────────────\n❯ "
-        A stale old spinner line far back in scrollback will NOT be
-        immediately before the separator, so the structural check is immune
-        to the stale-spinner false-positive.
+        2. Buffer path (tmux backend, or herdr backend error): Reads 500 lines
+           from the pane and runs structural regex analysis. Uses a
+           "thinking-before-separator" check as the primary PROCESSING indicator,
+           plus position-based fallbacks for edge cases.
 
         See: https://github.com/awslabs/cli-agent-orchestrator/issues/104
         """
+        # Native status: herdr knows agent state without pane content parsing.
+        # When the backend returns non-None, trust it and skip buffer reads.
+        # The only ambiguous case is IDLE: herdr "idle" fires both when no task
+        # has been dispatched yet AND when a task completed but the user focused
+        # the tab (resetting "done" -> "idle"). _task_dispatched disambiguates.
+        # Tmux backend always returns None -- falls through to buffer analysis.
+        native = get_backend().get_native_status(self.session_name, self.window_name)
+        logger.debug(
+            "[get_status] terminal=%s native=%s",
+            self.terminal_id,
+            native.value if native is not None else None,
+        )
+        if native is not None:
+            if native == TerminalStatus.PROCESSING:
+                # Reset flush-wait timers — herdr is actively working, so any
+                # previously stamped idle/done timestamp is from a pre-work gap
+                # and must not be counted toward the post-completion flush wait.
+                self._done_first_detected = 0.0
+                self._idle_first_detected = 0.0
+                logger.debug("[get_status] terminal=%s -> PROCESSING (native)", self.terminal_id)
+                return TerminalStatus.PROCESSING
+            if native == TerminalStatus.COMPLETED and self._task_dispatched:
+                # herdr "done": wait 10s from first detection for buffer to flush.
+                if self._done_first_detected == 0.0:
+                    self._done_first_detected = time.time()
+                waited = time.time() - self._done_first_detected
+                if waited >= 10.0:
+                    logger.debug(
+                        "[get_status] terminal=%s -> COMPLETED (native done, %.1fs flush wait elapsed)",
+                        self.terminal_id, waited,
+                    )
+                    return TerminalStatus.COMPLETED
+                logger.debug(
+                    "[get_status] terminal=%s -> PROCESSING (native done, flush wait %.1fs/10s)",
+                    self.terminal_id, waited,
+                )
+                return TerminalStatus.PROCESSING
+            if native == TerminalStatus.IDLE and self._task_dispatched:
+                # herdr "idle" post-dispatch: wait 10s from first detection, then
+                # keep returning PROCESSING until 5 min from dispatch (give up).
+                if self._idle_first_detected == 0.0:
+                    self._idle_first_detected = time.time()
+                waited = time.time() - self._idle_first_detected
+                elapsed = time.time() - self._last_dispatch_time
+                if waited >= 10.0:
+                    if elapsed >= 300.0:
+                        logger.warning(
+                            "[get_status] terminal=%s -> COMPLETED (native idle, %.0fs since dispatch, giving up)",
+                            self.terminal_id, elapsed,
+                        )
+                        return TerminalStatus.COMPLETED
+                    logger.debug(
+                        "[get_status] terminal=%s -> COMPLETED (native idle, %.1fs flush wait elapsed)",
+                        self.terminal_id, waited,
+                    )
+                    return TerminalStatus.COMPLETED
+                logger.debug(
+                    "[get_status] terminal=%s -> PROCESSING (native idle, flush wait %.1fs/10s)",
+                    self.terminal_id, waited,
+                )
+                return TerminalStatus.PROCESSING
+            if native == TerminalStatus.IDLE:
+                logger.debug(
+                    "[get_status] terminal=%s -> IDLE (native idle, no task dispatched)",
+                    self.terminal_id,
+                )
+                return TerminalStatus.IDLE
+            # COMPLETED (no task dispatched), WAITING_USER_ANSWER, ERROR -- return directly
+            logger.debug(
+                "[get_status] terminal=%s -> %s (native)", self.terminal_id, native.value
+            )
+            return native
 
-        output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
 
         if not output:
             return TerminalStatus.ERROR
 
         # PRIMARY PROCESSING check: walk backwards from the *last* separator.
-        # If we encounter a spinner line (spinner char + …) before we encounter
-        # another separator, the agent is actively processing.
-        # If we hit another separator first, the spinner belongs to a previously
-        # completed task — covers two distinct false-positive patterns:
-        # 1. Mid-conversation compaction: "✢ Compacting…" → sep → more output → last sep
-        # 2. Post-exit: live spinner → sep (task done) → ❯ /exit → last sep (exit menu)
         _sep_re = re.compile(r"(?:\x1b\[[0-9;]*m)*\u2500{20,}")
         _sep_positions = [m.start() for m in _sep_re.finditer(output)]
         if _sep_positions:
@@ -377,7 +425,7 @@ class ClaudeCodeProvider(BaseProvider):
                 if re.search(r"[✶✢✽✻✳·][^\n]*\u2026", line):
                     return TerminalStatus.PROCESSING  # spinner before another separator
                 if _sep_re.search(line):
-                    break  # hit another separator first — spinner is from a completed task
+                    break  # hit another separator first -- spinner is from a completed task
 
         # Find the LAST occurrence of each marker for fallback position checks.
         last_processing = None
@@ -393,14 +441,11 @@ class ClaudeCodeProvider(BaseProvider):
             last_response = m
 
         # FALLBACK PROCESSING: spinner visible AND no separator follows it yet
-        # (early in execution before the separator appears). Position comparison
-        # is used here only when no separator is present (safe case).
         if last_processing and not re.search(r"\u2500{20,}", output):
             if last_idle is None or last_processing.start() > last_idle.start():
                 return TerminalStatus.PROCESSING
 
         # Check for waiting user answer via the active Ink selection footer.
-        # Exclude startup prompts (trust + bypass), which also render the footer.
         if (
             re.search(WAITING_USER_ANSWER_PATTERN, output)
             and not re.search(TRUST_PROMPT_PATTERN, output)
@@ -408,7 +453,7 @@ class ClaudeCodeProvider(BaseProvider):
         ):
             return TerminalStatus.WAITING_USER_ANSWER
 
-        # COMPLETED: ⏺ response exists AND ❯ prompt is visible (agent finished).
+        # COMPLETED: response exists AND prompt is visible (agent finished).
         if last_response and last_idle:
             return TerminalStatus.COMPLETED
 
@@ -427,6 +472,18 @@ class ClaudeCodeProvider(BaseProvider):
         """
         return self._initialized
 
+    def mark_input_received(self) -> None:
+        """Record that a task was dispatched to this terminal.
+
+        Called by the terminal service after send_input() delivers a message.
+        Sets _task_dispatched=True so get_status() can distinguish herdr 'idle'
+        after task completion from 'idle' before any task was dispatched.
+        """
+        self._task_dispatched = True
+        self._last_dispatch_time = time.time()
+        self._done_first_detected = 0.0
+        self._idle_first_detected = 0.0
+
     def get_idle_pattern_for_log(self) -> str:
         """Return Claude Code IDLE prompt pattern for log files."""
         return IDLE_PROMPT_PATTERN_LOG
@@ -437,18 +494,18 @@ class ClaudeCodeProvider(BaseProvider):
     _SOL_IDLE_RE = re.compile(r"^\s*(?:\x1b\[[0-9;]*m)*[>❯](?:\x1b\[[0-9;]*m)*[\s\xa0]")
 
     def extract_last_message_from_script(self, script_output: str) -> str:
-        """Extract Claude's final response message using ⏺ indicator."""
+        """Extract Claude's final response message using ⏺/● response marker."""
         # Find all matches of response pattern
         matches = list(re.finditer(RESPONSE_PATTERN, script_output))
 
         if not matches:
-            raise ValueError("No Claude Code response found - no ⏺ pattern detected")
+            raise ValueError("No Claude Code response found - no ⏺/● pattern detected")
 
         # Get the last match (final answer)
         last_match = matches[-1]
         start_pos = last_match.end()
 
-        # Extract everything after the last ⏺ until:
+        # Extract everything after the last ⏺/● until:
         # 1. A start-of-line idle prompt (❯ or >) — the definitive boundary
         # 2. A completion stat line ("✻ Sautéed for 14s") — trims the stat
         # Using start-of-line anchor avoids false stops on ">" inside
@@ -463,13 +520,17 @@ class ClaudeCodeProvider(BaseProvider):
             clean_line = re.sub(ANSI_CODE_PATTERN, "", line).strip()
             if self._SOL_IDLE_RE.match(line):
                 break
-            if "────────" in line:
+            # Match full-width Claude UI separator (20+ U+2500 dashes spanning the line).
+            # Table borders also contain ──── runs but always pair with other box-drawing
+            # chars (corners, intersections U+2501-U+257F). Claude's separator uses only
+            # U+2500 dashes plus optional text — no other box-drawing chars present.
+            if re.search(r"─{20,}", clean_line) and not re.search("[━-╿]", clean_line):
                 break
 
             response_lines.append(clean_line)
 
         if not response_lines or not any(line.strip() for line in response_lines):
-            raise ValueError("Empty Claude Code response - no content found after ⏺")
+            raise ValueError("Empty Claude Code response - no content found after ⏺/●")
 
         # Join lines and clean up
         final_answer = "\n".join(response_lines).strip()

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -6,7 +6,7 @@ import shlex
 import time
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
@@ -266,7 +266,7 @@ class CodexProvider(BaseProvider):
         """
         start_time = time.time()
         while time.time() - start_time < timeout:
-            output = tmux_client.get_history(self.session_name, self.window_name)
+            output = get_backend().get_history(self.session_name, self.window_name)
             if not output:
                 time.sleep(1.0)
                 continue
@@ -276,17 +276,7 @@ class CodexProvider(BaseProvider):
 
             if re.search(TRUST_PROMPT_PATTERN, clean_output):
                 logger.info("Codex workspace trust prompt detected, auto-accepting")
-                session = tmux_client.server.sessions.get(session_name=self.session_name)
-                if session is None:
-                    time.sleep(1.0)
-                    continue
-                window = session.windows.get(window_name=self.window_name)
-                if window is None:
-                    time.sleep(1.0)
-                    continue
-                pane = window.active_pane
-                if pane:
-                    pane.send_keys("", enter=True)
+                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 return
 
             # Check if Codex has fully started (welcome banner visible)
@@ -299,13 +289,13 @@ class CodexProvider(BaseProvider):
 
     def initialize(self) -> bool:
         """Initialize Codex provider by starting codex command."""
-        if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+        if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         # Send a warm-up command before launching codex.
         # Codex exits immediately in freshly-created tmux sessions where the shell
         # has not yet processed a full interactive command cycle.
-        tmux_client.send_keys(self.session_name, self.window_name, "echo ready")
+        get_backend().send_keys(self.session_name, self.window_name, "echo ready")
         time.sleep(2.0)
 
         # Build command with flags and agent profile (developer_instructions).
@@ -314,7 +304,7 @@ class CodexProvider(BaseProvider):
         # --disable shell_snapshot: avoid TTY input conflicts (SIGTTIN) in tmux
         #   caused by the shell_snapshot subprocess inheriting stdin.
         command = self._build_codex_command()
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         # Handle workspace trust prompt if it appears (new/untrusted directories)
         self._handle_trust_prompt(timeout=20.0)
@@ -332,7 +322,7 @@ class CodexProvider(BaseProvider):
 
     def get_status(self, tail_lines: Optional[int] = None) -> TerminalStatus:
         """Get Codex status by analyzing terminal output."""
-        output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -322,7 +322,9 @@ class CodexProvider(BaseProvider):
 
     def get_status(self, tail_lines: Optional[int] = None) -> TerminalStatus:
         """Get Codex status by analyzing terminal output."""
-        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(
+            self.session_name, self.window_name, tail_lines=tail_lines
+        )
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/copilot_cli.py
+++ b/src/cli_agent_orchestrator/providers/copilot_cli.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from libtmux.exc import LibTmuxException
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.utils.terminal import wait_for_shell
@@ -81,7 +81,7 @@ class CopilotCliProvider(BaseProvider):
 
     def _history(self, tail_lines: Optional[int] = None) -> str:
         try:
-            raw = tmux_client.get_history(
+            raw = get_backend().get_history(
                 self.session_name, self.window_name, tail_lines=tail_lines
             )
         except (
@@ -145,7 +145,7 @@ class CopilotCliProvider(BaseProvider):
 
         command_parts.extend(["--config-dir", str(config_dir)])
         try:
-            pane_working_dir = tmux_client.get_pane_working_directory(
+            pane_working_dir = get_backend().get_pane_working_directory(
                 self.session_name,
                 self.window_name,
             )
@@ -199,10 +199,10 @@ class CopilotCliProvider(BaseProvider):
         return json.dumps({"mcpServers": merged_servers}, ensure_ascii=False)
 
     def _send_enter(self) -> None:
-        tmux_client.send_special_key(self.session_name, self.window_name, "Enter")
+        get_backend().send_special_key(self.session_name, self.window_name, "Enter")
 
     def _send_key(self, key: str) -> None:
-        tmux_client.send_special_key(self.session_name, self.window_name, key)
+        get_backend().send_special_key(self.session_name, self.window_name, key)
 
     def _accept_trust_prompts(self, timeout: float = 30.0) -> None:
         start = time.time()
@@ -267,7 +267,7 @@ class CopilotCliProvider(BaseProvider):
     def initialize(self) -> bool:
         try:
             shell_ready = wait_for_shell(
-                tmux_client, self.session_name, self.window_name, timeout=30.0
+                get_backend(), self.session_name, self.window_name, timeout=30.0
             )
         except Exception as exc:
             logger.warning(
@@ -281,7 +281,7 @@ class CopilotCliProvider(BaseProvider):
         if not shell_ready:
             raise TimeoutError("Shell initialization timed out after 30 seconds")
 
-        tmux_client.send_keys(self.session_name, self.window_name, self._command())
+        get_backend().send_keys(self.session_name, self.window_name, self._command())
 
         deadline = time.time() + 60.0
         self._accept_trust_prompts(timeout=10.0)

--- a/src/cli_agent_orchestrator/providers/gemini_cli.py
+++ b/src/cli_agent_orchestrator/providers/gemini_cli.py
@@ -37,7 +37,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import GEMINI_WORKSPACES_DIR
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
@@ -475,7 +475,7 @@ class GeminiCliProvider(BaseProvider):
             TimeoutError: If shell or Gemini CLI doesn't start within timeout
         """
         # Wait for shell prompt to appear in the tmux window
-        if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+        if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         # Send a warm-up command before launching Gemini.
@@ -486,11 +486,11 @@ class GeminiCliProvider(BaseProvider):
         # An echo round-trip with output verification ensures the shell has
         # fully processed its init before we launch gemini.
         warmup_marker = "CAO_SHELL_READY"
-        tmux_client.send_keys(self.session_name, self.window_name, f"echo {warmup_marker}")
+        get_backend().send_keys(self.session_name, self.window_name, f"echo {warmup_marker}")
         warmup_start = time.time()
         warmup_timeout = 15.0
         while time.time() - warmup_start < warmup_timeout:
-            output = tmux_client.get_history(self.session_name, self.window_name)
+            output = get_backend().get_history(self.session_name, self.window_name)
             if output and warmup_marker in output:
                 break
             time.sleep(0.5)
@@ -508,7 +508,7 @@ class GeminiCliProvider(BaseProvider):
         command = self._build_gemini_command()
 
         # Send Gemini command to the tmux window
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         # Wait for Gemini CLI to finish initialization.
         # Gemini takes 10-15+ seconds to load due to Node.js/Ink startup.
@@ -539,7 +539,7 @@ class GeminiCliProvider(BaseProvider):
             time.sleep(1.0)
         else:
             # Capture diagnostic info for debugging initialization failures.
-            diag_output = tmux_client.get_history(self.session_name, self.window_name)
+            diag_output = get_backend().get_history(self.session_name, self.window_name)
             diag_last_50 = "\n".join((diag_output or "").splitlines()[-50:])
             logger.error(
                 f"Gemini CLI init timeout diagnostic — terminal {self.terminal_id}, "
@@ -581,7 +581,7 @@ class GeminiCliProvider(BaseProvider):
         Returns:
             TerminalStatus indicating current state
         """
-        output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/gemini_cli.py
+++ b/src/cli_agent_orchestrator/providers/gemini_cli.py
@@ -581,7 +581,9 @@ class GeminiCliProvider(BaseProvider):
         Returns:
             TerminalStatus indicating current state
         """
-        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(
+            self.session_name, self.window_name, tail_lines=tail_lines
+        )
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -386,7 +386,9 @@ class KimiCliProvider(BaseProvider):
         Returns:
             TerminalStatus indicating current state
         """
-        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(
+            self.session_name, self.window_name, tail_lines=tail_lines
+        )
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -35,7 +35,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
@@ -334,14 +334,14 @@ class KimiCliProvider(BaseProvider):
             TimeoutError: If shell or Kimi CLI doesn't start within timeout
         """
         # Wait for shell prompt to appear in the tmux window
-        if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+        if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         # Build properly escaped command string
         command = self._build_kimi_command()
 
         # Send Kimi command to the tmux window
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         # Wait for Kimi CLI to reach IDLE or COMPLETED state (prompt visible).
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
@@ -386,7 +386,7 @@ class KimiCliProvider(BaseProvider):
         Returns:
             TerminalStatus indicating current state
         """
-        output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -295,7 +295,9 @@ class KiroCliProvider(BaseProvider):
             Current TerminalStatus enum value
         """
         logger.debug(f"get_status: tail_lines={tail_lines}")
-        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(
+            self.session_name, self.window_name, tail_lines=tail_lines
+        )
 
         # No output indicates a terminal error
         if not output:

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -22,7 +22,7 @@ import re
 import shlex
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
@@ -208,11 +208,11 @@ class KiroCliProvider(BaseProvider):
         """
         # Step 1: Wait for shell prompt to appear in the tmux window
         # This ensures the terminal is ready before we send commands
-        if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+        if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         # Capture the shell process name before launching kiro — used later to detect kiro exit
-        self.shell_baseline = tmux_client.get_pane_current_command(
+        self.shell_baseline = get_backend().get_pane_current_command(
             self.session_name, self.window_name
         )
 
@@ -245,7 +245,7 @@ class KiroCliProvider(BaseProvider):
             base_args.extend(["--model", model])
         base_args.extend(["--agent", self._agent_profile])
         command = shlex.join(base_args)
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         # Step 3: Wait for Kiro CLI to fully initialize and show the agent prompt.
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
@@ -259,15 +259,15 @@ class KiroCliProvider(BaseProvider):
             # Non-yolo TUI mode failed — fall back to --legacy-ui
             logger.warning("Kiro CLI TUI initialization timed out, retrying with --legacy-ui")
             # Exit the current session and start fresh with --legacy-ui
-            tmux_client.send_keys(self.session_name, self.window_name, "/exit")
-            if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+            get_backend().send_keys(self.session_name, self.window_name, "/exit")
+            if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
                 raise TimeoutError("Shell recovery timed out after --legacy-ui fallback")
             legacy_args = ["kiro-cli", "chat", "--legacy-ui"]
             if model:
                 legacy_args.extend(["--model", model])
             legacy_args.extend(["--agent", self._agent_profile])
             legacy_command = shlex.join(legacy_args)
-            tmux_client.send_keys(self.session_name, self.window_name, legacy_command)
+            get_backend().send_keys(self.session_name, self.window_name, legacy_command)
             if not wait_until_status(
                 self, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=30.0
             ):
@@ -289,13 +289,13 @@ class KiroCliProvider(BaseProvider):
 
         Args:
             tail_lines: Number of lines to capture from terminal history.
-                        If None, uses default from tmux_client.
+                        If None, uses default from get_backend().
 
         Returns:
             Current TerminalStatus enum value
         """
         logger.debug(f"get_status: tail_lines={tail_lines}")
-        output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
 
         # No output indicates a terminal error
         if not output:
@@ -347,7 +347,7 @@ class KiroCliProvider(BaseProvider):
         # by Kiro's boot screen and silently dropped.
         if not has_idle_prompt and not has_new_tui_idle:
             if self._initialized and self.shell_baseline:
-                current_cmd = tmux_client.get_pane_current_command(
+                current_cmd = get_backend().get_pane_current_command(
                     self.session_name, self.window_name
                 )
                 if current_cmd == self.shell_baseline:

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -22,7 +22,7 @@ import re
 import shlex
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
@@ -137,11 +137,11 @@ class OpenCodeCliProvider(BaseProvider):
         Raises:
             TimeoutError: If shell or OpenCode doesn't reach IDLE/COMPLETED in time.
         """
-        if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+        if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         command = self._build_launch_command()
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         # 120s covers first-run npm install (5–30s) and concurrent multi-agent launches.
         if not wait_until_status(
@@ -186,12 +186,12 @@ class OpenCodeCliProvider(BaseProvider):
         5. ERROR — fallback
 
         Args:
-            tail_lines: Lines to capture; None uses the tmux_client default.
+            tail_lines: Lines to capture; None uses the backend default.
 
         Returns:
             Current TerminalStatus.
         """
-        output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
         if not output:
             return TerminalStatus.ERROR
 

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -191,7 +191,9 @@ class OpenCodeCliProvider(BaseProvider):
         Returns:
             Current TerminalStatus.
         """
-        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(
+            self.session_name, self.window_name, tail_lines=tail_lines
+        )
         if not output:
             return TerminalStatus.ERROR
 

--- a/src/cli_agent_orchestrator/providers/q_cli.py
+++ b/src/cli_agent_orchestrator/providers/q_cli.py
@@ -68,7 +68,9 @@ class QCliProvider(BaseProvider):
     def get_status(self, tail_lines: Optional[int] = None) -> TerminalStatus:
         """Get Q CLI status by analyzing terminal output."""
         logger.debug(f"get_status: tail_lines={tail_lines}")
-        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(
+            self.session_name, self.window_name, tail_lines=tail_lines
+        )
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/providers/q_cli.py
+++ b/src/cli_agent_orchestrator/providers/q_cli.py
@@ -5,7 +5,7 @@ import re
 import shlex
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
@@ -51,11 +51,11 @@ class QCliProvider(BaseProvider):
     def initialize(self) -> bool:
         """Initialize Q CLI provider by starting q chat command."""
         # Wait for shell to be ready first
-        if not wait_for_shell(tmux_client, self.session_name, self.window_name, timeout=10.0):
+        if not wait_for_shell(get_backend(), self.session_name, self.window_name, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
         command = shlex.join(["q", "chat", "--agent", self._agent_profile])
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         if not wait_until_status(
             self, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=30.0
@@ -68,7 +68,7 @@ class QCliProvider(BaseProvider):
     def get_status(self, tail_lines: Optional[int] = None) -> TerminalStatus:
         """Get Q CLI status by analyzing terminal output."""
         logger.debug(f"get_status: tail_lines={tail_lines}")
-        output = tmux_client.get_history(self.session_name, self.window_name, tail_lines=tail_lines)
+        output = get_backend().get_history(self.session_name, self.window_name, tail_lines=tail_lines)
 
         if not output:
             return TerminalStatus.ERROR

--- a/src/cli_agent_orchestrator/services/flow_service.py
+++ b/src/cli_agent_orchestrator/services/flow_service.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Tuple, cast
 import frontmatter  # type: ignore
 from apscheduler.triggers.cron import CronTrigger  # type: ignore
 
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import create_flow as db_create_flow
 from cli_agent_orchestrator.clients.database import delete_flow as db_delete_flow
 from cli_agent_orchestrator.clients.database import (
@@ -26,7 +27,6 @@ from cli_agent_orchestrator.clients.database import update_flow_enabled as db_up
 from cli_agent_orchestrator.clients.database import (
     update_flow_run_times as db_update_flow_run_times,
 )
-from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import DEFAULT_PROVIDER, PROVIDERS
 from cli_agent_orchestrator.models.flow import Flow
 from cli_agent_orchestrator.models.terminal import TerminalStatus

--- a/src/cli_agent_orchestrator/services/flow_service.py
+++ b/src/cli_agent_orchestrator/services/flow_service.py
@@ -26,7 +26,7 @@ from cli_agent_orchestrator.clients.database import update_flow_enabled as db_up
 from cli_agent_orchestrator.clients.database import (
     update_flow_run_times as db_update_flow_run_times,
 )
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import DEFAULT_PROVIDER, PROVIDERS
 from cli_agent_orchestrator.models.flow import Flow
 from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -233,7 +233,7 @@ def execute_flow(name: str) -> bool:
 
         # Launch session
         session_name = f"cao-flow-{flow.name}"
-        if tmux_client.session_exists(session_name):
+        if get_backend().session_exists(session_name):
             terminals = list_terminals_by_session(session_name)
             # Only check the first (conductor) terminal for busy status.
             # Worker terminals spawned by the conductor may have stale status
@@ -244,7 +244,7 @@ def execute_flow(name: str) -> bool:
                 return False
             for t in terminals:
                 provider_manager.cleanup_provider(t["id"])
-            tmux_client.kill_session(session_name)
+            get_backend().kill_session(session_name)
             delete_terminals_by_session(session_name)
         terminal = create_terminal(
             session_name=session_name,

--- a/src/cli_agent_orchestrator/services/herdr_inbox_registry.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_registry.py
@@ -1,0 +1,33 @@
+"""HerdrInboxService registry — module-level service singleton management.
+
+This module provides get_herdr_inbox_service() and set_herdr_inbox_service() as the
+central access point for the configured HerdrInboxService. It uses a TYPE_CHECKING
+guard for the HerdrInboxService import so it has no runtime dependency on the service
+module, breaking the circular import chain.
+
+Unlike backends/registry.py, there is no lazy initialization: get_herdr_inbox_service()
+returns None until set_herdr_inbox_service() is called at application startup.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from cli_agent_orchestrator.services.herdr_inbox_service import HerdrInboxService
+
+# Module-level service instance. Set at application startup via set_herdr_inbox_service().
+_herdr_inbox_service: Optional["HerdrInboxService"] = None
+
+
+def get_herdr_inbox_service() -> Optional["HerdrInboxService"]:
+    """Return the configured HerdrInboxService, or None if not yet set."""
+    return _herdr_inbox_service
+
+
+def set_herdr_inbox_service(service: Optional["HerdrInboxService"]) -> None:
+    """Set the HerdrInboxService, or clear it by passing None.
+
+    Called with a service instance at application startup and with None during
+    shutdown so the module-level singleton does not outlive the running service.
+    """
+    global _herdr_inbox_service
+    _herdr_inbox_service = service

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -133,11 +133,91 @@ class HerdrInboxService:
     async def start(self) -> None:
         """Start the event loop: wait for first terminal, then connect and listen."""
         self._loop = asyncio.get_running_loop()
+        # Run DB cleanup before starting the socket loop so ghost records from
+        # prior server runs are removed even when no terminals are registered yet.
+        await self._startup_db_cleanup()
         kiro_task = asyncio.ensure_future(self._kiro_supplement_loop())
         try:
             await self._socket_loop()
         finally:
             kiro_task.cancel()
+
+    async def _startup_db_cleanup(self) -> None:
+        """Delete ghost DB terminals whose herdr tabs no longer exist.
+
+        Runs once at server startup before any pane registrations.  Cannot
+        rely on _pane_to_terminal (empty at startup) or _workspace_to_session
+        (populated later by _reconcile).  Builds the workspace map directly
+        from herdr workspace list.
+        """
+        from cli_agent_orchestrator.clients.database import (
+            delete_terminal,
+            list_terminals_by_session,
+        )
+
+        ws_result = subprocess.run(
+            ["herdr", "--session", self._herdr_session, "workspace", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if ws_result.returncode != 0:
+            logger.debug("Startup DB cleanup: herdr workspace list failed, skipping")
+            return
+
+        try:
+            ws_data = json.loads(ws_result.stdout)
+            workspaces = ws_data.get("result", {}).get("workspaces", [])
+            workspace_to_session = {
+                ws["workspace_id"]: ws["label"] for ws in workspaces
+            }
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.warning(f"Startup DB cleanup: failed to parse workspace list: {e}")
+            return
+
+        tab_result = subprocess.run(
+            ["herdr", "--session", self._herdr_session, "tab", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if tab_result.returncode != 0:
+            logger.debug("Startup DB cleanup: herdr tab list failed, skipping")
+            return
+
+        try:
+            tab_data = json.loads(tab_result.stdout)
+            tabs = tab_data.get("result", {}).get("tabs", [])
+            live_tabs_by_workspace: Dict[str, set] = {}
+            for tab in tabs:
+                ws_id = tab.get("workspace_id", "")
+                label = tab.get("label", "")
+                if ws_id and label:
+                    live_tabs_by_workspace.setdefault(ws_id, set()).add(label)
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.warning(f"Startup DB cleanup: failed to parse tab list: {e}")
+            return
+
+        deleted = 0
+        for ws_id, session_name in workspace_to_session.items():
+            live_labels = live_tabs_by_workspace.get(ws_id, set())
+            db_terminals = list_terminals_by_session(session_name)
+            for term in db_terminals:
+                window = term.get("tmux_window", "")
+                if window and window not in live_labels:
+                    logger.info(
+                        f"Startup DB cleanup: deleting ghost terminal {term['id']} "
+                        f"({session_name}:{window}) — tab not in herdr"
+                    )
+                    try:
+                        delete_terminal(term["id"])
+                        deleted += 1
+                    except Exception as e:
+                        logger.warning(
+                            f"Startup DB cleanup: failed to delete ghost terminal "
+                            f"{term['id']}: {e}"
+                        )
+
+        if deleted:
+            logger.info(f"Startup DB cleanup: removed {deleted} ghost terminal(s)")
+        else:
+            logger.debug("Startup DB cleanup: no ghost terminals found")
 
     async def _kiro_supplement_loop(self) -> None:
         """Periodically check kiro terminals stuck in working state."""

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -111,11 +111,20 @@ class HerdrInboxService:
 
         logger.info(f"Registered terminal {terminal_id} (pane={pane_id}, kiro={is_kiro})")
 
-        # Subscribe to events if connected and event loop is captured.
-        # register_terminal() may be called from a synchronous/non-event-loop thread,
-        # so we use run_coroutine_threadsafe instead of create_task.
+        # Start streaming events for the new pane by forcing a reconnect.
+        #
+        # herdr (0.6.8) resets the entire connection when it receives a SECOND
+        # events.subscribe on a connection that already has an active
+        # subscription, and it exposes no incremental "add subscription" API.
+        # So we cannot subscribe the new pane on the live connection — instead we
+        # close the socket, and _socket_loop reconnects and rebuilds the single
+        # combined subscription (all panes + lifecycle) in one call.
+        #
+        # register_terminal() may be called from a synchronous/non-event-loop
+        # thread, so we schedule the reconnect onto the captured loop via
+        # run_coroutine_threadsafe instead of create_task.
         if self._connected and self._loop is not None:
-            asyncio.run_coroutine_threadsafe(self._subscribe_pane(pane_id), self._loop)
+            asyncio.run_coroutine_threadsafe(self._force_reconnect(), self._loop)
 
     def unregister_terminal(self, terminal_id: str) -> None:
         """Remove a terminal from managed set.
@@ -249,11 +258,11 @@ class HerdrInboxService:
                 # Reconcile map against live herdr state before subscribing
                 await self._reconcile()
 
-                # Re-subscribe all managed panes (now only valid ones)
-                await self._resubscribe_all()
-
-                # Subscribe to lifecycle events for real-time cleanup
-                await self._subscribe_lifecycle_events()
+                # Subscribe to everything in ONE events.subscribe call: every
+                # managed pane's agent-status plus the lifecycle events. herdr
+                # resets the connection on a second events.subscribe, so this
+                # must be a single combined call.
+                await self._subscribe_all_events()
 
                 self._backoff = _BACKOFF_BASE  # Reset backoff after successful setup
 
@@ -410,61 +419,60 @@ class HerdrInboxService:
 
         logger.info(f"Reconcile: pruned {len(stale_pane_ids)} stale panes")
 
-    async def _subscribe_lifecycle_events(self) -> None:
-        """Subscribe to pane.closed and workspace.closed for real-time cleanup."""
-        message = {
-            "id": "sub_lifecycle",
-            "method": "events.subscribe",
-            "params": {
-                "subscriptions": [
-                    {"type": "pane.closed"},
-                    {"type": "workspace.closed"},
-                ]
-            },
-        }
-        await self._send(message)
-        logger.info("Subscribed to pane.closed and workspace.closed events")
-
     async def _connect(self) -> None:
         """Connect to the herdr socket."""
         self._reader, self._writer = await asyncio.open_unix_connection(self._socket_path)
         logger.info(f"Connected to herdr socket: {self._socket_path}")
 
-    async def _subscribe_pane(self, pane_id: str) -> None:
-        """Subscribe to agent_status_changed events for a pane.
+    async def _subscribe_all_events(self) -> None:
+        """Subscribe to all events in a SINGLE events.subscribe call.
 
-        Herdr requires per-pane subscription (wildcard not supported).
-        The correct format uses 'subscriptions' array with 'type' + 'pane_id'.
+        herdr (0.6.8) resets the entire connection when it receives a second
+        events.subscribe on a connection that already has an active
+        subscription. So every subscription this service needs — one
+        pane.agent_status_changed per managed pane (pane_id is required; herdr
+        rejects the wildcard form with invalid_request) plus the pane.closed and
+        workspace.closed lifecycle events — must be sent together in one call.
+
+        The pane_id → terminal_id mapping in _pane_to_terminal is already current:
+        a socket disconnect does not change pane_ids (only a herdr server restart
+        compacts them), and _reconcile() has already pruned stale panes before
+        this runs.
         """
+        subscriptions: list = [
+            {"type": "pane.agent_status_changed", "pane_id": pane_id}
+            for pane_id in self._pane_to_terminal
+        ]
+        subscriptions.append({"type": "pane.closed"})
+        subscriptions.append({"type": "workspace.closed"})
+
         message = {
-            "id": f"sub_{pane_id}",
+            "id": "sub_all",
             "method": "events.subscribe",
-            "params": {
-                "subscriptions": [
-                    {
-                        "type": "pane.agent_status_changed",
-                        "pane_id": pane_id,
-                    }
-                ]
-            },
+            "params": {"subscriptions": subscriptions},
         }
         await self._send(message)
+        logger.info(
+            f"Subscribed to {len(self._pane_to_terminal)} pane(s) + lifecycle events "
+            f"in one events.subscribe call"
+        )
 
-    async def _resubscribe_all(self) -> None:
-        """Re-subscribe all managed panes after socket reconnect.
+    async def _force_reconnect(self) -> None:
+        """Close the socket so _socket_loop reconnects and rebuilds the subscription.
 
-        The pane_id → terminal_id mapping in _pane_to_terminal is already current —
-        a socket disconnect does not change pane_ids (only a herdr server restart
-        compacts them). Re-subscribing with existing pane_ids is safe and correct.
-
-        Note: _terminal_to_pane keys are CAO UUIDs, not herdr-internal terminal_ids,
-        so we cannot match them against herdr pane list output. Use the existing
-        _pane_to_terminal mapping directly.
+        This is how a newly registered pane starts streaming events: herdr has no
+        incremental subscribe, and a second events.subscribe on the live
+        connection would reset it. Closing the writer makes the blocked
+        readline() in _event_loop return EOF, which raises ConnectionError and
+        drives _socket_loop through a fresh connect + combined re-subscribe.
         """
-        for pane_id in list(self._pane_to_terminal.keys()):
-            await self._subscribe_pane(pane_id)
-
-        logger.info(f"Re-subscribed {len(self._pane_to_terminal)} panes after reconnect")
+        writer = self._writer
+        if writer is None:
+            return
+        try:
+            writer.close()
+        except Exception as e:
+            logger.debug(f"Force reconnect: writer close raised (ignored): {e}")
 
     async def _event_loop(self) -> None:
         """Listen for events and dispatch delivery."""

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -231,6 +231,50 @@ class HerdrInboxService:
             except (json.JSONDecodeError, KeyError):
                 pass
 
+        # DB cross-check: find terminals in DB whose tab no longer exists in herdr.
+        # This catches ghost records from previous server runs where _pane_to_terminal
+        # starts empty (so the stale-pane diff below produces nothing).
+        tab_result = subprocess.run(
+            ["herdr", "--session", self._herdr_session, "tab", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if tab_result.returncode == 0:
+            try:
+                tab_data = json.loads(tab_result.stdout)
+                tabs = tab_data.get("result", {}).get("tabs", [])
+                # Build: workspace_id -> set of live tab labels
+                live_tabs_by_workspace: Dict[str, set] = {}
+                for tab in tabs:
+                    ws_id = tab.get("workspace_id", "")
+                    label = tab.get("label", "")
+                    if ws_id and label:
+                        live_tabs_by_workspace.setdefault(ws_id, set()).add(label)
+
+                from cli_agent_orchestrator.clients.database import (
+                    delete_terminal,
+                    list_terminals_by_session,
+                )
+
+                for ws_id, session_name in self._workspace_to_session.items():
+                    live_labels = live_tabs_by_workspace.get(ws_id, set())
+                    db_terminals = list_terminals_by_session(session_name)
+                    for term in db_terminals:
+                        window = term.get("tmux_window", "")
+                        if window and window not in live_labels:
+                            logger.info(
+                                f"Reconcile: deleting ghost terminal {term['id']} "
+                                f"({session_name}:{window}) — tab not in herdr"
+                            )
+                            try:
+                                delete_terminal(term["id"])
+                            except Exception as e:
+                                logger.warning(
+                                    f"Reconcile: failed to delete ghost terminal "
+                                    f"{term['id']}: {e}"
+                                )
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning(f"Reconcile: failed to parse tab list: {e}")
+
         # Find and prune stale panes
         stale_pane_ids = set(self._pane_to_terminal.keys()) - live_pane_ids
         if not stale_pane_ids:

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -582,11 +582,15 @@ class HerdrInboxService:
                     f"workspace.closed: failed to delete terminals for {session_name}: {e}"
                 )
 
-            # Prune maps — pane_ids from this workspace start with workspace_id prefix
+            # Prune maps for terminals belonging to this session. Match on each
+            # terminal's DB session rather than a pane_id/workspace_id string
+            # prefix: herdr renumbers compact pane_ids and does not guarantee
+            # they begin with the workspace_id, so a prefix test is unreliable.
+            # This mirrors the session match used in the pane.closed handler.
             to_remove = [
                 (pid, tid)
                 for pid, tid in self._pane_to_terminal.items()
-                if pid.startswith(workspace_id)
+                if (m := get_terminal_metadata(tid)) and m.get("tmux_session") == session_name
             ]
             for pid, tid in to_remove:
                 self._pane_to_terminal.pop(pid, None)

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -1,0 +1,313 @@
+"""HerdrInboxService — socket event-based inbox delivery for herdr backend.
+
+Replaces the pipe-pane + file watchdog approach with herdr's native socket API.
+Subscribes to pane.agent_status_changed events and delivers pending inbox
+messages when a pane transitions to idle or done.
+
+Design:
+- Maintains a pane_id → terminal_id map for managed panes
+- Subscribes per-pane (wildcard support is unverified; see design.md)
+- Reconnects with exponential backoff on socket disconnect
+- Supplements with periodic pane read for kiro-cli (working >30s check)
+"""
+
+import asyncio
+import json
+import logging
+import re
+import time
+from typing import Callable, Dict, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# Exponential backoff parameters
+_BACKOFF_BASE = 1.0  # seconds
+_BACKOFF_MAX = 30.0  # seconds
+_BACKOFF_MULTIPLIER = 2.0
+
+# Kiro supplement check: how long in "working" before we check pane read
+_KIRO_WORKING_THRESHOLD = 30.0  # seconds
+
+
+class HerdrInboxService:
+    """Event-driven inbox delivery service using herdr socket API.
+
+    Subscribes to agent status events for managed panes and delivers
+    pending messages when agents become idle/done.
+    """
+
+    def __init__(
+        self,
+        socket_path: Optional[str] = None,
+        delivery_callback: Optional[Callable[[str], None]] = None,
+        herdr_session: str = "cao",
+    ) -> None:
+        """Initialize the inbox service.
+
+        Args:
+            socket_path: Path to herdr socket. None = auto-detect from env.
+            delivery_callback: Function to call for message delivery.
+                Signature: callback(terminal_id) → checks and delivers pending messages.
+            herdr_session: Name of the herdr session to connect to. Used to
+                derive the default socket path and prefix CLI calls.
+        """
+        self._herdr_session = herdr_session
+        self._socket_path = socket_path or self._default_socket_path(herdr_session)
+        self._delivery_callback = delivery_callback
+
+        # Managed pane tracking
+        self._pane_to_terminal: Dict[str, str] = {}  # pane_id → terminal_id
+        self._terminal_to_pane: Dict[str, str] = {}  # terminal_id → pane_id
+
+        # Kiro-specific tracking for supplement check
+        self._kiro_terminals: Set[str] = set()  # terminal_ids using kiro-cli
+        self._working_since: Dict[str, float] = {}  # terminal_id → timestamp
+
+        # Connection state
+        self._connected = False
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._backoff = _BACKOFF_BASE
+
+    @staticmethod
+    def _default_socket_path(session_name: str = "cao") -> str:
+        """Determine default herdr socket path for a named session.
+
+        The default session (name ``"default"``) uses a flat path:
+        ``~/.config/herdr/herdr.sock``.
+
+        Named sessions use a sessions subdirectory:
+        ``~/.config/herdr/sessions/<session_name>/herdr.sock``.
+
+        Args:
+            session_name: Herdr session name. Defaults to ``"cao"``.
+        """
+        import os
+        from pathlib import Path
+
+        # Check XDG_CONFIG_HOME first, fallback to ~/.config
+        config_home = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+        if session_name == "default":
+            return f"{config_home}/herdr/herdr.sock"
+        return f"{config_home}/herdr/sessions/{session_name}/herdr.sock"
+
+    def register_terminal(self, terminal_id: str, pane_id: str, is_kiro: bool = False) -> None:
+        """Register a terminal for event-based inbox delivery.
+
+        Args:
+            terminal_id: CAO terminal identifier
+            pane_id: Current herdr compact pane_id
+            is_kiro: Whether this terminal runs kiro-cli (enables supplement check)
+        """
+        self._pane_to_terminal[pane_id] = terminal_id
+        self._terminal_to_pane[terminal_id] = pane_id
+        if is_kiro:
+            self._kiro_terminals.add(terminal_id)
+
+        logger.info(f"Registered terminal {terminal_id} (pane={pane_id}, kiro={is_kiro})")
+
+        # Subscribe to events if connected and an event loop is running.
+        # register_terminal() is called from the synchronous create_terminal path,
+        # so we must guard against no running event loop.
+        if self._connected:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._subscribe_pane(pane_id))
+            except RuntimeError:
+                # No running event loop — subscription will happen on next reconnect
+                # via _resubscribe_all()
+                pass
+
+    def unregister_terminal(self, terminal_id: str) -> None:
+        """Remove a terminal from managed set.
+
+        Args:
+            terminal_id: Terminal to unregister
+        """
+        pane_id = self._terminal_to_pane.pop(terminal_id, None)
+        if pane_id:
+            self._pane_to_terminal.pop(pane_id, None)
+        self._kiro_terminals.discard(terminal_id)
+        self._working_since.pop(terminal_id, None)
+        logger.info(f"Unregistered terminal {terminal_id}")
+
+    async def start(self) -> None:
+        """Start the event loop: wait for first terminal, then connect and listen."""
+        kiro_task = asyncio.ensure_future(self._kiro_supplement_loop())
+        try:
+            await self._socket_loop()
+        finally:
+            kiro_task.cancel()
+
+    async def _kiro_supplement_loop(self) -> None:
+        """Periodically check kiro terminals stuck in working state."""
+        while True:
+            await asyncio.sleep(10.0)
+            try:
+                await self.check_kiro_supplements()
+            except Exception:
+                logger.debug("Kiro supplement check error", exc_info=True)
+
+    async def _socket_loop(self) -> None:
+        """Connect to herdr socket and listen for events with reconnect.
+
+        Defers connection until at least one terminal is registered. This avoids
+        the disconnect/reconnect churn caused by herdr closing idle connections
+        that have no active subscriptions.
+        """
+        while True:
+            # Wait until there is at least one pane to subscribe to
+            while not self._pane_to_terminal:
+                await asyncio.sleep(0.5)
+
+            try:
+                await self._connect()
+                self._connected = True
+                self._backoff = _BACKOFF_BASE  # Reset backoff on success
+
+                # Re-subscribe all managed panes
+                await self._resubscribe_all()
+
+                # Listen for events
+                await self._event_loop()
+
+            except (ConnectionError, OSError, asyncio.IncompleteReadError) as e:
+                logger.warning(f"Herdr socket disconnected: {e}")
+                self._connected = False
+
+                # Exponential backoff
+                logger.info(f"Reconnecting in {self._backoff}s...")
+                await asyncio.sleep(self._backoff)
+                self._backoff = min(self._backoff * _BACKOFF_MULTIPLIER, _BACKOFF_MAX)
+
+    async def _connect(self) -> None:
+        """Connect to the herdr socket."""
+        self._reader, self._writer = await asyncio.open_unix_connection(self._socket_path)
+        logger.info(f"Connected to herdr socket: {self._socket_path}")
+
+    async def _subscribe_pane(self, pane_id: str) -> None:
+        """Subscribe to agent_status_changed events for a pane.
+
+        Herdr requires per-pane subscription (wildcard not supported).
+        The correct format uses 'subscriptions' array with 'type' + 'pane_id'.
+        """
+        message = {
+            "id": f"sub_{pane_id}",
+            "method": "events.subscribe",
+            "params": {
+                "subscriptions": [
+                    {
+                        "type": "pane.agent_status_changed",
+                        "pane_id": pane_id,
+                    }
+                ]
+            },
+        }
+        await self._send(message)
+
+    async def _resubscribe_all(self) -> None:
+        """Re-subscribe all managed panes after socket reconnect.
+
+        The pane_id → terminal_id mapping in _pane_to_terminal is already current —
+        a socket disconnect does not change pane_ids (only a herdr server restart
+        compacts them). Re-subscribing with existing pane_ids is safe and correct.
+
+        Note: _terminal_to_pane keys are CAO UUIDs, not herdr-internal terminal_ids,
+        so we cannot match them against herdr pane list output. Use the existing
+        _pane_to_terminal mapping directly.
+        """
+        for pane_id in list(self._pane_to_terminal.keys()):
+            await self._subscribe_pane(pane_id)
+
+        logger.info(f"Re-subscribed {len(self._pane_to_terminal)} panes after reconnect")
+
+    async def _event_loop(self) -> None:
+        """Listen for events and dispatch delivery."""
+        assert self._reader is not None
+        while True:
+            line = await self._reader.readline()
+            if not line:
+                raise ConnectionError("Socket closed")
+
+            try:
+                event = json.loads(line.decode())
+            except json.JSONDecodeError:
+                continue
+
+            data = event.get("data", {})
+            pane_id = data.get("pane_id", "")
+            status = data.get("agent_status", "")
+
+            # Only process events for managed panes
+            terminal_id = self._pane_to_terminal.get(pane_id)
+            if not terminal_id:
+                continue
+
+            if status in ("idle", "done"):
+                # Clear working timestamp
+                self._working_since.pop(terminal_id, None)
+                # Trigger delivery
+                self._deliver(terminal_id)
+
+            elif status == "working":
+                # Track working start for kiro supplement check
+                if terminal_id in self._kiro_terminals:
+                    if terminal_id not in self._working_since:
+                        self._working_since[terminal_id] = time.time()
+
+    def _deliver(self, terminal_id: str) -> None:
+        """Check and deliver pending messages for a terminal."""
+        if self._delivery_callback:
+            try:
+                self._delivery_callback(terminal_id)
+            except Exception as e:
+                logger.error(f"Delivery failed for terminal {terminal_id}: {e}")
+
+    async def check_kiro_supplements(self) -> None:
+        """Periodic check for kiro-cli terminals stuck in 'working' state.
+
+        For terminals in 'working' for >30s, read pane content and check
+        for permission prompt patterns.
+        """
+        import subprocess
+
+        now = time.time()
+        for terminal_id in list(self._working_since.keys()):
+            if terminal_id not in self._kiro_terminals:
+                continue
+
+            working_duration = now - self._working_since[terminal_id]
+            if working_duration < _KIRO_WORKING_THRESHOLD:
+                continue
+
+            # Read pane and check for permission prompt
+            pane_id = self._terminal_to_pane.get(terminal_id)
+            if not pane_id:
+                continue
+
+            result = subprocess.run(
+                ["herdr", "--session", self._herdr_session, "pane", "read", pane_id],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode != 0:
+                continue
+
+            # Check for kiro permission prompt pattern
+            # (WAITING_USER_ANSWER indicator)
+            from cli_agent_orchestrator.providers.kiro_cli import TUI_PERMISSION_PATTERN
+
+            if re.search(TUI_PERMISSION_PATTERN, result.stdout):
+                logger.info(
+                    f"Kiro permission prompt detected for {terminal_id} "
+                    f"(working for {working_duration:.0f}s)"
+                )
+                self._deliver(terminal_id)
+                # Reset the timer so we don't spam
+                self._working_since[terminal_id] = now
+
+    async def _send(self, message: dict) -> None:
+        """Send a JSON message to the herdr socket."""
+        assert self._writer is not None
+        data = json.dumps(message).encode() + b"\n"
+        self._writer.write(data)
+        await self._writer.drain()

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -68,6 +68,7 @@ class HerdrInboxService:
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
         self._backoff = _BACKOFF_BASE
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
     @staticmethod
     def _default_socket_path(session_name: str = "cao") -> str:
@@ -106,17 +107,11 @@ class HerdrInboxService:
 
         logger.info(f"Registered terminal {terminal_id} (pane={pane_id}, kiro={is_kiro})")
 
-        # Subscribe to events if connected and an event loop is running.
-        # register_terminal() is called from the synchronous create_terminal path,
-        # so we must guard against no running event loop.
-        if self._connected:
-            try:
-                loop = asyncio.get_running_loop()
-                loop.create_task(self._subscribe_pane(pane_id))
-            except RuntimeError:
-                # No running event loop — subscription will happen on next reconnect
-                # via _resubscribe_all()
-                pass
+        # Subscribe to events if connected and event loop is captured.
+        # register_terminal() may be called from a synchronous/non-event-loop thread,
+        # so we use run_coroutine_threadsafe instead of create_task.
+        if self._connected and self._loop is not None:
+            asyncio.run_coroutine_threadsafe(self._subscribe_pane(pane_id), self._loop)
 
     def unregister_terminal(self, terminal_id: str) -> None:
         """Remove a terminal from managed set.
@@ -133,6 +128,7 @@ class HerdrInboxService:
 
     async def start(self) -> None:
         """Start the event loop: wait for first terminal, then connect and listen."""
+        self._loop = asyncio.get_running_loop()
         kiro_task = asyncio.ensure_future(self._kiro_supplement_loop())
         try:
             await self._socket_loop()
@@ -255,6 +251,8 @@ class HerdrInboxService:
                     if terminal_id not in self._working_since:
                         self._working_since[terminal_id] = time.time()
 
+    # TODO: _deliver() calls callback synchronously — if callback is async,
+    # this will need a threadsafe bridge (out of scope for this change).
     def _deliver(self, terminal_id: str) -> None:
         """Check and deliver pending messages for a terminal."""
         if self._delivery_callback:

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -487,10 +487,18 @@ class HerdrInboxService:
             except json.JSONDecodeError:
                 continue
 
+            # herdr identifies the event in the "event" key. Lifecycle events use
+            # underscore names (pane_closed / workspace_closed); the agent-status
+            # event uses the dotted name (pane.agent_status_changed). Normalize the
+            # name so routing does not depend on the separator herdr happens to use.
+            # (Older code read "type" and matched dotted lifecycle names, which never
+            # matched herdr's real wire format — lifecycle cleanup silently never ran.)
+            raw_event = event.get("event", "") or event.get("type", "")
+            event_name = raw_event.replace("_", ".")
+
             # Handle lifecycle events
-            event_type = event.get("type", "")
-            if event_type in ("pane.closed", "workspace.closed"):
-                self._handle_lifecycle_event(event_type, event.get("data", {}))
+            if event_name in ("pane.closed", "workspace.closed"):
+                self._handle_lifecycle_event(event_name, event.get("data", {}))
                 continue
 
             data = event.get("data", {})

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -157,7 +157,9 @@ class HerdrInboxService:
 
         ws_result = subprocess.run(
             ["herdr", "--session", self._herdr_session, "workspace", "list"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         if ws_result.returncode != 0:
             logger.debug("Startup DB cleanup: herdr workspace list failed, skipping")
@@ -166,16 +168,16 @@ class HerdrInboxService:
         try:
             ws_data = json.loads(ws_result.stdout)
             workspaces = ws_data.get("result", {}).get("workspaces", [])
-            workspace_to_session = {
-                ws["workspace_id"]: ws["label"] for ws in workspaces
-            }
+            workspace_to_session = {ws["workspace_id"]: ws["label"] for ws in workspaces}
         except (json.JSONDecodeError, KeyError) as e:
             logger.warning(f"Startup DB cleanup: failed to parse workspace list: {e}")
             return
 
         tab_result = subprocess.run(
             ["herdr", "--session", self._herdr_session, "tab", "list"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         if tab_result.returncode != 0:
             logger.debug("Startup DB cleanup: herdr tab list failed, skipping")
@@ -282,7 +284,9 @@ class HerdrInboxService:
         # Get live panes from herdr
         result = subprocess.run(
             ["herdr", "--session", self._herdr_session, "pane", "list"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         if result.returncode != 0:
             logger.warning(f"Reconcile: herdr pane list failed: {result.stderr}")
@@ -299,15 +303,15 @@ class HerdrInboxService:
         # Build workspace_id -> session_name mapping
         ws_result = subprocess.run(
             ["herdr", "--session", self._herdr_session, "workspace", "list"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         if ws_result.returncode == 0:
             try:
                 ws_data = json.loads(ws_result.stdout)
                 workspaces = ws_data.get("result", {}).get("workspaces", [])
-                self._workspace_to_session = {
-                    ws["workspace_id"]: ws["label"] for ws in workspaces
-                }
+                self._workspace_to_session = {ws["workspace_id"]: ws["label"] for ws in workspaces}
             except (json.JSONDecodeError, KeyError):
                 pass
 
@@ -316,7 +320,9 @@ class HerdrInboxService:
         # starts empty (so the stale-pane diff below produces nothing).
         tab_result = subprocess.run(
             ["herdr", "--session", self._herdr_session, "tab", "list"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         if tab_result.returncode == 0:
             try:
@@ -535,7 +541,8 @@ class HerdrInboxService:
 
             # If session has no more terminals in our map, kill workspace
             remaining_in_session = [
-                t for t in self._pane_to_terminal.values()
+                t
+                for t in self._pane_to_terminal.values()
                 if (m := get_terminal_metadata(t)) and m.get("tmux_session") == session_name
             ]
             if session_name and not remaining_in_session:
@@ -555,11 +562,14 @@ class HerdrInboxService:
             try:
                 delete_terminals_by_session(session_name)
             except Exception as e:
-                logger.warning(f"workspace.closed: failed to delete terminals for {session_name}: {e}")
+                logger.warning(
+                    f"workspace.closed: failed to delete terminals for {session_name}: {e}"
+                )
 
             # Prune maps — pane_ids from this workspace start with workspace_id prefix
             to_remove = [
-                (pid, tid) for pid, tid in self._pane_to_terminal.items()
+                (pid, tid)
+                for pid, tid in self._pane_to_terminal.items()
                 if pid.startswith(workspace_id)
             ]
             for pid, tid in to_remove:
@@ -607,7 +617,9 @@ class HerdrInboxService:
 
             result = subprocess.run(
                 ["herdr", "--session", self._herdr_session, "pane", "read", pane_id],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             if result.returncode != 0:
                 continue

--- a/src/cli_agent_orchestrator/services/herdr_inbox_service.py
+++ b/src/cli_agent_orchestrator/services/herdr_inbox_service.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import re
+import subprocess
 import time
 from typing import Callable, Dict, Optional, Set
 
@@ -62,6 +63,9 @@ class HerdrInboxService:
         # Kiro-specific tracking for supplement check
         self._kiro_terminals: Set[str] = set()  # terminal_ids using kiro-cli
         self._working_since: Dict[str, float] = {}  # terminal_id → timestamp
+
+        # Workspace tracking for lifecycle events
+        self._workspace_to_session: Dict[str, str] = {}  # workspace_id → session_name
 
         # Connection state
         self._connected = False
@@ -159,10 +163,17 @@ class HerdrInboxService:
             try:
                 await self._connect()
                 self._connected = True
-                self._backoff = _BACKOFF_BASE  # Reset backoff on success
 
-                # Re-subscribe all managed panes
+                # Reconcile map against live herdr state before subscribing
+                await self._reconcile()
+
+                # Re-subscribe all managed panes (now only valid ones)
                 await self._resubscribe_all()
+
+                # Subscribe to lifecycle events for real-time cleanup
+                await self._subscribe_lifecycle_events()
+
+                self._backoff = _BACKOFF_BASE  # Reset backoff after successful setup
 
                 # Listen for events
                 await self._event_loop()
@@ -175,6 +186,114 @@ class HerdrInboxService:
                 logger.info(f"Reconnecting in {self._backoff}s...")
                 await asyncio.sleep(self._backoff)
                 self._backoff = min(self._backoff * _BACKOFF_MULTIPLIER, _BACKOFF_MAX)
+
+    async def _reconcile(self) -> None:
+        """Reconcile _pane_to_terminal map against live herdr state.
+
+        Prunes stale pane entries, deletes orphaned DB terminal records,
+        and kills workspaces with zero live terminals.
+        """
+        from cli_agent_orchestrator.backends.registry import get_backend
+        from cli_agent_orchestrator.clients.database import (
+            delete_terminal,
+            get_terminal_metadata,
+        )
+
+        # Get live panes from herdr
+        result = subprocess.run(
+            ["herdr", "--session", self._herdr_session, "pane", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            logger.warning(f"Reconcile: herdr pane list failed: {result.stderr}")
+            return
+
+        try:
+            data = json.loads(result.stdout)
+            panes = data.get("result", {}).get("panes", [])
+            live_pane_ids = {p["pane_id"] for p in panes}
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.warning(f"Reconcile: failed to parse pane list: {e}")
+            return
+
+        # Build workspace_id -> session_name mapping
+        ws_result = subprocess.run(
+            ["herdr", "--session", self._herdr_session, "workspace", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if ws_result.returncode == 0:
+            try:
+                ws_data = json.loads(ws_result.stdout)
+                workspaces = ws_data.get("result", {}).get("workspaces", [])
+                self._workspace_to_session = {
+                    ws["workspace_id"]: ws["label"] for ws in workspaces
+                }
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        # Find and prune stale panes
+        stale_pane_ids = set(self._pane_to_terminal.keys()) - live_pane_ids
+        if not stale_pane_ids:
+            logger.debug("Reconcile: all panes live, nothing to prune")
+            return
+
+        # Track which sessions lose terminals
+        affected_sessions: Dict[str, int] = {}  # session_name -> remaining count
+
+        for pane_id in stale_pane_ids:
+            terminal_id = self._pane_to_terminal.pop(pane_id, None)
+            if not terminal_id:
+                continue
+
+            # Get session name before deleting
+            meta = get_terminal_metadata(terminal_id)
+            session_name = meta["tmux_session"] if meta else None
+
+            # Remove from all maps
+            self._terminal_to_pane.pop(terminal_id, None)
+            self._kiro_terminals.discard(terminal_id)
+            self._working_since.pop(terminal_id, None)
+
+            # Delete orphaned DB record
+            try:
+                delete_terminal(terminal_id)
+            except Exception as e:
+                logger.warning(f"Reconcile: failed to delete terminal {terminal_id}: {e}")
+
+            if session_name:
+                affected_sessions.setdefault(session_name, 0)
+
+        # Count remaining terminals per affected session
+        for tid, _ in self._terminal_to_pane.items():
+            meta = get_terminal_metadata(tid)
+            if meta and meta["tmux_session"] in affected_sessions:
+                affected_sessions[meta["tmux_session"]] += 1
+
+        # Kill workspaces with zero remaining terminals
+        for session_name, remaining in affected_sessions.items():
+            if remaining == 0:
+                try:
+                    get_backend().kill_session(session_name)
+                    logger.info(f"Reconcile: killed empty workspace {session_name}")
+                except Exception as e:
+                    logger.warning(f"Reconcile: failed to kill workspace {session_name}: {e}")
+
+        logger.info(f"Reconcile: pruned {len(stale_pane_ids)} stale panes")
+
+    async def _subscribe_lifecycle_events(self) -> None:
+        """Subscribe to pane.closed and workspace.closed for real-time cleanup."""
+        message = {
+            "id": "sub_lifecycle",
+            "method": "events.subscribe",
+            "params": {
+                "subscriptions": [
+                    {"type": "pane.closed"},
+                    {"type": "workspace.closed"},
+                ]
+            },
+        }
+        await self._send(message)
+        logger.info("Subscribed to pane.closed and workspace.closed events")
 
     async def _connect(self) -> None:
         """Connect to the herdr socket."""
@@ -230,6 +349,12 @@ class HerdrInboxService:
             except json.JSONDecodeError:
                 continue
 
+            # Handle lifecycle events
+            event_type = event.get("type", "")
+            if event_type in ("pane.closed", "workspace.closed"):
+                self._handle_lifecycle_event(event_type, event.get("data", {}))
+                continue
+
             data = event.get("data", {})
             pane_id = data.get("pane_id", "")
             status = data.get("agent_status", "")
@@ -250,6 +375,79 @@ class HerdrInboxService:
                 if terminal_id in self._kiro_terminals:
                     if terminal_id not in self._working_since:
                         self._working_since[terminal_id] = time.time()
+
+    def _handle_lifecycle_event(self, event_type: str, data: dict) -> None:
+        """Handle pane.closed and workspace.closed events."""
+        from cli_agent_orchestrator.backends.registry import get_backend
+        from cli_agent_orchestrator.clients.database import (
+            delete_terminal,
+            delete_terminals_by_session,
+            get_terminal_metadata,
+        )
+
+        if event_type == "pane.closed":
+            pane_id = data.get("pane_id", "")
+            terminal_id = self._pane_to_terminal.get(pane_id)
+            if not terminal_id:
+                return
+
+            # Get session before cleanup
+            meta = get_terminal_metadata(terminal_id)
+            session_name = meta["tmux_session"] if meta else None
+
+            # Remove from maps
+            self._pane_to_terminal.pop(pane_id, None)
+            self._terminal_to_pane.pop(terminal_id, None)
+            self._kiro_terminals.discard(terminal_id)
+            self._working_since.pop(terminal_id, None)
+
+            # Delete DB record
+            try:
+                delete_terminal(terminal_id)
+            except Exception as e:
+                logger.warning(f"pane.closed: failed to delete terminal {terminal_id}: {e}")
+
+            logger.info(f"pane.closed: cleaned up terminal {terminal_id} (pane={pane_id})")
+
+            # If session has no more terminals in our map, kill workspace
+            remaining_in_session = [
+                t for t in self._pane_to_terminal.values()
+                if (m := get_terminal_metadata(t)) and m.get("tmux_session") == session_name
+            ]
+            if session_name and not remaining_in_session:
+                try:
+                    get_backend().kill_session(session_name)
+                    logger.info(f"pane.closed: killed empty workspace {session_name}")
+                except Exception as e:
+                    logger.warning(f"pane.closed: failed to kill workspace {session_name}: {e}")
+
+        elif event_type == "workspace.closed":
+            workspace_id = data.get("workspace_id", "")
+            session_name = self._workspace_to_session.get(workspace_id)
+            if not session_name:
+                return
+
+            # Delete all DB terminals for this session
+            try:
+                delete_terminals_by_session(session_name)
+            except Exception as e:
+                logger.warning(f"workspace.closed: failed to delete terminals for {session_name}: {e}")
+
+            # Prune maps — pane_ids from this workspace start with workspace_id prefix
+            to_remove = [
+                (pid, tid) for pid, tid in self._pane_to_terminal.items()
+                if pid.startswith(workspace_id)
+            ]
+            for pid, tid in to_remove:
+                self._pane_to_terminal.pop(pid, None)
+                self._terminal_to_pane.pop(tid, None)
+                self._kiro_terminals.discard(tid)
+                self._working_since.pop(tid, None)
+
+            self._workspace_to_session.pop(workspace_id, None)
+            logger.info(
+                f"workspace.closed: cleaned up session {session_name} ({len(to_remove)} terminals)"
+            )
 
     # TODO: _deliver() calls callback synchronously — if callback is async,
     # this will need a threadsafe bridge (out of scope for this change).

--- a/src/cli_agent_orchestrator/services/inbox_service.py
+++ b/src/cli_agent_orchestrator/services/inbox_service.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from watchdog.events import FileModifiedEvent, FileSystemEventHandler
 
+from cli_agent_orchestrator.backends.base import TerminalNotFoundError
 from cli_agent_orchestrator.clients.database import (
     get_pending_messages,
     list_pending_receiver_ids_by_provider,
@@ -148,6 +149,15 @@ def check_and_send_pending_messages(
             )
         logger.info(f"Delivered message {message.id} to terminal {terminal_id}")
         return True
+    except TerminalNotFoundError as e:
+        # The terminal's pane could not be resolved (e.g. herdr pane not found
+        # for this window). Treat as transient: leave the message PENDING for a
+        # later retry rather than marking it FAILED or silently misrouting.
+        logger.warning(
+            f"Pane not resolvable for terminal {terminal_id}; leaving message "
+            f"{message.id} pending for retry: {e}"
+        )
+        return False
     except Exception as e:
         logger.error(f"Failed to send message {message.id} to {terminal_id}: {e}")
         update_message_status(message.id, MessageStatus.FAILED)

--- a/src/cli_agent_orchestrator/services/inbox_service.py
+++ b/src/cli_agent_orchestrator/services/inbox_service.py
@@ -151,8 +151,11 @@ def check_and_send_pending_messages(
         return True
     except TerminalNotFoundError as e:
         # The terminal's pane could not be resolved (e.g. herdr pane not found
-        # for this window). Treat as transient: leave the message PENDING for a
-        # later retry rather than marking it FAILED or silently misrouting.
+        # for this window). Treat as transient: reset to PENDING for a later
+        # retry rather than marking it FAILED or silently misrouting. We must
+        # reset explicitly because the status was optimistically set to
+        # DELIVERED above before the send was attempted.
+        update_message_status(message.id, MessageStatus.PENDING)
         logger.warning(
             f"Pane not resolvable for terminal {terminal_id}; leaving message "
             f"{message.id} pending for retry: {e}"

--- a/src/cli_agent_orchestrator/services/inbox_service.py
+++ b/src/cli_agent_orchestrator/services/inbox_service.py
@@ -117,7 +117,7 @@ def check_and_send_pending_messages(
     eager_eligible = (
         EAGER_INBOX_DELIVERY
         and provider.accepts_input_while_processing
-        and status in (TerminalStatus.PROCESSING, TerminalStatus.WAITING_USER_ANSWER)
+        and status in (TerminalStatus.PROCESSING,)
     )
 
     if status not in (TerminalStatus.IDLE, TerminalStatus.COMPLETED) and not eager_eligible:

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -22,11 +22,11 @@ Session Lifecycle:
 import logging
 from typing import Dict, List
 
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import (
     delete_terminals_by_session,
     list_terminals_by_session,
 )
-from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import SESSION_PREFIX
 from cli_agent_orchestrator.models.terminal import Terminal
 from cli_agent_orchestrator.plugins import (

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -26,7 +26,7 @@ from cli_agent_orchestrator.clients.database import (
     delete_terminals_by_session,
     list_terminals_by_session,
 )
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import SESSION_PREFIX
 from cli_agent_orchestrator.models.terminal import Terminal
 from cli_agent_orchestrator.plugins import (
@@ -87,7 +87,7 @@ def create_session(
 def list_sessions() -> List[Dict]:
     """List all sessions from tmux."""
     try:
-        tmux_sessions = tmux_client.list_sessions()
+        tmux_sessions = get_backend().list_sessions()
         return [s for s in tmux_sessions if s["id"].startswith(SESSION_PREFIX)]
     except Exception as e:
         logger.error(f"Failed to list sessions: {e}")
@@ -97,10 +97,10 @@ def list_sessions() -> List[Dict]:
 def get_session(session_name: str) -> Dict:
     """Get session with terminals."""
     try:
-        if not tmux_client.session_exists(session_name):
+        if not get_backend().session_exists(session_name):
             raise ValueError(f"Session '{session_name}' not found")
 
-        tmux_sessions = tmux_client.list_sessions()
+        tmux_sessions = get_backend().list_sessions()
         session_data = next((s for s in tmux_sessions if s["id"] == session_name), None)
 
         if not session_data:
@@ -122,8 +122,7 @@ def delete_session(session_name: str, registry: PluginRegistry | None = None) ->
     """
     result: Dict = {"deleted": [], "errors": []}
     try:
-        if not tmux_client.session_exists(session_name):
-            raise ValueError(f"Session '{session_name}' not found")
+        session_alive = get_backend().session_exists(session_name)
 
         terminals = list_terminals_by_session(session_name)
 
@@ -134,8 +133,9 @@ def delete_session(session_name: str, registry: PluginRegistry | None = None) ->
             except Exception as e:
                 logger.warning(f"Provider cleanup failed for {terminal['id']}: {e}")
 
-        # Kill tmux session
-        tmux_client.kill_session(session_name)
+        # Kill backend session only if it still exists
+        if session_alive:
+            get_backend().kill_session(session_name)
 
         # Delete terminal metadata
         delete_terminals_by_session(session_name)

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, Optional
 
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import create_terminal as db_create_terminal
 from cli_agent_orchestrator.clients.database import delete_terminal as db_delete_terminal
 from cli_agent_orchestrator.clients.database import (
@@ -31,7 +32,6 @@ from cli_agent_orchestrator.clients.database import (
     update_last_active,
     update_terminal_shell_command,
 )
-from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import SESSION_PREFIX, TERMINAL_LOG_DIR
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.provider import ProviderType

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -31,7 +31,7 @@ from cli_agent_orchestrator.clients.database import (
     update_last_active,
     update_terminal_shell_command,
 )
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import SESSION_PREFIX, TERMINAL_LOG_DIR
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.provider import ProviderType
@@ -174,7 +174,7 @@ def create_terminal(
                 session_name = f"{SESSION_PREFIX}{session_name}"
 
             # Prevent duplicate sessions
-            if tmux_client.session_exists(session_name):
+            if get_backend().session_exists(session_name):
                 raise ValueError(f"Session '{session_name}' already exists")
 
             # Wipe any stale mapping a prior aborted lifecycle for this name
@@ -182,7 +182,7 @@ def create_terminal(
             clear_session_env(session_name)
 
             # Create new tmux session with initial window
-            tmux_client.create_session(
+            get_backend().create_session(
                 session_name,
                 window_name,
                 terminal_id,
@@ -198,9 +198,9 @@ def create_terminal(
                 set_session_env(session_name, env_vars)
         else:
             # Add window to existing session
-            if not tmux_client.session_exists(session_name):
+            if not get_backend().session_exists(session_name):
                 raise ValueError(f"Session '{session_name}' not found")
-            window_name = tmux_client.create_window(
+            window_name = get_backend().create_window(
                 session_name,
                 window_name,
                 terminal_id,
@@ -266,7 +266,7 @@ def create_terminal(
         # This captures all terminal output to a log file for inbox monitoring
         log_path = TERMINAL_LOG_DIR / f"{terminal_id}.log"
         log_path.touch()  # Ensure file exists before watching
-        tmux_client.pipe_pane(session_name, window_name, str(log_path))
+        get_backend().pipe_pane(session_name, window_name, str(log_path))
 
         # Build and return the Terminal object
         terminal = Terminal(
@@ -305,7 +305,7 @@ def create_terminal(
             pass  # Ignore cleanup errors
         if session_created and session_name:
             try:
-                tmux_client.kill_session(session_name)
+                get_backend().kill_session(session_name)
             except:
                 pass  # Ignore cleanup errors
             # Session is gone, drop any forwarded env we stashed for it so
@@ -362,7 +362,7 @@ def get_working_directory(terminal_id: str) -> Optional[str]:
         if not metadata:
             raise ValueError(f"Terminal '{terminal_id}' not found")
 
-        working_dir = tmux_client.get_pane_working_directory(
+        working_dir = get_backend().get_pane_working_directory(
             metadata["tmux_session"], metadata["tmux_window"]
         )
         return working_dir
@@ -424,7 +424,7 @@ def send_input(
         # Check how many Enter keys the provider needs after paste
         enter_count = provider.paste_enter_count if provider else 1
 
-        tmux_client.send_keys(
+        get_backend().send_keys(
             metadata["tmux_session"],
             metadata["tmux_window"],
             message,
@@ -481,7 +481,7 @@ def send_special_key(terminal_id: str, key: str) -> bool:
         if not metadata:
             raise ValueError(f"Terminal '{terminal_id}' not found")
 
-        tmux_client.send_special_key(metadata["tmux_session"], metadata["tmux_window"], key)
+        get_backend().send_special_key(metadata["tmux_session"], metadata["tmux_window"], key)
 
         update_last_active(terminal_id)
         logger.info(f"Sent special key '{key}' to terminal: {terminal_id}")
@@ -500,55 +500,113 @@ def get_output(terminal_id: str, mode: OutputMode = OutputMode.FULL) -> str:
     TUI-based providers (e.g. Gemini CLI's Ink renderer) whose notification
     spinners can temporarily obscure response text in the tmux capture buffer.
 
-    If the provider exposes an ``extraction_tail_lines`` attribute, the
-    history capture for LAST mode uses that value instead of the default
-    ``TMUX_HISTORY_LINES``. Status-check captures are unaffected (they go
-    through get_status directly). A single capture-pane call is made per
-    get_output invocation.
+    If the provider exposes an ``extraction_tail_lines`` attribute, that
+    fixed value is used for the history capture and the escalating-fetch
+    logic below is skipped.
+
+    Otherwise, extraction uses an escalating fetch strategy: start with a
+    small capture window and widen until the response marker is found.
+    Steps: 200 -> 500 -> 1000 -> 5000.  If no marker is found at 5000 lines,
+    the raw tail is returned with a [PARTIAL RESPONSE] prefix so the caller
+    knows the output may be incomplete.
     """
+    # Escalation steps used when the provider does not declare extraction_tail_lines.
+    _ESCALATION_STEPS = [200, 500, 1000, 5000]
+
     try:
         metadata = get_terminal_metadata(terminal_id)
         if not metadata:
             raise ValueError(f"Terminal '{terminal_id}' not found")
 
         if mode == OutputMode.FULL:
-            return tmux_client.get_history(metadata["tmux_session"], metadata["tmux_window"])
+            return get_backend().get_history(metadata["tmux_session"], metadata["tmux_window"])
         elif mode == OutputMode.LAST:
             provider = provider_manager.get_provider(terminal_id)
             if provider is None:
                 raise ValueError(f"Provider not found for terminal {terminal_id}")
 
-            # Capability check: providers that need deeper scrollback for extraction
-            # opt in by defining ``extraction_tail_lines``. Base providers don't.
-            extract_lines = getattr(provider, "extraction_tail_lines", None)
-            full_output = tmux_client.get_history(
-                metadata["tmux_session"],
-                metadata["tmux_window"],
-                tail_lines=extract_lines,
-            )
-
-            retries = provider.extraction_retries
-            last_err: Exception | None = None
-            for attempt in range(1 + retries):
-                try:
-                    if attempt > 0:
-                        time.sleep(10.0)
-                        full_output = tmux_client.get_history(
-                            metadata["tmux_session"],
-                            metadata["tmux_window"],
-                            tail_lines=extract_lines,
+            # If the provider pins a fixed scrollback depth, honour it and skip
+            # escalation — the provider knows what it needs.
+            fixed_extract_lines = getattr(provider, "extraction_tail_lines", None)
+            if fixed_extract_lines is not None:
+                full_output = get_backend().get_history(
+                    metadata["tmux_session"],
+                    metadata["tmux_window"],
+                    tail_lines=fixed_extract_lines,
+                )
+                retries = provider.extraction_retries
+                last_err: Exception | None = None
+                for attempt in range(1 + retries):
+                    try:
+                        if attempt > 0:
+                            time.sleep(10.0)
+                            full_output = get_backend().get_history(
+                                metadata["tmux_session"],
+                                metadata["tmux_window"],
+                                tail_lines=fixed_extract_lines,
+                            )
+                        return provider.extract_last_message_from_script(full_output)
+                    except ValueError as exc:
+                        last_err = exc
+                        logger.debug(
+                            "Output extraction attempt %d/%d for %s failed: %s",
+                            attempt + 1,
+                            1 + retries,
+                            terminal_id,
+                            exc,
                         )
-                    return provider.extract_last_message_from_script(full_output)
+                raise last_err  # type: ignore[misc]
+
+            # Escalating fetch: try progressively larger capture windows until
+            # the response marker is found or we hit the cap.
+            last_err = None
+            full_output = ""
+            for step_lines in _ESCALATION_STEPS:
+                full_output = get_backend().get_history(
+                    metadata["tmux_session"],
+                    metadata["tmux_window"],
+                    tail_lines=step_lines,
+                )
+                try:
+                    result = provider.extract_last_message_from_script(full_output)
+                    if step_lines > _ESCALATION_STEPS[0]:
+                        logger.debug(
+                            "get_output: %s marker found at %d lines",
+                            terminal_id,
+                            step_lines,
+                        )
+                    return result
                 except ValueError as exc:
                     last_err = exc
                     logger.debug(
-                        "Output extraction attempt %d/%d for %s failed: %s",
-                        attempt + 1,
-                        1 + retries,
+                        "get_output: %s no marker at %d lines, escalating",
                         terminal_id,
-                        exc,
+                        step_lines,
                     )
-            raise last_err  # type: ignore[misc]
+
+            # All tail-based steps failed — try full scrollback before giving up.
+            logger.debug(
+                "get_output: %s escalation exhausted, trying full_history",
+                terminal_id,
+            )
+            full_output = get_backend().get_history(
+                metadata["tmux_session"],
+                metadata["tmux_window"],
+                full_history=True,
+            )
+            try:
+                result = provider.extract_last_message_from_script(full_output)
+                logger.debug("get_output: %s marker found in full_history", terminal_id)
+                return result
+            except ValueError:
+                pass
+
+            # Full scrollback also failed — return partial.
+            logger.warning(
+                "get_output: %s response marker not found in full_history, returning partial",
+                terminal_id,
+            )
+            return f"[PARTIAL RESPONSE - response marker not found in {_ESCALATION_STEPS[-1]} lines]\n{full_output}"
 
     except Exception as e:
         logger.error(f"Failed to get output from terminal {terminal_id}: {e}")
@@ -565,7 +623,7 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
             # Snapshot scrollback + metadata before killing (for debugging/restore)
             try:
                 # Capture plain text full scrollback (no -e, no line cap)
-                scrollback = tmux_client.get_history(
+                scrollback = get_backend().get_history(
                     metadata["tmux_session"],
                     metadata["tmux_window"],
                     strip_escapes=True,
@@ -582,7 +640,7 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
                     "window_name": metadata["tmux_window"],
                     "agent_profile": metadata.get("agent_profile"),
                     "provider": metadata["provider"],
-                    "working_directory": tmux_client.get_pane_working_directory(
+                    "working_directory": get_backend().get_pane_working_directory(
                         metadata["tmux_session"], metadata["tmux_window"]
                     ),
                     "allowed_tools": metadata.get("allowed_tools"),
@@ -594,13 +652,13 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
 
             # Stop pipe-pane logging
             try:
-                tmux_client.stop_pipe_pane(metadata["tmux_session"], metadata["tmux_window"])
+                get_backend().stop_pipe_pane(metadata["tmux_session"], metadata["tmux_window"])
             except Exception as e:
                 logger.warning(f"Failed to stop pipe-pane for {terminal_id}: {e}")
 
             # Kill the tmux window (this terminates the agent process)
             try:
-                tmux_client.kill_window(metadata["tmux_session"], metadata["tmux_window"])
+                get_backend().kill_window(metadata["tmux_session"], metadata["tmux_window"])
             except Exception as e:
                 logger.warning(f"Failed to kill tmux window for {terminal_id}: {e}")
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -617,7 +617,9 @@ def get_output(terminal_id: str, mode: OutputMode = OutputMode.FULL) -> str:
                 "get_output: %s response marker not found in full_history, returning partial",
                 terminal_id,
             )
-            return f"[PARTIAL RESPONSE - response marker not found in {_ESCALATION_STEPS[-1]} lines]\n{full_output}"
+            return (
+                f"[PARTIAL RESPONSE - response marker not found in full scrollback]\n{full_output}"
+            )
 
     except Exception as e:
         logger.error(f"Failed to get output from terminal {terminal_id}: {e}")

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -43,6 +43,7 @@ from cli_agent_orchestrator.plugins import (
     PostSendMessageEvent,
 )
 from cli_agent_orchestrator.providers.manager import provider_manager
+from cli_agent_orchestrator.services.herdr_inbox_registry import get_herdr_inbox_service
 from cli_agent_orchestrator.services.memory_service import MemoryService
 from cli_agent_orchestrator.services.plugin_dispatch import dispatch_plugin_event
 from cli_agent_orchestrator.services.session_env import (
@@ -294,6 +295,16 @@ def create_terminal(
                 provider=provider,
             ),
         )
+
+        # Register with herdr inbox service for message delivery
+        svc = get_herdr_inbox_service()
+        if svc:
+            try:
+                pane_id = get_backend().get_pane_id(terminal_id, session_name, window_name)
+                is_kiro = provider == ProviderType.KIRO_CLI.value
+                svc.register_terminal(terminal_id, pane_id, is_kiro)
+            except Exception as e:
+                logger.warning(f"Failed to register terminal {terminal_id} with herdr inbox: {e}")
         return terminal
 
     except Exception as e:
@@ -616,6 +627,14 @@ def get_output(terminal_id: str, mode: OutputMode = OutputMode.FULL) -> str:
 def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) -> bool:
     """Delete terminal and kill its tmux window."""
     try:
+        # Unregister from herdr inbox service
+        svc = get_herdr_inbox_service()
+        if svc:
+            try:
+                svc.unregister_terminal(terminal_id)
+            except Exception as e:
+                logger.warning(f"Failed to unregister terminal {terminal_id} from herdr inbox: {e}")
+
         # Get metadata before deletion
         metadata = get_terminal_metadata(terminal_id)
 

--- a/src/cli_agent_orchestrator/utils/terminal.py
+++ b/src/cli_agent_orchestrator/utils/terminal.py
@@ -13,7 +13,7 @@ from cli_agent_orchestrator.constants import API_BASE_URL, SESSION_PREFIX
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 
 if TYPE_CHECKING:
-    from cli_agent_orchestrator.clients.tmux import TmuxClient
+    from cli_agent_orchestrator.backends.base import TerminalBackend
     from cli_agent_orchestrator.providers.base import BaseProvider
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ def generate_window_name(agent_profile: str) -> str:
 
 
 def wait_for_shell(
-    tmux_client: "TmuxClient",
+    backend: "TerminalBackend",
     session_name: str,
     window_name: str,
     timeout: float = 10.0,
@@ -82,7 +82,7 @@ def wait_for_shell(
     previous_output = None
 
     while time.time() - start_time < timeout:
-        output = tmux_client.get_history(session_name, window_name)
+        output = backend.get_history(session_name, window_name)
 
         if output and output.strip() and previous_output is not None and output == previous_output:
             logger.info(f"Shell ready")

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -1188,7 +1188,7 @@ class TestMainEntryPoint:
             patch("argparse.ArgumentParser.parse_args") as mock_args,
             patch("uvicorn.run") as mock_uvicorn,
         ):
-            mock_args.return_value = MagicMock(agents_dir=None, host=None, port=None)
+            mock_args.return_value = MagicMock(agents_dir=None, host=None, port=None, terminal=None)
 
             from cli_agent_orchestrator.api.main import main
 
@@ -1205,7 +1205,9 @@ class TestMainEntryPoint:
             patch("argparse.ArgumentParser.parse_args") as mock_args,
             patch("uvicorn.run") as mock_uvicorn,
         ):
-            mock_args.return_value = MagicMock(agents_dir=None, host="0.0.0.0", port=9999)
+            mock_args.return_value = MagicMock(
+                agents_dir=None, host="0.0.0.0", port=9999, terminal=None
+            )
 
             from cli_agent_orchestrator.api.main import main
 
@@ -1220,7 +1222,9 @@ class TestMainEntryPoint:
             patch("uvicorn.run"),
             patch("cli_agent_orchestrator.constants.KIRO_AGENTS_DIR") as _,
         ):
-            mock_args.return_value = MagicMock(agents_dir="/custom/agents", host=None, port=None)
+            mock_args.return_value = MagicMock(
+                agents_dir="/custom/agents", host=None, port=None, terminal=None
+            )
 
             from cli_agent_orchestrator.api.main import main
 
@@ -1242,7 +1246,9 @@ class TestMainEntryPoint:
         ):
             parent.attach_mock(mock_add, "add_cors")
             parent.attach_mock(mock_uvicorn, "uvicorn_run")
-            mock_args.return_value = MagicMock(agents_dir=None, host="0.0.0.0", port=9999)
+            mock_args.return_value = MagicMock(
+                agents_dir=None, host="0.0.0.0", port=9999, terminal=None
+            )
 
             from cli_agent_orchestrator.api.main import main
 
@@ -1252,3 +1258,37 @@ class TestMainEntryPoint:
                 call.add_cors("0.0.0.0", 9999),
                 call.uvicorn_run(app, host="0.0.0.0", port=9999),
             ]
+
+    def test_main_terminal_flag_overrides_backend(self):
+        """--terminal sets the backend via the factory before the server starts."""
+        with (
+            patch("argparse.ArgumentParser.parse_args") as mock_args,
+            patch("uvicorn.run"),
+            patch("cli_agent_orchestrator.backends.factory.BackendFactory.create") as mock_create,
+            patch("cli_agent_orchestrator.backends.registry.set_backend") as mock_set,
+        ):
+            mock_args.return_value = MagicMock(
+                agents_dir=None, host=None, port=None, terminal="herdr"
+            )
+
+            from cli_agent_orchestrator.api.main import main
+
+            main()
+
+            mock_create.assert_called_once_with(backend_override="herdr")
+            mock_set.assert_called_once_with(mock_create.return_value)
+
+    def test_main_no_terminal_flag_leaves_backend_lazy(self):
+        """Without --terminal, main() does not eagerly set the backend."""
+        with (
+            patch("argparse.ArgumentParser.parse_args") as mock_args,
+            patch("uvicorn.run"),
+            patch("cli_agent_orchestrator.backends.registry.set_backend") as mock_set,
+        ):
+            mock_args.return_value = MagicMock(agents_dir=None, host=None, port=None, terminal=None)
+
+            from cli_agent_orchestrator.api.main import main
+
+            main()
+
+            mock_set.assert_not_called()

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -28,12 +28,16 @@ class TestHealthCheck:
     """Tests for GET /health endpoint."""
 
     def test_health_check_returns_ok(self, client):
-        """GET /health returns status ok."""
+        """GET /health returns status ok with component health."""
         response = client.get("/health")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
         assert data["service"] == "cli-agent-orchestrator"
+        components = data["components"]
+        assert components["cao"] == "ok"
+        assert components["herdr"] in ("ok", "unavailable")
+        assert components["claude"] in ("ok", "unavailable")
 
 
 # ── Agent profiles endpoint ──────────────────────────────────────────

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -1108,6 +1108,7 @@ class TestLifespan:
     async def test_lifespan_startup_and_shutdown(self):
         """lifespan starts background tasks on entry, cleans up on exit."""
         from cli_agent_orchestrator.api.main import lifespan
+        from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend
 
         mock_observer = MagicMock()
 
@@ -1118,6 +1119,10 @@ class TestLifespan:
             patch("cli_agent_orchestrator.api.main.setup_logging"),
             patch("cli_agent_orchestrator.api.main.init_db"),
             patch("cli_agent_orchestrator.api.main.cleanup_old_data"),
+            patch(
+                "cli_agent_orchestrator.api.main.get_backend",
+                return_value=MagicMock(spec=TmuxBackend),
+            ),
             patch(
                 "cli_agent_orchestrator.api.main.PollingObserver",
                 return_value=mock_observer,

--- a/test/api/test_lifespan_inbox.py
+++ b/test/api/test_lifespan_inbox.py
@@ -31,7 +31,6 @@ from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
 from cli_agent_orchestrator.constants import INBOX_POLLING_INTERVAL, TERMINAL_LOG_DIR
 from cli_agent_orchestrator.plugins import PluginRegistry
 
-
 # --- Test doubles -------------------------------------------------------
 
 
@@ -96,9 +95,7 @@ def _patched_lifespan(backend: object, tasks: list):
     with ExitStack() as stack:
 
         def patch_main(name: str, **kwargs):
-            return stack.enter_context(
-                patch(f"cli_agent_orchestrator.api.main.{name}", **kwargs)
-            )
+            return stack.enter_context(patch(f"cli_agent_orchestrator.api.main.{name}", **kwargs))
 
         # Intercept task creation so no real background tasks run.
         stack.enter_context(patch("asyncio.create_task", _make_fake_create_task(tasks)))
@@ -116,9 +113,7 @@ def _patched_lifespan(backend: object, tasks: list):
             set_svc=patch_main("set_herdr_inbox_service"),
             observer_cls=patch_main("PollingObserver"),
             log_handler_cls=patch_main("LogFileHandler"),
-            load=stack.enter_context(
-                patch.object(PluginRegistry, "load", new_callable=AsyncMock)
-            ),
+            load=stack.enter_context(patch.object(PluginRegistry, "load", new_callable=AsyncMock)),
             teardown=stack.enter_context(
                 patch.object(PluginRegistry, "teardown", new_callable=AsyncMock)
             ),

--- a/test/api/test_lifespan_inbox.py
+++ b/test/api/test_lifespan_inbox.py
@@ -1,0 +1,227 @@
+"""Tests for the inbox-watcher branch of the FastAPI lifespan.
+
+The lifespan (api/main.py) starts one of two inbox watchers depending on the
+active terminal backend:
+
+- HerdrBackend  -> HerdrInboxService (socket events), scheduled as an asyncio task
+- anything else -> PollingObserver (tmux log-file watchdog)
+
+These tests pin both the startup wiring and the matching shutdown teardown for
+each path. Everything external is mocked, so no herdr socket, watchdog thread,
+database, or real background task is created.
+
+Mocking notes:
+- ``asyncio.create_task`` is replaced with a fake that returns a ``_FakeTask``.
+  A real task can't be created from ``MagicMock().start()`` (not a coroutine),
+  and we need to spy on ``.cancel()`` while still being awaitable for the
+  ``await task`` in shutdown. ``_FakeTask`` raises ``CancelledError`` once
+  cancelled, exercising the ``except asyncio.CancelledError`` branch.
+- ``MagicMock(spec=HerdrBackend)`` satisfies ``isinstance(backend, HerdrBackend)``.
+"""
+
+import asyncio
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.api.main import app, lifespan
+from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
+from cli_agent_orchestrator.constants import INBOX_POLLING_INTERVAL, TERMINAL_LOG_DIR
+from cli_agent_orchestrator.plugins import PluginRegistry
+
+
+# --- Test doubles -------------------------------------------------------
+
+
+class _FakeTask:
+    """Stand-in for asyncio.Task: awaitable and records ``cancel()`` calls.
+
+    Mirrors the one behavior shutdown depends on: awaiting a task that has been
+    cancelled raises ``CancelledError``. ``source`` keeps the original argument
+    passed to ``create_task`` so a specific task can be located in assertions.
+    """
+
+    def __init__(self, source: object) -> None:
+        self.source = source
+        # Close real coroutines so Python does not warn "never awaited".
+        if asyncio.iscoroutine(source):
+            source.close()
+        self.cancel = MagicMock(name="cancel")
+
+    def __await__(self):
+        async def _body() -> None:
+            if self.cancel.called:
+                raise asyncio.CancelledError()
+            return None
+
+        return _body().__await__()
+
+
+def _make_fake_create_task(tasks: list) -> object:
+    """Build a ``create_task`` replacement that records every created task."""
+
+    def _fake_create_task(coro, *_args, **_kwargs) -> _FakeTask:
+        task = _FakeTask(coro)
+        tasks.append(task)
+        return task
+
+    return _fake_create_task
+
+
+def _find_task(tasks: list, source: object) -> "_FakeTask | None":
+    """Return the recorded task created from ``source``, or None."""
+    for task in tasks:
+        if task.source is source:
+            return task
+    return None
+
+
+async def _fake_flow_daemon() -> None:
+    """Replacement for flow_daemon so create_task gets a closeable coroutine."""
+
+
+async def _fake_opencode_daemon(registry: object) -> None:
+    """Replacement for opencode_inbox_delivery_daemon (takes a registry arg)."""
+    del registry
+
+
+@contextmanager
+def _patched_lifespan(backend: object, tasks: list):
+    """Patch every external dependency the lifespan touches at startup/shutdown.
+
+    Yields a namespace of the mocks tests assert against.
+    """
+    with ExitStack() as stack:
+
+        def patch_main(name: str, **kwargs):
+            return stack.enter_context(
+                patch(f"cli_agent_orchestrator.api.main.{name}", **kwargs)
+            )
+
+        # Intercept task creation so no real background tasks run.
+        stack.enter_context(patch("asyncio.create_task", _make_fake_create_task(tasks)))
+
+        # No-op the side-effecting startup calls.
+        patch_main("setup_logging")
+        patch_main("init_db")
+        patch_main("cleanup_old_data")
+        patch_main("flow_daemon", new=_fake_flow_daemon)
+        patch_main("opencode_inbox_delivery_daemon", new=_fake_opencode_daemon)
+
+        namespace = SimpleNamespace(
+            get_backend=patch_main("get_backend", return_value=backend),
+            herdr_cls=patch_main("HerdrInboxService"),
+            set_svc=patch_main("set_herdr_inbox_service"),
+            observer_cls=patch_main("PollingObserver"),
+            log_handler_cls=patch_main("LogFileHandler"),
+            load=stack.enter_context(
+                patch.object(PluginRegistry, "load", new_callable=AsyncMock)
+            ),
+            teardown=stack.enter_context(
+                patch.object(PluginRegistry, "teardown", new_callable=AsyncMock)
+            ),
+        )
+        yield namespace
+
+
+class TestLifespanInboxWiring:
+    """Startup + shutdown wiring for both inbox-watcher backends."""
+
+    @pytest.mark.asyncio
+    async def test_herdr_backend_starts_service_and_sets_registry(self) -> None:
+        """Herdr backend builds the service, registers it, and schedules start()."""
+        # Arrange
+        tasks: list = []
+        backend = MagicMock(spec=HerdrBackend)
+        backend.herdr_session = "cao"
+
+        # Act
+        with _patched_lifespan(backend, tasks) as mocks:
+            async with lifespan(app):
+                # Assert (startup)
+                mocks.herdr_cls.assert_called_once_with(
+                    herdr_session="cao",
+                    delivery_callback=ANY,
+                )
+                # The delivery callback must be a callable closure.
+                callback = mocks.herdr_cls.call_args.kwargs["delivery_callback"]
+                assert callable(callback)
+
+                svc = mocks.herdr_cls.return_value
+                mocks.set_svc.assert_called_once_with(svc)
+
+                # svc.start() was scheduled as a task.
+                svc.start.assert_called_once()
+                assert _find_task(tasks, svc.start.return_value) is not None
+
+                # The tmux watcher path must not run.
+                mocks.observer_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tmux_backend_starts_polling_observer(self) -> None:
+        """Non-herdr backend builds, schedules, and starts the PollingObserver."""
+        # Arrange
+        tasks: list = []
+        backend = MagicMock()  # not a HerdrBackend instance
+
+        # Act
+        with _patched_lifespan(backend, tasks) as mocks:
+            async with lifespan(app):
+                # Assert (startup)
+                mocks.observer_cls.assert_called_once_with(timeout=INBOX_POLLING_INTERVAL)
+                observer = mocks.observer_cls.return_value
+
+                # LogFileHandler is built with the registry stored on app.state...
+                mocks.log_handler_cls.assert_called_once_with(app.state.plugin_registry)
+                # ...and that handler is scheduled on the terminal log dir.
+                observer.schedule.assert_called_once_with(
+                    mocks.log_handler_cls.return_value,
+                    str(TERMINAL_LOG_DIR),
+                    recursive=False,
+                )
+                observer.start.assert_called_once()
+
+                # The herdr path must not run.
+                mocks.herdr_cls.assert_not_called()
+                mocks.set_svc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_herdr_shutdown_cancels_task_and_skips_observer(self) -> None:
+        """On exit the herdr path cancels its task; observer teardown never runs."""
+        # Arrange
+        tasks: list = []
+        backend = MagicMock(spec=HerdrBackend)
+        backend.herdr_session = "cao"
+
+        # Act
+        with _patched_lifespan(backend, tasks) as mocks:
+            async with lifespan(app):
+                svc = mocks.herdr_cls.return_value
+            # Assert (shutdown — after context exit)
+            herdr_task = _find_task(tasks, svc.start.return_value)
+            assert herdr_task is not None
+            herdr_task.cancel.assert_called_once()
+
+            # Observer was never constructed, so stop()/join() cannot run.
+            mocks.observer_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tmux_shutdown_stops_observer_and_skips_herdr_task(self) -> None:
+        """On exit the tmux path stops+joins the observer; no herdr task exists."""
+        # Arrange
+        tasks: list = []
+        backend = MagicMock()  # not a HerdrBackend instance
+
+        # Act
+        with _patched_lifespan(backend, tasks) as mocks:
+            async with lifespan(app):
+                observer = mocks.observer_cls.return_value
+            # Assert (shutdown — after context exit)
+            observer.stop.assert_called_once()
+            observer.join.assert_called_once()
+
+            # No herdr inbox service or task was ever created to cancel.
+            mocks.herdr_cls.assert_not_called()
+            assert _find_task(tasks, mocks.herdr_cls.return_value.start.return_value) is None

--- a/test/api/test_plugin_lifespan.py
+++ b/test/api/test_plugin_lifespan.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import Request
 
 from cli_agent_orchestrator.api.main import app, get_plugin_registry, lifespan
+from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend
 from cli_agent_orchestrator.plugins import CaoPlugin, PluginRegistry, hook
 from cli_agent_orchestrator.plugins.events import PostSendMessageEvent
 
@@ -37,6 +38,10 @@ class TestPluginRegistryLifespan:
             patch("cli_agent_orchestrator.api.main.setup_logging"),
             patch("cli_agent_orchestrator.api.main.init_db"),
             patch("cli_agent_orchestrator.api.main.cleanup_old_data"),
+            patch(
+                "cli_agent_orchestrator.api.main.get_backend",
+                return_value=MagicMock(spec=TmuxBackend),
+            ),
             patch(
                 "cli_agent_orchestrator.api.main.PollingObserver",
                 return_value=mock_observer,

--- a/test/backends/test_factory.py
+++ b/test/backends/test_factory.py
@@ -1,0 +1,71 @@
+"""Unit tests for BackendFactory — config-driven backend selection."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cli_agent_orchestrator.backends.factory import BackendFactory, ConfigurationError
+from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
+from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend
+
+
+class TestBackendFactoryDefaults:
+    """Test default behavior when config is absent or incomplete."""
+
+    def test_returns_tmux_when_config_missing(self, tmp_path):
+        """TmuxBackend is returned when config file doesn't exist."""
+        nonexistent = tmp_path / "config.json"
+        backend = BackendFactory.create(config_path=nonexistent)
+        assert isinstance(backend, TmuxBackend)
+
+    def test_returns_tmux_when_key_absent(self, tmp_path):
+        """TmuxBackend is returned when terminal_backend key is missing."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"other_setting": "value"}))
+        backend = BackendFactory.create(config_path=config_file)
+        assert isinstance(backend, TmuxBackend)
+
+    def test_returns_tmux_when_value_is_tmux(self, tmp_path):
+        """TmuxBackend is returned when terminal_backend is explicitly 'tmux'."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"terminal_backend": "tmux"}))
+        backend = BackendFactory.create(config_path=config_file)
+        assert isinstance(backend, TmuxBackend)
+
+
+class TestBackendFactoryHerdr:
+    """Test herdr backend selection."""
+
+    def test_returns_herdr_when_configured(self, tmp_path):
+        """HerdrBackend is returned when terminal_backend is 'herdr'."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"terminal_backend": "herdr"}))
+        backend = BackendFactory.create(config_path=config_file)
+        assert isinstance(backend, HerdrBackend)
+
+
+class TestBackendFactoryErrors:
+    """Test error handling for invalid configs."""
+
+    def test_raises_configuration_error_for_unknown_backend(self, tmp_path):
+        """ConfigurationError raised for unrecognized backend names."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"terminal_backend": "screen"}))
+        with pytest.raises(ConfigurationError, match="Unknown terminal_backend.*screen"):
+            BackendFactory.create(config_path=config_file)
+
+    def test_handles_malformed_json_gracefully(self, tmp_path):
+        """Malformed JSON falls back to tmux default with a warning."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text("not valid json {{{")
+        backend = BackendFactory.create(config_path=config_file)
+        assert isinstance(backend, TmuxBackend)
+
+    def test_handles_empty_file_gracefully(self, tmp_path):
+        """Empty file falls back to tmux default."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text("")
+        backend = BackendFactory.create(config_path=config_file)
+        assert isinstance(backend, TmuxBackend)

--- a/test/backends/test_factory.py
+++ b/test/backends/test_factory.py
@@ -42,7 +42,15 @@ class TestBackendFactoryHerdr:
         """HerdrBackend is returned when terminal_backend is 'herdr'."""
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({"terminal_backend": "herdr"}))
-        backend = BackendFactory.create(config_path=config_file)
+        # Patch os.path.exists so HerdrBackend.__init__ -> _ensure_session_running
+        # finds the session socket and skips the subprocess.Popen(["herdr", ...])
+        # startup, which would raise FileNotFoundError where herdr is not installed
+        # (e.g. CI). Mirrors the fixture in test_herdr_backend.py.
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists",
+            return_value=True,
+        ):
+            backend = BackendFactory.create(config_path=config_file)
         assert isinstance(backend, HerdrBackend)
 
 

--- a/test/backends/test_factory.py
+++ b/test/backends/test_factory.py
@@ -54,6 +54,59 @@ class TestBackendFactoryHerdr:
         assert isinstance(backend, HerdrBackend)
 
 
+class TestBackendFactoryOverride:
+    """Test the backend_override parameter (e.g. cao-server --terminal)."""
+
+    def test_override_herdr_wins_over_tmux_config(self, tmp_path):
+        """backend_override='herdr' beats terminal_backend='tmux' in config."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"terminal_backend": "tmux"}))
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists",
+            return_value=True,
+        ):
+            backend = BackendFactory.create(config_path=config_file, backend_override="herdr")
+        assert isinstance(backend, HerdrBackend)
+
+    def test_override_tmux_wins_over_herdr_config(self, tmp_path):
+        """backend_override='tmux' beats terminal_backend='herdr' in config."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"terminal_backend": "herdr"}))
+        backend = BackendFactory.create(config_path=config_file, backend_override="tmux")
+        assert isinstance(backend, TmuxBackend)
+
+    def test_override_works_without_config_file(self, tmp_path):
+        """backend_override selects the backend even when no config file exists."""
+        nonexistent = tmp_path / "config.json"
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists",
+            return_value=True,
+        ):
+            backend = BackendFactory.create(config_path=nonexistent, backend_override="herdr")
+        assert isinstance(backend, HerdrBackend)
+
+    def test_override_herdr_still_reads_herdr_session_from_config(self, tmp_path):
+        """Override picks the backend; other config keys (herdr_session) still apply."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps({"terminal_backend": "tmux", "herdr_session": "my-session"})
+        )
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists",
+            return_value=True,
+        ):
+            backend = BackendFactory.create(config_path=config_file, backend_override="herdr")
+        assert isinstance(backend, HerdrBackend)
+        assert backend.herdr_session == "my-session"
+
+    def test_unknown_override_raises_configuration_error(self, tmp_path):
+        """An unrecognized override name raises ConfigurationError."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"terminal_backend": "tmux"}))
+        with pytest.raises(ConfigurationError, match="Unknown terminal_backend.*screen"):
+            BackendFactory.create(config_path=config_file, backend_override="screen")
+
+
 class TestBackendFactoryErrors:
     """Test error handling for invalid configs."""
 

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -213,12 +213,14 @@ class TestHerdrBackendCommands:
     @patch("subprocess.run")
     def test_send_keys_calls_send_text_then_enter(self, mock_run, backend):
         """send_keys should call pane send-text then pane send-keys Enter."""
-        # Mock workspace list (for _resolve_pane_id_from_window)
+        # Resolution path: workspace list + tab list + pane list (3 calls)
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
-        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
 
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),  # workspace list
+            _completed(_make_tab_list_response(tabs)),      # tab list
             _completed(_make_pane_list_response(panes)),    # pane list
             _completed(),  # send-text
             _completed(),  # send-keys Enter
@@ -227,21 +229,22 @@ class TestHerdrBackendCommands:
         backend.send_keys("cao-test", "window-0", "hello world", enter_count=1)
 
         calls = [c[0][0] for c in mock_run.call_args_list]
-        # Third call should be send-text
-        assert "send-text" in calls[2]
-        assert "hello world" in calls[2]
-        # Fourth call should be send-keys Enter
-        assert "send-keys" in calls[3]
-        assert "Enter" in calls[3]
+        # After the 3 resolution calls: send-text then send-keys Enter
+        assert "send-text" in calls[-2]
+        assert "hello world" in calls[-2]
+        assert "send-keys" in calls[-1]
+        assert "Enter" in calls[-1]
 
     @patch("subprocess.run")
     def test_send_special_key_enter(self, mock_run, backend):
         """send_special_key with empty string sends Enter."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
-        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
 
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
             _completed(_make_pane_list_response(panes)),
             _completed(),  # send-keys Enter
         ]
@@ -256,10 +259,12 @@ class TestHerdrBackendCommands:
     def test_get_history_calls_pane_read(self, mock_run, backend):
         """get_history should call herdr pane read with correct flags."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
-        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
 
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
             _completed(_make_pane_list_response(panes)),
             _completed(stdout="pane output here"),  # pane read
         ]
@@ -277,7 +282,8 @@ class TestHerdrBackendCommands:
     def test_get_pane_working_directory(self, mock_run, backend):
         """get_pane_working_directory should parse cwd from pane get."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
-        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
         pane_info = json.dumps({
             "id": "cli:pane:get",
             "result": {"pane": {"cwd": "/home/user/project"}, "type": "pane_info"},
@@ -285,6 +291,7 @@ class TestHerdrBackendCommands:
 
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
             _completed(_make_pane_list_response(panes)),
             _completed(stdout=pane_info),  # pane get
         ]
@@ -357,9 +364,6 @@ class TestMultiPaneResolution:
         First call: workspace list (cache miss) + tab list + pane list = 3 subprocess calls.
         Second call: workspace cache hit + tab list + pane list = 2 subprocess calls.
         """
-        backend._window_to_terminal["cao-test:developer-abc1"] = "tid_1"
-        backend._window_to_terminal["cao-test:developer-abc2"] = "tid_2"
-
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
         tabs = [
             {"tab_id": "tab-1", "workspace_id": "w1", "label": "developer-abc1"},
@@ -384,9 +388,7 @@ class TestMultiPaneResolution:
 
     @patch("subprocess.run")
     def test_wrong_window_raises_not_found(self, mock_run, backend):
-        """Mapped terminal_id with no matching pane for the tab raises TerminalNotFoundError."""
-        backend._window_to_terminal["cao-test:unknown-win"] = "tid_gone"
-
+        """A tab with no matching pane raises TerminalNotFoundError keyed on session:window."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
         # Tab exists but no panes match its tab_id
         tabs = [{"tab_id": "tab-x", "workspace_id": "w1", "label": "unknown-win"}]
@@ -398,26 +400,25 @@ class TestMultiPaneResolution:
             _completed(_make_pane_list_response(panes)),
         ]
 
-        with pytest.raises(TerminalNotFoundError, match="tid_gone"):
+        with pytest.raises(TerminalNotFoundError, match="cao-test:unknown-win"):
             backend._resolve_pane_id_from_window("cao-test", "unknown-win")
 
     @patch("subprocess.run")
-    def test_fallback_without_mapping_returns_first_pane(self, mock_run, backend):
-        """Without a window→terminal mapping, falls back to first pane in workspace."""
-        # No mapping registered — simulates pre-existing pane
+    def test_no_matching_tab_raises_not_found(self, mock_run, backend):
+        """No tab for the window: _resolve_tab_id raises TerminalBackendError, which is
+        re-raised as TerminalNotFoundError keyed on session:window. No silent fallback to
+        an arbitrary pane in the workspace."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
-        panes = [
-            {"terminal_id": "tid_1", "pane_id": "w1-1", "workspace_id": "w1"},
-            {"terminal_id": "tid_2", "pane_id": "w1-2", "workspace_id": "w1"},
-        ]
+        # Tabs exist in the workspace but none match the requested window label
+        tabs = [{"tab_id": "tab-other", "workspace_id": "w1", "label": "some-other-window"}]
 
         mock_run.side_effect = [
-            _completed(_make_workspace_list_response(ws)),  # workspace list (resolve_workspace_id)
-            _completed(_make_pane_list_response(panes)),    # pane list
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
         ]
 
-        result = backend._resolve_pane_id_from_window("cao-test", "unmapped-window")
-        assert result == "w1-1"
+        with pytest.raises(TerminalNotFoundError, match="cao-test:unmapped-window"):
+            backend._resolve_pane_id_from_window("cao-test", "unmapped-window")
 
     @patch("subprocess.run")
     def test_three_terminals_each_resolves_correctly(self, mock_run, backend):
@@ -427,10 +428,6 @@ class TestMultiPaneResolution:
         Second/third calls: workspace cache hit + tab + pane = 2 calls each.
         Total: 7 subprocess calls.
         """
-        backend._window_to_terminal["cao-proj:conductor-a1"] = "tid_cond"
-        backend._window_to_terminal["cao-proj:worker-b2"] = "tid_work"
-        backend._window_to_terminal["cao-proj:reviewer-c3"] = "tid_rev"
-
         ws = [{"label": "cao-proj", "workspace_id": "w5"}]
         tabs = [
             {"tab_id": "tab-c", "workspace_id": "w5", "label": "conductor-a1"},
@@ -467,8 +464,6 @@ class TestMultiPaneResolution:
         Second call: workspace cache hit + tab list + pane list = 2 subprocess calls.
         Total: 5 subprocess calls.
         """
-        backend._window_to_terminal["cao-test:window-0"] = "tid1"
-
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
         tabs = [{"tab_id": "tab-1", "workspace_id": "w1", "label": "window-0"}]
         # First call: pane_id is w1-3; second call: pane_id shifted to w1-2
@@ -496,8 +491,6 @@ class TestMultiPaneResolution:
     def test_resolve_pane_id_from_window_uses_tab_id(self, mock_run, backend):
         """When multiple panes exist in the workspace, the correct one is returned by
         matching tab_id (not just the first pane in workspace order)."""
-        backend._window_to_terminal["cao-test:target-window"] = "tid_target"
-
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
         tabs = [
             {"tab_id": "tab-other", "workspace_id": "w1", "label": "other-window"},
@@ -691,13 +684,12 @@ class TestGetNativeStatus:
         })
 
     def _setup_fresh_resolution(self, backend):
-        """Pre-populate workspace cache and register window mapping for tests.
+        """Pre-populate the workspace cache for tests.
 
-        _resolve_pane_id_from_window now performs fresh tab+pane lookups. Pre-populating
+        _resolve_pane_id_from_window performs fresh tab+pane lookups. Pre-populating
         the workspace cache (which has a TTL and is stable) means tests only need to
         mock tab list, pane list, and pane get — not workspace list as well.
         """
-        backend._window_to_terminal["s:w"] = "tid1"
         backend._workspace_cache["s"] = ("w1", time.time())
 
     def _make_resolution_side_effects(self, pane_get_response):

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -209,6 +209,135 @@ class TestHerdrBackendCommands:
         assert "CAO_TERMINAL_ID=tid1" in env_cmd[-1]
         assert "CAO_SESSION_NAME=cao-myproj" in env_cmd[-1]
 
+    @staticmethod
+    def _workspace_create_resp():
+        """workspace create response carrying a root pane_id for env injection."""
+        return _completed(
+            json.dumps(
+                {
+                    "id": "cli:workspace:create",
+                    "result": {
+                        "workspace_id": "w_new",
+                        "root_pane": {
+                            "pane_id": "w_new-1",
+                            "workspace_id": "w_new",
+                            "tab_id": "tab-0",
+                        },
+                        "type": "workspace_created",
+                    },
+                }
+            )
+        )
+
+    @patch("subprocess.run")
+    def test_create_session_forwards_extra_env(self, mock_run, backend):
+        """extra_env from cao launch --env is exported into the pane (shell-quoted)."""
+        mock_run.side_effect = [
+            self._workspace_create_resp(),  # workspace create
+            _completed(),  # tab rename
+            _completed(),  # pane send-text (env export)
+            _completed(),  # pane send-keys Enter
+        ]
+
+        backend.create_session(
+            "cao-myproj",
+            "window-0",
+            "tid1",
+            "/home/user/project",
+            extra_env={"AWS_REGION": "us-west-2", "MNEMOSYNE_DIR": "/root/mn"},
+        )
+
+        env_cmd = mock_run.call_args_list[2][0][0][-1]
+        assert "export AWS_REGION=us-west-2" in env_cmd
+        assert "export MNEMOSYNE_DIR=/root/mn" in env_cmd
+        # CAO identity vars still present
+        assert "CAO_TERMINAL_ID=tid1" in env_cmd
+
+    @patch("subprocess.run")
+    def test_create_session_drops_blocked_and_oversized_env(self, mock_run, backend):
+        """Blocked-prefix and oversized extra_env values are filtered out (tmux parity)."""
+        mock_run.side_effect = [
+            self._workspace_create_resp(),
+            _completed(),
+            _completed(),
+            _completed(),
+        ]
+
+        backend.create_session(
+            "cao-myproj",
+            "window-0",
+            "tid1",
+            "/home/user/project",
+            extra_env={
+                "CLAUDE_SECRET": "x",  # blocked prefix
+                "BIG": "x" * 2048,  # at the 2048-byte cap -> dropped
+                "OK": "kept",
+            },
+        )
+
+        env_cmd = mock_run.call_args_list[2][0][0][-1]
+        assert "CLAUDE_SECRET" not in env_cmd
+        assert "BIG=" not in env_cmd
+        assert "export OK=kept" in env_cmd
+
+    @patch("subprocess.run")
+    def test_create_session_quotes_env_values(self, mock_run, backend):
+        """Operator-supplied values are shell-quoted to stay injection-safe."""
+        mock_run.side_effect = [
+            self._workspace_create_resp(),
+            _completed(),
+            _completed(),
+            _completed(),
+        ]
+
+        backend.create_session(
+            "cao-myproj",
+            "window-0",
+            "tid1",
+            "/home/user/project",
+            extra_env={"DANGER": "a; rm -rf /"},
+        )
+
+        env_cmd = mock_run.call_args_list[2][0][0][-1]
+        # shlex.quote wraps the value so the embedded "; rm" cannot break out.
+        assert "export DANGER='a; rm -rf /'" in env_cmd
+
+    @patch("subprocess.run")
+    def test_create_window_forwards_extra_env(self, mock_run, backend):
+        """create_window threads extra_env into the injected exports too."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tab_create_resp = _completed(
+            json.dumps(
+                {
+                    "id": "cli:tab:create",
+                    "result": {
+                        "root_pane": {
+                            "pane_id": "w1-2",
+                            "workspace_id": "w1",
+                            "tab_id": "tab-1",
+                        },
+                        "type": "tab_created",
+                    },
+                }
+            )
+        )
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # _resolve_workspace_id
+            tab_create_resp,  # tab create
+            _completed(),  # pane send-text (env export)
+            _completed(),  # pane send-keys Enter
+        ]
+
+        backend.create_window(
+            "cao-test",
+            "window-1",
+            "tid2",
+            extra_env={"AWS_REGION": "eu-central-1"},
+        )
+
+        send_text_call = next(c[0][0] for c in mock_run.call_args_list if "send-text" in c[0][0])
+        assert "export AWS_REGION=eu-central-1" in send_text_call[-1]
+
     @patch("subprocess.run")
     def test_kill_session_calls_workspace_close(self, mock_run, backend):
         """kill_session should resolve workspace_id then call herdr workspace close <id>."""

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -603,15 +603,15 @@ class TestEnsureSessionRunning:
         assert cmd == ["herdr", "--session", "cao", "server"]
 
     def test_logs_warning_when_socket_never_appears(self):
-        """If socket never appears within 5s, a warning is logged and no error raised."""
-        # Simulate clock: first call returns 0.0 (sets deadline=5.0),
-        # all subsequent calls return 6.0 (past deadline, exits loop).
+        """If socket never appears within 15s, a warning is logged and no error raised."""
+        # Simulate clock: first call returns 0.0 (sets deadline=15.0),
+        # all subsequent calls return 16.0 (past deadline, exits loop).
         # Using a counter so exhaustion from logging internals is not an issue.
         call_count = {"n": 0}
 
         def fake_time():
             call_count["n"] += 1
-            return 0.0 if call_count["n"] == 1 else 6.0
+            return 0.0 if call_count["n"] == 1 else 16.0
 
         with patch(
             "cli_agent_orchestrator.backends.herdr_backend.os.path.exists",

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -13,7 +13,6 @@ from cli_agent_orchestrator.backends.base import (
 )
 from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
 
-
 # --- Fixtures ---
 
 
@@ -62,10 +61,20 @@ class TestHerdrBackendABC:
 
     def test_all_methods_implemented(self, backend):
         for method in [
-            "create_session", "session_exists", "list_sessions", "kill_session",
-            "create_window", "kill_window", "send_keys", "send_special_key",
-            "get_history", "get_pane_working_directory", "get_pane_current_command",
-            "attach_session", "pipe_pane", "stop_pipe_pane",
+            "create_session",
+            "session_exists",
+            "list_sessions",
+            "kill_session",
+            "create_window",
+            "kill_window",
+            "send_keys",
+            "send_special_key",
+            "get_history",
+            "get_pane_working_directory",
+            "get_pane_current_command",
+            "attach_session",
+            "pipe_pane",
+            "stop_pipe_pane",
         ]:
             assert callable(getattr(backend, method))
 
@@ -160,19 +169,27 @@ class TestHerdrBackendCommands:
         """create_session should call herdr workspace create with --label and inject env."""
         # Include root_pane.pane_id so _parse_new_pane_id succeeds and _inject_env_vars
         # uses the known pane_id directly (no fallback pane list scan needed).
-        ws_create_resp = _completed(json.dumps({
-            "id": "cli:workspace:create",
-            "result": {
-                "workspace_id": "w_new",
-                "root_pane": {"pane_id": "w_new-1", "workspace_id": "w_new", "tab_id": "tab-0"},
-                "type": "workspace_created",
-            },
-        }))
+        ws_create_resp = _completed(
+            json.dumps(
+                {
+                    "id": "cli:workspace:create",
+                    "result": {
+                        "workspace_id": "w_new",
+                        "root_pane": {
+                            "pane_id": "w_new-1",
+                            "workspace_id": "w_new",
+                            "tab_id": "tab-0",
+                        },
+                        "type": "workspace_created",
+                    },
+                }
+            )
+        )
         mock_run.side_effect = [
             ws_create_resp,  # workspace create
-            _completed(),    # tab rename (root tab labeled with window_name)
-            _completed(),    # pane send-text (env export)
-            _completed(),    # pane send-keys Enter
+            _completed(),  # tab rename (root tab labeled with window_name)
+            _completed(),  # pane send-text (env export)
+            _completed(),  # pane send-keys Enter
         ]
 
         backend.create_session("cao-myproj", "window-0", "tid1", "/home/user/project")
@@ -198,7 +215,7 @@ class TestHerdrBackendCommands:
         ws = [{"label": "cao-test", "workspace_id": "w_abc123"}]
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),  # _resolve_workspace_id
-            _completed(),                                    # workspace close
+            _completed(),  # workspace close
         ]
 
         result = backend.kill_session("cao-test")
@@ -220,8 +237,8 @@ class TestHerdrBackendCommands:
 
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),  # workspace list
-            _completed(_make_tab_list_response(tabs)),      # tab list
-            _completed(_make_pane_list_response(panes)),    # pane list
+            _completed(_make_tab_list_response(tabs)),  # tab list
+            _completed(_make_pane_list_response(panes)),  # pane list
             _completed(),  # send-text
             _completed(),  # send-keys Enter
         ]
@@ -284,10 +301,12 @@ class TestHerdrBackendCommands:
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
         tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
         panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
-        pane_info = json.dumps({
-            "id": "cli:pane:get",
-            "result": {"pane": {"cwd": "/home/user/project"}, "type": "pane_info"},
-        })
+        pane_info = json.dumps(
+            {
+                "id": "cli:pane:get",
+                "result": {"pane": {"cwd": "/home/user/project"}, "type": "pane_info"},
+            }
+        )
 
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),
@@ -354,7 +373,9 @@ class TestMultiPaneResolution:
 
     @pytest.fixture
     def backend(self):
-        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True
+        ):
             yield HerdrBackend(send_delay_ms=0)
 
     @patch("subprocess.run")
@@ -376,8 +397,8 @@ class TestMultiPaneResolution:
 
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),  # workspace list (cache miss)
-            _completed(_make_tab_list_response(tabs)),       # tab list
-            _completed(_make_pane_list_response(panes)),     # pane list
+            _completed(_make_tab_list_response(tabs)),  # tab list
+            _completed(_make_pane_list_response(panes)),  # pane list
             # second call: workspace cache hit, so only tab + pane needed
             _completed(_make_tab_list_response(tabs)),
             _completed(_make_pane_list_response(panes)),
@@ -471,7 +492,7 @@ class TestMultiPaneResolution:
         second_panes = [{"tab_id": "tab-1", "pane_id": "w1-2", "workspace_id": "w1"}]
 
         mock_run.side_effect = [
-            _completed(_make_workspace_list_response(ws)),   # workspace list (cache miss)
+            _completed(_make_workspace_list_response(ws)),  # workspace list (cache miss)
             _completed(_make_tab_list_response(tabs)),
             _completed(_make_pane_list_response(first_panes)),
             # second call: workspace cache hit, so only tab + pane
@@ -521,21 +542,27 @@ class TestSessionSocketPath:
     @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
     def test_named_session_uses_subdir(self):
         """Named session should produce <config_home>/herdr/<name>/herdr.sock."""
-        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True
+        ):
             b = HerdrBackend(herdr_session="cao")
         assert b._session_socket_path() == "/custom/config/herdr/sessions/cao/herdr.sock"
 
     @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
     def test_default_session_uses_flat_path(self):
         """'default' session should produce <config_home>/herdr/herdr.sock (no subdir)."""
-        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True
+        ):
             b = HerdrBackend(herdr_session="default")
         assert b._session_socket_path() == "/custom/config/herdr/herdr.sock"
 
     @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
     def test_arbitrary_session_name(self):
         """An arbitrary session name should appear as a subdirectory."""
-        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True
+        ):
             b = HerdrBackend(herdr_session="my-workspace")
         assert b._session_socket_path() == "/custom/config/herdr/sessions/my-workspace/herdr.sock"
 
@@ -548,7 +575,9 @@ class TestEnsureSessionRunning:
 
     def test_does_nothing_when_socket_exists(self):
         """If socket already exists, no Popen should be called."""
-        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True
+        ):
             with patch("subprocess.Popen") as mock_popen:
                 HerdrBackend(herdr_session="cao")
         mock_popen.assert_not_called()
@@ -609,23 +638,30 @@ class TestCreateWindowWindowShell:
     def test_create_window_with_window_shell(self, mock_run, mock_sleep, backend):
         """When window_shell is provided, pane run is called after a 0.5s sleep."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
-        tab_create_resp = _completed(json.dumps({
-            "id": "cli:tab:create",
-            "result": {
-                "root_pane": {"pane_id": "w1-5", "workspace_id": "w1"},
-                "type": "tab_created",
-            },
-        }))
+        tab_create_resp = _completed(
+            json.dumps(
+                {
+                    "id": "cli:tab:create",
+                    "result": {
+                        "root_pane": {"pane_id": "w1-5", "workspace_id": "w1"},
+                        "type": "tab_created",
+                    },
+                }
+            )
+        )
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),  # _resolve_workspace_id
-            tab_create_resp,                                 # tab create
-            _completed(),                                    # pane send-text (env export)
-            _completed(),                                    # pane send-keys Enter
-            _completed(),                                    # pane run
+            tab_create_resp,  # tab create
+            _completed(),  # pane send-text (env export)
+            _completed(),  # pane send-keys Enter
+            _completed(),  # pane run
         ]
 
         backend.create_window(
-            "cao-test", "restored-win", "tid99", "/home/user",
+            "cao-test",
+            "restored-win",
+            "tid99",
+            "/home/user",
             window_shell="cat '/path/file'; exec /bin/bash -l",
         )
 
@@ -641,25 +677,32 @@ class TestCreateWindowWindowShell:
     def test_create_window_window_shell_failure_is_nonfatal(self, mock_run, mock_sleep, backend):
         """If pane run raises, create_window still returns window_name without raising."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]
-        tab_create_resp = _completed(json.dumps({
-            "id": "cli:tab:create",
-            "result": {
-                "root_pane": {"pane_id": "w1-6", "workspace_id": "w1"},
-                "type": "tab_created",
-            },
-        }))
+        tab_create_resp = _completed(
+            json.dumps(
+                {
+                    "id": "cli:tab:create",
+                    "result": {
+                        "root_pane": {"pane_id": "w1-6", "workspace_id": "w1"},
+                        "type": "tab_created",
+                    },
+                }
+            )
+        )
         pane_run_fail = _completed(returncode=1)
         pane_run_fail.stderr = "pane not found"
         mock_run.side_effect = [
             _completed(_make_workspace_list_response(ws)),  # _resolve_workspace_id
-            tab_create_resp,                                 # tab create
-            _completed(),                                    # pane send-text (env export)
-            _completed(),                                    # pane send-keys Enter
-            pane_run_fail,                                   # pane run (fails)
+            tab_create_resp,  # tab create
+            _completed(),  # pane send-text (env export)
+            _completed(),  # pane send-keys Enter
+            pane_run_fail,  # pane run (fails)
         ]
 
         result = backend.create_window(
-            "cao-test", "restored-win", "tid99", "/home/user",
+            "cao-test",
+            "restored-win",
+            "tid99",
+            "/home/user",
             window_shell="exec /bin/bash -l",
         )
 
@@ -675,13 +718,15 @@ class TestGetNativeStatus:
     from cli_agent_orchestrator.models.terminal import TerminalStatus as _TS
 
     def _make_pane_get_response(self, agent_status: str) -> str:
-        return json.dumps({
-            "id": "cli:pane:get",
-            "result": {
-                "pane": {"pane_id": "w1-1", "agent_status": agent_status},
-                "type": "pane_info",
-            },
-        })
+        return json.dumps(
+            {
+                "id": "cli:pane:get",
+                "result": {
+                    "pane": {"pane_id": "w1-1", "agent_status": agent_status},
+                    "type": "pane_info",
+                },
+            }
+        )
 
     def _setup_fresh_resolution(self, backend):
         """Pre-populate the workspace cache for tests.
@@ -697,9 +742,9 @@ class TestGetNativeStatus:
         tabs = [{"tab_id": "tab-1", "workspace_id": "w1", "label": "w"}]
         panes = [{"tab_id": "tab-1", "pane_id": "w1-1", "workspace_id": "w1"}]
         return [
-            _completed(_make_tab_list_response(tabs)),   # tab list
-            _completed(_make_pane_list_response(panes)), # pane list
-            pane_get_response,                            # pane get
+            _completed(_make_tab_list_response(tabs)),  # tab list
+            _completed(_make_pane_list_response(panes)),  # pane list
+            pane_get_response,  # pane get
         ]
 
     @patch("subprocess.run")
@@ -710,6 +755,7 @@ class TestGetNativeStatus:
         )
 
         from cli_agent_orchestrator.models.terminal import TerminalStatus
+
         result = backend.get_native_status("s", "w")
         assert result == TerminalStatus.PROCESSING
 
@@ -721,6 +767,7 @@ class TestGetNativeStatus:
         )
 
         from cli_agent_orchestrator.models.terminal import TerminalStatus
+
         result = backend.get_native_status("s", "w")
         assert result == TerminalStatus.WAITING_USER_ANSWER
 
@@ -732,6 +779,7 @@ class TestGetNativeStatus:
         )
 
         from cli_agent_orchestrator.models.terminal import TerminalStatus
+
         result = backend.get_native_status("s", "w")
         assert result == TerminalStatus.COMPLETED
 
@@ -743,6 +791,7 @@ class TestGetNativeStatus:
         )
 
         from cli_agent_orchestrator.models.terminal import TerminalStatus
+
         result = backend.get_native_status("s", "w")
         assert result == TerminalStatus.IDLE
 
@@ -754,6 +803,7 @@ class TestGetNativeStatus:
         )
 
         from cli_agent_orchestrator.models.terminal import TerminalStatus
+
         result = backend.get_native_status("s", "w")
         assert result == TerminalStatus.ERROR
 

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -296,6 +296,45 @@ class TestHerdrBackendCommands:
         assert "50" in cmd
 
     @patch("subprocess.run")
+    def test_get_history_strip_escapes_requests_text_format(self, mock_run, backend):
+        """strip_escapes=True maps to herdr's --format text (ANSI stripped)."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(stdout="plain text"),  # pane read
+        ]
+
+        backend.get_history("cao-test", "window-0", tail_lines=50, strip_escapes=True)
+
+        cmd = mock_run.call_args_list[-1][0][0]
+        assert "--format" in cmd
+        assert cmd[cmd.index("--format") + 1] == "text"
+
+    @patch("subprocess.run")
+    def test_get_history_default_omits_format(self, mock_run, backend):
+        """strip_escapes=False leaves format unset (herdr default preserved)."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(stdout="output"),  # pane read
+        ]
+
+        backend.get_history("cao-test", "window-0", tail_lines=50)
+
+        cmd = mock_run.call_args_list[-1][0][0]
+        assert "--format" not in cmd
+
+    @patch("subprocess.run")
     def test_get_pane_working_directory(self, mock_run, backend):
         """get_pane_working_directory should parse cwd from pane get."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -1,0 +1,775 @@
+"""Unit tests for HerdrBackend — pane_id resolution and command construction."""
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.backends.base import (
+    TerminalBackend,
+    TerminalBackendError,
+    TerminalNotFoundError,
+)
+from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def backend():
+    # Patch os.path.exists so _ensure_session_running finds the socket immediately,
+    # avoiding the 5-second poll timeout in unit tests.
+    with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+        yield HerdrBackend(send_delay_ms=0)
+
+
+def _make_pane_list_response(panes):
+    """Build a herdr pane list JSON envelope."""
+    return json.dumps({"id": "cli:pane:list", "result": {"panes": panes, "type": "pane_list"}})
+
+
+def _make_workspace_list_response(workspaces):
+    """Build a herdr workspace list JSON envelope."""
+    return json.dumps(
+        {"id": "cli:workspace:list", "result": {"workspaces": workspaces, "type": "workspace_list"}}
+    )
+
+
+def _make_tab_list_response(tabs):
+    """Build a herdr tab list JSON envelope."""
+    return json.dumps({"id": "cli:tab:list", "result": {"tabs": tabs, "type": "tab_list"}})
+
+
+def _completed(stdout="", returncode=0):
+    """Create a mock CompletedProcess."""
+    mock = MagicMock()
+    mock.stdout = stdout
+    mock.returncode = returncode
+    mock.stderr = ""
+    return mock
+
+
+# --- ABC Compliance ---
+
+
+class TestHerdrBackendABC:
+    """Verify HerdrBackend satisfies the ABC."""
+
+    def test_is_instance_of_terminal_backend(self, backend):
+        assert isinstance(backend, TerminalBackend)
+
+    def test_all_methods_implemented(self, backend):
+        for method in [
+            "create_session", "session_exists", "list_sessions", "kill_session",
+            "create_window", "kill_window", "send_keys", "send_special_key",
+            "get_history", "get_pane_working_directory", "get_pane_current_command",
+            "attach_session", "pipe_pane", "stop_pipe_pane",
+        ]:
+            assert callable(getattr(backend, method))
+
+
+# --- Pane ID Resolution ---
+
+
+class TestPaneIdResolution:
+    """Test terminal_id → pane_id resolution with cache."""
+
+    @patch("subprocess.run")
+    def test_resolves_pane_id_from_list(self, mock_run, backend):
+        """Should resolve terminal_id to pane_id via herdr pane list."""
+        panes = [
+            {"terminal_id": "term_abc", "pane_id": "w1-1", "workspace_id": "w1"},
+            {"terminal_id": "term_def", "pane_id": "w1-2", "workspace_id": "w1"},
+        ]
+        mock_run.return_value = _completed(_make_pane_list_response(panes))
+
+        result = backend._resolve_pane_id("term_abc")
+        assert result == "w1-1"
+
+    @patch("subprocess.run")
+    def test_cache_hit_avoids_subprocess(self, mock_run, backend):
+        """Cached pane_id should be returned without calling herdr."""
+        backend._pane_cache["term_cached"] = ("w2-3", time.time())
+
+        result = backend._resolve_pane_id("term_cached")
+        assert result == "w2-3"
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_cache_expired_calls_subprocess(self, mock_run, backend):
+        """Expired cache entry should trigger a fresh resolve."""
+        backend._pane_cache["term_old"] = ("w2-3", time.time() - 10.0)  # expired
+
+        panes = [{"terminal_id": "term_old", "pane_id": "w2-4", "workspace_id": "w2"}]
+        mock_run.return_value = _completed(_make_pane_list_response(panes))
+
+        result = backend._resolve_pane_id("term_old")
+        assert result == "w2-4"
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_raises_terminal_not_found(self, mock_run, backend):
+        """Should raise TerminalNotFoundError when terminal_id is not in list."""
+        panes = [{"terminal_id": "term_other", "pane_id": "w1-1", "workspace_id": "w1"}]
+        mock_run.return_value = _completed(_make_pane_list_response(panes))
+
+        with pytest.raises(TerminalNotFoundError, match="term_missing"):
+            backend._resolve_pane_id("term_missing")
+
+
+# --- Command Construction ---
+
+
+class TestHerdrBackendCommands:
+    """Verify correct herdr CLI command construction for each method."""
+
+    @patch("subprocess.run")
+    def test_session_exists_true(self, mock_run, backend):
+        """session_exists returns True when workspace label matches."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        mock_run.return_value = _completed(_make_workspace_list_response(ws))
+
+        assert backend.session_exists("cao-test") is True
+
+    @patch("subprocess.run")
+    def test_session_exists_false(self, mock_run, backend):
+        """session_exists returns False when no workspace matches."""
+        ws = [{"label": "other", "workspace_id": "w1"}]
+        mock_run.return_value = _completed(_make_workspace_list_response(ws))
+
+        assert backend.session_exists("cao-test") is False
+
+    @patch("subprocess.run")
+    def test_list_sessions(self, mock_run, backend):
+        """list_sessions returns workspace labels."""
+        ws = [
+            {"label": "cao-proj1", "workspace_id": "w1"},
+            {"label": "cao-proj2", "workspace_id": "w2"},
+        ]
+        mock_run.return_value = _completed(_make_workspace_list_response(ws))
+
+        result = backend.list_sessions()
+        assert len(result) == 2
+        assert result[0]["name"] == "cao-proj1"
+        assert result[1]["name"] == "cao-proj2"
+
+    @patch("subprocess.run")
+    def test_create_session_calls_workspace_create(self, mock_run, backend):
+        """create_session should call herdr workspace create with --label and inject env."""
+        # Include root_pane.pane_id so _parse_new_pane_id succeeds and _inject_env_vars
+        # uses the known pane_id directly (no fallback pane list scan needed).
+        ws_create_resp = _completed(json.dumps({
+            "id": "cli:workspace:create",
+            "result": {
+                "workspace_id": "w_new",
+                "root_pane": {"pane_id": "w_new-1", "workspace_id": "w_new", "tab_id": "tab-0"},
+                "type": "workspace_created",
+            },
+        }))
+        mock_run.side_effect = [
+            ws_create_resp,  # workspace create
+            _completed(),    # tab rename (root tab labeled with window_name)
+            _completed(),    # pane send-text (env export)
+            _completed(),    # pane send-keys Enter
+        ]
+
+        backend.create_session("cao-myproj", "window-0", "tid1", "/home/user/project")
+
+        # First call should be workspace create
+        cmd = mock_run.call_args_list[0][0][0]
+        assert cmd[:3] == ["herdr", "--session", "cao"]
+        assert "workspace" in cmd
+        assert "create" in cmd
+        assert "--label" in cmd
+        assert "cao-myproj" in cmd
+        assert "--cwd" in cmd
+        assert "/home/user/project" in cmd
+        # Env injection should have sent the export command (call index 2)
+        env_cmd = mock_run.call_args_list[2][0][0]
+        assert "send-text" in env_cmd
+        assert "CAO_TERMINAL_ID=tid1" in env_cmd[-1]
+        assert "CAO_SESSION_NAME=cao-myproj" in env_cmd[-1]
+
+    @patch("subprocess.run")
+    def test_kill_session_calls_workspace_close(self, mock_run, backend):
+        """kill_session should resolve workspace_id then call herdr workspace close <id>."""
+        ws = [{"label": "cao-test", "workspace_id": "w_abc123"}]
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # _resolve_workspace_id
+            _completed(),                                    # workspace close
+        ]
+
+        result = backend.kill_session("cao-test")
+
+        assert result is True
+        close_call = mock_run.call_args_list[1][0][0]
+        assert "workspace" in close_call
+        assert "close" in close_call
+        assert "w_abc123" in close_call
+        assert "--label" not in close_call
+
+    @patch("subprocess.run")
+    def test_send_keys_calls_send_text_then_enter(self, mock_run, backend):
+        """send_keys should call pane send-text then pane send-keys Enter."""
+        # Mock workspace list (for _resolve_pane_id_from_window)
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # workspace list
+            _completed(_make_pane_list_response(panes)),    # pane list
+            _completed(),  # send-text
+            _completed(),  # send-keys Enter
+        ]
+
+        backend.send_keys("cao-test", "window-0", "hello world", enter_count=1)
+
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        # Third call should be send-text
+        assert "send-text" in calls[2]
+        assert "hello world" in calls[2]
+        # Fourth call should be send-keys Enter
+        assert "send-keys" in calls[3]
+        assert "Enter" in calls[3]
+
+    @patch("subprocess.run")
+    def test_send_special_key_enter(self, mock_run, backend):
+        """send_special_key with empty string sends Enter."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(),  # send-keys Enter
+        ]
+
+        backend.send_special_key("cao-test", "window-0", "")
+
+        cmd = mock_run.call_args_list[-1][0][0]
+        assert "send-keys" in cmd
+        assert "Enter" in cmd
+
+    @patch("subprocess.run")
+    def test_get_history_calls_pane_read(self, mock_run, backend):
+        """get_history should call herdr pane read with correct flags."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(stdout="pane output here"),  # pane read
+        ]
+
+        result = backend.get_history("cao-test", "window-0", tail_lines=50)
+
+        assert result == "pane output here"
+        cmd = mock_run.call_args_list[-1][0][0]
+        assert "pane" in cmd
+        assert "read" in cmd
+        assert "--lines" in cmd
+        assert "50" in cmd
+
+    @patch("subprocess.run")
+    def test_get_pane_working_directory(self, mock_run, backend):
+        """get_pane_working_directory should parse cwd from pane get."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        panes = [{"terminal_id": "tid1", "pane_id": "w1-1", "workspace_id": "w1"}]
+        pane_info = json.dumps({
+            "id": "cli:pane:get",
+            "result": {"pane": {"cwd": "/home/user/project"}, "type": "pane_info"},
+        })
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(stdout=pane_info),  # pane get
+        ]
+
+        result = backend.get_pane_working_directory("cao-test", "window-0")
+        assert result == "/home/user/project"
+
+    @patch("subprocess.run")
+    def test_pipe_pane_is_noop(self, mock_run, backend):
+        """pipe_pane should be a no-op (no subprocess calls)."""
+        backend.pipe_pane("cao-test", "window-0", "/tmp/log.txt")
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_stop_pipe_pane_is_noop(self, mock_run, backend):
+        """stop_pipe_pane should be a no-op (no subprocess calls)."""
+        backend.stop_pipe_pane("cao-test", "window-0")
+        mock_run.assert_not_called()
+
+
+# --- Error Handling ---
+
+
+class TestHerdrBackendErrors:
+    """Verify error wrapping behavior."""
+
+    @patch("subprocess.run")
+    def test_nonzero_exit_raises_backend_error(self, mock_run, backend):
+        """Non-zero herdr exit should raise TerminalBackendError."""
+        mock_run.return_value = _completed(returncode=1)
+        mock_run.return_value.stderr = "workspace not found"
+
+        with pytest.raises(TerminalBackendError, match="herdr command failed"):
+            backend._run_herdr(["workspace", "close", "--label", "missing"])
+
+    @patch("subprocess.run")
+    def test_herdr_not_found_raises_backend_error(self, mock_run, backend):
+        """FileNotFoundError from herdr should raise TerminalBackendError."""
+        mock_run.side_effect = FileNotFoundError("herdr")
+
+        with pytest.raises(TerminalBackendError, match="herdr CLI not found"):
+            backend._run_herdr(["workspace", "list"])
+
+    def test_invalidate_cache_clears_all(self, backend):
+        """invalidate_cache should empty both caches."""
+        backend._pane_cache["tid1"] = ("w1-1", time.time())
+        backend._workspace_cache["cao-test"] = ("w1", time.time())
+
+        backend.invalidate_cache()
+
+        assert backend._pane_cache == {}
+        assert backend._workspace_cache == {}
+
+
+# --- Multi-pane resolution (S-008) ---
+
+
+class TestMultiPaneResolution:
+    """Test _resolve_pane_id_from_window with multiple panes in one workspace."""
+
+    @pytest.fixture
+    def backend(self):
+        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+            yield HerdrBackend(send_delay_ms=0)
+
+    @patch("subprocess.run")
+    def test_resolves_correct_pane_via_window_mapping(self, mock_run, backend):
+        """With window→terminal mapping, resolves correct pane via fresh tab+pane lookup.
+
+        First call: workspace list (cache miss) + tab list + pane list = 3 subprocess calls.
+        Second call: workspace cache hit + tab list + pane list = 2 subprocess calls.
+        """
+        backend._window_to_terminal["cao-test:developer-abc1"] = "tid_1"
+        backend._window_to_terminal["cao-test:developer-abc2"] = "tid_2"
+
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [
+            {"tab_id": "tab-1", "workspace_id": "w1", "label": "developer-abc1"},
+            {"tab_id": "tab-2", "workspace_id": "w1", "label": "developer-abc2"},
+        ]
+        panes = [
+            {"tab_id": "tab-1", "pane_id": "w1-1", "workspace_id": "w1"},
+            {"tab_id": "tab-2", "pane_id": "w1-2", "workspace_id": "w1"},
+        ]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # workspace list (cache miss)
+            _completed(_make_tab_list_response(tabs)),       # tab list
+            _completed(_make_pane_list_response(panes)),     # pane list
+            # second call: workspace cache hit, so only tab + pane needed
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+        ]
+
+        assert backend._resolve_pane_id_from_window("cao-test", "developer-abc1") == "w1-1"
+        assert backend._resolve_pane_id_from_window("cao-test", "developer-abc2") == "w1-2"
+
+    @patch("subprocess.run")
+    def test_wrong_window_raises_not_found(self, mock_run, backend):
+        """Mapped terminal_id with no matching pane for the tab raises TerminalNotFoundError."""
+        backend._window_to_terminal["cao-test:unknown-win"] = "tid_gone"
+
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        # Tab exists but no panes match its tab_id
+        tabs = [{"tab_id": "tab-x", "workspace_id": "w1", "label": "unknown-win"}]
+        panes = [{"tab_id": "tab-other", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+        ]
+
+        with pytest.raises(TerminalNotFoundError, match="tid_gone"):
+            backend._resolve_pane_id_from_window("cao-test", "unknown-win")
+
+    @patch("subprocess.run")
+    def test_fallback_without_mapping_returns_first_pane(self, mock_run, backend):
+        """Without a window→terminal mapping, falls back to first pane in workspace."""
+        # No mapping registered — simulates pre-existing pane
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        panes = [
+            {"terminal_id": "tid_1", "pane_id": "w1-1", "workspace_id": "w1"},
+            {"terminal_id": "tid_2", "pane_id": "w1-2", "workspace_id": "w1"},
+        ]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # workspace list (resolve_workspace_id)
+            _completed(_make_pane_list_response(panes)),    # pane list
+        ]
+
+        result = backend._resolve_pane_id_from_window("cao-test", "unmapped-window")
+        assert result == "w1-1"
+
+    @patch("subprocess.run")
+    def test_three_terminals_each_resolves_correctly(self, mock_run, backend):
+        """Three terminals each resolve to their distinct pane via fresh tab+pane lookup.
+
+        First call: workspace list (cache miss) + tab + pane = 3 calls.
+        Second/third calls: workspace cache hit + tab + pane = 2 calls each.
+        Total: 7 subprocess calls.
+        """
+        backend._window_to_terminal["cao-proj:conductor-a1"] = "tid_cond"
+        backend._window_to_terminal["cao-proj:worker-b2"] = "tid_work"
+        backend._window_to_terminal["cao-proj:reviewer-c3"] = "tid_rev"
+
+        ws = [{"label": "cao-proj", "workspace_id": "w5"}]
+        tabs = [
+            {"tab_id": "tab-c", "workspace_id": "w5", "label": "conductor-a1"},
+            {"tab_id": "tab-w", "workspace_id": "w5", "label": "worker-b2"},
+            {"tab_id": "tab-r", "workspace_id": "w5", "label": "reviewer-c3"},
+        ]
+        panes = [
+            {"tab_id": "tab-c", "pane_id": "w5-1", "workspace_id": "w5"},
+            {"tab_id": "tab-w", "pane_id": "w5-2", "workspace_id": "w5"},
+            {"tab_id": "tab-r", "pane_id": "w5-3", "workspace_id": "w5"},
+        ]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # workspace list (cache miss)
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            # second + third calls: workspace cache hit
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+        ]
+
+        assert backend._resolve_pane_id_from_window("cao-proj", "conductor-a1") == "w5-1"
+        assert backend._resolve_pane_id_from_window("cao-proj", "worker-b2") == "w5-2"
+        assert backend._resolve_pane_id_from_window("cao-proj", "reviewer-c3") == "w5-3"
+
+    @patch("subprocess.run")
+    def test_resolve_pane_id_from_window_always_does_fresh_lookup(self, mock_run, backend):
+        """Calling _resolve_pane_id_from_window twice returns fresh results each call,
+        even when pane_id shifts between calls (simulates post-deletion renumbering).
+
+        First call: workspace list (cache miss) + tab list + pane list = 3 subprocess calls.
+        Second call: workspace cache hit + tab list + pane list = 2 subprocess calls.
+        Total: 5 subprocess calls.
+        """
+        backend._window_to_terminal["cao-test:window-0"] = "tid1"
+
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-1", "workspace_id": "w1", "label": "window-0"}]
+        # First call: pane_id is w1-3; second call: pane_id shifted to w1-2
+        first_panes = [{"tab_id": "tab-1", "pane_id": "w1-3", "workspace_id": "w1"}]
+        second_panes = [{"tab_id": "tab-1", "pane_id": "w1-2", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),   # workspace list (cache miss)
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(first_panes)),
+            # second call: workspace cache hit, so only tab + pane
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(second_panes)),
+        ]
+
+        first_result = backend._resolve_pane_id_from_window("cao-test", "window-0")
+        second_result = backend._resolve_pane_id_from_window("cao-test", "window-0")
+
+        assert first_result == "w1-3"
+        assert second_result == "w1-2"
+        # 3 calls (first) + 2 calls (second, workspace cached) = 5 total
+        assert mock_run.call_count == 5
+
+    @patch("subprocess.run")
+    def test_resolve_pane_id_from_window_uses_tab_id(self, mock_run, backend):
+        """When multiple panes exist in the workspace, the correct one is returned by
+        matching tab_id (not just the first pane in workspace order)."""
+        backend._window_to_terminal["cao-test:target-window"] = "tid_target"
+
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [
+            {"tab_id": "tab-other", "workspace_id": "w1", "label": "other-window"},
+            {"tab_id": "tab-target", "workspace_id": "w1", "label": "target-window"},
+        ]
+        # target pane appears second — a first-pane-wins strategy would return wrong result
+        panes = [
+            {"tab_id": "tab-other", "pane_id": "w1-1", "workspace_id": "w1"},
+            {"tab_id": "tab-target", "pane_id": "w1-2", "workspace_id": "w1"},
+        ]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+        ]
+
+        result = backend._resolve_pane_id_from_window("cao-test", "target-window")
+        assert result == "w1-2"
+
+
+# --- Session socket path ---
+
+
+class TestSessionSocketPath:
+    """Test _session_socket_path for named and default sessions."""
+
+    @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
+    def test_named_session_uses_subdir(self):
+        """Named session should produce <config_home>/herdr/<name>/herdr.sock."""
+        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+            b = HerdrBackend(herdr_session="cao")
+        assert b._session_socket_path() == "/custom/config/herdr/sessions/cao/herdr.sock"
+
+    @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
+    def test_default_session_uses_flat_path(self):
+        """'default' session should produce <config_home>/herdr/herdr.sock (no subdir)."""
+        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+            b = HerdrBackend(herdr_session="default")
+        assert b._session_socket_path() == "/custom/config/herdr/herdr.sock"
+
+    @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
+    def test_arbitrary_session_name(self):
+        """An arbitrary session name should appear as a subdirectory."""
+        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+            b = HerdrBackend(herdr_session="my-workspace")
+        assert b._session_socket_path() == "/custom/config/herdr/sessions/my-workspace/herdr.sock"
+
+
+# --- Ensure session running ---
+
+
+class TestEnsureSessionRunning:
+    """Test _ensure_session_running startup logic."""
+
+    def test_does_nothing_when_socket_exists(self):
+        """If socket already exists, no Popen should be called."""
+        with patch("cli_agent_orchestrator.backends.herdr_backend.os.path.exists", return_value=True):
+            with patch("subprocess.Popen") as mock_popen:
+                HerdrBackend(herdr_session="cao")
+        mock_popen.assert_not_called()
+
+    def test_starts_server_when_socket_absent(self):
+        """If socket is absent, Popen should be called with herdr server args."""
+        # Socket absent initially, then appears after first poll.
+        exists_sequence = [False, True]
+
+        def exists_side_effect(path):
+            return exists_sequence.pop(0) if exists_sequence else True
+
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists",
+            side_effect=exists_side_effect,
+        ):
+            with patch("subprocess.Popen") as mock_popen:
+                with patch("time.sleep"):
+                    HerdrBackend(herdr_session="cao")
+
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
+        assert cmd == ["herdr", "--session", "cao", "server"]
+
+    def test_logs_warning_when_socket_never_appears(self):
+        """If socket never appears within 5s, a warning is logged and no error raised."""
+        # Simulate clock: first call returns 0.0 (sets deadline=5.0),
+        # all subsequent calls return 6.0 (past deadline, exits loop).
+        # Using a counter so exhaustion from logging internals is not an issue.
+        call_count = {"n": 0}
+
+        def fake_time():
+            call_count["n"] += 1
+            return 0.0 if call_count["n"] == 1 else 6.0
+
+        with patch(
+            "cli_agent_orchestrator.backends.herdr_backend.os.path.exists",
+            return_value=False,
+        ):
+            with patch("subprocess.Popen"):
+                with patch("cli_agent_orchestrator.backends.herdr_backend.time.sleep"):
+                    with patch(
+                        "cli_agent_orchestrator.backends.herdr_backend.time.time",
+                        side_effect=fake_time,
+                    ):
+                        # Should not raise
+                        HerdrBackend(herdr_session="cao")
+
+
+# --- create_window window_shell ---
+
+
+class TestCreateWindowWindowShell:
+    """Verify create_window handles window_shell correctly."""
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    def test_create_window_with_window_shell(self, mock_run, mock_sleep, backend):
+        """When window_shell is provided, pane run is called after a 0.5s sleep."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tab_create_resp = _completed(json.dumps({
+            "id": "cli:tab:create",
+            "result": {
+                "root_pane": {"pane_id": "w1-5", "workspace_id": "w1"},
+                "type": "tab_created",
+            },
+        }))
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # _resolve_workspace_id
+            tab_create_resp,                                 # tab create
+            _completed(),                                    # pane send-text (env export)
+            _completed(),                                    # pane send-keys Enter
+            _completed(),                                    # pane run
+        ]
+
+        backend.create_window(
+            "cao-test", "restored-win", "tid99", "/home/user",
+            window_shell="cat '/path/file'; exec /bin/bash -l",
+        )
+
+        mock_sleep.assert_called_once_with(0.5)
+        pane_run_call = mock_run.call_args_list[-1][0][0]
+        assert "pane" in pane_run_call
+        assert "run" in pane_run_call
+        assert "w1-5" in pane_run_call
+        assert "cat '/path/file'; exec /bin/bash -l" in pane_run_call
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    def test_create_window_window_shell_failure_is_nonfatal(self, mock_run, mock_sleep, backend):
+        """If pane run raises, create_window still returns window_name without raising."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tab_create_resp = _completed(json.dumps({
+            "id": "cli:tab:create",
+            "result": {
+                "root_pane": {"pane_id": "w1-6", "workspace_id": "w1"},
+                "type": "tab_created",
+            },
+        }))
+        pane_run_fail = _completed(returncode=1)
+        pane_run_fail.stderr = "pane not found"
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),  # _resolve_workspace_id
+            tab_create_resp,                                 # tab create
+            _completed(),                                    # pane send-text (env export)
+            _completed(),                                    # pane send-keys Enter
+            pane_run_fail,                                   # pane run (fails)
+        ]
+
+        result = backend.create_window(
+            "cao-test", "restored-win", "tid99", "/home/user",
+            window_shell="exec /bin/bash -l",
+        )
+
+        assert result == "restored-win"
+
+
+# --- get_native_status() mapping ---
+
+
+class TestGetNativeStatus:
+    """Verify get_native_status() returns correct TerminalStatus for all herdr states."""
+
+    from cli_agent_orchestrator.models.terminal import TerminalStatus as _TS
+
+    def _make_pane_get_response(self, agent_status: str) -> str:
+        return json.dumps({
+            "id": "cli:pane:get",
+            "result": {
+                "pane": {"pane_id": "w1-1", "agent_status": agent_status},
+                "type": "pane_info",
+            },
+        })
+
+    def _setup_fresh_resolution(self, backend):
+        """Pre-populate workspace cache and register window mapping for tests.
+
+        _resolve_pane_id_from_window now performs fresh tab+pane lookups. Pre-populating
+        the workspace cache (which has a TTL and is stable) means tests only need to
+        mock tab list, pane list, and pane get — not workspace list as well.
+        """
+        backend._window_to_terminal["s:w"] = "tid1"
+        backend._workspace_cache["s"] = ("w1", time.time())
+
+    def _make_resolution_side_effects(self, pane_get_response):
+        """Build the mock side_effect sequence for a fresh resolution + pane get call."""
+        tabs = [{"tab_id": "tab-1", "workspace_id": "w1", "label": "w"}]
+        panes = [{"tab_id": "tab-1", "pane_id": "w1-1", "workspace_id": "w1"}]
+        return [
+            _completed(_make_tab_list_response(tabs)),   # tab list
+            _completed(_make_pane_list_response(panes)), # pane list
+            pane_get_response,                            # pane get
+        ]
+
+    @patch("subprocess.run")
+    def test_working_returns_processing(self, mock_run, backend):
+        self._setup_fresh_resolution(backend)
+        mock_run.side_effect = self._make_resolution_side_effects(
+            _completed(self._make_pane_get_response("working"))
+        )
+
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+        result = backend.get_native_status("s", "w")
+        assert result == TerminalStatus.PROCESSING
+
+    @patch("subprocess.run")
+    def test_blocked_returns_waiting_user_answer(self, mock_run, backend):
+        self._setup_fresh_resolution(backend)
+        mock_run.side_effect = self._make_resolution_side_effects(
+            _completed(self._make_pane_get_response("blocked"))
+        )
+
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+        result = backend.get_native_status("s", "w")
+        assert result == TerminalStatus.WAITING_USER_ANSWER
+
+    @patch("subprocess.run")
+    def test_done_returns_completed(self, mock_run, backend):
+        self._setup_fresh_resolution(backend)
+        mock_run.side_effect = self._make_resolution_side_effects(
+            _completed(self._make_pane_get_response("done"))
+        )
+
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+        result = backend.get_native_status("s", "w")
+        assert result == TerminalStatus.COMPLETED
+
+    @patch("subprocess.run")
+    def test_idle_returns_idle(self, mock_run, backend):
+        self._setup_fresh_resolution(backend)
+        mock_run.side_effect = self._make_resolution_side_effects(
+            _completed(self._make_pane_get_response("idle"))
+        )
+
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+        result = backend.get_native_status("s", "w")
+        assert result == TerminalStatus.IDLE
+
+    @patch("subprocess.run")
+    def test_unknown_returns_error(self, mock_run, backend):
+        self._setup_fresh_resolution(backend)
+        mock_run.side_effect = self._make_resolution_side_effects(
+            _completed(self._make_pane_get_response("unknown"))
+        )
+
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+        result = backend.get_native_status("s", "w")
+        assert result == TerminalStatus.ERROR
+
+    @patch("subprocess.run")
+    def test_command_failure_returns_none(self, mock_run, backend):
+        self._setup_fresh_resolution(backend)
+        pane_get_fail = _completed(returncode=1)
+        mock_run.side_effect = self._make_resolution_side_effects(pane_get_fail)
+
+        result = backend.get_native_status("s", "w")
+        assert result is None

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -51,6 +52,62 @@ class TestHerdrInboxServiceRegistration:
         """unregister_terminal for unknown terminal should not raise."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service.unregister_terminal("nonexistent")  # Should not raise
+
+
+class TestHerdrInboxServiceCrossThreadRegistration:
+    """Test that register_terminal works from threads without an event loop.
+
+    register_terminal may be called from a synchronous, non-event-loop thread.
+    When connected, it must schedule the subscribe coroutine onto the captured
+    loop via run_coroutine_threadsafe rather than asyncio.create_task (which
+    requires a running loop in the calling thread and would raise RuntimeError).
+    """
+
+    def test_register_from_non_event_loop_thread_subscribes(self):
+        """register_terminal from a non-loop thread should schedule subscribe via run_coroutine_threadsafe."""
+
+        async def run():
+            service = HerdrInboxService(socket_path="/tmp/test.sock")
+            service._connected = True
+            service._loop = asyncio.get_running_loop()
+            service._writer = AsyncMock()
+
+            # Call register from a separate thread that has no event loop of its own.
+            t = threading.Thread(
+                target=service.register_terminal, args=("tid_cross", "pane-cross")
+            )
+            t.start()
+            t.join()
+
+            # Give the cross-thread-scheduled coroutine time to run on this loop.
+            await asyncio.sleep(0.05)
+
+            # Subscribe message must have been written to the socket.
+            service._writer.write.assert_called_once()
+            written = service._writer.write.call_args[0][0]
+            msg = json.loads(written.decode().strip())
+            assert msg["method"] == "events.subscribe"
+            assert msg["params"]["subscriptions"][0]["type"] == "pane.agent_status_changed"
+            assert msg["params"]["subscriptions"][0]["pane_id"] == "pane-cross"
+
+        _run_async(run())
+
+    def test_register_before_start_does_not_subscribe(self):
+        """register_terminal before start (no loop, not connected) must not attempt subscribe."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._writer = AsyncMock()
+
+        # Pre-start state: start() has not run, so no loop captured and not connected.
+        assert service._connected is False
+        assert service._loop is None
+
+        service.register_terminal("tid_early", "pane-early")
+
+        # Mapping is still recorded...
+        assert service._pane_to_terminal["pane-early"] == "tid_early"
+        assert service._terminal_to_pane["tid_early"] == "pane-early"
+        # ...but no subscribe was sent (guarded by _connected and _loop).
+        service._writer.write.assert_not_called()
 
 
 class TestHerdrInboxServiceDelivery:

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -744,24 +744,40 @@ class TestHerdrInboxServiceLifecycleEvents:
         mock_delete.assert_not_called()
         mock_meta.assert_not_called()
 
+    @patch("cli_agent_orchestrator.clients.database.get_terminal_metadata")
     @patch("cli_agent_orchestrator.clients.database.delete_terminals_by_session")
-    def test_workspace_closed_removes_all_terminals_for_session(self, mock_delete_by_session):
-        """workspace.closed should prune all terminals whose pane_id starts with workspace_id."""
+    def test_workspace_closed_removes_all_terminals_for_session(
+        self, mock_delete_by_session, mock_meta
+    ):
+        """workspace.closed prunes terminals by their DB session, not by a
+        pane_id/workspace_id string prefix.
+
+        Uses compact pane_ids that do NOT start with the workspace_id (herdr
+        renumbers panes and gives no prefix guarantee) to prove the prune keys
+        off DB session ownership rather than the pane_id string.
+        """
         service = HerdrInboxService(socket_path="/tmp/test.sock")
-        service.register_terminal("tid1", "ws-abc/0")
-        service.register_terminal("tid2", "ws-abc/1")
-        service.register_terminal("tid3", "ws-other/0")  # Different workspace
+        service.register_terminal("tid1", "p-7")
+        service.register_terminal("tid2", "p-8")
+        service.register_terminal("tid3", "p-9")  # Different session
         service._workspace_to_session["ws-abc"] = "my-session"
+
+        session_by_terminal = {
+            "tid1": {"tmux_session": "my-session"},
+            "tid2": {"tmux_session": "my-session"},
+            "tid3": {"tmux_session": "other-session"},
+        }
+        mock_meta.side_effect = lambda tid: session_by_terminal.get(tid)
 
         service._handle_lifecycle_event("workspace.closed", {"workspace_id": "ws-abc"})
 
-        # ws-abc terminals pruned
-        assert "ws-abc/0" not in service._pane_to_terminal
-        assert "ws-abc/1" not in service._pane_to_terminal
+        # my-session terminals pruned despite no pane_id/workspace_id prefix match
+        assert "p-7" not in service._pane_to_terminal
+        assert "p-8" not in service._pane_to_terminal
         assert "tid1" not in service._terminal_to_pane
         assert "tid2" not in service._terminal_to_pane
-        # Other workspace unaffected
-        assert "ws-other/0" in service._pane_to_terminal
+        # Terminal owned by a different session is untouched
+        assert "p-9" in service._pane_to_terminal
         assert "tid3" in service._terminal_to_pane
         # Workspace entry cleaned up
         assert "ws-abc" not in service._workspace_to_session

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -525,6 +525,75 @@ class TestHerdrInboxServiceReconcile:
         mock_delete.assert_not_called()
 
 
+class TestHerdrInboxServiceStartupDbCleanup:
+    """Test _startup_db_cleanup removes ghost terminals on server start."""
+
+    def _make_subprocess_side_effect(self, ws_response, tab_response):
+        def side_effect(cmd, **_):
+            m = MagicMock()
+            m.returncode = 0
+            if "workspace" in cmd and "list" in cmd:
+                m.stdout = ws_response
+            else:
+                m.stdout = tab_response
+            return m
+        return side_effect
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
+    def test_startup_cleanup_deletes_ghost_terminals(self, mock_list, mock_delete, mock_run):
+        """Ghost terminals (window not in live herdr tabs) are deleted at startup."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+
+        ws_response = json.dumps({"result": {"workspaces": [
+            {"workspace_id": "ws-abc", "label": "my-session"}
+        ]}})
+        tab_response = json.dumps({"result": {"tabs": [
+            {"label": "live-window", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
+        ]}})
+        mock_run.side_effect = self._make_subprocess_side_effect(ws_response, tab_response)
+        mock_list.return_value = [
+            {"id": "tid-live", "tmux_window": "live-window"},
+            {"id": "tid-ghost", "tmux_window": "dead-window"},
+        ]
+
+        _run_async(service._startup_db_cleanup())
+
+        mock_delete.assert_called_once_with("tid-ghost")
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
+    def test_startup_cleanup_skips_when_workspace_list_fails(self, mock_list, mock_run):
+        """When herdr workspace list fails, no DB queries run."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+
+        fail = MagicMock(returncode=1, stdout="")
+        mock_run.return_value = fail
+        _run_async(service._startup_db_cleanup())
+        mock_list.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
+    def test_startup_cleanup_no_deletes_when_all_live(self, mock_list, mock_delete, mock_run):
+        """No deletions when all DB terminals have matching live tabs."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+
+        ws_response = json.dumps({"result": {"workspaces": [
+            {"workspace_id": "ws-abc", "label": "my-session"}
+        ]}})
+        tab_response = json.dumps({"result": {"tabs": [
+            {"label": "conductor-10e0", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
+        ]}})
+        mock_run.side_effect = self._make_subprocess_side_effect(ws_response, tab_response)
+        mock_list.return_value = [{"id": "tid-1", "tmux_window": "conductor-10e0"}]
+
+        _run_async(service._startup_db_cleanup())
+
+        mock_delete.assert_not_called()
+
+
 class TestHerdrInboxServiceLifecycleSubscription:
     """Test _subscribe_lifecycle_events sends correct message."""
 

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -1,12 +1,11 @@
 """Unit tests for HerdrInboxService — event delivery, reconnect, kiro supplement."""
 
 import asyncio
+import inspect
 import json
 import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
 
 from cli_agent_orchestrator.services.herdr_inbox_service import HerdrInboxService
 
@@ -315,14 +314,11 @@ class TestHerdrInboxServiceKiroSupplement:
 class TestHerdrInboxServiceReconcile:
     """Test _reconcile() prunes stale panes and cleans up DB/workspace."""
 
-    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
-    @patch("cli_agent_orchestrator.services.herdr_inbox_service.HerdrInboxService._reconcile")
-    def test_reconcile_is_called_before_resubscribe(self, mock_reconcile, mock_run):
+    def test_reconcile_is_called_before_resubscribe(self):
         """_reconcile must be awaited before _resubscribe_all in _socket_loop."""
-        # Verify ordering through call_count inspection — reconcile before subscribe.
-        # This is a structural test: just confirms _reconcile exists and is async.
+        # Structural test: confirms _reconcile is an async coroutine.
         service = HerdrInboxService(socket_path="/tmp/test.sock")
-        assert asyncio.iscoroutinefunction(service._reconcile)
+        assert inspect.iscoroutinefunction(service._reconcile)
 
     @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
     @patch("cli_agent_orchestrator.clients.database.delete_terminal")
@@ -357,6 +353,8 @@ class TestHerdrInboxServiceReconcile:
         assert "tid2" not in service._terminal_to_pane
         assert "pane-live" in service._pane_to_terminal
         assert "tid1" in service._terminal_to_pane
+        # DB record for stale terminal deleted
+        mock_delete.assert_called_once_with("tid2")
 
     @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
     def test_reconcile_no_op_when_all_panes_live(self, mock_run):
@@ -403,6 +401,129 @@ class TestHerdrInboxServiceReconcile:
         # Map unchanged
         assert "pane-a" in service._pane_to_terminal
 
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
+    def test_reconcile_deletes_ghost_db_terminals(
+        self, mock_list_terminals, mock_delete, mock_run
+    ):
+        """Ghost DB terminals (tab not in herdr) are deleted; live terminals are kept."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._workspace_to_session = {"ws-abc": "my-session"}
+
+        pane_list_response = json.dumps({"result": {"panes": []}})
+        ws_list_response = json.dumps({
+            "result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}
+        })
+        tab_list_response = json.dumps({
+            "result": {
+                "tabs": [
+                    {"label": "live-window", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"}
+                ]
+            }
+        })
+
+        def subprocess_side_effect(cmd, **_):
+            m = MagicMock()
+            m.returncode = 0
+            if "pane" in cmd and "list" in cmd:
+                m.stdout = pane_list_response
+            elif "tab" in cmd and "list" in cmd:
+                m.stdout = tab_list_response
+            else:
+                m.stdout = ws_list_response
+            return m
+
+        mock_run.side_effect = subprocess_side_effect
+
+        mock_list_terminals.return_value = [
+            {"id": "tid-live", "tmux_window": "live-window"},
+            {"id": "tid-ghost", "tmux_window": "ghost-window"},
+        ]
+
+        _run_async(service._reconcile())
+
+        # Only the ghost terminal should be deleted
+        mock_delete.assert_called_once_with("tid-ghost")
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
+    def test_reconcile_skips_db_check_when_tab_list_fails(
+        self, mock_list_terminals, mock_run
+    ):
+        """When herdr tab list returns non-zero, list_terminals_by_session is never called."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._workspace_to_session = {"ws-abc": "my-session"}
+
+        pane_list_response = json.dumps({"result": {"panes": []}})
+        ws_list_response = json.dumps({"result": {"workspaces": []}})
+
+        def subprocess_side_effect(cmd, **_):
+            m = MagicMock()
+            if "pane" in cmd and "list" in cmd:
+                m.returncode = 0
+                m.stdout = pane_list_response
+            elif "tab" in cmd and "list" in cmd:
+                m.returncode = 1
+                m.stdout = ""
+                m.stderr = "tab list failed"
+            else:
+                m.returncode = 0
+                m.stdout = ws_list_response
+            return m
+
+        mock_run.side_effect = subprocess_side_effect
+
+        # Should not raise
+        _run_async(service._reconcile())
+
+        mock_list_terminals.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
+    def test_reconcile_no_ghost_when_all_tabs_match(
+        self, mock_list_terminals, mock_delete, mock_run
+    ):
+        """When all DB terminals have matching live tabs, delete_terminal is never called."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._workspace_to_session = {"ws-abc": "my-session"}
+
+        pane_list_response = json.dumps({"result": {"panes": []}})
+        ws_list_response = json.dumps({
+            "result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}
+        })
+        tab_list_response = json.dumps({
+            "result": {
+                "tabs": [
+                    {"label": "window-one", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
+                    {"label": "window-two", "tab_id": "ws-abc:2", "workspace_id": "ws-abc"},
+                ]
+            }
+        })
+
+        def subprocess_side_effect(cmd, **_):
+            m = MagicMock()
+            m.returncode = 0
+            if "pane" in cmd and "list" in cmd:
+                m.stdout = pane_list_response
+            elif "tab" in cmd and "list" in cmd:
+                m.stdout = tab_list_response
+            else:
+                m.stdout = ws_list_response
+            return m
+
+        mock_run.side_effect = subprocess_side_effect
+
+        mock_list_terminals.return_value = [
+            {"id": "tid-1", "tmux_window": "window-one"},
+            {"id": "tid-2", "tmux_window": "window-two"},
+        ]
+
+        _run_async(service._reconcile())
+
+        mock_delete.assert_not_called()
+
 
 class TestHerdrInboxServiceLifecycleSubscription:
     """Test _subscribe_lifecycle_events sends correct message."""
@@ -428,11 +549,10 @@ class TestHerdrInboxServiceLifecycleSubscription:
 class TestHerdrInboxServiceLifecycleEvents:
     """Test _handle_lifecycle_event for pane.closed and workspace.closed."""
 
-    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
     @patch("cli_agent_orchestrator.clients.database.delete_terminal")
     @patch("cli_agent_orchestrator.clients.database.get_terminal_metadata")
-    def test_pane_closed_removes_from_maps(self, mock_meta, mock_delete, mock_run):
-        """pane.closed should remove the terminal from tracking maps."""
+    def test_pane_closed_removes_from_maps(self, mock_meta, mock_delete):
+        """pane.closed should remove the terminal from tracking maps and delete DB record."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service.register_terminal("tid1", "pane-a", is_kiro=True)
         service._working_since["tid1"] = time.time()
@@ -444,6 +564,7 @@ class TestHerdrInboxServiceLifecycleEvents:
         assert "tid1" not in service._terminal_to_pane
         assert "tid1" not in service._kiro_terminals
         assert "tid1" not in service._working_since
+        mock_delete.assert_called_once_with("tid1")
 
     @patch("cli_agent_orchestrator.clients.database.delete_terminal")
     @patch("cli_agent_orchestrator.clients.database.get_terminal_metadata")
@@ -489,8 +610,7 @@ class TestHerdrInboxServiceLifecycleEvents:
 
         mock_delete.assert_not_called()
 
-    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
-    def test_event_loop_routes_lifecycle_events(self, mock_run):
+    def test_event_loop_routes_lifecycle_events(self):
         """_event_loop should call _handle_lifecycle_event for pane.closed/workspace.closed."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._workspace_to_session["ws-x"] = "sess-x"

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -53,23 +53,33 @@ class TestHerdrInboxServiceRegistration:
         service.unregister_terminal("nonexistent")  # Should not raise
 
 
-class TestHerdrInboxServiceCrossThreadRegistration:
-    """Test that register_terminal works from threads without an event loop.
+class TestHerdrInboxServiceRegisterReconnect:
+    """Registering a terminal on a live connection must force a reconnect, never
+    a second events.subscribe.
 
-    register_terminal may be called from a synchronous, non-event-loop thread.
-    When connected, it must schedule the subscribe coroutine onto the captured
-    loop via run_coroutine_threadsafe rather than asyncio.create_task (which
-    requires a running loop in the calling thread and would raise RuntimeError).
+    herdr 0.6.8 resets the entire connection when it receives a second
+    events.subscribe on a connection that already has an active subscription.
+    Because herdr exposes no incremental "add subscription" API, the only safe
+    way to start streaming events for a newly registered pane is to drop the
+    socket and rebuild the single combined subscription on a fresh connection.
+
+    register_terminal may be called from a synchronous, non-event-loop thread,
+    so it must schedule the reconnect onto the captured loop via
+    run_coroutine_threadsafe rather than asyncio.create_task (which requires a
+    running loop in the calling thread and would raise RuntimeError).
     """
 
-    def test_register_from_non_event_loop_thread_subscribes(self):
-        """register_terminal from a non-loop thread should schedule subscribe via run_coroutine_threadsafe."""
+    def test_register_while_connected_triggers_reconnect_not_second_subscribe(self):
+        """register from a non-loop thread, while connected, closes the socket to
+        force a reconnect and must NOT write a second events.subscribe."""
 
         async def run():
             service = HerdrInboxService(socket_path="/tmp/test.sock")
             service._connected = True
             service._loop = asyncio.get_running_loop()
-            service._writer = AsyncMock()
+            # close() is synchronous; use a plain MagicMock so write/close are tracked.
+            writer = MagicMock()
+            service._writer = writer
 
             # Call register from a separate thread that has no event loop of its own.
             t = threading.Thread(target=service.register_terminal, args=("tid_cross", "pane-cross"))
@@ -79,20 +89,20 @@ class TestHerdrInboxServiceCrossThreadRegistration:
             # Give the cross-thread-scheduled coroutine time to run on this loop.
             await asyncio.sleep(0.05)
 
-            # Subscribe message must have been written to the socket.
-            service._writer.write.assert_called_once()
-            written = service._writer.write.call_args[0][0]
-            msg = json.loads(written.decode().strip())
-            assert msg["method"] == "events.subscribe"
-            assert msg["params"]["subscriptions"][0]["type"] == "pane.agent_status_changed"
-            assert msg["params"]["subscriptions"][0]["pane_id"] == "pane-cross"
+            # Mapping recorded.
+            assert service._pane_to_terminal["pane-cross"] == "tid_cross"
+            # Reconnect forced by closing the writer...
+            writer.close.assert_called_once()
+            # ...and NO second events.subscribe was written on the live connection.
+            writer.write.assert_not_called()
 
         _run_async(run())
 
-    def test_register_before_start_does_not_subscribe(self):
-        """register_terminal before start (no loop, not connected) must not attempt subscribe."""
+    def test_register_before_start_does_not_reconnect(self):
+        """register_terminal before start (no loop, not connected) must not touch the socket."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
-        service._writer = AsyncMock()
+        writer = MagicMock()
+        service._writer = writer
 
         # Pre-start state: start() has not run, so no loop captured and not connected.
         assert service._connected is False
@@ -103,8 +113,9 @@ class TestHerdrInboxServiceCrossThreadRegistration:
         # Mapping is still recorded...
         assert service._pane_to_terminal["pane-early"] == "tid_early"
         assert service._terminal_to_pane["tid_early"] == "pane-early"
-        # ...but no subscribe was sent (guarded by _connected and _loop).
-        service._writer.write.assert_not_called()
+        # ...but the socket was left untouched (guarded by _connected and _loop).
+        writer.close.assert_not_called()
+        writer.write.assert_not_called()
 
 
 class TestHerdrInboxServiceDelivery:
@@ -134,22 +145,57 @@ class TestHerdrInboxServiceDelivery:
 
 
 class TestHerdrInboxServiceSubscription:
-    """Test event subscription message format."""
+    """Test combined event subscription message format.
 
-    def test_subscribe_pane_sends_correct_message(self):
-        """_subscribe_pane should send correct JSON to socket."""
+    herdr 0.6.8 resets the connection on a second events.subscribe, so all
+    subscriptions (every managed pane's agent-status plus the two lifecycle
+    events) must be sent in a SINGLE events.subscribe call.
+    """
+
+    def test_subscribe_all_events_sends_single_combined_message(self):
+        """_subscribe_all_events should send exactly one events.subscribe containing
+        every managed pane's agent-status subscription plus the lifecycle events."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._writer = AsyncMock()
+        service._pane_to_terminal = {"pane-1": "tid1", "pane-2": "tid2"}
+        service._terminal_to_pane = {"tid1": "pane-1", "tid2": "pane-2"}
 
-        _run_async(service._subscribe_pane("w1-1"))
+        _run_async(service._subscribe_all_events())
 
+        # Exactly ONE write — never a second subscribe call.
         service._writer.write.assert_called_once()
         written = service._writer.write.call_args[0][0]
         msg = json.loads(written.decode().strip())
 
         assert msg["method"] == "events.subscribe"
-        assert msg["params"]["subscriptions"][0]["type"] == "pane.agent_status_changed"
-        assert msg["params"]["subscriptions"][0]["pane_id"] == "w1-1"
+        subs = msg["params"]["subscriptions"]
+
+        # Every managed pane has an agent-status subscription with its pane_id.
+        agent_subs = [s for s in subs if s["type"] == "pane.agent_status_changed"]
+        assert {s["pane_id"] for s in agent_subs} == {"pane-1", "pane-2"}
+
+        # Lifecycle events are included in the same single call.
+        types = {s["type"] for s in subs}
+        assert "pane.closed" in types
+        assert "workspace.closed" in types
+
+    def test_subscribe_all_events_with_no_panes_still_includes_lifecycle(self):
+        """With no managed panes, the single subscribe still covers lifecycle events."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._writer = AsyncMock()
+
+        _run_async(service._subscribe_all_events())
+
+        service._writer.write.assert_called_once()
+        msg = json.loads(service._writer.write.call_args[0][0].decode().strip())
+        types = {s["type"] for s in msg["params"]["subscriptions"]}
+        assert types == {"pane.closed", "workspace.closed"}
+        # No agent-status entry without a pane_id (herdr rejects that as invalid_request).
+        assert all(
+            "pane_id" in s
+            for s in msg["params"]["subscriptions"]
+            if s["type"] == "pane.agent_status_changed"
+        )
 
 
 class TestHerdrInboxServiceEventParsing:
@@ -254,14 +300,13 @@ class TestHerdrInboxServiceEventParsing:
 
 
 class TestHerdrInboxServiceReconnect:
-    """Test reconnection re-subscribe behavior."""
+    """Test reconnect re-subscribe behavior: a single combined subscribe per connection."""
 
-    def test_resubscribe_sends_subscribe_for_all_managed_panes(self):
-        """_resubscribe_all should re-subscribe existing pane_ids without scanning pane list.
+    def test_reconnect_resubscribe_sends_single_call_for_all_panes(self):
+        """On reconnect, all managed panes are re-subscribed in ONE events.subscribe call.
 
-        CAO UUIDs in _terminal_to_pane do not match herdr's internal terminal_ids,
-        so re-resolution via pane list scan is incorrect. Re-subscribe with the
-        existing _pane_to_terminal mapping directly.
+        herdr resets the connection on a second events.subscribe, so re-subscribing
+        N panes must be one combined call, not N separate calls.
         """
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._writer = AsyncMock()
@@ -271,10 +316,17 @@ class TestHerdrInboxServiceReconnect:
         service._terminal_to_pane["tid2"] = "pane-2"
         service._pane_to_terminal["pane-2"] = "tid2"
 
-        _run_async(service._resubscribe_all())
+        _run_async(service._subscribe_all_events())
 
-        # Should have sent 2 subscribe messages, one per pane
-        assert service._writer.write.call_count == 2
+        # Exactly ONE subscribe message for all panes (not one per pane).
+        service._writer.write.assert_called_once()
+        msg = json.loads(service._writer.write.call_args[0][0].decode().strip())
+        agent_panes = {
+            s["pane_id"]
+            for s in msg["params"]["subscriptions"]
+            if s["type"] == "pane.agent_status_changed"
+        }
+        assert agent_panes == {"pane-1", "pane-2"}
         # Mapping should be unchanged
         assert service._terminal_to_pane["tid1"] == "pane-1"
         assert service._terminal_to_pane["tid2"] == "pane-2"
@@ -337,11 +389,13 @@ class TestHerdrInboxServiceKiroSupplement:
 class TestHerdrInboxServiceReconcile:
     """Test _reconcile() prunes stale panes and cleans up DB/workspace."""
 
-    def test_reconcile_is_called_before_resubscribe(self):
-        """_reconcile must be awaited before _resubscribe_all in _socket_loop."""
-        # Structural test: confirms _reconcile is an async coroutine.
+    def test_reconcile_is_called_before_subscribe(self):
+        """_reconcile must be awaited before _subscribe_all_events in _socket_loop
+        so the combined subscription only covers live panes."""
+        # Structural test: confirms both are async coroutines.
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         assert inspect.iscoroutinefunction(service._reconcile)
+        assert inspect.iscoroutinefunction(service._subscribe_all_events)
 
     @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
     @patch("cli_agent_orchestrator.clients.database.delete_terminal")
@@ -628,25 +682,35 @@ class TestHerdrInboxServiceStartupDbCleanup:
         mock_delete.assert_not_called()
 
 
-class TestHerdrInboxServiceLifecycleSubscription:
-    """Test _subscribe_lifecycle_events sends correct message."""
+class TestHerdrInboxServiceSingleSubscribePerConnection:
+    """Guard against regressing to multiple events.subscribe calls per connection.
 
-    def test_subscribe_lifecycle_events_sends_correct_message(self):
-        """Should subscribe to pane.closed and workspace.closed."""
+    The reconnect storm (herdr 0.6.8 resets on a 2nd events.subscribe) is fixed
+    by sending exactly one combined subscribe. These tests pin that contract.
+    """
+
+    def test_no_separate_subscribe_pane_method(self):
+        """The per-pane _subscribe_pane helper is removed — its existence reintroduces
+        a second subscribe call when a terminal registers on a live connection."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        assert not hasattr(service, "_subscribe_pane")
+
+    def test_no_separate_lifecycle_subscribe_method(self):
+        """_subscribe_lifecycle_events is merged into _subscribe_all_events; a separate
+        method means a second subscribe call on the same connection."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        assert not hasattr(service, "_subscribe_lifecycle_events")
+
+    def test_socket_setup_issues_exactly_one_subscribe(self):
+        """A full connect cycle (reconcile already done) writes exactly one subscribe."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._writer = AsyncMock()
+        service._pane_to_terminal = {"pane-1": "tid1"}
+        service._terminal_to_pane = {"tid1": "pane-1"}
 
-        _run_async(service._subscribe_lifecycle_events())
+        _run_async(service._subscribe_all_events())
 
         service._writer.write.assert_called_once()
-        written = service._writer.write.call_args[0][0]
-        msg = json.loads(written.decode().strip())
-
-        assert msg["method"] == "events.subscribe"
-        subs = msg["params"]["subscriptions"]
-        types = {s["type"] for s in subs}
-        assert "pane.closed" in types
-        assert "workspace.closed" in types
 
 
 class TestHerdrInboxServiceLifecycleEvents:

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -1,0 +1,289 @@
+"""Unit tests for HerdrInboxService — event delivery, reconnect, kiro supplement."""
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.services.herdr_inbox_service import HerdrInboxService
+
+
+def _run_async(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+class TestHerdrInboxServiceRegistration:
+    """Test terminal registration and unregistration."""
+
+    def test_register_terminal(self):
+        """register_terminal should add to both maps."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid1", "w1-1", is_kiro=False)
+
+        assert service._pane_to_terminal["w1-1"] == "tid1"
+        assert service._terminal_to_pane["tid1"] == "w1-1"
+        assert "tid1" not in service._kiro_terminals
+
+    def test_register_kiro_terminal(self):
+        """register_terminal with is_kiro=True tracks in kiro set."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid2", "w1-2", is_kiro=True)
+
+        assert "tid2" in service._kiro_terminals
+
+    def test_unregister_terminal(self):
+        """unregister_terminal should remove from all tracking structures."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid1", "w1-1", is_kiro=True)
+        service._working_since["tid1"] = time.time()
+
+        service.unregister_terminal("tid1")
+
+        assert "w1-1" not in service._pane_to_terminal
+        assert "tid1" not in service._terminal_to_pane
+        assert "tid1" not in service._kiro_terminals
+        assert "tid1" not in service._working_since
+
+    def test_unregister_nonexistent_is_safe(self):
+        """unregister_terminal for unknown terminal should not raise."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.unregister_terminal("nonexistent")  # Should not raise
+
+
+class TestHerdrInboxServiceDelivery:
+    """Test message delivery callback invocation."""
+
+    def test_deliver_calls_callback(self):
+        """_deliver should invoke the delivery_callback with terminal_id."""
+        callback = MagicMock()
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+
+        service._deliver("tid1")
+
+        callback.assert_called_once_with("tid1")
+
+    def test_deliver_handles_callback_error(self):
+        """_deliver should log and not raise if callback fails."""
+        callback = MagicMock(side_effect=RuntimeError("delivery failed"))
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+
+        # Should not raise
+        service._deliver("tid1")
+
+    def test_deliver_without_callback(self):
+        """_deliver with no callback should be a no-op."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._deliver("tid1")  # Should not raise
+
+
+class TestHerdrInboxServiceSubscription:
+    """Test event subscription message format."""
+
+    def test_subscribe_pane_sends_correct_message(self):
+        """_subscribe_pane should send correct JSON to socket."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._writer = AsyncMock()
+
+        _run_async(service._subscribe_pane("w1-1"))
+
+        service._writer.write.assert_called_once()
+        written = service._writer.write.call_args[0][0]
+        msg = json.loads(written.decode().strip())
+
+        assert msg["method"] == "events.subscribe"
+        assert msg["params"]["subscriptions"][0]["type"] == "pane.agent_status_changed"
+        assert msg["params"]["subscriptions"][0]["pane_id"] == "w1-1"
+
+
+class TestHerdrInboxServiceEventParsing:
+    """Test that _event_loop correctly unwraps the 'data' wrapper in socket events."""
+
+    def test_event_loop_parses_data_wrapper_and_delivers(self):
+        """Events with 'data' wrapper are correctly parsed and delivery is triggered."""
+        callback = MagicMock()
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+
+        # Register a pane
+        service.register_terminal("tid1", "pane-x", is_kiro=False)
+
+        # Simulate two events: one "idle" (delivery) and one "working" (no delivery)
+        idle_event = json.dumps({
+            "event": "pane.agent_status_changed",
+            "data": {"pane_id": "pane-x", "agent_status": "idle"},
+        }).encode() + b"\n"
+        done_event = json.dumps({
+            "event": "pane.agent_status_changed",
+            "data": {"pane_id": "pane-x", "agent_status": "done"},
+        }).encode() + b"\n"
+        # "working" event — should NOT trigger delivery
+        working_event = json.dumps({
+            "event": "pane.agent_status_changed",
+            "data": {"pane_id": "pane-x", "agent_status": "working"},
+        }).encode() + b"\n"
+        # Unknown pane — should NOT trigger delivery
+        other_event = json.dumps({
+            "event": "pane.agent_status_changed",
+            "data": {"pane_id": "pane-other", "agent_status": "idle"},
+        }).encode() + b"\n"
+
+        async def run():
+            reader = asyncio.StreamReader()
+            service._reader = reader
+            # Write events then close to end the loop
+            reader.feed_data(idle_event + done_event + working_event + other_event)
+            reader.feed_eof()
+            try:
+                await service._event_loop()
+            except ConnectionError:
+                pass  # EOF raises ConnectionError — expected
+
+        _run_async(run())
+
+        # Only idle and done events on managed pane should trigger delivery
+        assert callback.call_count == 2
+        callback.assert_any_call("tid1")
+
+    def test_event_loop_ignores_flat_format_without_data_wrapper(self):
+        """Events without 'data' wrapper (old flat format) are silently ignored."""
+        callback = MagicMock()
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+        service.register_terminal("tid1", "pane-x", is_kiro=False)
+
+        # Old flat format — pane_id and agent_status at top level (not wrapped)
+        flat_event = json.dumps({
+            "pane_id": "pane-x",
+            "agent_status": "idle",
+        }).encode() + b"\n"
+
+        async def run():
+            reader = asyncio.StreamReader()
+            service._reader = reader
+            reader.feed_data(flat_event)
+            reader.feed_eof()
+            try:
+                await service._event_loop()
+            except ConnectionError:
+                pass
+
+        _run_async(run())
+
+        # Flat format is not parsed — no delivery expected
+        callback.assert_not_called()
+
+
+class TestHerdrInboxServiceReconnect:
+    """Test reconnection re-subscribe behavior."""
+
+    def test_resubscribe_sends_subscribe_for_all_managed_panes(self):
+        """_resubscribe_all should re-subscribe existing pane_ids without scanning pane list.
+
+        CAO UUIDs in _terminal_to_pane do not match herdr's internal terminal_ids,
+        so re-resolution via pane list scan is incorrect. Re-subscribe with the
+        existing _pane_to_terminal mapping directly.
+        """
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._writer = AsyncMock()
+        # Register two terminals with their current pane_ids
+        service._terminal_to_pane["tid1"] = "pane-1"
+        service._pane_to_terminal["pane-1"] = "tid1"
+        service._terminal_to_pane["tid2"] = "pane-2"
+        service._pane_to_terminal["pane-2"] = "tid2"
+
+        _run_async(service._resubscribe_all())
+
+        # Should have sent 2 subscribe messages, one per pane
+        assert service._writer.write.call_count == 2
+        # Mapping should be unchanged
+        assert service._terminal_to_pane["tid1"] == "pane-1"
+        assert service._terminal_to_pane["tid2"] == "pane-2"
+
+
+class TestHerdrInboxServiceKiroSupplement:
+    """Test kiro supplement check for long-running working states."""
+
+    @patch("subprocess.run")
+    def test_kiro_supplement_delivers_on_permission_prompt(self, mock_run):
+        """Should deliver when pane read reveals permission prompt after 30s working."""
+        callback = MagicMock()
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+
+        # Register kiro terminal that's been working for 35s
+        service.register_terminal("tid_kiro", "w1-5", is_kiro=True)
+        service._working_since["tid_kiro"] = time.time() - 35.0
+
+        # Mock pane read output containing kiro permission prompt pattern
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Agent wants to: Execute command\n[Y]es / [N]o / Yes to [A]ll",
+        )
+
+        with patch(
+            "cli_agent_orchestrator.services.herdr_inbox_service.re.search",
+            return_value=True,
+        ):
+            _run_async(service.check_kiro_supplements())
+
+        callback.assert_called_once_with("tid_kiro")
+
+    @patch("subprocess.run")
+    def test_kiro_supplement_skips_under_threshold(self, mock_run):
+        """Should not check terminals working for less than 30s."""
+        callback = MagicMock()
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+
+        service.register_terminal("tid_kiro", "w1-5", is_kiro=True)
+        service._working_since["tid_kiro"] = time.time() - 10.0  # Only 10s
+
+        _run_async(service.check_kiro_supplements())
+
+        mock_run.assert_not_called()
+        callback.assert_not_called()
+
+    def test_kiro_supplement_skips_non_kiro(self):
+        """Should not check non-kiro terminals."""
+        callback = MagicMock()
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+
+        service.register_terminal("tid_claude", "w1-3", is_kiro=False)
+        service._working_since["tid_claude"] = time.time() - 60.0
+
+        _run_async(service.check_kiro_supplements())
+
+        callback.assert_not_called()
+
+
+class TestHerdrInboxServiceSocketPath:
+    """Test socket path resolution."""
+
+    @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
+    def test_uses_xdg_config_home(self):
+        """Should use XDG_CONFIG_HOME when set."""
+        path = HerdrInboxService._default_socket_path("cao")
+        assert path == "/custom/config/herdr/sessions/cao/herdr.sock"
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("pathlib.Path.home")
+    def test_falls_back_to_home_config(self, mock_home):
+        """Should fall back to ~/.config when XDG_CONFIG_HOME is unset."""
+        from pathlib import PurePosixPath
+
+        mock_home.return_value = PurePosixPath("/home/user")
+        import os
+        os.environ.pop("XDG_CONFIG_HOME", None)
+        path = HerdrInboxService._default_socket_path("cao")
+        assert path.endswith("/.config/herdr/sessions/cao/herdr.sock")
+
+    @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
+    def test_custom_session_name_in_socket_path(self):
+        """Should include session name in the socket path."""
+        path = HerdrInboxService._default_socket_path("my-session")
+        assert path == "/custom/config/herdr/sessions/my-session/herdr.sock"
+
+    @patch.dict("os.environ", {"XDG_CONFIG_HOME": "/custom/config"})
+    def test_default_session_name_uses_flat_path(self):
+        """The 'default' session should use ~/.config/herdr/herdr.sock (no subdir)."""
+        path = HerdrInboxService._default_socket_path("default")
+        assert path == "/custom/config/herdr/herdr.sock"

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -72,9 +72,7 @@ class TestHerdrInboxServiceCrossThreadRegistration:
             service._writer = AsyncMock()
 
             # Call register from a separate thread that has no event loop of its own.
-            t = threading.Thread(
-                target=service.register_terminal, args=("tid_cross", "pane-cross")
-            )
+            t = threading.Thread(target=service.register_terminal, args=("tid_cross", "pane-cross"))
             t.start()
             t.join()
 
@@ -166,24 +164,44 @@ class TestHerdrInboxServiceEventParsing:
         service.register_terminal("tid1", "pane-x", is_kiro=False)
 
         # Simulate two events: one "idle" (delivery) and one "working" (no delivery)
-        idle_event = json.dumps({
-            "event": "pane.agent_status_changed",
-            "data": {"pane_id": "pane-x", "agent_status": "idle"},
-        }).encode() + b"\n"
-        done_event = json.dumps({
-            "event": "pane.agent_status_changed",
-            "data": {"pane_id": "pane-x", "agent_status": "done"},
-        }).encode() + b"\n"
+        idle_event = (
+            json.dumps(
+                {
+                    "event": "pane.agent_status_changed",
+                    "data": {"pane_id": "pane-x", "agent_status": "idle"},
+                }
+            ).encode()
+            + b"\n"
+        )
+        done_event = (
+            json.dumps(
+                {
+                    "event": "pane.agent_status_changed",
+                    "data": {"pane_id": "pane-x", "agent_status": "done"},
+                }
+            ).encode()
+            + b"\n"
+        )
         # "working" event — should NOT trigger delivery
-        working_event = json.dumps({
-            "event": "pane.agent_status_changed",
-            "data": {"pane_id": "pane-x", "agent_status": "working"},
-        }).encode() + b"\n"
+        working_event = (
+            json.dumps(
+                {
+                    "event": "pane.agent_status_changed",
+                    "data": {"pane_id": "pane-x", "agent_status": "working"},
+                }
+            ).encode()
+            + b"\n"
+        )
         # Unknown pane — should NOT trigger delivery
-        other_event = json.dumps({
-            "event": "pane.agent_status_changed",
-            "data": {"pane_id": "pane-other", "agent_status": "idle"},
-        }).encode() + b"\n"
+        other_event = (
+            json.dumps(
+                {
+                    "event": "pane.agent_status_changed",
+                    "data": {"pane_id": "pane-other", "agent_status": "idle"},
+                }
+            ).encode()
+            + b"\n"
+        )
 
         async def run():
             reader = asyncio.StreamReader()
@@ -209,10 +227,15 @@ class TestHerdrInboxServiceEventParsing:
         service.register_terminal("tid1", "pane-x", is_kiro=False)
 
         # Old flat format — pane_id and agent_status at top level (not wrapped)
-        flat_event = json.dumps({
-            "pane_id": "pane-x",
-            "agent_status": "idle",
-        }).encode() + b"\n"
+        flat_event = (
+            json.dumps(
+                {
+                    "pane_id": "pane-x",
+                    "agent_status": "idle",
+                }
+            ).encode()
+            + b"\n"
+        )
 
         async def run():
             reader = asyncio.StreamReader()
@@ -329,9 +352,7 @@ class TestHerdrInboxServiceReconcile:
         service.register_terminal("tid1", "pane-live")
         service.register_terminal("tid2", "pane-stale")
 
-        pane_list_response = json.dumps({
-            "result": {"panes": [{"pane_id": "pane-live"}]}
-        })
+        pane_list_response = json.dumps({"result": {"panes": [{"pane_id": "pane-live"}]}})
         ws_list_response = json.dumps({"result": {"workspaces": []}})
 
         def subprocess_side_effect(cmd, **_):
@@ -363,9 +384,9 @@ class TestHerdrInboxServiceReconcile:
         service.register_terminal("tid1", "pane-a")
         service.register_terminal("tid2", "pane-b")
 
-        pane_list_response = json.dumps({
-            "result": {"panes": [{"pane_id": "pane-a"}, {"pane_id": "pane-b"}]}
-        })
+        pane_list_response = json.dumps(
+            {"result": {"panes": [{"pane_id": "pane-a"}, {"pane_id": "pane-b"}]}}
+        )
         ws_list_response = json.dumps({"result": {"workspaces": []}})
 
         def subprocess_side_effect(cmd, **_):
@@ -404,24 +425,24 @@ class TestHerdrInboxServiceReconcile:
     @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
     @patch("cli_agent_orchestrator.clients.database.delete_terminal")
     @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
-    def test_reconcile_deletes_ghost_db_terminals(
-        self, mock_list_terminals, mock_delete, mock_run
-    ):
+    def test_reconcile_deletes_ghost_db_terminals(self, mock_list_terminals, mock_delete, mock_run):
         """Ghost DB terminals (tab not in herdr) are deleted; live terminals are kept."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._workspace_to_session = {"ws-abc": "my-session"}
 
         pane_list_response = json.dumps({"result": {"panes": []}})
-        ws_list_response = json.dumps({
-            "result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}
-        })
-        tab_list_response = json.dumps({
-            "result": {
-                "tabs": [
-                    {"label": "live-window", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"}
-                ]
+        ws_list_response = json.dumps(
+            {"result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}}
+        )
+        tab_list_response = json.dumps(
+            {
+                "result": {
+                    "tabs": [
+                        {"label": "live-window", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"}
+                    ]
+                }
             }
-        })
+        )
 
         def subprocess_side_effect(cmd, **_):
             m = MagicMock()
@@ -448,9 +469,7 @@ class TestHerdrInboxServiceReconcile:
 
     @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
     @patch("cli_agent_orchestrator.clients.database.list_terminals_by_session")
-    def test_reconcile_skips_db_check_when_tab_list_fails(
-        self, mock_list_terminals, mock_run
-    ):
+    def test_reconcile_skips_db_check_when_tab_list_fails(self, mock_list_terminals, mock_run):
         """When herdr tab list returns non-zero, list_terminals_by_session is never called."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._workspace_to_session = {"ws-abc": "my-session"}
@@ -490,17 +509,19 @@ class TestHerdrInboxServiceReconcile:
         service._workspace_to_session = {"ws-abc": "my-session"}
 
         pane_list_response = json.dumps({"result": {"panes": []}})
-        ws_list_response = json.dumps({
-            "result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}
-        })
-        tab_list_response = json.dumps({
-            "result": {
-                "tabs": [
-                    {"label": "window-one", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
-                    {"label": "window-two", "tab_id": "ws-abc:2", "workspace_id": "ws-abc"},
-                ]
+        ws_list_response = json.dumps(
+            {"result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}}
+        )
+        tab_list_response = json.dumps(
+            {
+                "result": {
+                    "tabs": [
+                        {"label": "window-one", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
+                        {"label": "window-two", "tab_id": "ws-abc:2", "workspace_id": "ws-abc"},
+                    ]
+                }
             }
-        })
+        )
 
         def subprocess_side_effect(cmd, **_):
             m = MagicMock()
@@ -537,6 +558,7 @@ class TestHerdrInboxServiceStartupDbCleanup:
             else:
                 m.stdout = tab_response
             return m
+
         return side_effect
 
     @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
@@ -546,12 +568,18 @@ class TestHerdrInboxServiceStartupDbCleanup:
         """Ghost terminals (window not in live herdr tabs) are deleted at startup."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
 
-        ws_response = json.dumps({"result": {"workspaces": [
-            {"workspace_id": "ws-abc", "label": "my-session"}
-        ]}})
-        tab_response = json.dumps({"result": {"tabs": [
-            {"label": "live-window", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
-        ]}})
+        ws_response = json.dumps(
+            {"result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}}
+        )
+        tab_response = json.dumps(
+            {
+                "result": {
+                    "tabs": [
+                        {"label": "live-window", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
+                    ]
+                }
+            }
+        )
         mock_run.side_effect = self._make_subprocess_side_effect(ws_response, tab_response)
         mock_list.return_value = [
             {"id": "tid-live", "tmux_window": "live-window"},
@@ -580,12 +608,18 @@ class TestHerdrInboxServiceStartupDbCleanup:
         """No deletions when all DB terminals have matching live tabs."""
         service = HerdrInboxService(socket_path="/tmp/test.sock")
 
-        ws_response = json.dumps({"result": {"workspaces": [
-            {"workspace_id": "ws-abc", "label": "my-session"}
-        ]}})
-        tab_response = json.dumps({"result": {"tabs": [
-            {"label": "conductor-10e0", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
-        ]}})
+        ws_response = json.dumps(
+            {"result": {"workspaces": [{"workspace_id": "ws-abc", "label": "my-session"}]}}
+        )
+        tab_response = json.dumps(
+            {
+                "result": {
+                    "tabs": [
+                        {"label": "conductor-10e0", "tab_id": "ws-abc:1", "workspace_id": "ws-abc"},
+                    ]
+                }
+            }
+        )
         mock_run.side_effect = self._make_subprocess_side_effect(ws_response, tab_response)
         mock_list.return_value = [{"id": "tid-1", "tmux_window": "conductor-10e0"}]
 
@@ -684,14 +718,24 @@ class TestHerdrInboxServiceLifecycleEvents:
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._workspace_to_session["ws-x"] = "sess-x"
 
-        pane_closed = json.dumps({
-            "type": "pane.closed",
-            "data": {"pane_id": "pane-gone"},
-        }).encode() + b"\n"
-        ws_closed = json.dumps({
-            "type": "workspace.closed",
-            "data": {"workspace_id": "ws-unknown"},
-        }).encode() + b"\n"
+        pane_closed = (
+            json.dumps(
+                {
+                    "type": "pane.closed",
+                    "data": {"pane_id": "pane-gone"},
+                }
+            ).encode()
+            + b"\n"
+        )
+        ws_closed = (
+            json.dumps(
+                {
+                    "type": "workspace.closed",
+                    "data": {"workspace_id": "ws-unknown"},
+                }
+            ).encode()
+            + b"\n"
+        )
 
         handled = []
 
@@ -736,6 +780,7 @@ class TestHerdrInboxServiceSocketPath:
 
         mock_home.return_value = PurePosixPath("/home/user")
         import os
+
         os.environ.pop("XDG_CONFIG_HOME", None)
         path = HerdrInboxService._default_socket_path("cao")
         assert path.endswith("/.config/herdr/sessions/cao/herdr.sock")

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -778,15 +778,27 @@ class TestHerdrInboxServiceLifecycleEvents:
         mock_delete.assert_not_called()
 
     def test_event_loop_routes_lifecycle_events(self):
-        """_event_loop should call _handle_lifecycle_event for pane.closed/workspace.closed."""
+        """_event_loop must route herdr's real lifecycle event wire format.
+
+        Captured live from herdr 0.6.8: lifecycle events carry the name in the
+        "event" key (NOT "type") using UNDERSCORE names:
+            {"event":"pane_closed","data":{"pane_id":...,"workspace_id":...}}
+            {"event":"workspace_closed","data":{"workspace_id":...}}
+        The agent-status event uses the DOTTED name in the same "event" key:
+            {"event":"pane.agent_status_changed","data":{...}}
+        """
         service = HerdrInboxService(socket_path="/tmp/test.sock")
         service._workspace_to_session["ws-x"] = "sess-x"
 
         pane_closed = (
             json.dumps(
                 {
-                    "type": "pane.closed",
-                    "data": {"pane_id": "pane-gone"},
+                    "event": "pane_closed",
+                    "data": {
+                        "pane_id": "pane-gone",
+                        "type": "pane_closed",
+                        "workspace_id": "ws-x",
+                    },
                 }
             ).encode()
             + b"\n"
@@ -794,8 +806,8 @@ class TestHerdrInboxServiceLifecycleEvents:
         ws_closed = (
             json.dumps(
                 {
-                    "type": "workspace.closed",
-                    "data": {"workspace_id": "ws-unknown"},
+                    "event": "workspace_closed",
+                    "data": {"type": "workspace_closed", "workspace_id": "ws-unknown"},
                 }
             ).encode()
             + b"\n"
@@ -823,8 +835,82 @@ class TestHerdrInboxServiceLifecycleEvents:
 
         _run_async(run())
 
+        # Both lifecycle events must be routed (normalized to dotted names).
         assert "pane.closed" in handled
         assert "workspace.closed" in handled
+
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.get_terminal_metadata")
+    def test_event_loop_pane_closed_real_shape_cleans_up(self, mock_meta, mock_delete):
+        """End-to-end: a real-shape pane_closed event removes the managed terminal."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid-x", "pane-x", is_kiro=False)
+        mock_meta.return_value = None  # no session → no kill_session
+
+        event = (
+            json.dumps(
+                {
+                    "event": "pane_closed",
+                    "data": {
+                        "pane_id": "pane-x",
+                        "type": "pane_closed",
+                        "workspace_id": "ws-x",
+                    },
+                }
+            ).encode()
+            + b"\n"
+        )
+
+        async def run():
+            reader = asyncio.StreamReader()
+            service._reader = reader
+            reader.feed_data(event)
+            reader.feed_eof()
+            try:
+                await service._event_loop()
+            except ConnectionError:
+                pass
+
+        _run_async(run())
+
+        assert "pane-x" not in service._pane_to_terminal
+        assert "tid-x" not in service._terminal_to_pane
+        mock_delete.assert_called_once_with("tid-x")
+
+    def test_event_loop_agent_status_real_shape_delivers(self):
+        """A real-shape agent_status_changed (event key, dotted name) triggers delivery."""
+        callback = MagicMock()
+        service = HerdrInboxService(socket_path="/tmp/test.sock", delivery_callback=callback)
+        service.register_terminal("tid-a", "pane-a", is_kiro=False)
+
+        idle_event = (
+            json.dumps(
+                {
+                    "event": "pane.agent_status_changed",
+                    "data": {
+                        "agent": "claude",
+                        "agent_status": "idle",
+                        "pane_id": "pane-a",
+                        "workspace_id": "ws-a",
+                    },
+                }
+            ).encode()
+            + b"\n"
+        )
+
+        async def run():
+            reader = asyncio.StreamReader()
+            service._reader = reader
+            reader.feed_data(idle_event)
+            reader.feed_eof()
+            try:
+                await service._event_loop()
+            except ConnectionError:
+                pass
+
+        _run_async(run())
+
+        callback.assert_called_once_with("tid-a")
 
 
 class TestHerdrInboxServiceSocketPath:

--- a/test/backends/test_herdr_inbox_service.py
+++ b/test/backends/test_herdr_inbox_service.py
@@ -312,6 +312,224 @@ class TestHerdrInboxServiceKiroSupplement:
         callback.assert_not_called()
 
 
+class TestHerdrInboxServiceReconcile:
+    """Test _reconcile() prunes stale panes and cleans up DB/workspace."""
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.HerdrInboxService._reconcile")
+    def test_reconcile_is_called_before_resubscribe(self, mock_reconcile, mock_run):
+        """_reconcile must be awaited before _resubscribe_all in _socket_loop."""
+        # Verify ordering through call_count inspection — reconcile before subscribe.
+        # This is a structural test: just confirms _reconcile exists and is async.
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        assert asyncio.iscoroutinefunction(service._reconcile)
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.get_terminal_metadata")
+    def test_reconcile_prunes_stale_pane(self, mock_meta, mock_delete, mock_run):
+        """Stale pane_ids (not in live herdr list) are pruned from maps and DB."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid1", "pane-live")
+        service.register_terminal("tid2", "pane-stale")
+
+        pane_list_response = json.dumps({
+            "result": {"panes": [{"pane_id": "pane-live"}]}
+        })
+        ws_list_response = json.dumps({"result": {"workspaces": []}})
+
+        def subprocess_side_effect(cmd, **_):
+            m = MagicMock()
+            m.returncode = 0
+            if "pane" in cmd and "list" in cmd:
+                m.stdout = pane_list_response
+            else:
+                m.stdout = ws_list_response
+            return m
+
+        mock_run.side_effect = subprocess_side_effect
+        mock_meta.return_value = None  # No session tracking needed
+
+        _run_async(service._reconcile())
+
+        # pane-stale pruned; pane-live kept
+        assert "pane-stale" not in service._pane_to_terminal
+        assert "tid2" not in service._terminal_to_pane
+        assert "pane-live" in service._pane_to_terminal
+        assert "tid1" in service._terminal_to_pane
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    def test_reconcile_no_op_when_all_panes_live(self, mock_run):
+        """No pruning when all registered panes are still live."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid1", "pane-a")
+        service.register_terminal("tid2", "pane-b")
+
+        pane_list_response = json.dumps({
+            "result": {"panes": [{"pane_id": "pane-a"}, {"pane_id": "pane-b"}]}
+        })
+        ws_list_response = json.dumps({"result": {"workspaces": []}})
+
+        def subprocess_side_effect(cmd, **_):
+            m = MagicMock()
+            m.returncode = 0
+            if "pane" in cmd and "list" in cmd:
+                m.stdout = pane_list_response
+            else:
+                m.stdout = ws_list_response
+            return m
+
+        mock_run.side_effect = subprocess_side_effect
+
+        _run_async(service._reconcile())
+
+        # Maps unchanged
+        assert service._pane_to_terminal == {"pane-a": "tid1", "pane-b": "tid2"}
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    def test_reconcile_continues_on_pane_list_failure(self, mock_run):
+        """When herdr pane list fails, reconcile logs warning and returns without pruning."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid1", "pane-a")
+
+        m = MagicMock()
+        m.returncode = 1
+        m.stderr = "socket not found"
+        mock_run.return_value = m
+
+        # Should not raise
+        _run_async(service._reconcile())
+
+        # Map unchanged
+        assert "pane-a" in service._pane_to_terminal
+
+
+class TestHerdrInboxServiceLifecycleSubscription:
+    """Test _subscribe_lifecycle_events sends correct message."""
+
+    def test_subscribe_lifecycle_events_sends_correct_message(self):
+        """Should subscribe to pane.closed and workspace.closed."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._writer = AsyncMock()
+
+        _run_async(service._subscribe_lifecycle_events())
+
+        service._writer.write.assert_called_once()
+        written = service._writer.write.call_args[0][0]
+        msg = json.loads(written.decode().strip())
+
+        assert msg["method"] == "events.subscribe"
+        subs = msg["params"]["subscriptions"]
+        types = {s["type"] for s in subs}
+        assert "pane.closed" in types
+        assert "workspace.closed" in types
+
+
+class TestHerdrInboxServiceLifecycleEvents:
+    """Test _handle_lifecycle_event for pane.closed and workspace.closed."""
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.get_terminal_metadata")
+    def test_pane_closed_removes_from_maps(self, mock_meta, mock_delete, mock_run):
+        """pane.closed should remove the terminal from tracking maps."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid1", "pane-a", is_kiro=True)
+        service._working_since["tid1"] = time.time()
+        mock_meta.return_value = None  # No session → no kill_session
+
+        service._handle_lifecycle_event("pane.closed", {"pane_id": "pane-a"})
+
+        assert "pane-a" not in service._pane_to_terminal
+        assert "tid1" not in service._terminal_to_pane
+        assert "tid1" not in service._kiro_terminals
+        assert "tid1" not in service._working_since
+
+    @patch("cli_agent_orchestrator.clients.database.delete_terminal")
+    @patch("cli_agent_orchestrator.clients.database.get_terminal_metadata")
+    def test_pane_closed_unknown_pane_is_noop(self, mock_meta, mock_delete):
+        """pane.closed for unregistered pane_id should be silent no-op."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+
+        service._handle_lifecycle_event("pane.closed", {"pane_id": "unknown-pane"})
+
+        mock_delete.assert_not_called()
+        mock_meta.assert_not_called()
+
+    @patch("cli_agent_orchestrator.clients.database.delete_terminals_by_session")
+    def test_workspace_closed_removes_all_terminals_for_session(self, mock_delete_by_session):
+        """workspace.closed should prune all terminals whose pane_id starts with workspace_id."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service.register_terminal("tid1", "ws-abc/0")
+        service.register_terminal("tid2", "ws-abc/1")
+        service.register_terminal("tid3", "ws-other/0")  # Different workspace
+        service._workspace_to_session["ws-abc"] = "my-session"
+
+        service._handle_lifecycle_event("workspace.closed", {"workspace_id": "ws-abc"})
+
+        # ws-abc terminals pruned
+        assert "ws-abc/0" not in service._pane_to_terminal
+        assert "ws-abc/1" not in service._pane_to_terminal
+        assert "tid1" not in service._terminal_to_pane
+        assert "tid2" not in service._terminal_to_pane
+        # Other workspace unaffected
+        assert "ws-other/0" in service._pane_to_terminal
+        assert "tid3" in service._terminal_to_pane
+        # Workspace entry cleaned up
+        assert "ws-abc" not in service._workspace_to_session
+        # DB cleanup called
+        mock_delete_by_session.assert_called_once_with("my-session")
+
+    @patch("cli_agent_orchestrator.clients.database.delete_terminals_by_session")
+    def test_workspace_closed_unknown_workspace_is_noop(self, mock_delete):
+        """workspace.closed for workspace_id not in _workspace_to_session is silent no-op."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+
+        service._handle_lifecycle_event("workspace.closed", {"workspace_id": "unknown-ws"})
+
+        mock_delete.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.herdr_inbox_service.subprocess.run")
+    def test_event_loop_routes_lifecycle_events(self, mock_run):
+        """_event_loop should call _handle_lifecycle_event for pane.closed/workspace.closed."""
+        service = HerdrInboxService(socket_path="/tmp/test.sock")
+        service._workspace_to_session["ws-x"] = "sess-x"
+
+        pane_closed = json.dumps({
+            "type": "pane.closed",
+            "data": {"pane_id": "pane-gone"},
+        }).encode() + b"\n"
+        ws_closed = json.dumps({
+            "type": "workspace.closed",
+            "data": {"workspace_id": "ws-unknown"},
+        }).encode() + b"\n"
+
+        handled = []
+
+        original = service._handle_lifecycle_event
+
+        def capture(event_type, data):
+            handled.append(event_type)
+            original(event_type, data)
+
+        service._handle_lifecycle_event = capture
+
+        async def run():
+            reader = asyncio.StreamReader()
+            service._reader = reader
+            reader.feed_data(pane_closed + ws_closed)
+            reader.feed_eof()
+            try:
+                await service._event_loop()
+            except ConnectionError:
+                pass
+
+        _run_async(run())
+
+        assert "pane.closed" in handled
+        assert "workspace.closed" in handled
+
+
 class TestHerdrInboxServiceSocketPath:
     """Test socket path resolution."""
 

--- a/test/backends/test_tmux_backend.py
+++ b/test/backends/test_tmux_backend.py
@@ -1,0 +1,142 @@
+"""Unit tests for TmuxBackend — verify it satisfies the TerminalBackend ABC."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.backends.base import TerminalBackend, TerminalBackendError
+from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend
+
+
+class TestTmuxBackendSatisfiesABC:
+    """Verify TmuxBackend is a valid TerminalBackend implementation."""
+
+    def test_is_instance_of_terminal_backend(self):
+        """TmuxBackend should be an instance of TerminalBackend ABC."""
+        with patch("cli_agent_orchestrator.backends.tmux_backend.TmuxClient"):
+            backend = TmuxBackend(client=MagicMock())
+        assert isinstance(backend, TerminalBackend)
+
+    def test_all_abstract_methods_implemented(self):
+        """TmuxBackend should implement all abstract methods without error."""
+        # If any method is missing, instantiation would raise TypeError
+        with patch("cli_agent_orchestrator.backends.tmux_backend.TmuxClient"):
+            backend = TmuxBackend(client=MagicMock())
+        # Verify all methods exist
+        assert hasattr(backend, "create_session")
+        assert hasattr(backend, "session_exists")
+        assert hasattr(backend, "list_sessions")
+        assert hasattr(backend, "kill_session")
+        assert hasattr(backend, "create_window")
+        assert hasattr(backend, "kill_window")
+        assert hasattr(backend, "send_keys")
+        assert hasattr(backend, "send_special_key")
+        assert hasattr(backend, "get_history")
+        assert hasattr(backend, "get_pane_working_directory")
+        assert hasattr(backend, "get_pane_current_command")
+        assert hasattr(backend, "attach_session")
+        assert hasattr(backend, "pipe_pane")
+        assert hasattr(backend, "stop_pipe_pane")
+
+
+class TestTmuxBackendDelegation:
+    """Verify TmuxBackend delegates all calls to TmuxClient."""
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def backend(self, mock_client):
+        return TmuxBackend(client=mock_client)
+
+    def test_create_session_delegates(self, backend, mock_client):
+        mock_client.create_session.return_value = "window-0"
+        result = backend.create_session("cao-test", "window-0", "tid123", "/tmp")
+        mock_client.create_session.assert_called_once_with("cao-test", "window-0", "tid123", "/tmp")
+        assert result == "window-0"
+
+    def test_create_session_wraps_error(self, backend, mock_client):
+        mock_client.create_session.side_effect = RuntimeError("tmux failed")
+        with pytest.raises(TerminalBackendError, match="Failed to create session"):
+            backend.create_session("cao-test", "window-0", "tid123")
+
+    def test_session_exists_delegates(self, backend, mock_client):
+        mock_client.session_exists.return_value = True
+        assert backend.session_exists("cao-test") is True
+        mock_client.session_exists.assert_called_once_with("cao-test")
+
+    def test_list_sessions_delegates(self, backend, mock_client):
+        mock_client.list_sessions.return_value = [{"id": "s1", "name": "s1", "status": "active"}]
+        result = backend.list_sessions()
+        assert len(result) == 1
+        mock_client.list_sessions.assert_called_once()
+
+    def test_kill_session_delegates(self, backend, mock_client):
+        mock_client.kill_session.return_value = True
+        assert backend.kill_session("cao-test") is True
+        mock_client.kill_session.assert_called_once_with("cao-test")
+
+    def test_create_window_delegates(self, backend, mock_client):
+        mock_client.create_window.return_value = "dev-1234"
+        result = backend.create_window("cao-test", "dev-1234", "tid456", "/home")
+        mock_client.create_window.assert_called_once_with(
+            "cao-test", "dev-1234", "tid456", "/home", None
+        )
+        assert result == "dev-1234"
+
+    def test_create_window_wraps_error(self, backend, mock_client):
+        mock_client.create_window.side_effect = ValueError("Session not found")
+        with pytest.raises(TerminalBackendError, match="Failed to create window"):
+            backend.create_window("cao-test", "dev-1234", "tid456")
+
+    def test_kill_window_delegates(self, backend, mock_client):
+        mock_client.kill_window.return_value = True
+        assert backend.kill_window("cao-test", "window-0") is True
+        mock_client.kill_window.assert_called_once_with("cao-test", "window-0")
+
+    def test_send_keys_delegates(self, backend, mock_client):
+        backend.send_keys("cao-test", "window-0", "hello", enter_count=2)
+        mock_client.send_keys.assert_called_once_with(
+            "cao-test", "window-0", "hello",
+            enter_count=2, force_bracketed_paste=False,
+        )
+
+    def test_send_special_key_delegates(self, backend, mock_client):
+        backend.send_special_key("cao-test", "window-0", "C-c")
+        mock_client.send_special_key.assert_called_once_with("cao-test", "window-0", "C-c")
+
+    def test_get_history_delegates(self, backend, mock_client):
+        mock_client.get_history.return_value = "output text"
+        result = backend.get_history("cao-test", "window-0", tail_lines=50)
+        mock_client.get_history.assert_called_once_with(
+            "cao-test", "window-0", tail_lines=50, strip_escapes=False, full_history=False,
+        )
+        assert result == "output text"
+
+    def test_get_pane_working_directory_delegates(self, backend, mock_client):
+        mock_client.get_pane_working_directory.return_value = "/home/user"
+        result = backend.get_pane_working_directory("cao-test", "window-0")
+        assert result == "/home/user"
+
+    def test_get_pane_current_command_delegates(self, backend, mock_client):
+        mock_client.get_pane_current_command.return_value = "python"
+        result = backend.get_pane_current_command("cao-test", "window-0")
+        assert result == "python"
+
+    def test_pipe_pane_delegates(self, backend, mock_client):
+        backend.pipe_pane("cao-test", "window-0", "/tmp/log.txt")
+        mock_client.pipe_pane.assert_called_once_with("cao-test", "window-0", "/tmp/log.txt")
+
+    def test_stop_pipe_pane_delegates(self, backend, mock_client):
+        backend.stop_pipe_pane("cao-test", "window-0")
+        mock_client.stop_pipe_pane.assert_called_once_with("cao-test", "window-0")
+
+
+class TestTmuxBackendDefaultClient:
+    """Verify TmuxBackend uses module singleton when no client is provided."""
+
+    @patch("cli_agent_orchestrator.clients.tmux.tmux_client")
+    def test_uses_module_singleton(self, mock_singleton):
+        backend = TmuxBackend()
+        assert backend._client is mock_singleton

--- a/test/backends/test_tmux_backend.py
+++ b/test/backends/test_tmux_backend.py
@@ -98,8 +98,11 @@ class TestTmuxBackendDelegation:
     def test_send_keys_delegates(self, backend, mock_client):
         backend.send_keys("cao-test", "window-0", "hello", enter_count=2)
         mock_client.send_keys.assert_called_once_with(
-            "cao-test", "window-0", "hello",
-            enter_count=2, force_bracketed_paste=False,
+            "cao-test",
+            "window-0",
+            "hello",
+            enter_count=2,
+            force_bracketed_paste=False,
         )
 
     def test_send_special_key_delegates(self, backend, mock_client):
@@ -110,7 +113,11 @@ class TestTmuxBackendDelegation:
         mock_client.get_history.return_value = "output text"
         result = backend.get_history("cao-test", "window-0", tail_lines=50)
         mock_client.get_history.assert_called_once_with(
-            "cao-test", "window-0", tail_lines=50, strip_escapes=False, full_history=False,
+            "cao-test",
+            "window-0",
+            tail_lines=50,
+            strip_escapes=False,
+            full_history=False,
         )
         assert result == "output text"
 

--- a/test/backends/test_tmux_backend.py
+++ b/test/backends/test_tmux_backend.py
@@ -53,7 +53,9 @@ class TestTmuxBackendDelegation:
     def test_create_session_delegates(self, backend, mock_client):
         mock_client.create_session.return_value = "window-0"
         result = backend.create_session("cao-test", "window-0", "tid123", "/tmp")
-        mock_client.create_session.assert_called_once_with("cao-test", "window-0", "tid123", "/tmp")
+        mock_client.create_session.assert_called_once_with(
+            "cao-test", "window-0", "tid123", "/tmp", extra_env=None
+        )
         assert result == "window-0"
 
     def test_create_session_wraps_error(self, backend, mock_client):
@@ -81,7 +83,7 @@ class TestTmuxBackendDelegation:
         mock_client.create_window.return_value = "dev-1234"
         result = backend.create_window("cao-test", "dev-1234", "tid456", "/home")
         mock_client.create_window.assert_called_once_with(
-            "cao-test", "dev-1234", "tid456", "/home", None
+            "cao-test", "dev-1234", "tid456", "/home", None, extra_env=None
         )
         assert result == "dev-1234"
 

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -612,7 +612,7 @@ def test_launch_yolo_still_resolves_profile_provider():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
         patch(
             "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
@@ -643,7 +643,7 @@ def test_launch_allowed_tools_still_resolves_profile_provider():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch(
             "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
             return_value="gemini_cli",
@@ -683,7 +683,7 @@ def test_launch_explicit_provider_skips_profile_resolution():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
         patch("cli_agent_orchestrator.utils.agent_profiles.resolve_provider") as mock_resolve,
     ):
@@ -715,7 +715,7 @@ def test_launch_yolo_falls_back_to_default_when_profile_lacks_provider():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
         patch(
             "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
@@ -802,7 +802,7 @@ def test_launch_forwards_env_in_json_body_not_url():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
         mock_post.return_value.json.return_value = {
@@ -847,7 +847,7 @@ def test_launch_without_env_omits_request_body():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
         mock_post.return_value.json.return_value = {

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -15,9 +15,10 @@ def test_launch_passes_cwd_by_default():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
+        mock_get_backend.return_value.attach_session.return_value = None
 
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -42,9 +43,10 @@ def test_launch_passes_explicit_working_directory():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
+        mock_get_backend.return_value.attach_session.return_value = None
 
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -132,9 +134,10 @@ def test_launch_with_session_name():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
+        mock_get_backend.return_value.attach_session.return_value = None
         mock_post.return_value.json.return_value = {
             "session_name": "custom-session",
             "id": "test-terminal-id",
@@ -183,12 +186,12 @@ def test_launch_generic_exception():
 
 
 def test_launch_headless_mode():
-    """Test launch in headless mode doesn't attach to tmux."""
+    """Test launch in headless mode doesn't attach to the backend."""
     runner = CliRunner()
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -199,16 +202,16 @@ def test_launch_headless_mode():
         result = runner.invoke(launch, ["--agents", "test-agent", "--headless", "--yolo"])
 
         assert result.exit_code == 0
-        # In headless mode, subprocess.run should not be called
-        mock_subprocess.assert_not_called()
+        # In headless mode, attach_session should not be called
+        mock_get_backend.return_value.attach_session.assert_not_called()
 
 
 def test_launch_non_headless_waits_for_idle_before_attach():
-    """Non-headless launch must wait for IDLE/COMPLETED before tmux attach.
+    """Non-headless launch must wait for IDLE/COMPLETED before attaching.
 
     Regression guard for #220: attaching before the TUI finishes initializing
     races with input-handler wiring and silently drops keystrokes. The wait
-    must be called with the terminal id before subprocess.run.
+    must be called with the terminal id before attach_session.
     """
     runner = CliRunner()
 
@@ -216,7 +219,7 @@ def test_launch_non_headless_waits_for_idle_before_attach():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
         mock_post.return_value.json.return_value = {
@@ -234,7 +237,7 @@ def test_launch_non_headless_waits_for_idle_before_attach():
             call_order.append("attach")
 
         mock_wait.side_effect = record_wait
-        mock_subprocess.side_effect = record_attach
+        mock_get_backend.return_value.attach_session.side_effect = record_attach
 
         result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
 
@@ -248,14 +251,14 @@ def test_launch_non_headless_waits_for_idle_before_attach():
 def test_launch_non_headless_attaches_even_if_wait_times_out():
     """Non-headless launch warns but still attaches if the idle wait times out.
 
-    The wait is advisory: orphaning the session in tmux (by refusing to attach)
+    The wait is advisory: orphaning the session (by refusing to attach)
     would be worse than letting the user inspect a slow-initializing session.
     """
     runner = CliRunner()
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
         mock_post.return_value.json.return_value = {
@@ -265,14 +268,13 @@ def test_launch_non_headless_attaches_even_if_wait_times_out():
         }
         mock_post.return_value.raise_for_status.return_value = None
         mock_wait.return_value = False
+        mock_get_backend.return_value.attach_session.return_value = None
 
         result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
 
         assert result.exit_code == 0
         assert "did not reach idle within 120s" in result.output
-        mock_subprocess.assert_called_once()
-        attach_cmd = mock_subprocess.call_args.args[0]
-        assert attach_cmd[:2] == ["tmux", "attach-session"]
+        mock_get_backend.return_value.attach_session.assert_called_once_with("test-session")
 
 
 def test_launch_workspace_confirmation_accepted():
@@ -281,7 +283,7 @@ def test_launch_workspace_confirmation_accepted():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -323,7 +325,7 @@ def test_launch_workspace_confirmation_skipped_with_yolo_flag():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -348,7 +350,7 @@ def test_launch_workspace_confirmation_for_default_provider():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -370,7 +372,7 @@ def test_launch_yolo_sets_unrestricted_allowed_tools():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
         mock_post.return_value.json.return_value = {
@@ -395,7 +397,7 @@ def test_launch_allowed_tools_override():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -429,7 +431,7 @@ def test_launch_builtin_profile_resolves_role_defaults():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run") as mock_subprocess,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -573,7 +575,7 @@ def test_launch_honors_profile_provider_when_flag_not_given():
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
-        patch("cli_agent_orchestrator.cli.commands.launch.subprocess.run"),
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
         patch(
             "cli_agent_orchestrator.utils.agent_profiles.resolve_provider",
             return_value="claude_code",

--- a/test/cli/commands/test_terminal.py
+++ b/test/cli/commands/test_terminal.py
@@ -226,7 +226,10 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
+                with patch(
+                    "cli_agent_orchestrator.cli.commands.terminal.get_backend",
+                    return_value=mock_tmux,
+                ):
                     result = runner.invoke(terminal, ["restore", "abc12345"])
 
         assert result.exit_code != 0
@@ -254,7 +257,10 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
+                with patch(
+                    "cli_agent_orchestrator.cli.commands.terminal.get_backend",
+                    return_value=mock_tmux,
+                ):
                     result = runner.invoke(terminal, ["restore", "abc12345"])
 
         assert result.exit_code == 0
@@ -285,7 +291,10 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
+                with patch(
+                    "cli_agent_orchestrator.cli.commands.terminal.get_backend",
+                    return_value=mock_tmux,
+                ):
                     with patch.dict("os.environ", {"SHELL": "/bin/zsh"}):
                         result = runner.invoke(terminal, ["restore", "abc12345"])
 
@@ -323,7 +332,10 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
+                with patch(
+                    "cli_agent_orchestrator.cli.commands.terminal.get_backend",
+                    return_value=mock_tmux,
+                ):
                     result = runner.invoke(terminal, ["restore", "abc12345"])
 
         assert result.exit_code == 0

--- a/test/cli/commands/test_terminal.py
+++ b/test/cli/commands/test_terminal.py
@@ -17,7 +17,7 @@ from cli_agent_orchestrator.cli.commands.terminal import terminal
 
 
 class TestSnapshotOnDelete:
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
@@ -55,7 +55,7 @@ class TestSnapshotOnDelete:
         assert snapshot["agent_profile"] == "developer"
         assert snapshot["working_directory"] == "/home/user/project"
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
@@ -226,7 +226,7 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.tmux_client", mock_tmux):
+                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
                     result = runner.invoke(terminal, ["restore", "abc12345"])
 
         assert result.exit_code != 0
@@ -254,7 +254,7 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.tmux_client", mock_tmux):
+                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
                     result = runner.invoke(terminal, ["restore", "abc12345"])
 
         assert result.exit_code == 0
@@ -285,7 +285,7 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.tmux_client", mock_tmux):
+                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
                     with patch.dict("os.environ", {"SHELL": "/bin/zsh"}):
                         result = runner.invoke(terminal, ["restore", "abc12345"])
 
@@ -323,7 +323,7 @@ class TestRestoreCommand:
             with patch(
                 "cli_agent_orchestrator.cli.commands.terminal.requests.get", return_value=mock_resp
             ):
-                with patch("cli_agent_orchestrator.cli.commands.terminal.tmux_client", mock_tmux):
+                with patch("cli_agent_orchestrator.cli.commands.terminal.get_backend", return_value=mock_tmux):
                     result = runner.invoke(terminal, ["restore", "abc12345"])
 
         assert result.exit_code == 0

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -636,11 +636,14 @@ class TestFlowOperations:
 
     @patch("cli_agent_orchestrator.clients.database.SessionLocal")
     def test_create_inbox_message(self, mock_session_class):
-        """Test creating an inbox message."""
+        """Test creating an inbox message when receiver terminal exists."""
         mock_session = MagicMock()
         mock_session.__enter__ = MagicMock(return_value=mock_session)
         mock_session.__exit__ = MagicMock(return_value=False)
         mock_session_class.return_value = mock_session
+
+        # Receiver terminal exists
+        mock_session.query.return_value.filter.return_value.first.return_value = MagicMock()
 
         # Setup mock to update message attributes on refresh
         def mock_refresh(msg):
@@ -660,6 +663,20 @@ class TestFlowOperations:
         assert result.message == "Hello"
         mock_session.add.assert_called_once()
         mock_session.commit.assert_called_once()
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_create_inbox_message_receiver_not_found(self, mock_session_class):
+        """create_inbox_message raises ValueError when receiver terminal does not exist."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session_class.return_value = mock_session
+
+        # Receiver terminal does not exist
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            create_inbox_message("sender-123", "dead-terminal", "Hello")
 
 
 class TestInitDb:

--- a/test/providers/test_claude_code_coverage.py
+++ b/test/providers/test_claude_code_coverage.py
@@ -14,7 +14,7 @@ import pytest
 @pytest.fixture
 def provider():
     """Create a ClaudeCodeProvider with mocked dependencies."""
-    with patch("cli_agent_orchestrator.providers.claude_code.tmux_client"):
+    with patch("cli_agent_orchestrator.backends.registry._backend"):
         from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
 
         p = ClaudeCodeProvider("tid1", "ses", "win", "test-agent")
@@ -51,53 +51,51 @@ class TestBuildCommandMcpServerModelDump:
 class TestHandleStartupPromptsBranches:
     """Test _handle_startup_prompts branches."""
 
-    @patch("cli_agent_orchestrator.providers.claude_code.subprocess")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
-    def test_bypass_permissions_prompt(self, mock_tmux, mock_subprocess, provider):
-        """Detects bypass permissions prompt and sends Down + Enter."""
-        mock_tmux.get_history.return_value = (
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_bypass_permissions_prompt(self, mock_backend, provider):
+        """Detects bypass permissions prompt and sends Down arrow + Enter via backend."""
+        mock_backend.get_history.return_value = (
             "⚠ Bypass Permissions mode\n" "1. No, exit\n" "2. Yes, I accept\n"
         )
 
         provider._handle_startup_prompts(timeout=1.0)
 
-        # Should have called subprocess.run twice (Down arrow + Enter)
-        assert mock_subprocess.run.call_count == 2
+        # Down arrow sent via send_keys, Enter via send_special_key
+        mock_backend.send_keys.assert_called_once()
+        mock_backend.send_special_key.assert_called_once_with(
+            provider.session_name, provider.window_name, "Enter"
+        )
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
-    def test_idle_prompt_detected_early_return(self, mock_tmux, provider):
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_idle_prompt_detected_early_return(self, mock_backend, provider):
         """When idle prompt is visible, returns immediately without sending keys."""
         from cli_agent_orchestrator.providers.claude_code import IDLE_PROMPT_PATTERN
 
-        mock_tmux.get_history.return_value = "❯ "
+        mock_backend.get_history.return_value = "❯ "
 
         provider._handle_startup_prompts(timeout=1.0)
 
         # No exception means early return worked
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
-    def test_welcome_banner_detected_early_return(self, mock_tmux, provider):
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_welcome_banner_detected_early_return(self, mock_backend, provider):
         """When welcome banner is visible, returns immediately."""
-        mock_tmux.get_history.return_value = "Welcome to Claude Code v2.5.0"
+        mock_backend.get_history.return_value = "Welcome to Claude Code v2.5.0"
 
         provider._handle_startup_prompts(timeout=1.0)
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
-    def test_trust_prompt_detected(self, mock_tmux, provider):
-        """Trust prompt sends Enter to accept."""
-        mock_tmux.get_history.return_value = (
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_trust_prompt_detected(self, mock_backend, provider):
+        """Trust prompt sends Enter to accept via backend send_special_key."""
+        mock_backend.get_history.return_value = (
             "Do you trust the files in this folder?\n" "❯ Yes, I trust this folder"
         )
-        mock_pane = MagicMock()
-        mock_window = MagicMock()
-        mock_window.active_pane = mock_pane
-        mock_session = MagicMock()
-        mock_session.windows.get.return_value = mock_window
-        mock_tmux.server.sessions.get.return_value = mock_session
 
         provider._handle_startup_prompts(timeout=1.0)
 
-        mock_pane.send_keys.assert_called_once_with("", enter=True)
+        mock_backend.send_special_key.assert_called_once_with(
+            provider.session_name, provider.window_name, "Enter"
+        )
 
 
 class TestDatabaseListAllTerminals:

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -816,7 +816,6 @@ Map<String, List<Integer>> nested = getMap();
         assert "value 1" in result
         assert "End of response" in result
 
-
     def test_extract_message_bullet_marker(self):
         """● (U+25CF) is accepted as a response marker — newer Claude versions use this."""
         output = "● Here is the bullet response\nthat spans lines\n> "
@@ -1114,9 +1113,7 @@ class TestClaudeCodeProviderStartupPrompts:
 
         # Verify Down arrow sent via send_keys and Enter via send_special_key
         mock_tmux.send_keys.assert_called_once()
-        mock_tmux.send_special_key.assert_called_once_with(
-            "test-session", "window-0", "Enter"
-        )
+        mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_handle_bypass_then_trust_prompt(self, mock_tmux):

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1,6 +1,7 @@
 """Unit tests for Claude Code provider."""
 
 import json
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -20,7 +21,7 @@ class TestClaudeCodeProviderInitialization:
     @_PATCH_SETTINGS
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_success(self, mock_tmux, mock_wait_status, mock_wait_shell, _):
         """Test successful initialization."""
         mock_wait_shell.return_value = True
@@ -42,7 +43,7 @@ class TestClaudeCodeProviderInitialization:
         mock_tmux.send_keys.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_shell_timeout(self, mock_tmux, mock_wait_shell):
         """Test initialization with shell timeout."""
         mock_wait_shell.return_value = False
@@ -55,7 +56,7 @@ class TestClaudeCodeProviderInitialization:
     @_PATCH_SETTINGS
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_timeout(self, mock_tmux, mock_wait_status, mock_wait_shell, _):
         """Test initialization timeout when no Claude markers appear."""
         mock_wait_shell.return_value = True
@@ -77,7 +78,7 @@ class TestClaudeCodeProviderInitialization:
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_with_agent_profile(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load, _
     ):
@@ -106,7 +107,7 @@ class TestClaudeCodeProviderInitialization:
     @_PATCH_SETTINGS
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_with_missing_profile_falls_back_to_native_agent(
         self, mock_tmux, mock_load, mock_wait_shell, _
     ):
@@ -136,7 +137,7 @@ class TestClaudeCodeProviderInitialization:
     @_PATCH_SETTINGS
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_with_broken_profile_raises_provider_error(
         self, mock_tmux, mock_load, mock_wait_shell, _
     ):
@@ -168,7 +169,7 @@ class TestClaudeCodeProviderInitialization:
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_with_mcp_servers(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load, _
     ):
@@ -196,7 +197,7 @@ class TestClaudeCodeProviderInitialization:
     @_PATCH_SETTINGS
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_sends_claude_command(self, mock_tmux, mock_wait_status, mock_wait_shell, _):
         """Test that initialize sends the 'claude' command to tmux."""
         mock_wait_shell.return_value = True
@@ -220,9 +221,10 @@ class TestClaudeCodeProviderInitialization:
 class TestClaudeCodeProviderStatusDetection:
     """Tests for ClaudeCodeProvider status detection."""
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_idle_old_prompt(self, mock_tmux):
         """Test IDLE status detection with old '>' prompt."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "> "
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -230,9 +232,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_idle_new_prompt(self, mock_tmux):
         """Test IDLE status detection with new '❯' prompt."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "❯ "
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -240,9 +243,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_idle_with_ansi_codes(self, mock_tmux):
         """Test IDLE status detection with ANSI codes around prompt."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "\x1b[2m\x1b[38;2;136;136;136m────────────\n"
             '\x1b[0m❯ \x1b[7mT\x1b[0;2mry\x1b[0m \x1b[2m"hello"\x1b[0m\n'
@@ -254,9 +258,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED status detection."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "⏺ Here is the response\n> "
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -264,9 +269,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_completed_with_new_prompt(self, mock_tmux):
         """Test COMPLETED status detection with new '❯' prompt."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "⏺ Here is the response\n❯ "
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -274,9 +280,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING status detection."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "✶ Processing… (esc to interrupt)"
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -284,9 +291,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing_minimal_spinner(self, mock_tmux):
         """Test PROCESSING detection with minimal spinner format (no parenthesized text)."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "✻ Orbiting…"
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -294,9 +302,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing_beats_stale_completed(self, mock_tmux):
         """Test that PROCESSING is detected even when stale ⏺ and ❯ markers are in scrollback."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "⏺ Previous response from init\n"
             "❯ user task message\n"
@@ -309,9 +318,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_completed_despite_stale_spinner_in_scrollback(self, mock_tmux):
         """Stale spinner in scrollback must not block COMPLETED detection (#104)."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "✻ Orbiting…\n"
             "⏺ Previous response\n"
@@ -323,9 +333,10 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_idle_despite_stale_spinner_in_scrollback(self, mock_tmux):
         """Stale spinner in scrollback must not block IDLE detection (#104)."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "✶ Processing… (esc to interrupt)\n" "Some previous output\n" "❯ "
         )
@@ -333,9 +344,10 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing_spinner_before_separator(self, mock_tmux):
         """Spinner immediately before ──────── separator → PROCESSING (structural check)."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ do the task\n"
             "⏺ Let me read the file\n"
@@ -347,18 +359,20 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_completed_no_spinner_before_separator(self, mock_tmux):
         """Response text (no spinner) before separator → COMPLETED, not PROCESSING."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ do the task\n" "⏺ Here is the completed response\n" "────────────────────────\n" "❯ "
         )
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_stale_spinner_far_back_not_processing(self, mock_tmux):
         """Stale spinner far back in scrollback + current separator with no spinner → COMPLETED."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "✢ Thinking…\n"
             "⏺ Old response from first task line 1\n"
@@ -374,16 +388,18 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing_no_separator_yet(self, mock_tmux):
         """Early execution with spinner but no separator yet → position fallback PROCESSING."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "✻ Orbiting…"
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing_ansi_separator(self, mock_tmux):
         """Spinner before separator with ANSI colour codes on separator → PROCESSING."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ do the task\n"
             "⏺ Reading file…\n"
@@ -395,18 +411,20 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing_middle_dot_spinner(self, mock_tmux):
         """New · Swirling… spinner variant → PROCESSING via structural check."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ do the task\n" "· Swirling…\n" "\n" "────────────────────────\n" "❯ "
         )
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_idle_not_false_processing_from_status_bar(self, mock_tmux):
         """Status bar '· latest:…' must not false-positive as PROCESSING."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "Claude Code v2.1.63\n"
             "────────────────────\n"
@@ -417,9 +435,10 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
         """Test WAITING_USER_ANSWER status detection."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ 1. Option one\n"
             "  2. Option two\n"
@@ -431,9 +450,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_stale_scrollback_not_waiting_user_answer(self, mock_tmux):
         """Stale numbered scrollback without the active footer must not block input."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ 1. Option one\n" "  2. Option two\n" "⏺ Selection handled earlier\n" "❯ "
         )
@@ -444,9 +464,10 @@ class TestClaudeCodeProviderStatusDetection:
         assert status != TerminalStatus.WAITING_USER_ANSWER
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_error_empty(self, mock_tmux):
         """Test ERROR status with empty output."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = ""
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -454,9 +475,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_error_unrecognized(self, mock_tmux):
         """Test ERROR status with unrecognized output."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "Some random output without patterns"
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -464,9 +486,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_with_tail_lines(self, mock_tmux):
         """Test status detection with tail_lines parameter."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = "> "
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -474,9 +497,10 @@ class TestClaudeCodeProviderStatusDetection:
 
         mock_tmux.get_history.assert_called_with("test-session", "window-0", tail_lines=50)
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_completed_after_compaction_not_false_processing(self, mock_tmux):
         """Compaction spinner before its own separator, then more output; last sep has no spinner → COMPLETED."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ do the task\n"
             "⏺ Starting work…\n"
@@ -489,9 +513,10 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_processing_after_compaction_when_still_running(self, mock_tmux):
         """Spinner before the last separator (agent resumes after compaction) → PROCESSING."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ do the task\n"
             "✢ Compacting conversation…\n"
@@ -504,9 +529,10 @@ class TestClaudeCodeProviderStatusDetection:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_completed_after_exit_not_false_processing(self, mock_tmux):
         """Spinner → sep (task done) → /exit → second sep; spinner NOT before last sep → not PROCESSING."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ do the task\n"
             "⏺ Working on it…\n"
@@ -519,6 +545,189 @@ class TestClaudeCodeProviderStatusDetection:
         )
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         assert provider.get_status() != TerminalStatus.PROCESSING
+
+
+class TestClaudeCodeProviderNativeStatus:
+    """Tests for get_status() native-first path (herdr backend)."""
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_processing_skips_buffer(self, mock_backend):
+        """When native returns PROCESSING, get_history is not called."""
+        mock_backend.get_native_status.return_value = TerminalStatus.PROCESSING
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.get_status()
+
+        assert result == TerminalStatus.PROCESSING
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_processing_resets_flush_wait_timers(self, mock_backend):
+        """native=PROCESSING must reset flush-wait timestamps stamped during a pre-work idle gap.
+
+        Scenario: send_input() fires, herdr briefly shows idle before transitioning
+        to processing. _idle_first_detected gets stamped at T0. Then native=processing
+        arrives. If we don't reset, the timer keeps accumulating. When herdr finishes
+        and shows idle again 112s later, waited >= 10s already -> COMPLETED fires before
+        the buffer is flushed.
+        """
+        mock_backend.get_native_status.return_value = TerminalStatus.PROCESSING
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider._task_dispatched = True
+        # Simulate timestamps stamped during the pre-work idle gap
+        provider._done_first_detected = time.time() - 5.0
+        provider._idle_first_detected = time.time() - 5.0
+
+        provider.get_status()
+
+        assert provider._done_first_detected == 0.0
+        assert provider._idle_first_detected == 0.0
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_waiting_user_answer_skips_buffer(self, mock_backend):
+        """When native returns WAITING_USER_ANSWER, get_history is not called."""
+        mock_backend.get_native_status.return_value = TerminalStatus.WAITING_USER_ANSWER
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.get_status()
+
+        assert result == TerminalStatus.WAITING_USER_ANSWER
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_completed_no_task_dispatched_returns_completed(self, mock_backend):
+        """Native COMPLETED with no task dispatched returns COMPLETED directly (no buffer read)."""
+        mock_backend.get_native_status.return_value = TerminalStatus.COMPLETED
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        # _task_dispatched is False by default
+        result = provider.get_status()
+
+        assert result == TerminalStatus.COMPLETED
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_done_task_dispatched_within_10s_returns_processing(self, mock_backend):
+        """Native 'done' + task dispatched: <10s since first detection -> PROCESSING."""
+        mock_backend.get_native_status.return_value = TerminalStatus.COMPLETED
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider._task_dispatched = True
+        provider._last_dispatch_time = time.time()
+        # _done_first_detected=0.0: first detection happens now, elapsed < 10s
+
+        result = provider.get_status()
+
+        assert result == TerminalStatus.PROCESSING
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_done_task_dispatched_after_10s_returns_completed(self, mock_backend):
+        """Native 'done' + task dispatched: >=10s since first detection -> COMPLETED."""
+        mock_backend.get_native_status.return_value = TerminalStatus.COMPLETED
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider._task_dispatched = True
+        provider._last_dispatch_time = time.time()
+        provider._done_first_detected = time.time() - 11.0
+
+        result = provider.get_status()
+
+        assert result == TerminalStatus.COMPLETED
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_error_skips_buffer(self, mock_backend):
+        """When native returns ERROR (herdr 'unknown'), get_history is not called."""
+        mock_backend.get_native_status.return_value = TerminalStatus.ERROR
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.get_status()
+
+        assert result == TerminalStatus.ERROR
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_idle_no_task_dispatched_returns_idle(self, mock_backend):
+        """Native 'idle' with _task_dispatched=False returns IDLE."""
+        mock_backend.get_native_status.return_value = TerminalStatus.IDLE
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.get_status()
+
+        assert result == TerminalStatus.IDLE
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_idle_task_dispatched_within_10s_returns_processing(self, mock_backend):
+        """Native idle + task dispatched: <10s since first detection -> PROCESSING."""
+        mock_backend.get_native_status.return_value = TerminalStatus.IDLE
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider._task_dispatched = True
+        provider._last_dispatch_time = time.time()
+        # _idle_first_detected=0.0: first detection happens now, elapsed < 10s
+
+        result = provider.get_status()
+
+        assert result == TerminalStatus.PROCESSING
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_idle_task_dispatched_after_10s_returns_completed(self, mock_backend):
+        """Native idle + task dispatched: >=10s since first detection -> COMPLETED."""
+        mock_backend.get_native_status.return_value = TerminalStatus.IDLE
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider._task_dispatched = True
+        provider._last_dispatch_time = time.time()
+        provider._idle_first_detected = time.time() - 11.0
+
+        result = provider.get_status()
+
+        assert result == TerminalStatus.COMPLETED
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_idle_task_dispatched_5min_timeout_returns_completed(self, mock_backend):
+        """Native idle + task dispatched: >5 min since dispatch -> COMPLETED (give up)."""
+        mock_backend.get_native_status.return_value = TerminalStatus.IDLE
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider._task_dispatched = True
+        provider._last_dispatch_time = time.time() - 301.0
+        provider._idle_first_detected = time.time() - 301.0
+
+        result = provider.get_status()
+
+        assert result == TerminalStatus.COMPLETED
+        mock_backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_mark_input_received_resets_detection_flags(self, mock_backend):
+        """mark_input_received() sets _task_dispatched=True and resets detection flags."""
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider._done_first_detected = 999.0
+        provider._idle_first_detected = 999.0
+
+        provider.mark_input_received()
+
+        assert provider._task_dispatched is True
+        assert provider._done_first_detected == 0.0
+        assert provider._idle_first_detected == 0.0
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_falls_through_to_buffer(self, mock_backend):
+        """When native returns None (tmux backend), buffer analysis runs."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.get_history.return_value = "❯ "
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.get_status()
+
+        assert result == TerminalStatus.IDLE
+        mock_backend.get_history.assert_called_once()
 
 
 class TestClaudeCodeProviderMessageExtraction:
@@ -578,16 +787,51 @@ Map<String, List<Integer>> nested = getMap();
         assert "Map<String, List<Integer>>" in result
 
     def test_extract_message_with_separator(self):
-        """Test extraction stops at separator."""
-        output = """⏺ Response content
-────────
-More content
-> """
+        """Test extraction stops at Claude's full-width UI separator (20+ dashes, no box chars)."""
+        # Claude's turn separator spans the full terminal width — always 20+ dashes
+        output = "⏺ Response content\n" + "─" * 80 + "\nMore content\n> "
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         result = provider.extract_last_message_from_script(output)
 
         assert "Response content" in result
         assert "More content" not in result
+
+    def test_extract_message_with_table_not_truncated(self):
+        """Extraction must NOT stop at table borders containing ─ runs inside │ box chars."""
+        output = (
+            "⏺ Here is a table:\n"
+            "┌──────────────┬──────────────┐\n"
+            "│ Col A        │ Col B        │\n"
+            "├──────────────┼──────────────┤\n"
+            "│ value 1      │ value 2      │\n"
+            "└──────────────┴──────────────┘\n"
+            "End of response\n"
+            "> "
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.extract_last_message_from_script(output)
+
+        assert "Here is a table" in result
+        assert "Col A" in result
+        assert "value 1" in result
+        assert "End of response" in result
+
+
+    def test_extract_message_bullet_marker(self):
+        """● (U+25CF) is accepted as a response marker — newer Claude versions use this."""
+        output = "● Here is the bullet response\nthat spans lines\n> "
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.extract_last_message_from_script(output)
+        assert "Here is the bullet response" in result
+        assert "that spans lines" in result
+
+    def test_extract_message_last_of_mixed_markers(self):
+        """When both ⏺ and ● appear, the last one wins."""
+        output = "⏺ Old response\n> \n● New response\n> "
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.extract_last_message_from_script(output)
+        assert "New response" in result
+        assert "Old response" not in result
 
 
 class TestClaudeCodeProviderMisc:
@@ -807,25 +1051,19 @@ class TestClaudeCodeProviderPermissionMode:
 class TestClaudeCodeProviderStartupPrompts:
     """Tests for Claude Code startup prompt handling (trust + bypass)."""
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_handle_startup_prompts_detected_and_accepted(self, mock_tmux):
         """Test that trust prompt is detected and auto-accepted."""
         mock_tmux.get_history.return_value = (
             "\x1b[1m❯\x1b[0m 1. Yes, I trust this folder\n  2. No, don't trust\n"
         )
-        mock_session = MagicMock()
-        mock_window = MagicMock()
-        mock_pane = MagicMock()
-        mock_tmux.server.sessions.get.return_value = mock_session
-        mock_session.windows.get.return_value = mock_window
-        mock_window.active_pane = mock_pane
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         provider._handle_startup_prompts(timeout=2.0)
 
-        mock_pane.send_keys.assert_called_once_with("", enter=True)
+        mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_handle_startup_prompts_not_needed(self, mock_tmux):
         """Test early return when Claude Code starts without prompts."""
         mock_tmux.get_history.return_value = "Welcome to Claude Code v2.1.0"
@@ -833,10 +1071,10 @@ class TestClaudeCodeProviderStartupPrompts:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         provider._handle_startup_prompts(timeout=2.0)
 
-        mock_tmux.server.sessions.get.assert_not_called()
+        mock_tmux.send_special_key.assert_not_called()
 
     @patch("cli_agent_orchestrator.providers.claude_code.time")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_handle_startup_prompts_timeout(self, mock_tmux, mock_time):
         """Test startup prompt handler times out gracefully."""
         mock_tmux.get_history.return_value = "Loading..."
@@ -846,30 +1084,23 @@ class TestClaudeCodeProviderStartupPrompts:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         provider._handle_startup_prompts(timeout=20.0)
 
-        mock_tmux.server.sessions.get.assert_not_called()
+        mock_tmux.send_special_key.assert_not_called()
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_handle_startup_prompts_empty_output_then_detected(self, mock_tmux):
         """Test trust prompt detection after initially empty output."""
         mock_tmux.get_history.side_effect = [
             "",
             "❯ 1. Yes, I trust this folder\n  2. No",
         ]
-        mock_session = MagicMock()
-        mock_window = MagicMock()
-        mock_pane = MagicMock()
-        mock_tmux.server.sessions.get.return_value = mock_session
-        mock_session.windows.get.return_value = mock_window
-        mock_window.active_pane = mock_pane
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         provider._handle_startup_prompts(timeout=5.0)
 
-        mock_pane.send_keys.assert_called_once_with("", enter=True)
+        mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
-    @patch("cli_agent_orchestrator.providers.claude_code.subprocess")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
-    def test_handle_bypass_prompt_detected_and_accepted(self, mock_tmux, mock_subprocess):
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_handle_bypass_prompt_detected_and_accepted(self, mock_tmux):
         """Test that bypass permissions prompt is detected and auto-accepted."""
         # First poll: bypass prompt; second poll: welcome banner (after dismissal)
         mock_tmux.get_history.side_effect = [
@@ -881,57 +1112,33 @@ class TestClaudeCodeProviderStartupPrompts:
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         provider._handle_startup_prompts(timeout=5.0)
 
-        # Verify raw Down arrow escape sequence + Enter was sent via subprocess
-        calls = mock_subprocess.run.call_args_list
-        assert len(calls) == 2
-        assert calls[0].args[0] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "test-session:window-0",
-            "-l",
-            "\x1b[B",
-        ]
-        assert calls[1].args[0] == ["tmux", "send-keys", "-t", "test-session:window-0", "Enter"]
+        # Verify Down arrow sent via send_keys and Enter via send_special_key
+        mock_tmux.send_keys.assert_called_once()
+        mock_tmux.send_special_key.assert_called_once_with(
+            "test-session", "window-0", "Enter"
+        )
 
-    @patch("cli_agent_orchestrator.providers.claude_code.subprocess")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
-    def test_handle_bypass_then_trust_prompt(self, mock_tmux, mock_subprocess):
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_handle_bypass_then_trust_prompt(self, mock_tmux):
         """Test that bypass prompt is handled, then trust prompt follows."""
         # Poll 1: bypass prompt; Poll 2: trust prompt (after bypass dismissed)
         mock_tmux.get_history.side_effect = [
             "WARNING: Bypass Permissions mode\n❯ 1. No, exit\n  2. Yes, I accept\n",
             "❯ 1. Yes, I trust this folder\n  2. No",
         ]
-        mock_session = MagicMock()
-        mock_window = MagicMock()
-        mock_pane = MagicMock()
-        mock_tmux.server.sessions.get.return_value = mock_session
-        mock_session.windows.get.return_value = mock_window
-        mock_window.active_pane = mock_pane
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         provider._handle_startup_prompts(timeout=5.0)
 
-        # Bypass: 2 subprocess calls (Down + Enter), then trust: 1 pane.send_keys call
-        sub_calls = mock_subprocess.run.call_args_list
-        assert len(sub_calls) == 2
-        assert sub_calls[0].args[0] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "test-session:window-0",
-            "-l",
-            "\x1b[B",
-        ]
-        pane_calls = mock_pane.send_keys.call_args_list
-        assert len(pane_calls) == 1
-        assert pane_calls[0].args == ("",)
-        assert pane_calls[0].kwargs == {"enter": True}
+        # Bypass: send_keys (Down) + send_special_key (Enter)
+        # Trust: send_special_key (Enter) — called twice total
+        assert mock_tmux.send_keys.call_count == 1  # Down arrow for bypass
+        assert mock_tmux.send_special_key.call_count == 2  # Enter for bypass + Enter for trust
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_trust_prompt_not_waiting_user_answer(self, mock_tmux):
         """Test that trust prompt is NOT detected as WAITING_USER_ANSWER."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "❯ 1. Yes, I trust this folder\n"
             "  2. No, don't trust this folder\n"
@@ -943,9 +1150,10 @@ class TestClaudeCodeProviderStartupPrompts:
 
         assert status != TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_get_status_bypass_prompt_not_waiting_user_answer(self, mock_tmux):
         """Test that bypass prompt is NOT detected as WAITING_USER_ANSWER."""
+        mock_tmux.get_native_status.return_value = None
         mock_tmux.get_history.return_value = (
             "WARNING: Bypass Permissions mode\n"
             "❯ 1. No, exit\n"
@@ -961,7 +1169,7 @@ class TestClaudeCodeProviderStartupPrompts:
     @_PATCH_SETTINGS
     @patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.claude_code.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_initialize_calls_handle_startup_prompts(
         self, mock_tmux, mock_wait_status, mock_wait_shell, _
     ):
@@ -970,19 +1178,12 @@ class TestClaudeCodeProviderStartupPrompts:
         mock_wait_status.return_value = True
         trust_output = "❯ 1. Yes, I trust this folder\n  2. No"
         mock_tmux.get_history.side_effect = ["", trust_output, trust_output]
-        mock_session = MagicMock()
-        mock_window = MagicMock()
-        mock_pane = MagicMock()
-        mock_tmux.server.sessions.get.return_value = mock_session
-        mock_session.windows.get.return_value = mock_window
-        mock_window.active_pane = mock_pane
-
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
             result = provider.initialize()
 
         assert result is True
-        mock_pane.send_keys.assert_called_with("", enter=True)
+        mock_tmux.send_special_key.assert_called_with("test-session", "window-0", "Enter")
 
 
 class TestClaudeCodeProviderSettings:

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -452,7 +452,9 @@ class TestCodexProviderStatusDetection:
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = load_fixture("codex_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "codex_processing_output.txt"
+        )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
@@ -461,7 +463,9 @@ class TestCodexProviderStatusDetection:
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = load_fixture("codex_permission_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "codex_permission_output.txt"
+        )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
@@ -494,7 +498,9 @@ class TestCodexProviderStatusDetection:
         status = provider.get_status(tail_lines=50)
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.return_value.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
+        mock_tmux.return_value.get_history.assert_called_once_with(
+            "test-session", "window-0", tail_lines=50
+        )
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_when_old_prompt_present(self, mock_tmux):
@@ -537,7 +543,9 @@ class TestCodexProviderStatusDetection:
     def test_get_status_idle_if_no_assistant_after_last_user(self, mock_tmux):
         # If there is a user message but no assistant response after it, we should not
         # treat the session as COMPLETED.
-        mock_tmux.return_value.get_history.return_value = "assistant: Welcome\n" "You Do the thing\n" "\n" "❯ \n"
+        mock_tmux.return_value.get_history.return_value = (
+            "assistant: Welcome\n" "You Do the thing\n" "\n" "❯ \n"
+        )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
@@ -759,7 +767,9 @@ class TestCodexBulletFormatStatusDetection:
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_error_not_masked_by_bullet_pattern(self, mock_tmux):
         """ERROR still detected when no • response and error after › user message."""
-        mock_tmux.return_value.get_history.return_value = "› do something\nError: connection refused\n"
+        mock_tmux.return_value.get_history.return_value = (
+            "› do something\nError: connection refused\n"
+        )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -963,10 +963,10 @@ class TestCodexV0136FooterFormat:
     terminal status pinned at IDLE forever.
     """
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_v0136_footer(self, mock_tmux):
         """COMPLETED with v0.136 footer (suggestion hint must not mask the • response)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› Create a Python function called 'greet'.\n"
             "• def greet(name):\n"
             '      return f"Hello, {name}!"\n'
@@ -981,10 +981,10 @@ class TestCodexV0136FooterFormat:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_idle_v0136_footer(self, mock_tmux):
         """IDLE with v0.136 footer format (no user message, no response yet)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "╭───────────────────────────────────────────╮\n"
             "│ >_ OpenAI Codex (v0.136.0)                │\n"
             "│ model: openai.gpt-5.5 medium              │\n"
@@ -1001,10 +1001,10 @@ class TestCodexV0136FooterFormat:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_v0136_spinner(self, mock_tmux):
         """PROCESSING when TUI shows spinner with v0.136 footer."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› [CAO Handoff] Do the task.\n"
             "\n"
             "• Working (0s • esc to interrupt)\n"
@@ -1019,8 +1019,7 @@ class TestCodexV0136FooterFormat:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
-    def test_extract_last_message_v0136_footer(self, mock_tmux):
+    def test_extract_last_message_v0136_footer(self):
         """extract_last_message_from_script ignores v0.136 suggestion-hint footer."""
         script_output = (
             "› Create a Python function called 'greet'.\n"

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -19,11 +19,11 @@ def load_fixture(filename: str) -> str:
 class TestCodexProviderInitialization:
     @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
     @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_initialize_success(self, mock_tmux, mock_wait_shell, mock_wait_status):
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.return_value = "OpenAI Codex (v0.98.0)"
+        mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
 
         provider = CodexProvider("test1234", "test-session", "window-0", None)
         result = provider.initialize()
@@ -31,9 +31,9 @@ class TestCodexProviderInitialization:
         assert result is True
         mock_wait_shell.assert_called_once()
         # Two send_keys calls: warm-up echo + codex with tmux-compatible flags
-        assert mock_tmux.send_keys.call_count == 2
-        mock_tmux.send_keys.assert_any_call("test-session", "window-0", "echo ready")
-        mock_tmux.send_keys.assert_any_call(
+        assert mock_tmux.return_value.send_keys.call_count == 2
+        mock_tmux.return_value.send_keys.assert_any_call("test-session", "window-0", "echo ready")
+        mock_tmux.return_value.send_keys.assert_any_call(
             "test-session",
             "window-0",
             "codex --yolo --no-alt-screen --disable shell_snapshot",
@@ -41,7 +41,7 @@ class TestCodexProviderInitialization:
         mock_wait_status.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_initialize_shell_timeout(self, mock_tmux, mock_wait_shell):
         mock_wait_shell.return_value = False
 
@@ -52,11 +52,11 @@ class TestCodexProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
     @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_initialize_codex_timeout(self, mock_tmux, mock_wait_shell, mock_wait_status):
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = False
-        mock_tmux.get_history.return_value = "OpenAI Codex (v0.98.0)"
+        mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
 
         provider = CodexProvider("test1234", "test-session", "window-0", None)
 
@@ -259,13 +259,13 @@ class TestCodexBuildCommand:
     @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
     @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_initialize_with_agent_profile(
         self, mock_tmux, mock_load_profile, mock_wait_shell, mock_wait_status
     ):
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.return_value = "OpenAI Codex (v0.98.0)"
+        mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
         mock_profile = MagicMock()
         mock_profile.model = None
         mock_profile.system_prompt = "You are a supervisor."
@@ -278,7 +278,7 @@ class TestCodexBuildCommand:
 
         assert result is True
         # The second send_keys call should contain developer_instructions
-        codex_call = mock_tmux.send_keys.call_args_list[1]
+        codex_call = mock_tmux.return_value.send_keys.call_args_list[1]
         assert "developer_instructions=" in codex_call.args[2]
         assert "You are a supervisor." in codex_call.args[2]
 
@@ -432,76 +432,76 @@ class TestCodexProviderCodexProfile:
 
 
 class TestCodexProviderStatusDetection:
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_idle(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("codex_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("codex_idle_output.txt")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("codex_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("codex_completed_output.txt")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("codex_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("codex_processing_output.txt")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("codex_permission_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("codex_permission_output.txt")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_error(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("codex_error_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("codex_error_output.txt")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_empty_output(self, mock_tmux):
-        mock_tmux.get_history.return_value = ""
+        mock_tmux.return_value.get_history.return_value = ""
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_with_tail_lines(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("codex_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("codex_idle_output.txt")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status(tail_lines=50)
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
+        mock_tmux.return_value.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_when_old_prompt_present(self, mock_tmux):
         # If the captured history contains an earlier prompt but the *latest* output is processing,
         # we should report PROCESSING. The old prompt should be far enough from the bottom
         # (more than IDLE_PROMPT_TAIL_LINES) to avoid false idle detection.
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Welcome to Codex\n"
             "❯ \n"
             "You Fix the failing tests\n"
@@ -517,11 +517,11 @@ class TestCodexProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_not_error_on_failed_in_message(self, mock_tmux):
         # "failed" is commonly used in normal assistant output; it should not automatically
         # force ERROR.
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "You Explain why the test failed\n"
             "assistant: The test failed because the assertion is incorrect.\n"
             "\n"
@@ -533,31 +533,31 @@ class TestCodexProviderStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_idle_if_no_assistant_after_last_user(self, mock_tmux):
         # If there is a user message but no assistant response after it, we should not
         # treat the session as COMPLETED.
-        mock_tmux.get_history.return_value = "assistant: Welcome\n" "You Do the thing\n" "\n" "❯ \n"
+        mock_tmux.return_value.get_history.return_value = "assistant: Welcome\n" "You Do the thing\n" "\n" "❯ \n"
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_when_no_prompt_and_no_keywords(self, mock_tmux):
         # Codex output may not always include explicit "thinking/processing" keywords.
         # Without an idle prompt at the end, we should assume it's still processing.
-        mock_tmux.get_history.return_value = "You Run the command\nWorking...\n"
+        mock_tmux.return_value.get_history.return_value = "You Run the command\nWorking...\n"
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_not_error_when_assistant_mentions_error_text(self, mock_tmux):
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "You Explain the failure\n"
             "assistant: Here's an example error:\n"
             "Error: example only\n"
@@ -570,9 +570,9 @@ class TestCodexProviderStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_not_waiting_when_assistant_mentions_approval_text(self, mock_tmux):
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "You Explain approvals\n"
             "assistant: You might see this prompt:\n"
             "Approve this command? [y/n]\n"
@@ -585,37 +585,37 @@ class TestCodexProviderStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_error_when_error_after_user_and_prompt(self, mock_tmux):
-        mock_tmux.get_history.return_value = "You Run thing\nError: failed\n\n❯ \n"
+        mock_tmux.return_value.get_history.return_value = "You Run thing\nError: failed\n\n❯ \n"
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_waiting_user_answer_when_no_user_prefix(self, mock_tmux):
-        mock_tmux.get_history.return_value = "Approve this command? [y/n]\n"
+        mock_tmux.return_value.get_history.return_value = "Approve this command? [y/n]\n"
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_error_when_no_user_prefix(self, mock_tmux):
-        mock_tmux.get_history.return_value = "Error: something failed\n"
+        mock_tmux.return_value.get_history.return_value = "Error: something failed\n"
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_idle_tui_with_status_bar(self, mock_tmux):
         """Test IDLE detection with realistic TUI output (status bar after prompt)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "╭───────────────────────────────────────────╮\n"
             "│ >_ OpenAI Codex (v0.98.0)                 │\n"
             "│ model: gpt-5.3-codex high                 │\n"
@@ -631,10 +631,10 @@ class TestCodexProviderStatusDetection:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_tui_with_status_bar(self, mock_tmux):
         """Test COMPLETED detection with TUI output (status bar after prompt)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "You Fix the bug\n"
             "assistant: I've fixed the issue in main.py.\n"
             "\n"
@@ -651,10 +651,10 @@ class TestCodexProviderStatusDetection:
 class TestCodexBulletFormatStatusDetection:
     """Tests for Codex's real interactive output format using › prompt and • bullets."""
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_bullet_format(self, mock_tmux):
         """COMPLETED when › user message followed by • response and idle prompt."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› what is your role?\n"
             "• I am the Coding Supervisor Agent.\n"
             "• I coordinate tasks between developer and reviewer agents.\n"
@@ -667,10 +667,10 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_bullet_format(self, mock_tmux):
         """PROCESSING when • response started but no idle prompt at bottom."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› fix the failing tests\n"
             "• Let me look at the test files.\n"
             "Reading src/test_main.py...\n"
@@ -685,17 +685,17 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_idle_bullet_format_no_response(self, mock_tmux):
         """IDLE when › user message but no • response yet and idle prompt at bottom."""
-        mock_tmux.get_history.return_value = "› hello\n\n› \n"
+        mock_tmux.return_value.get_history.return_value = "› hello\n\n› \n"
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_idle_when_only_tool_call_after_user(self, mock_tmux):
         """IDLE when the only "•" bullet after the user prompt is an MCP
         tool-call marker — the model hasn't actually replied yet.
@@ -704,7 +704,7 @@ class TestCodexBulletFormatStatusDetection:
         being satisfied by a tool-call marker. A "• Called <server>.<tool>(...)"
         bullet must not trip COMPLETED on its own.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› [CAO Handoff] do task\n"
             '• Called cao-mcp-server.load_skill({"name":"cao-worker-protocols"})\n'
             "  └ skill body text\n"
@@ -717,10 +717,10 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_when_real_reply_after_tool_call(self, mock_tmux):
         """COMPLETED when a real "•" reply follows the MCP tool-call marker."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› [CAO Handoff] do task\n"
             '• Called cao-mcp-server.load_skill({"name":"cao-worker-protocols"})\n'
             "  └ skill body text\n"
@@ -734,10 +734,10 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_bullet_with_code_block(self, mock_tmux):
         """COMPLETED with • response containing code blocks."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› show me a function\n"
             "• Here's the function:\n"
             "\n"
@@ -756,20 +756,20 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_error_not_masked_by_bullet_pattern(self, mock_tmux):
         """ERROR still detected when no • response and error after › user message."""
-        mock_tmux.get_history.return_value = "› do something\nError: connection refused\n"
+        mock_tmux.return_value.get_history.return_value = "› do something\nError: connection refused\n"
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_multi_turn_bullet(self, mock_tmux):
         """COMPLETED uses last user message in multi-turn bullet format."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› first question\n"
             "• First answer.\n"
             "\n"
@@ -784,10 +784,10 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_bullet_with_tui_status_bar(self, mock_tmux):
         """COMPLETED with bullet format and TUI status bar after prompt."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› fix the bug\n"
             "• I've fixed the issue in main.py by correcting the import.\n"
             "\n"
@@ -800,10 +800,10 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_tui_spinner(self, mock_tmux):
         """PROCESSING when TUI shows • Working spinner, not false COMPLETED."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› [CAO Handoff] Supervisor terminal ID: sup-123. Do the task.\n"
             "\n"
             "• Working (0s • esc to interrupt)\n"
@@ -818,10 +818,10 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_tui_thinking_spinner(self, mock_tmux):
         """PROCESSING when TUI shows • Thinking spinner."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› Implement feature X\n"
             "\n"
             "• Thinking (3s • esc to interrupt)\n"
@@ -836,10 +836,10 @@ class TestCodexBulletFormatStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_dynamic_spinner_text(self, mock_tmux):
         """PROCESSING when TUI shows spinner with dynamic prefix text."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› [CAO Handoff] Do the task.\n"
             "\n"
             "• Creating /tmp/file.py\n"
@@ -866,10 +866,10 @@ class TestCodexV0111FooterFormat:
     The new format uses "N% left" instead of "N% context left" and removes "? for shortcuts".
     """
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_idle_v0111_footer(self, mock_tmux):
         """IDLE with v0.111.0 footer format (no '? for shortcuts')."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "╭───────────────────────────────────────────╮\n"
             "│ >_ OpenAI Codex (v0.111.0)                │\n"
             "│ model: gpt-5.3-codex high                 │\n"
@@ -887,10 +887,10 @@ class TestCodexV0111FooterFormat:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_v0111_footer(self, mock_tmux):
         """COMPLETED with v0.111.0 footer (suggestion hint must not be treated as user input)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› fix the bug\n"
             "• I've fixed the issue in main.py by correcting the import.\n"
             "\n"
@@ -904,10 +904,10 @@ class TestCodexV0111FooterFormat:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_completed_v0111_multi_turn(self, mock_tmux):
         """COMPLETED in multi-turn with v0.111.0 footer."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› first question\n"
             "• First answer.\n"
             "\n"
@@ -924,10 +924,10 @@ class TestCodexV0111FooterFormat:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_processing_v0111_spinner(self, mock_tmux):
         """PROCESSING when TUI shows spinner with v0.111.0 footer."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "› [CAO Handoff] Do the task.\n"
             "\n"
             "• Working (0s • esc to interrupt)\n"
@@ -1339,10 +1339,10 @@ class TestCodexProviderMisc:
 class TestCodexProviderTrustPrompt:
     """Tests for Codex workspace trust prompt handling."""
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_handle_trust_prompt_detected_and_accepted(self, mock_tmux):
         """Test that trust prompt is detected and auto-accepted."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "> You are running Codex in /Users/test/project\n"
             "\n"
             "  Since this folder is version controlled, you may wish to "
@@ -1351,32 +1351,28 @@ class TestCodexProviderTrustPrompt:
             "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
             "  2. No, ask me to approve edits and commands\n"
         )
-        mock_session = MagicMock()
-        mock_window = MagicMock()
-        mock_pane = MagicMock()
-        mock_tmux.server.sessions.get.return_value = mock_session
-        mock_session.windows.get.return_value = mock_window
-        mock_window.active_pane = mock_pane
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         provider._handle_trust_prompt(timeout=2.0)
 
-        mock_pane.send_keys.assert_called_once_with("", enter=True)
+        mock_tmux.return_value.send_special_key.assert_called_once_with(
+            "test-session", "window-0", "Enter"
+        )
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_handle_trust_prompt_not_needed(self, mock_tmux):
         """Test early return when Codex starts without trust prompt."""
-        mock_tmux.get_history.return_value = "OpenAI Codex (v0.98.0)\n› "
+        mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)\n› "
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         provider._handle_trust_prompt(timeout=2.0)
 
-        mock_tmux.server.sessions.get.assert_not_called()
+        mock_tmux.return_value.send_special_key.assert_not_called()
 
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_get_status_trust_prompt_is_waiting_user_answer(self, mock_tmux):
         """Test that trust prompt reports WAITING_USER_ANSWER, not PROCESSING."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "> You are running Codex in /Users/test/project\n"
             "allow Codex to work in this folder without asking for approval.\n"
             "› 1. Yes\n"
@@ -1390,23 +1386,19 @@ class TestCodexProviderTrustPrompt:
 
     @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
     @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_initialize_with_trust_prompt(self, mock_tmux, mock_wait_shell, mock_wait_status):
         """Test that initialize handles trust prompt during startup."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "allow Codex to work in this folder without asking for approval.\n"
         )
-        mock_session = MagicMock()
-        mock_window = MagicMock()
-        mock_pane = MagicMock()
-        mock_tmux.server.sessions.get.return_value = mock_session
-        mock_session.windows.get.return_value = mock_window
-        mock_window.active_pane = mock_pane
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         result = provider.initialize()
 
         assert result is True
-        mock_pane.send_keys.assert_called_with("", enter=True)
+        mock_tmux.return_value.send_special_key.assert_called_with(
+            "test-session", "window-0", "Enter"
+        )

--- a/test/providers/test_copilot_cli_unit.py
+++ b/test/providers/test_copilot_cli_unit.py
@@ -348,7 +348,9 @@ class TestCopilotCliProviderStatusDetection:
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_idle_with_no_user_message(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = "GitHub Copilot v0.0.415\n❯ Type @ to mention files"
+        mock_tmux.return_value.get_history.return_value = (
+            "GitHub Copilot v0.0.415\n❯ Type @ to mention files"
+        )
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
@@ -379,7 +381,9 @@ class TestCopilotCliProviderStatusDetection:
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_completed_when_response_present_and_idle(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = "❯ refactor this\n● Edit file.py (+1 -1)\n❯ "
+        mock_tmux.return_value.get_history.return_value = (
+            "❯ refactor this\n● Edit file.py (+1 -1)\n❯ "
+        )
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
@@ -399,13 +403,17 @@ class TestCopilotCliProviderStatusDetection:
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_error_when_idle_and_error_without_assistant_marker(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = "❯ refactor this\nError: failed to parse\n❯ "
+        mock_tmux.return_value.get_history.return_value = (
+            "❯ refactor this\nError: failed to parse\n❯ "
+        )
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.ERROR
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_completed_when_idle_and_error_with_assistant_marker(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = "❯ refactor this\nassistant: note\nError: sample\n❯ "
+        mock_tmux.return_value.get_history.return_value = (
+            "❯ refactor this\nassistant: note\nError: sample\n❯ "
+        )
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
@@ -538,7 +546,9 @@ class TestCopilotCliProviderMisc:
     def test_send_enter_uses_tmux_client(self, mock_tmux):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         provider._send_enter()
-        mock_tmux.return_value.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
+        mock_tmux.return_value.send_special_key.assert_called_once_with(
+            "test-session", "window-0", "Enter"
+        )
 
     def test_get_idle_pattern_for_log(self):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")

--- a/test/providers/test_copilot_cli_unit.py
+++ b/test/providers/test_copilot_cli_unit.py
@@ -17,12 +17,12 @@ class TestCopilotCliProviderCommand:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_builds_default(self, mock_tmux, mock_build_mcp, mock_supports_flag):
         mock_supports_flag.return_value = True
         mock_build_mcp.return_value = '{"mcpServers":{"cao-mcp-server":{"command":"x"}}}'
-        mock_tmux.get_pane_working_directory.return_value = "/tmp/project"
+        mock_tmux.return_value.get_pane_working_directory.return_value = "/tmp/project"
 
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         command = provider._command()
@@ -42,12 +42,12 @@ class TestCopilotCliProviderCommand:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_does_not_use_model_env(self, mock_tmux, mock_build_mcp, mock_supports_flag):
         mock_supports_flag.return_value = True
         mock_build_mcp.return_value = '{"mcpServers":{"cao-mcp-server":{"command":"x"}}}'
-        mock_tmux.get_pane_working_directory.return_value = "/tmp/project"
+        mock_tmux.return_value.get_pane_working_directory.return_value = "/tmp/project"
 
         with patch.dict("os.environ", {"CAO_COPILOT_MODEL": "gpt-4.1"}, clear=False):
             provider = CopilotCliProvider("test1234", "test-session", "window-0")
@@ -66,7 +66,7 @@ class TestCopilotCliProviderCommand:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_passes_agent_name_directly(
         self,
@@ -76,7 +76,7 @@ class TestCopilotCliProviderCommand:
     ):
         mock_supports_flag.return_value = True
         mock_build_mcp.return_value = '{"mcpServers":{"cao-mcp-server":{"command":"x"}}}'
-        mock_tmux.get_pane_working_directory.return_value = "/tmp/project"
+        mock_tmux.return_value.get_pane_working_directory.return_value = "/tmp/project"
 
         provider = CopilotCliProvider(
             "test1234", "test-session", "window-0", agent_profile="repo-agent"
@@ -88,7 +88,7 @@ class TestCopilotCliProviderCommand:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_skips_mcp_flag_if_unsupported(
         self,
@@ -97,7 +97,7 @@ class TestCopilotCliProviderCommand:
         mock_supports_flag,
     ):
         mock_supports_flag.return_value = False
-        mock_tmux.get_pane_working_directory.return_value = "/tmp/project"
+        mock_tmux.return_value.get_pane_working_directory.return_value = "/tmp/project"
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         command = provider._command()
         assert "--additional-mcp-config" not in command
@@ -107,7 +107,7 @@ class TestCopilotCliProviderCommand:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_falls_back_to_process_cwd_when_pane_dir_missing(
         self,
@@ -117,7 +117,7 @@ class TestCopilotCliProviderCommand:
     ):
         mock_supports_flag.return_value = True
         mock_build_mcp.return_value = '{"mcpServers":{"cao-mcp-server":{"command":"x"}}}'
-        mock_tmux.get_pane_working_directory.return_value = None
+        mock_tmux.return_value.get_pane_working_directory.return_value = None
 
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         parts = shlex.split(provider._command())
@@ -138,12 +138,12 @@ class TestCopilotCliProviderModelFlag:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_appends_model_when_set(self, mock_tmux, mock_build_mcp, mock_supports_flag):
         mock_supports_flag.return_value = True
         mock_build_mcp.return_value = '{"mcpServers":{"cao-mcp-server":{"command":"x"}}}'
-        mock_tmux.get_pane_working_directory.return_value = "/tmp/project"
+        mock_tmux.return_value.get_pane_working_directory.return_value = "/tmp/project"
 
         provider = CopilotCliProvider(
             "test1234",
@@ -161,12 +161,12 @@ class TestCopilotCliProviderModelFlag:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_omits_model_when_unset(self, mock_tmux, mock_build_mcp, mock_supports_flag):
         mock_supports_flag.return_value = True
         mock_build_mcp.return_value = '{"mcpServers":{"cao-mcp-server":{"command":"x"}}}'
-        mock_tmux.get_pane_working_directory.return_value = "/tmp/project"
+        mock_tmux.return_value.get_pane_working_directory.return_value = "/tmp/project"
 
         provider = CopilotCliProvider(
             "test1234", "test-session", "window-0", agent_profile="repo-agent"
@@ -179,7 +179,7 @@ class TestCopilotCliProviderModelFlag:
     @patch(
         "cli_agent_orchestrator.providers.copilot_cli.CopilotCliProvider._build_runtime_mcp_config"
     )
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.dict("os.environ", {}, clear=True)
     def test_command_omits_model_when_no_agent_profile(
         self, mock_tmux, mock_build_mcp, mock_supports_flag
@@ -188,7 +188,7 @@ class TestCopilotCliProviderModelFlag:
         # profile the flag is not emitted even if a model is passed.
         mock_supports_flag.return_value = True
         mock_build_mcp.return_value = '{"mcpServers":{"cao-mcp-server":{"command":"x"}}}'
-        mock_tmux.get_pane_working_directory.return_value = "/tmp/project"
+        mock_tmux.return_value.get_pane_working_directory.return_value = "/tmp/project"
 
         provider = CopilotCliProvider(
             "test1234", "test-session", "window-0", model="claude-sonnet-4.5"
@@ -208,7 +208,7 @@ class TestCopilotCliProviderInitialization:
             provider.initialize()
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.object(CopilotCliProvider, "_accept_trust_prompts")
     @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
     def test_initialize_success_with_ui_probe(
@@ -223,11 +223,11 @@ class TestCopilotCliProviderInitialization:
         with patch.object(provider, "get_status", return_value=TerminalStatus.IDLE):
             assert provider.initialize() is True
 
-        mock_tmux.send_keys.assert_called_once()
+        mock_tmux.return_value.send_keys.assert_called_once()
         mock_accept.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.object(CopilotCliProvider, "_accept_trust_prompts")
     @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
     @patch("cli_agent_orchestrator.providers.copilot_cli.time.time")
@@ -252,7 +252,7 @@ class TestCopilotCliProviderInitialization:
         assert mock_accept.call_count == 1
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     @patch.object(CopilotCliProvider, "_accept_trust_prompts")
     @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
     def test_initialize_reaccepts_trust_when_waiting(
@@ -277,7 +277,7 @@ class TestCopilotCliProviderInitialization:
 
 class TestCopilotCliProviderTrustPrompts:
     @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_accept_trust_prompts_answers_yes_then_returns(self, mock_tmux, _mock_sleep):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
 
@@ -294,7 +294,7 @@ class TestCopilotCliProviderTrustPrompts:
         ):
             provider._accept_trust_prompts(timeout=2.0)
 
-        mock_tmux.send_special_key.assert_any_call("test-session", "window-0", "y")
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "y")
         assert mock_enter.call_count >= 1
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.logger")
@@ -316,7 +316,7 @@ class TestCopilotCliProviderTrustPrompts:
         )
 
     @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_accept_trust_prompts_answers_yes_for_spaced_yes_no_prompt(
         self, mock_tmux, _mock_sleep
     ):
@@ -335,26 +335,26 @@ class TestCopilotCliProviderTrustPrompts:
         ):
             provider._accept_trust_prompts(timeout=2.0)
 
-        mock_tmux.send_special_key.assert_any_call("test-session", "window-0", "y")
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "y")
         assert mock_enter.call_count >= 1
 
 
 class TestCopilotCliProviderStatusDetection:
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
-        mock_tmux.get_history.return_value = "confirm folder trust [y/n]"
+        mock_tmux.return_value.get_history.return_value = "confirm folder trust [y/n]"
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_idle_with_no_user_message(self, mock_tmux):
-        mock_tmux.get_history.return_value = "GitHub Copilot v0.0.415\n❯ Type @ to mention files"
+        mock_tmux.return_value.get_history.return_value = "GitHub Copilot v0.0.415\n❯ Type @ to mention files"
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_idle_with_wrapped_prompt_helper(self, mock_tmux):
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "● Environment loaded: 2 MCP servers, 3 agents\n"
             "────────────────────────────────────────────────────────────────────────────────\n"
             "❯  Type @ to mention files, # for issues/PRs, / for commands, or ? for \n"
@@ -365,27 +365,27 @@ class TestCopilotCliProviderStatusDetection:
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_processing_when_no_idle_prompt(self, mock_tmux):
-        mock_tmux.get_history.return_value = "Working on edits..."
+        mock_tmux.return_value.get_history.return_value = "Working on edits..."
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_error_while_processing_if_error_after_user(self, mock_tmux):
-        mock_tmux.get_history.return_value = "❯ refactor this\nError: failed to parse"
+        mock_tmux.return_value.get_history.return_value = "❯ refactor this\nError: failed to parse"
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_completed_when_response_present_and_idle(self, mock_tmux):
-        mock_tmux.get_history.return_value = "❯ refactor this\n● Edit file.py (+1 -1)\n❯ "
+        mock_tmux.return_value.get_history.return_value = "❯ refactor this\n● Edit file.py (+1 -1)\n❯ "
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_processing_when_spinner_visible_with_idle_prompt(self, mock_tmux):
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "❯ Analyze the dataset and calculate standard \n"
             "  deviation.\n"
             "∙ Thinking (Esc to cancel)\n"
@@ -397,15 +397,15 @@ class TestCopilotCliProviderStatusDetection:
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_error_when_idle_and_error_without_assistant_marker(self, mock_tmux):
-        mock_tmux.get_history.return_value = "❯ refactor this\nError: failed to parse\n❯ "
+        mock_tmux.return_value.get_history.return_value = "❯ refactor this\nError: failed to parse\n❯ "
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_completed_when_idle_and_error_with_assistant_marker(self, mock_tmux):
-        mock_tmux.get_history.return_value = "❯ refactor this\nassistant: note\nError: sample\n❯ "
+        mock_tmux.return_value.get_history.return_value = "❯ refactor this\nassistant: note\nError: sample\n❯ "
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
@@ -413,10 +413,10 @@ class TestCopilotCliProviderStatusDetection:
     # Copilot v1.0.31+ layout: bare ❯ followed by the status bar line
     # ------------------------------------------------------------------
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_idle_with_v1031_autopilot_status_bar(self, mock_tmux):
         """Bare ❯ + 'autopilot · / commands ...' status bar → IDLE (no prior user turn)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "● Selected custom agent: developer\n"
             "\n"
             "● Environment loaded: 3 custom instructions, 1 hook, 2 MCP servers\n"
@@ -430,10 +430,10 @@ class TestCopilotCliProviderStatusDetection:
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_idle_with_v1031_plan_status_bar(self, mock_tmux):
         """Bare ❯ + 'plan · / commands ...' status bar → IDLE."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             " ~/repo [⎇ main]\n"
             "────────────────────────────────────────────────────────────────────────────────\n"
             "❯\n"
@@ -443,10 +443,10 @@ class TestCopilotCliProviderStatusDetection:
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_idle_with_v1031_interactive_status_bar(self, mock_tmux):
         """Bare ❯ + 'interactive · / commands ...' status bar → IDLE."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             " ~/repo [⎇ main]\n"
             "────────────────────────────────────────────────────────────────────────────────\n"
             "❯\n"
@@ -456,10 +456,10 @@ class TestCopilotCliProviderStatusDetection:
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_completed_with_v1031_status_bar_after_user_turn(self, mock_tmux):
         """User turn + agent response + bare ❯ + status bar → COMPLETED."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "❯ fix the bug\n"
             "● Edit src/main.py (+3 -1)\n"
             " ~/repo [⎇ main*%]\n"
@@ -471,10 +471,10 @@ class TestCopilotCliProviderStatusDetection:
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_processing_with_spinner_and_v1031_status_bar(self, mock_tmux):
         """Spinner line present alongside status bar → still PROCESSING."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "❯ refactor utils.py\n"
             "∙ Thinking (Esc to cancel)\n"
             " ~/repo [⎇ main*%]\n"
@@ -486,10 +486,10 @@ class TestCopilotCliProviderStatusDetection:
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_get_status_idle_with_v1031_absolute_path_breadcrumb(self, mock_tmux):
         """Bare ❯ + absolute-path breadcrumb (CWD outside $HOME) → IDLE."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             " /tmp/pr184-e2e [⎇ pr-184]\n"
             "────────────────────────────────────────────────────────────────────────────────\n"
             "❯\n"
@@ -534,11 +534,11 @@ class TestCopilotCliProviderMessageExtraction:
 
 
 class TestCopilotCliProviderMisc:
-    @patch("cli_agent_orchestrator.providers.copilot_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
     def test_send_enter_uses_tmux_client(self, mock_tmux):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         provider._send_enter()
-        mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
+        mock_tmux.return_value.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
     def test_get_idle_pattern_for_log(self):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")

--- a/test/providers/test_gemini_cli_unit.py
+++ b/test/providers/test_gemini_cli_unit.py
@@ -51,7 +51,7 @@ class TestGeminiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.time")
     @patch("cli_agent_orchestrator.providers.gemini_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_initialize_success(self, mock_tmux, mock_wait_shell, mock_time):
         """Test successful initialization sends warm-up + gemini command and reaches IDLE."""
         # Configure time mock: first call returns 0 (warm-up start), subsequent calls
@@ -60,18 +60,18 @@ class TestGeminiCliProviderInitialization:
         mock_time.sleep = MagicMock()
         # Simulate warm-up marker appearing in shell output, then IDLE status
         idle_output = " *   Type your message or @path/to/file\n"
-        mock_tmux.get_history.side_effect = ["CAO_SHELL_READY", idle_output]
+        mock_tmux.return_value.get_history.side_effect = ["CAO_SHELL_READY", idle_output]
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         result = provider.initialize()
 
         assert result is True
         assert provider._initialized is True
-        assert mock_tmux.send_keys.call_count == 2  # warm-up echo + gemini command
-        mock_tmux.send_keys.assert_any_call("session-1", "window-1", "echo CAO_SHELL_READY")
+        assert mock_tmux.return_value.send_keys.call_count == 2  # warm-up echo + gemini command
+        mock_tmux.return_value.send_keys.assert_any_call("session-1", "window-1", "echo CAO_SHELL_READY")
         mock_wait_shell.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.wait_for_shell", return_value=False)
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_initialize_shell_timeout(self, mock_tmux, mock_wait_shell):
         """Test shell init timeout raises TimeoutError."""
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
@@ -80,7 +80,7 @@ class TestGeminiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.time")
     @patch("cli_agent_orchestrator.providers.gemini_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_initialize_gemini_timeout(self, mock_tmux, mock_wait_shell, mock_time):
         """Test Gemini CLI init timeout raises TimeoutError."""
         # Simulate time progressing past timeout (120s)
@@ -93,14 +93,14 @@ class TestGeminiCliProviderInitialization:
         mock_time.time.side_effect = advancing_time
         mock_time.sleep = MagicMock()
         # Warm-up succeeds, but CLI never reaches IDLE (always returns PROCESSING)
-        mock_tmux.get_history.return_value = "CAO_SHELL_READY"
+        mock_tmux.return_value.get_history.return_value = "CAO_SHELL_READY"
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         with pytest.raises(TimeoutError, match="Gemini CLI initialization timed out"):
             provider.initialize()
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.time")
     @patch("cli_agent_orchestrator.providers.gemini_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
     def test_initialize_with_mcp_servers(
         self, mock_load, mock_tmux, mock_wait_shell, mock_time, tmp_path
@@ -109,7 +109,7 @@ class TestGeminiCliProviderInitialization:
         mock_time.time.side_effect = [0, 0, 0, 0, 0]
         mock_time.sleep = MagicMock()
         idle_output = " *   Type your message or @path/to/file\n"
-        mock_tmux.get_history.side_effect = ["CAO_SHELL_READY", idle_output]
+        mock_tmux.return_value.get_history.side_effect = ["CAO_SHELL_READY", idle_output]
         mock_profile = MagicMock()
         mock_profile.model = None
         mock_profile.system_prompt = None
@@ -141,27 +141,27 @@ class TestGeminiCliProviderInitialization:
         assert settings["mcpServers"]["cao-mcp-server"]["command"] == "npx"
         assert settings["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "term-1"
         # Command should be plain gemini launch (no chained mcp add)
-        call_args = mock_tmux.send_keys.call_args_list[1]
+        call_args = mock_tmux.return_value.send_keys.call_args_list[1]
         command = call_args[0][2]
         assert command == "gemini --yolo --sandbox false"
         assert "cao-mcp-server" in provider._mcp_server_names
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.time")
     @patch("cli_agent_orchestrator.providers.gemini_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_initialize_sends_gemini_command(self, mock_tmux, mock_wait_shell, mock_time):
         """Test that initialize sends warm-up echo then the correct gemini --yolo command."""
         mock_time.time.side_effect = [0, 0, 0, 0, 0]
         mock_time.sleep = MagicMock()
         idle_output = " *   Type your message or @path/to/file\n"
-        mock_tmux.get_history.side_effect = ["CAO_SHELL_READY", idle_output]
+        mock_tmux.return_value.get_history.side_effect = ["CAO_SHELL_READY", idle_output]
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         provider.initialize()
 
         # First call: warm-up echo
-        assert mock_tmux.send_keys.call_args_list[0][0][2] == "echo CAO_SHELL_READY"
+        assert mock_tmux.return_value.send_keys.call_args_list[0][0][2] == "echo CAO_SHELL_READY"
         # Second call: gemini command
-        assert mock_tmux.send_keys.call_args_list[1][0][2] == "gemini --yolo --sandbox false"
+        assert mock_tmux.return_value.send_keys.call_args_list[1][0][2] == "gemini --yolo --sandbox false"
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
     def test_initialize_with_invalid_profile(self, mock_load):
@@ -174,7 +174,7 @@ class TestGeminiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.time")
     @patch("cli_agent_orchestrator.providers.gemini_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
     def test_initialize_with_prompt_interactive_waits_for_completed(
         self, mock_load, mock_tmux, mock_wait_shell, mock_time
@@ -201,12 +201,12 @@ class TestGeminiCliProviderInitialization:
             "✦ I understand. I am a supervisor.\n"
             " *   Type your message or @path/to/file\n"
         )
-        mock_tmux.get_history.side_effect = [
+        mock_tmux.return_value.get_history.side_effect = [
             "CAO_SHELL_READY",
             idle_output,  # 1st status check: IDLE — skipped because -i requires COMPLETED
             completed_output,  # 2nd status check: COMPLETED — accepted
         ]
-        mock_tmux.get_pane_working_directory.return_value = None
+        mock_tmux.return_value.get_pane_working_directory.return_value = None
 
         provider = GeminiCliProvider("term-1", "session-1", "window-1", agent_profile="supervisor")
         result = provider.initialize()
@@ -223,7 +223,7 @@ class TestGeminiCliProviderInitialization:
         assert provider._uses_prompt_interactive is False
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_build_command_sets_prompt_interactive_flag(self, mock_tmux, mock_load):
         """Test _build_gemini_command sets _uses_prompt_interactive when -i is used."""
         mock_profile = MagicMock()
@@ -231,7 +231,7 @@ class TestGeminiCliProviderInitialization:
         mock_profile.system_prompt = "You are a supervisor."
         mock_profile.mcpServers = {}
         mock_load.return_value = mock_profile
-        mock_tmux.get_pane_working_directory.return_value = None
+        mock_tmux.return_value.get_pane_working_directory.return_value = None
 
         provider = GeminiCliProvider("term-1", "session-1", "window-1", agent_profile="supervisor")
         command = provider._build_gemini_command()
@@ -240,7 +240,7 @@ class TestGeminiCliProviderInitialization:
         assert "-i" in command
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_build_command_no_prompt_interactive_without_system_prompt(self, mock_tmux, mock_load):
         """Test _uses_prompt_interactive stays False when profile has no system prompt."""
         mock_profile = MagicMock()
@@ -264,56 +264,56 @@ class TestGeminiCliProviderInitialization:
 class TestGeminiCliProviderStatusDetection:
     """Tests for GeminiCliProvider.get_status()."""
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_idle(self, mock_tmux):
         """Test IDLE detection from fresh startup output."""
-        mock_tmux.get_history.return_value = _read_fixture("gemini_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_idle_output.txt")
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED detection when response is present with prompt."""
-        mock_tmux.get_history.return_value = _read_fixture("gemini_cli_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_completed_output.txt")
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_completed_complex(self, mock_tmux):
         """Test COMPLETED detection with tool call response."""
-        mock_tmux.get_history.return_value = _read_fixture("gemini_cli_complex_response.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_complex_response.txt")
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING detection when user query is in input box."""
-        mock_tmux.get_history.return_value = _read_fixture("gemini_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_processing_output.txt")
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_error_empty(self, mock_tmux):
         """Test ERROR on empty output."""
-        mock_tmux.get_history.return_value = ""
+        mock_tmux.return_value.get_history.return_value = ""
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_error_none(self, mock_tmux):
         """Test ERROR on None output."""
-        mock_tmux.get_history.return_value = None
+        mock_tmux.return_value.get_history.return_value = None
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_error_pattern(self, mock_tmux):
         """Test ERROR detection from error output fixture."""
-        mock_tmux.get_history.return_value = _read_fixture("gemini_cli_error_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_error_output.txt")
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_idle_with_ansi_codes(self, mock_tmux):
         """Test IDLE detection with ANSI escape codes in output."""
         output = (
@@ -324,19 +324,19 @@ class TestGeminiCliProviderStatusDetection:
             "\x1b[30m▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
             "\x1b[39m ~/dir (main)   sandbox   Auto\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_with_tail_lines(self, mock_tmux):
         """Test status detection with tail_lines parameter passed through."""
-        mock_tmux.get_history.return_value = _read_fixture("gemini_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_idle_output.txt")
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         provider.get_status(tail_lines=20)
-        mock_tmux.get_history.assert_called_once_with("session-1", "window-1", tail_lines=20)
+        mock_tmux.return_value.get_history.assert_called_once_with("session-1", "window-1", tail_lines=20)
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_idle_tall_terminal(self, mock_tmux):
         """Test IDLE detection in tall terminals (46+ rows) where prompt is far from bottom.
 
@@ -353,11 +353,11 @@ class TestGeminiCliProviderStatusDetection:
             + "\n" * 32  # 32 empty padding lines (typical for tall terminal)
             + " .../project (main*)   sandbox   Auto (Gemini 3) /model | 200 MB\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_processing_no_idle_prompt(self, mock_tmux):
         """Test PROCESSING when response is mid-stream (no idle prompt, no error)."""
         output = (
@@ -368,11 +368,11 @@ class TestGeminiCliProviderStatusDetection:
             "✦ Here's the function:\n"
             "\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_not_error_when_response_mentions_error(self, mock_tmux):
         """Test COMPLETED (not ERROR) when response text discusses errors.
 
@@ -394,11 +394,11 @@ class TestGeminiCliProviderStatusDetection:
             "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
             " .../dir (main)   no sandbox   Auto (Gemini 3) /model | 100 MB\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_processing_spinner_with_idle_prompt(self, mock_tmux):
         """Test PROCESSING when spinner is visible despite idle prompt being shown.
 
@@ -424,11 +424,11 @@ class TestGeminiCliProviderStatusDetection:
             "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
             " .../dir (main)   no sandbox   Auto (Gemini 3) /model | 234 MB\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_processing_spinner_retry(self, mock_tmux):
         """Test PROCESSING when model is retrying API call (Attempt N/M spinner)."""
         output = (
@@ -443,11 +443,11 @@ class TestGeminiCliProviderStatusDetection:
             "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
             " .../dir (main)   no sandbox   Auto (Gemini 3) /model | 100 MB\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_completed_no_spinner(self, mock_tmux):
         """Test COMPLETED when response finished and no spinner is present.
 
@@ -470,11 +470,11 @@ class TestGeminiCliProviderStatusDetection:
             "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
             " .../dir (main)   no sandbox   Auto (Gemini 3) /model | 234 MB\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_processing_multi_turn_old_response(self, mock_tmux):
         """Test PROCESSING on second query when old ✦ response is in scrollback.
 
@@ -494,7 +494,7 @@ class TestGeminiCliProviderStatusDetection:
             "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\n"
             "  Responding with gemini-3-flash-preview\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
@@ -1038,10 +1038,10 @@ class TestEnsureWorkspacesParentTrusted:
 class TestGeminiCliProviderModelFlag:
     """Tests that profile.model is forwarded to Gemini CLI via --model."""
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
     def test_build_command_appends_model_when_set(self, mock_load, mock_tmux, tmp_path):
-        mock_tmux.get_pane_working_directory.return_value = str(tmp_path)
+        mock_tmux.return_value.get_pane_working_directory.return_value = str(tmp_path)
         mock_profile = MagicMock()
         mock_profile.model = "gemini-2.5-pro"
         mock_profile.name = "agent"
@@ -1054,10 +1054,10 @@ class TestGeminiCliProviderModelFlag:
 
         assert "--model gemini-2.5-pro" in command
 
-    @patch("cli_agent_orchestrator.providers.gemini_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
     def test_build_command_omits_model_when_unset(self, mock_load, mock_tmux, tmp_path):
-        mock_tmux.get_pane_working_directory.return_value = str(tmp_path)
+        mock_tmux.return_value.get_pane_working_directory.return_value = str(tmp_path)
         mock_profile = MagicMock()
         mock_profile.model = None
         mock_profile.name = "agent"

--- a/test/providers/test_gemini_cli_unit.py
+++ b/test/providers/test_gemini_cli_unit.py
@@ -67,7 +67,9 @@ class TestGeminiCliProviderInitialization:
         assert result is True
         assert provider._initialized is True
         assert mock_tmux.return_value.send_keys.call_count == 2  # warm-up echo + gemini command
-        mock_tmux.return_value.send_keys.assert_any_call("session-1", "window-1", "echo CAO_SHELL_READY")
+        mock_tmux.return_value.send_keys.assert_any_call(
+            "session-1", "window-1", "echo CAO_SHELL_READY"
+        )
         mock_wait_shell.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.wait_for_shell", return_value=False)
@@ -161,7 +163,10 @@ class TestGeminiCliProviderInitialization:
         # First call: warm-up echo
         assert mock_tmux.return_value.send_keys.call_args_list[0][0][2] == "echo CAO_SHELL_READY"
         # Second call: gemini command
-        assert mock_tmux.return_value.send_keys.call_args_list[1][0][2] == "gemini --yolo --sandbox false"
+        assert (
+            mock_tmux.return_value.send_keys.call_args_list[1][0][2]
+            == "gemini --yolo --sandbox false"
+        )
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.load_agent_profile")
     def test_initialize_with_invalid_profile(self, mock_load):
@@ -267,28 +272,36 @@ class TestGeminiCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_idle(self, mock_tmux):
         """Test IDLE detection from fresh startup output."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "gemini_cli_idle_output.txt"
+        )
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED detection when response is present with prompt."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "gemini_cli_completed_output.txt"
+        )
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_completed_complex(self, mock_tmux):
         """Test COMPLETED detection with tool call response."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_complex_response.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "gemini_cli_complex_response.txt"
+        )
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING detection when user query is in input box."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "gemini_cli_processing_output.txt"
+        )
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
@@ -309,7 +322,9 @@ class TestGeminiCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_error_pattern(self, mock_tmux):
         """Test ERROR detection from error output fixture."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_error_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "gemini_cli_error_output.txt"
+        )
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.ERROR
 
@@ -331,10 +346,14 @@ class TestGeminiCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_with_tail_lines(self, mock_tmux):
         """Test status detection with tail_lines parameter passed through."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("gemini_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "gemini_cli_idle_output.txt"
+        )
         provider = GeminiCliProvider("term-1", "session-1", "window-1")
         provider.get_status(tail_lines=20)
-        mock_tmux.return_value.get_history.assert_called_once_with("session-1", "window-1", tail_lines=20)
+        mock_tmux.return_value.get_history.assert_called_once_with(
+            "session-1", "window-1", tail_lines=20
+        )
 
     @patch("cli_agent_orchestrator.providers.gemini_cli.get_backend")
     def test_get_status_idle_tall_terminal(self, mock_tmux):

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -193,21 +193,27 @@ class TestKimiCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED detection when response is present with prompt."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "kimi_cli_completed_output.txt"
+        )
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_completed_complex(self, mock_tmux):
         """Test COMPLETED detection with multi-line code response."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_complex_response.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "kimi_cli_complex_response.txt"
+        )
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING detection when no prompt at bottom."""
-        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture(
+            "kimi_cli_processing_output.txt"
+        )
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
@@ -252,7 +258,9 @@ class TestKimiCliProviderStatusDetection:
         mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_idle_output.txt")
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         provider.get_status(tail_lines=20)
-        mock_tmux.return_value.get_history.assert_called_once_with("session-1", "window-1", tail_lines=20)
+        mock_tmux.return_value.get_history.assert_called_once_with(
+            "session-1", "window-1", tail_lines=20
+        )
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_idle_tall_terminal(self, mock_tmux):

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -47,7 +47,7 @@ class TestKimiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status", return_value=True)
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_initialize_success(self, mock_tmux, mock_wait_shell, mock_wait_status):
         """Test successful initialization sends kimi command and reaches IDLE."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
@@ -55,12 +55,12 @@ class TestKimiCliProviderInitialization:
 
         assert result is True
         assert provider._initialized is True
-        mock_tmux.send_keys.assert_called_once()
+        mock_tmux.return_value.send_keys.assert_called_once()
         mock_wait_shell.assert_called_once()
         mock_wait_status.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell", return_value=False)
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_initialize_shell_timeout(self, mock_tmux, mock_wait_shell):
         """Test shell init timeout raises TimeoutError."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
@@ -69,7 +69,7 @@ class TestKimiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_initialize_kimi_timeout(self, mock_tmux, mock_wait_shell, mock_wait_status):
         """Test Kimi CLI init timeout raises TimeoutError."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
@@ -78,7 +78,7 @@ class TestKimiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status", return_value=True)
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
     def test_initialize_with_agent_profile(
         self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status
@@ -95,7 +95,7 @@ class TestKimiCliProviderInitialization:
         assert result is True
 
         # Verify kimi command includes --agent-file
-        call_args = mock_tmux.send_keys.call_args
+        call_args = mock_tmux.return_value.send_keys.call_args
         command = call_args[0][2]
         assert "--agent-file" in command
         assert "--yolo" in command
@@ -114,7 +114,7 @@ class TestKimiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status", return_value=True)
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
     def test_initialize_with_mcp_servers(
         self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status
@@ -140,7 +140,7 @@ class TestKimiCliProviderInitialization:
             result = provider.initialize()
         assert result is True
 
-        call_args = mock_tmux.send_keys.call_args
+        call_args = mock_tmux.return_value.send_keys.call_args
         command = call_args[0][2]
         assert "--mcp-config" in command
         # No --config flag in command (breaks OAuth authentication)
@@ -148,13 +148,13 @@ class TestKimiCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status", return_value=True)
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell", return_value=True)
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_initialize_sends_kimi_command(self, mock_tmux, mock_wait_shell, mock_wait_status):
         """Test that initialize sends the kimi --yolo command with cd and TERM override."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         provider.initialize()
 
-        call_args = mock_tmux.send_keys.call_args
+        call_args = mock_tmux.return_value.send_keys.call_args
         command = call_args[0][2]
         assert "cd " in command
         assert "TERM=xterm-256color" in command
@@ -170,14 +170,14 @@ class TestKimiCliProviderInitialization:
 class TestKimiCliProviderStatusDetection:
     """Tests for KimiCliProvider.get_status()."""
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_idle(self, mock_tmux):
         """Test IDLE detection from fresh startup output."""
-        mock_tmux.get_history.return_value = _read_fixture("kimi_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_idle_output.txt")
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_idle_no_thinking(self, mock_tmux):
         """Test IDLE detection with ✨ prompt (no-thinking mode)."""
         output = (
@@ -186,53 +186,53 @@ class TestKimiCliProviderStatusDetection:
             "\n\n"
             "23:14  yolo  agent (kimi-for-coding)  ctrl-x: toggle mode  context: 0.0%"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED detection when response is present with prompt."""
-        mock_tmux.get_history.return_value = _read_fixture("kimi_cli_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_completed_output.txt")
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_completed_complex(self, mock_tmux):
         """Test COMPLETED detection with multi-line code response."""
-        mock_tmux.get_history.return_value = _read_fixture("kimi_cli_complex_response.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_complex_response.txt")
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING detection when no prompt at bottom."""
-        mock_tmux.get_history.return_value = _read_fixture("kimi_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_processing_output.txt")
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_error_empty(self, mock_tmux):
         """Test ERROR on empty output."""
-        mock_tmux.get_history.return_value = ""
+        mock_tmux.return_value.get_history.return_value = ""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_error_none(self, mock_tmux):
         """Test ERROR on None output."""
-        mock_tmux.get_history.return_value = None
+        mock_tmux.return_value.get_history.return_value = None
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_error_pattern(self, mock_tmux):
         """Test ERROR detection from error output fixture."""
-        mock_tmux.get_history.return_value = _read_fixture("kimi_cli_error_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_error_output.txt")
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_idle_with_ansi_codes(self, mock_tmux):
         """Test IDLE detection with ANSI escape codes in output."""
         # Simulate raw ANSI output: bold prompt with color codes
@@ -242,19 +242,19 @@ class TestKimiCliProviderStatusDetection:
             "\n\n"
             "23:14  yolo  agent (kimi-for-coding, thinking)  ctrl-x: toggle mode  context: 0.0%"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_with_tail_lines(self, mock_tmux):
         """Test status detection with tail_lines parameter passed through."""
-        mock_tmux.get_history.return_value = _read_fixture("kimi_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = _read_fixture("kimi_cli_idle_output.txt")
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         provider.get_status(tail_lines=20)
-        mock_tmux.get_history.assert_called_once_with("session-1", "window-1", tail_lines=20)
+        mock_tmux.return_value.get_history.assert_called_once_with("session-1", "window-1", tail_lines=20)
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_idle_tall_terminal(self, mock_tmux):
         """Test IDLE detection in tall terminals (46+ rows) where prompt is far from bottom.
 
@@ -272,11 +272,11 @@ class TestKimiCliProviderStatusDetection:
             + "\n" * 32  # 32 empty padding lines (typical for 46-row terminal)
             + "00:05  yolo  agent (kimi-for-coding, thinking)  ctrl-x: toggle mode  context: 0.0%\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_processing_streaming(self, mock_tmux):
         """Test PROCESSING when response is mid-stream (no prompt, no error)."""
         output = (
@@ -288,11 +288,11 @@ class TestKimiCliProviderStatusDetection:
             "def foo():\n"
             "    pass\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         provider = KimiCliProvider("term-1", "session-1", "window-1")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_completed_long_response_no_bullets(self, mock_tmux):
         """Test COMPLETED for long structured responses without • bullet markers.
 
@@ -311,7 +311,7 @@ class TestKimiCliProviderStatusDetection:
             "  ━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
             "  1. Summary section...\n"
         )
-        mock_tmux.get_history.return_value = processing_output
+        mock_tmux.return_value.get_history.return_value = processing_output
         assert provider.get_status() == TerminalStatus.PROCESSING
         # Flag should now be latched
         assert provider._has_received_input is True
@@ -326,10 +326,10 @@ class TestKimiCliProviderStatusDetection:
             "\n\n"
             "19:12  yolo  agent (kimi-for-coding, thinking)  ctrl-x: toggle mode  context: 2.9%"
         )
-        mock_tmux.get_history.return_value = completed_output
+        mock_tmux.return_value.get_history.return_value = completed_output
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_latching_persists_after_scrollout(self, mock_tmux):
         """Test that _has_received_input flag persists after user input box scrolls out."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
@@ -344,10 +344,10 @@ class TestKimiCliProviderStatusDetection:
             "\n\n"
             "23:14  yolo  agent (kimi-for-coding, thinking)  ctrl-x: toggle mode  context: 1.0%"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_idle_before_any_input(self, mock_tmux):
         """Test IDLE when no user input has been received yet (fresh startup)."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
@@ -359,11 +359,11 @@ class TestKimiCliProviderStatusDetection:
             "\n\n"
             "23:14  yolo  agent (kimi-for-coding, thinking)  ctrl-x: toggle mode  context: 0.0%"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         assert provider.get_status() == TerminalStatus.IDLE
         assert provider._has_received_input is False
 
-    @patch("cli_agent_orchestrator.providers.kimi_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     def test_get_status_processing_latches_flag(self, mock_tmux):
         """Test that user input box detected during PROCESSING latches the flag."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
@@ -376,7 +376,7 @@ class TestKimiCliProviderStatusDetection:
             "╰──────────────────╯\n"
             "Response content streaming...\n"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
         status = provider.get_status()
         assert status == TerminalStatus.PROCESSING
         assert provider._has_received_input is True

--- a/test/providers/test_kiro_cli_integration.py
+++ b/test/providers/test_kiro_cli_integration.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from cli_agent_orchestrator.backends import registry
 from cli_agent_orchestrator.backends.registry import set_backend
 from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend
 from cli_agent_orchestrator.clients.tmux import tmux_client
@@ -88,9 +89,16 @@ def use_tmux_backend():
     by BackendFactory which reads config.json, so on a host configured for
     herdr this would fail. Pin to tmux explicitly since the session fixture
     creates tmux sessions.
+
+    The backend registry is a module-level singleton, so the previous value is
+    saved and restored to avoid leaking the tmux pin into later tests.
     """
+    previous = registry._backend
     set_backend(TmuxBackend())
-    yield
+    try:
+        yield
+    finally:
+        registry._backend = previous
 
 
 @pytest.fixture

--- a/test/providers/test_kiro_cli_integration.py
+++ b/test/providers/test_kiro_cli_integration.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from cli_agent_orchestrator.backends.registry import set_backend
+from cli_agent_orchestrator.backends.tmux_backend import TmuxBackend
 from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
@@ -76,6 +78,19 @@ def cleanup_session(test_session_name):
         tmux_client.kill_session(test_session_name)
     except Exception:
         pass
+
+
+@pytest.fixture(autouse=True)
+def use_tmux_backend():
+    """Pin the backend registry to TmuxBackend for these integration tests.
+
+    KiroCliProvider calls get_backend() internally. The global backend is set
+    by BackendFactory which reads config.json, so on a host configured for
+    herdr this would fail. Pin to tmux explicitly since the session fixture
+    creates tmux sessions.
+    """
+    set_backend(TmuxBackend())
+    yield
 
 
 @pytest.fixture

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -263,7 +263,9 @@ class TestKiroCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED status detection."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_completed_output.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -273,7 +275,9 @@ class TestKiroCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING status detection."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_processing_output.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -283,7 +287,9 @@ class TestKiroCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
         """Test WAITING_USER_ANSWER status detection."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_permission_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_permission_output.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -319,7 +325,9 @@ class TestKiroCliProviderStatusDetection:
         status = provider.get_status(tail_lines=50)
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.return_value.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
+        mock_tmux.return_value.get_history.assert_called_once_with(
+            "test-session", "window-0", tail_lines=50
+        )
 
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_status_processing_response_started_no_final_prompt(self, mock_tmux):
@@ -388,7 +396,9 @@ class TestKiroCliProviderStatusDetection:
         assert status == TerminalStatus.COMPLETED
 
         # Verify extraction gets the last response
-        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
+        message = provider.extract_last_message_from_script(
+            mock_tmux.return_value.get_history.return_value
+        )
         assert "Second response" in message
         assert "First response" not in message
 
@@ -798,7 +808,9 @@ class TestKiroCliProviderPromptPatterns:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_prompt_with_percentage(self, mock_tmux):
         """Test prompt with usage percentage."""
-        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = (
+            "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -808,7 +820,9 @@ class TestKiroCliProviderPromptPatterns:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_prompt_with_special_profile_characters(self, mock_tmux):
         """Test prompt with special characters in profile name."""
-        mock_tmux.return_value.get_history.return_value = "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = (
+            "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "code-reviewer_v2")
         status = provider.get_status()
@@ -822,7 +836,9 @@ class TestKiroCliProviderHandoffScenarios:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_successful_status(self, mock_tmux):
         """Test COMPLETED status detection with successful handoff."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_handoff_successful.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_handoff_successful.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
@@ -873,7 +889,9 @@ class TestKiroCliProviderHandoffScenarios:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_with_permission_prompt(self, mock_tmux):
         """Test WAITING_USER_ANSWER status during handoff requiring permission."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_handoff_with_permission.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_handoff_with_permission.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
@@ -950,7 +968,9 @@ class TestKiroCliProviderEdgeCases:
     def test_long_agent_profile_name(self, mock_tmux):
         """Test with very long agent profile name."""
         long_profile = "very_long_agent_profile_name_that_exceeds_normal_length"
-        mock_tmux.return_value.get_history.return_value = f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = (
+            f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", long_profile)
         status = provider.get_status()
@@ -971,7 +991,9 @@ class TestKiroCliProviderEdgeCases:
         assert status == TerminalStatus.COMPLETED
 
         # Test message extraction
-        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
+        message = provider.extract_last_message_from_script(
+            mock_tmux.return_value.get_history.return_value
+        )
         assert "日本語" in message
         assert "café" in message
         assert "🚀" in message
@@ -985,7 +1007,9 @@ class TestKiroCliProviderEdgeCases:
         )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
-        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
+        message = provider.extract_last_message_from_script(
+            mock_tmux.return_value.get_history.return_value
+        )
 
         # Control characters should be cleaned
         assert "\x07" not in message  # Bell
@@ -1133,7 +1157,9 @@ class TestKiroCliTuiMode:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_idle_detection(self, mock_tmux):
         """Test IDLE detection with pure TUI output."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_tui_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_tui_idle_output.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -1143,7 +1169,9 @@ class TestKiroCliTuiMode:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_completed_detection(self, mock_tmux):
         """Test COMPLETED detection with Credits marker + idle prompt."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_tui_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_tui_completed_output.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -1153,7 +1181,9 @@ class TestKiroCliTuiMode:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_processing_detection(self, mock_tmux):
         """Test PROCESSING when TUI idle prompt is absent."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_tui_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_tui_processing_output.txt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -1577,7 +1607,9 @@ class TestKiroCliCheck3ShellBaseline:
         current command is still the shell, so honoring it would let
         pastes leak into Kiro's boot screen.
         """
-        mock_tmux.return_value.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.return_value.get_history.return_value = (
+            "Some processing output without idle prompt"
+        )
         mock_tmux.return_value.get_pane_current_command.return_value = "bash"
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
@@ -1586,7 +1618,9 @@ class TestKiroCliCheck3ShellBaseline:
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.return_value.get_pane_current_command.assert_called_once_with("test-session", "window-0")
+        mock_tmux.return_value.get_pane_current_command.assert_called_once_with(
+            "test-session", "window-0"
+        )
 
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check3_pre_init_shell_match_returns_processing(self, mock_backend):
@@ -1597,7 +1631,9 @@ class TestKiroCliCheck3ShellBaseline:
         must report PROCESSING in this window so callers don't paste into
         Kiro's pre-interactive boot screen.
         """
-        mock_backend.return_value.get_history.return_value = "Some processing output without idle prompt"
+        mock_backend.return_value.get_history.return_value = (
+            "Some processing output without idle prompt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider.shell_baseline = "bash"
@@ -1610,7 +1646,9 @@ class TestKiroCliCheck3ShellBaseline:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check3_shell_mismatch_returns_processing(self, mock_tmux):
         """No idle prompt + current command differs from shell_baseline → PROCESSING."""
-        mock_tmux.return_value.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.return_value.get_history.return_value = (
+            "Some processing output without idle prompt"
+        )
         mock_tmux.return_value.get_pane_current_command.return_value = "kiro"
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
@@ -1622,7 +1660,9 @@ class TestKiroCliCheck3ShellBaseline:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check3_no_baseline_returns_processing_without_pane_query(self, mock_tmux):
         """No idle prompt + shell_baseline is None → PROCESSING, no pane command query."""
-        mock_tmux.return_value.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.return_value.get_history.return_value = (
+            "Some processing output without idle prompt"
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         # shell_baseline defaults to None
@@ -1663,7 +1703,9 @@ class TestKiroCliCheck6NoCredits:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check6_completed_after_input_received(self, mock_tmux):
         """Check 6 returns COMPLETED when idle prompt present and input was sent."""
-        mock_tmux.return_value.get_history.return_value = self._tui_output("validate this", "All checks pass.")
+        mock_tmux.return_value.get_history.return_value = self._tui_output(
+            "validate this", "All checks pass."
+        )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider._input_received = True

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -25,7 +25,7 @@ class TestKiroCliProviderInitialization:
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_success(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -39,13 +39,13 @@ class TestKiroCliProviderInitialization:
 
         assert result is True
         mock_wait_shell.assert_called_once()
-        mock_tmux.send_keys.assert_called_once_with(
+        mock_tmux.return_value.send_keys.assert_called_once_with(
             "test-session", "window-0", "kiro-cli chat --agent developer"
         )
         mock_wait_status.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_shell_timeout(self, mock_tmux, mock_wait_shell):
         """Test initialization with shell timeout."""
         mock_wait_shell.return_value = False
@@ -58,7 +58,7 @@ class TestKiroCliProviderInitialization:
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_kiro_cli_timeout(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -75,7 +75,7 @@ class TestKiroCliProviderInitialization:
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_legacy_ui_fallback(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -90,7 +90,7 @@ class TestKiroCliProviderInitialization:
 
         assert result is True
         # Should have sent /exit then --legacy-ui command
-        calls = mock_tmux.send_keys.call_args_list
+        calls = mock_tmux.return_value.send_keys.call_args_list
         assert len(calls) == 3  # TUI command, /exit, legacy command
         assert calls[0].args == (
             "test-session",
@@ -107,7 +107,7 @@ class TestKiroCliProviderInitialization:
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_yolo_forces_legacy_ui_with_trust_all_tools(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -125,7 +125,7 @@ class TestKiroCliProviderInitialization:
         )
         provider.initialize()
 
-        mock_tmux.send_keys.assert_called_once_with(
+        mock_tmux.return_value.send_keys.assert_called_once_with(
             "test-session",
             "window-0",
             "kiro-cli chat --legacy-ui --trust-all-tools --agent developer",
@@ -134,7 +134,7 @@ class TestKiroCliProviderInitialization:
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_passes_profile_model(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -148,7 +148,7 @@ class TestKiroCliProviderInitialization:
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider.initialize()
 
-        mock_tmux.send_keys.assert_called_once_with(
+        mock_tmux.return_value.send_keys.assert_called_once_with(
             "test-session",
             "window-0",
             "kiro-cli chat --model claude-opus-4-6 --agent developer",
@@ -157,7 +157,7 @@ class TestKiroCliProviderInitialization:
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_yolo_and_model_combine(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -173,7 +173,7 @@ class TestKiroCliProviderInitialization:
         )
         provider.initialize()
 
-        mock_tmux.send_keys.assert_called_once_with(
+        mock_tmux.return_value.send_keys.assert_called_once_with(
             "test-session",
             "window-0",
             "kiro-cli chat --legacy-ui --trust-all-tools --model claude-opus-4.6 --agent developer",
@@ -182,7 +182,7 @@ class TestKiroCliProviderInitialization:
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_yolo_no_fallback_on_timeout(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -203,12 +203,12 @@ class TestKiroCliProviderInitialization:
             provider.initialize()
 
         # Only one launch attempt — no /exit, no second launch.
-        assert mock_tmux.send_keys.call_count == 1
+        assert mock_tmux.return_value.send_keys.call_count == 1
 
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_initialize_non_yolo_legacy_ui_fallback_preserves_model(
         self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile
     ):
@@ -222,7 +222,7 @@ class TestKiroCliProviderInitialization:
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider.initialize()
 
-        calls = mock_tmux.send_keys.call_args_list
+        calls = mock_tmux.return_value.send_keys.call_args_list
         assert len(calls) == 3
         assert calls[0].args == (
             "test-session",
@@ -250,82 +250,82 @@ class TestKiroCliProviderInitialization:
 class TestKiroCliProviderStatusDetection:
     """Test status detection logic."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_idle(self, mock_tmux):
         """Test IDLE status detection."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_idle_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED status detection."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_completed_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING status detection."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_processing_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
         """Test WAITING_USER_ANSWER status detection."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_permission_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_permission_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_error(self, mock_tmux):
         """Test ERROR status detection."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_error_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_error_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_with_empty_output(self, mock_tmux):
         """Test status detection with empty output."""
-        mock_tmux.get_history.return_value = ""
+        mock_tmux.return_value.get_history.return_value = ""
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_get_status_with_tail_lines(self, mock_tmux):
         """Test status detection with tail_lines parameter."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_idle_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status(tail_lines=50)
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
+        mock_tmux.return_value.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_status_processing_response_started_no_final_prompt(self, mock_tmux):
         """Test status returns PROCESSING when response started but no final prompt."""
         # Response started (green arrow) but no idle prompt after it
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m user question\n"
             "\x1b[38;5;10m> \x1b[39mPartial response being generated..."
         )
@@ -335,11 +335,11 @@ class TestKiroCliProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_status_completed_prompt_after_response(self, mock_tmux):
         """Test status returns COMPLETED when prompt appears after response."""
         # Complete response with idle prompt after green arrow
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m user question\n"
             "\x1b[38;5;10m> \x1b[39mComplete response here\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
@@ -350,7 +350,7 @@ class TestKiroCliProviderStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_extraction_succeeds_when_status_completed(self, mock_tmux):
         """Test extraction succeeds when status is COMPLETED."""
         output = (
@@ -358,7 +358,7 @@ class TestKiroCliProviderStatusDetection:
             "\x1b[38;5;10m> \x1b[39mComplete response here\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
 
@@ -370,11 +370,11 @@ class TestKiroCliProviderStatusDetection:
         message = provider.extract_last_message_from_script(output)
         assert "Complete response here" in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_multiple_prompts_in_buffer_edge_case(self, mock_tmux):
         """Test with multiple prompts in buffer (edge case)."""
         # Multiple interactions in buffer - should use last response
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m first question\n"
             "\x1b[38;5;10m> \x1b[39mFirst response\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m second question\n"
@@ -388,15 +388,15 @@ class TestKiroCliProviderStatusDetection:
         assert status == TerminalStatus.COMPLETED
 
         # Verify extraction gets the last response
-        message = provider.extract_last_message_from_script(mock_tmux.get_history.return_value)
+        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
         assert "Second response" in message
         assert "First response" not in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_status_processing_multiple_green_arrows_no_final_prompt(self, mock_tmux):
         """Test PROCESSING status with multiple green arrows but no final prompt."""
         # Multiple responses but still processing (no final prompt after last arrow)
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m question\n"
             "\x1b[38;5;10m> \x1b[39mFirst part of response\n"
             "\x1b[38;5;10m> \x1b[39mSecond part still generating..."
@@ -407,18 +407,18 @@ class TestKiroCliProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_status_idle_only_prompt_no_response(self, mock_tmux):
         """Test IDLE status when only prompt present, no response."""
         # Just the idle prompt, no green arrow response
-        mock_tmux.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m"
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m"
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_status_synchronization_guarantee(self, mock_tmux):
         """Test that COMPLETED status guarantees extraction will succeed."""
         test_cases = [
@@ -448,7 +448,7 @@ class TestKiroCliProviderStatusDetection:
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
 
         for output, expected_content in test_cases:
-            mock_tmux.get_history.return_value = output
+            mock_tmux.return_value.get_history.return_value = output
 
             # Status must be COMPLETED
             status = provider.get_status()
@@ -755,7 +755,7 @@ class TestKiroCliProviderRegexPatterns:
         permission_text = "Allow this action? [y/n/t]: [developer]>"
         assert re.search(provider._permission_prompt_pattern, permission_text)
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_permission_prompt_no_match_stale_history(self, mock_tmux):
         """Test that stale permission prompts are not detected as active.
 
@@ -765,7 +765,7 @@ class TestKiroCliProviderRegexPatterns:
         stale = (
             "Allow this action? [y/n/t]:\n\n[developer] 29% > y\nsome output\n[developer] 29% > "
         )
-        mock_tmux.get_history.return_value = stale
+        mock_tmux.return_value.get_history.return_value = stale
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -785,30 +785,30 @@ class TestKiroCliProviderRegexPatterns:
 class TestKiroCliProviderPromptPatterns:
     """Test various prompt pattern combinations."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_basic_prompt(self, mock_tmux):
         """Test basic prompt without extras."""
-        mock_tmux.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m "
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_prompt_with_percentage(self, mock_tmux):
         """Test prompt with usage percentage."""
-        mock_tmux.get_history.return_value = "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_prompt_with_special_profile_characters(self, mock_tmux):
         """Test prompt with special characters in profile name."""
-        mock_tmux.get_history.return_value = "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "code-reviewer_v2")
         status = provider.get_status()
@@ -819,21 +819,21 @@ class TestKiroCliProviderPromptPatterns:
 class TestKiroCliProviderHandoffScenarios:
     """Test handoff scenarios between agents."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_successful_status(self, mock_tmux):
         """Test COMPLETED status detection with successful handoff."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_handoff_successful.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_handoff_successful.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_successful_message_extraction(self, mock_tmux):
         """Test message extraction from successful handoff output."""
         output = load_fixture("kiro_cli_handoff_successful.txt")
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "supervisor")
         message = provider.extract_last_message_from_script(output)
@@ -845,21 +845,21 @@ class TestKiroCliProviderHandoffScenarios:
         assert "completed successfully" in message.lower()
         assert "developer agent" in message.lower()
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_error_status(self, mock_tmux):
         """Test ERROR status detection with failed handoff."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_handoff_error.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_handoff_error.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_error_message_extraction(self, mock_tmux):
         """Test message extraction from failed handoff output."""
         output = load_fixture("kiro_cli_handoff_error.txt")
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "supervisor")
 
@@ -870,17 +870,17 @@ class TestKiroCliProviderHandoffScenarios:
         assert "\x1b[" not in message
         assert "error" in message.lower() or "unable" in message.lower()
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_with_permission_prompt(self, mock_tmux):
         """Test WAITING_USER_ANSWER status during handoff requiring permission."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_handoff_with_permission.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_handoff_with_permission.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_message_preserves_content(self, mock_tmux):
         """Test that handoff message extraction preserves all content without truncation."""
         output = load_fixture("kiro_cli_handoff_successful.txt")
@@ -895,7 +895,7 @@ class TestKiroCliProviderHandoffScenarios:
         # Verify it's not truncated or corrupted
         assert len(message.split()) >= 8  # Should have multiple words
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_handoff_indices_not_corrupted(self, mock_tmux):
         """Test that ANSI code cleaning doesn't corrupt index-based extraction."""
         output = load_fixture("kiro_cli_handoff_successful.txt")
@@ -946,21 +946,21 @@ class TestKiroCliProviderEdgeCases:
 
         assert provider._initialized is False
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_long_agent_profile_name(self, mock_tmux):
         """Test with very long agent profile name."""
         long_profile = "very_long_agent_profile_name_that_exceeds_normal_length"
-        mock_tmux.get_history.return_value = f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", long_profile)
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_output_with_unicode_characters(self, mock_tmux):
         """Test handling of unicode characters in output."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;10m> \x1b[39mResponse with unicode: 日本語 café naïve 🚀\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
         )
@@ -971,30 +971,30 @@ class TestKiroCliProviderEdgeCases:
         assert status == TerminalStatus.COMPLETED
 
         # Test message extraction
-        message = provider.extract_last_message_from_script(mock_tmux.get_history.return_value)
+        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
         assert "日本語" in message
         assert "café" in message
         assert "🚀" in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_output_with_control_characters(self, mock_tmux):
         """Test handling of control characters."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;10m> \x1b[39mResponse\x07with\x1bcontrol\x00chars\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
         )
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
-        message = provider.extract_last_message_from_script(mock_tmux.get_history.return_value)
+        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
 
         # Control characters should be cleaned
         assert "\x07" not in message  # Bell
         assert "\x00" not in message  # Null
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_multiple_error_indicators(self, mock_tmux):
         """Test detection with multiple error indicators."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Kiro is having trouble responding right now\n"
             "Kiro is having trouble responding right now\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
@@ -1014,7 +1014,7 @@ class TestKiroCliProviderEdgeCases:
         assert provider.window_name == "window-0"
         assert provider._agent_profile == "developer"
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_whitespace_variations_in_prompt(self, mock_tmux):
         """Test various whitespace scenarios in prompts."""
         test_cases = [
@@ -1027,7 +1027,7 @@ class TestKiroCliProviderEdgeCases:
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
 
         for test_output in test_cases:
-            mock_tmux.get_history.return_value = test_output
+            mock_tmux.return_value.get_history.return_value = test_output
             status = provider.get_status()
             assert status == TerminalStatus.IDLE
 
@@ -1035,10 +1035,10 @@ class TestKiroCliProviderEdgeCases:
 class TestKiroCliNewTuiSupport:
     """Test new Kiro CLI TUI format detection (without --legacy-ui)."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_new_tui_idle_detection(self, mock_tmux):
         """Test IDLE detection with new TUI prompt format."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "code_supervisor · claude-opus-4.6-1m · ◔ 1%\n" " ask a question, or describe a task ↵"
         )
 
@@ -1047,10 +1047,10 @@ class TestKiroCliNewTuiSupport:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_new_tui_completed_detection(self, mock_tmux):
         """Test COMPLETED detection with new TUI: green arrow + new idle prompt."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "> Here is the response to your question.\n"
             "Some more response text.\n"
             "code_supervisor · claude-opus-4.6-1m · ◔ 2%\n"
@@ -1062,10 +1062,10 @@ class TestKiroCliNewTuiSupport:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_new_tui_processing_detection(self, mock_tmux):
         """Test PROCESSING when new TUI idle prompt is absent."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "code_supervisor · claude-opus-4.6-1m · ◔ 1%\n" "Generating response..."
         )
 
@@ -1074,7 +1074,7 @@ class TestKiroCliNewTuiSupport:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_new_tui_extraction(self, mock_tmux):
         """Test message extraction with new TUI idle prompt as boundary."""
         output = (
@@ -1090,10 +1090,10 @@ class TestKiroCliNewTuiSupport:
         assert "Complete response here" in message
         assert "multiple lines" in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_new_tui_permission_prompt(self, mock_tmux):
         """Test WAITING_USER_ANSWER with new TUI and permission prompt."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Allow this action? [y/n/t]:\n"
             "code_supervisor · claude-opus-4.6-1m · ◔ 1%\n"
             " ask a question, or describe a task ↵"
@@ -1130,41 +1130,41 @@ class TestKiroCliTuiMode:
     separator-based message extraction used in Kiro CLI's new TUI.
     """
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_idle_detection(self, mock_tmux):
         """Test IDLE detection with pure TUI output."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_tui_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_tui_idle_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_completed_detection(self, mock_tmux):
         """Test COMPLETED detection with Credits marker + idle prompt."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_tui_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_tui_completed_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_processing_detection(self, mock_tmux):
         """Test PROCESSING when TUI idle prompt is absent."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_tui_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_tui_processing_output.txt")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_message_extraction(self, mock_tmux):
         """Test message extraction from TUI completed output."""
         output = load_fixture("kiro_cli_tui_completed_output.txt")
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         message = provider.extract_last_message_from_script(output)
@@ -1178,11 +1178,11 @@ class TestKiroCliTuiMode:
         # Should NOT contain Credits line
         assert "Credits:" not in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_complex_extraction(self, mock_tmux):
         """Test extraction of complex TUI response with code blocks."""
         output = load_fixture("kiro_cli_tui_complex_response.txt")
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         message = provider.extract_last_message_from_script(output)
@@ -1195,7 +1195,7 @@ class TestKiroCliTuiMode:
         # Should NOT contain user message
         assert "Show me Python and JavaScript examples" not in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_extraction_no_credits(self, mock_tmux):
         """Test extraction fails when no Credits marker or green arrow present."""
         output = (
@@ -1211,7 +1211,7 @@ class TestKiroCliTuiMode:
         with pytest.raises(ValueError, match="no Credits marker"):
             provider.extract_last_message_from_script(output)
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_extraction_no_separator(self, mock_tmux):
         """Test extraction fails when Credits present but no separator."""
         output = (
@@ -1226,7 +1226,7 @@ class TestKiroCliTuiMode:
         with pytest.raises(ValueError, match="no separator found near Credits"):
             provider.extract_last_message_from_script(output)
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_extraction_kiro2_forward_scan(self, mock_tmux):
         """Test extraction exercises the Kiro 2.0 forward scan path.
 
@@ -1274,11 +1274,11 @@ class TestKiroCliTuiMode:
         assert not re.search(TUI_SEPARATOR_PATTERN, "---")  # Wrong character
         assert not re.search(TUI_SEPARATOR_PATTERN, "────────")  # 8 chars — could be markdown, skip
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_status_extraction_synchronization(self, mock_tmux):
         """Test that COMPLETED status guarantees extraction succeeds for TUI output."""
         output = load_fixture("kiro_cli_tui_completed_output.txt")
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
 
@@ -1291,10 +1291,10 @@ class TestKiroCliTuiMode:
         assert len(message) > 0
         assert "comprehensive response" in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_credits_without_idle_is_processing(self, mock_tmux):
         """Test that Credits marker without idle prompt after it = PROCESSING."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "────────────────────────────────────────────────────\n"
             "  User question\n"
             "\n"
@@ -1309,10 +1309,10 @@ class TestKiroCliTuiMode:
         # Credits present but no idle prompt after → still processing (TUI redrawing)
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_kiro_is_working_processing(self, mock_tmux):
         """Test PROCESSING detected via 'Kiro is working' ghost text."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "────────────────────────────────────────────────────\n"
             "developer · claude-opus-4.6-1m · ◔ 3%\n"
             "\n"
@@ -1324,7 +1324,7 @@ class TestKiroCliTuiMode:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_kiro_is_working_takes_priority(self, mock_tmux):
         """Test 'Kiro is working' after idle prompt still returns PROCESSING.
 
@@ -1332,7 +1332,7 @@ class TestKiroCliTuiMode:
         started a new task after the previous idle.  The last 'Kiro is working'
         has no idle prompt after it, so the result must be PROCESSING.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "developer · auto · ◔ 3%\n"
             " Ask a question or describe a task ↵\n"
             " Kiro is working\n"
@@ -1344,7 +1344,7 @@ class TestKiroCliTuiMode:
         # idle prompt is BEFORE "Kiro is working" → no idle after last working → PROCESSING
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_stale_kiro_is_working_before_idle_yields_idle(self, mock_tmux):
         """Test that a stale 'Kiro is working' line does not block IDLE detection.
 
@@ -1353,7 +1353,7 @@ class TestKiroCliTuiMode:
         The fix: only return PROCESSING when no idle prompt appears *after* the
         last 'Kiro is working' occurrence.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "────────────────────────────────────────────────────\n"
             " Kiro is working\n"
             "────────────────────────────────────────────────────\n"
@@ -1366,7 +1366,7 @@ class TestKiroCliTuiMode:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_stale_kiro_is_working_with_credits_yields_completed(self, mock_tmux):
         """Test COMPLETED when stale 'Kiro is working' precedes credits + idle prompt.
 
@@ -1377,7 +1377,7 @@ class TestKiroCliTuiMode:
 
         The stale ghost text must not block the COMPLETED detection.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             " Kiro is working\n"
             "────────────────────────────────────────────────────\n"
             "> Here is the result you asked for.\n"
@@ -1391,11 +1391,11 @@ class TestKiroCliTuiMode:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_multiple_stale_kiro_is_working_lines_yield_idle(self, mock_tmux):
         """Test that multiple stale 'Kiro is working' lines all before the idle
         prompt still resolve to IDLE (uses the *last* working-line position)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             " Kiro is working\n"
             " Kiro is working\n"
             "developer · auto · ◔ 0%\n"
@@ -1407,10 +1407,10 @@ class TestKiroCliTuiMode:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_permission_prompt_detection(self, mock_tmux):
         """Test WAITING_USER_ANSWER with TUI permission prompt (Yes/No/Always Allow)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "────────────────────────────────────────────────────\n"
             "I need to write to /tmp/test.txt\n"
             "Yes  No  Always Allow for this session\n"
@@ -1431,7 +1431,7 @@ class TestKiroCliTuiMode:
         assert re.search(TUI_PROCESSING_PATTERN, " Kiro is working ")
         assert not re.search(TUI_PROCESSING_PATTERN, "Kiro is idle")
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_initializing_yields_processing_despite_idle_placeholder(self, mock_tmux):
         """Test PROCESSING while Kiro TUI is initializing.
 
@@ -1441,7 +1441,7 @@ class TestKiroCliTuiMode:
         IDLE ~1s after launch and the first user message would be sent before
         Kiro can accept input (issue #211).
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "● Initializing...\n"
             "────────────────────────────────────────────────────\n"
             "agent-ops · auto · ◔ 0%\n"
@@ -1453,10 +1453,10 @@ class TestKiroCliTuiMode:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_initializing_cleared_allows_idle(self, mock_tmux):
         """After init completes, Kiro clears 'Initializing...' and IDLE resolves."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "────────────────────────────────────────────────────\n"
             "agent-ops · auto · ◔ 0%\n"
             " Ask a question or describe a task ↵\n"
@@ -1512,7 +1512,7 @@ class TestKiroCliTuiMode:
         assert not re.search(TUI_PERMISSION_PATTERN, "Yes, I can help")
         assert not re.search(TUI_PERMISSION_PATTERN, "No problem")
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_extraction_with_separator_in_agent_output(self, mock_tmux):
         """Test extraction works when agent output itself contains separator chars."""
         output = (
@@ -1536,7 +1536,7 @@ class TestKiroCliTuiMode:
         assert "box drawing character" in message
         assert "That line above" in message
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_tui_extraction_multi_turn(self, mock_tmux):
         """Test extraction picks latest turn when multiple Credits lines exist."""
         output = (
@@ -1568,7 +1568,7 @@ class TestKiroCliTuiMode:
 class TestKiroCliCheck3ShellBaseline:
     """Tests for Check 3: shell-baseline IDLE detection."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check3_shell_match_returns_idle(self, mock_tmux):
         """No idle prompt + current command matches shell_baseline → IDLE.
 
@@ -1577,8 +1577,8 @@ class TestKiroCliCheck3ShellBaseline:
         current command is still the shell, so honoring it would let
         pastes leak into Kiro's boot screen.
         """
-        mock_tmux.get_history.return_value = "Some processing output without idle prompt"
-        mock_tmux.get_pane_current_command.return_value = "bash"
+        mock_tmux.return_value.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.return_value.get_pane_current_command.return_value = "bash"
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider.shell_baseline = "bash"
@@ -1586,10 +1586,10 @@ class TestKiroCliCheck3ShellBaseline:
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.get_pane_current_command.assert_called_once_with("test-session", "window-0")
+        mock_tmux.return_value.get_pane_current_command.assert_called_once_with("test-session", "window-0")
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
-    def test_check3_pre_init_shell_match_returns_processing(self, mock_tmux):
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
+    def test_check3_pre_init_shell_match_returns_processing(self, mock_backend):
         """Pre-init (`_initialized=False`) + current command matches shell_baseline → PROCESSING.
 
         Between send_keys('kiro-cli chat ...') and the moment kiro exec's,
@@ -1597,7 +1597,7 @@ class TestKiroCliCheck3ShellBaseline:
         must report PROCESSING in this window so callers don't paste into
         Kiro's pre-interactive boot screen.
         """
-        mock_tmux.get_history.return_value = "Some processing output without idle prompt"
+        mock_backend.return_value.get_history.return_value = "Some processing output without idle prompt"
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider.shell_baseline = "bash"
@@ -1605,13 +1605,13 @@ class TestKiroCliCheck3ShellBaseline:
         status = provider.get_status()
 
         assert status == TerminalStatus.PROCESSING
-        mock_tmux.get_pane_current_command.assert_not_called()
+        mock_backend.return_value.get_pane_current_command.assert_not_called()
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check3_shell_mismatch_returns_processing(self, mock_tmux):
         """No idle prompt + current command differs from shell_baseline → PROCESSING."""
-        mock_tmux.get_history.return_value = "Some processing output without idle prompt"
-        mock_tmux.get_pane_current_command.return_value = "kiro"
+        mock_tmux.return_value.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.return_value.get_pane_current_command.return_value = "kiro"
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider.shell_baseline = "bash"
@@ -1619,17 +1619,17 @@ class TestKiroCliCheck3ShellBaseline:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check3_no_baseline_returns_processing_without_pane_query(self, mock_tmux):
         """No idle prompt + shell_baseline is None → PROCESSING, no pane command query."""
-        mock_tmux.get_history.return_value = "Some processing output without idle prompt"
+        mock_tmux.return_value.get_history.return_value = "Some processing output without idle prompt"
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         # shell_baseline defaults to None
         status = provider.get_status()
 
         assert status == TerminalStatus.PROCESSING
-        mock_tmux.get_pane_current_command.assert_not_called()
+        mock_tmux.return_value.get_pane_current_command.assert_not_called()
 
 
 class TestKiroCliCheck6NoCredits:
@@ -1660,10 +1660,10 @@ class TestKiroCliCheck6NoCredits:
     # Check 6 — get_status()
     # -------------------------------------------------------------------------
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check6_completed_after_input_received(self, mock_tmux):
         """Check 6 returns COMPLETED when idle prompt present and input was sent."""
-        mock_tmux.get_history.return_value = self._tui_output("validate this", "All checks pass.")
+        mock_tmux.return_value.get_history.return_value = self._tui_output("validate this", "All checks pass.")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         provider._input_received = True
@@ -1671,7 +1671,7 @@ class TestKiroCliCheck6NoCredits:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check6_idle_before_input_received(self, mock_tmux):
         """Check 6 must NOT fire during startup before any input is sent.
 
@@ -1679,7 +1679,7 @@ class TestKiroCliCheck6NoCredits:
         _input_received guard, get_status() would return COMPLETED immediately
         after launch before the agent has done any work.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             f"{self.SEP}\n"
             "developer · claude-sonnet-4.6 · ◔ 0%\n"
             " Ask a question or describe a task ↵\n"
@@ -1691,10 +1691,10 @@ class TestKiroCliCheck6NoCredits:
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_check6_not_triggered_while_processing(self, mock_tmux):
         """Check 6 must not fire when 'Kiro is working' appears after idle prompt."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "developer · auto · ◔ 3%\n"
             " Ask a question or describe a task ↵\n"
             " Kiro is working\n"

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -1518,13 +1518,13 @@ class TestKiroCliTuiMode:
             "2 of 5 mcp servers initialized. ctrl-c to start chatting now",
         )
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
-    def test_mcp_server_init_yields_processing(self, mock_tmux):
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
+    def test_mcp_server_init_yields_processing(self, mock_backend):
         """Kiro shows the idle-prompt placeholder before MCP servers finish
         loading. A paste sent during this window is silently absorbed by
         the boot screen, so we must report PROCESSING until init completes.
         """
-        mock_tmux.get_history.return_value = (
+        mock_backend.return_value.get_history.return_value = (
             "0 of 1 mcp servers initialized. ctrl-c to start chatting now\n"
             "────────────────────────────────────────────────────\n"
             "[developer] !> Need help with features or setup? Use /help\n"

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -100,80 +100,80 @@ class TestGetStatusFromFixtures:
     def _mock_provider(self, fixture_content: str) -> OpenCodeCliProvider:
         provider = make_provider()
         mock_tmux = MagicMock()
-        mock_tmux.get_history.return_value = fixture_content
+        mock_tmux.return_value.get_history.return_value = fixture_content
         provider._tmux_client = mock_tmux  # not used directly — patch below
         return provider
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_idle_splash_returns_idle(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("opencode_cli_idle_splash.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("opencode_cli_idle_splash.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_idle_splash_ansi_returns_idle(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_ansi_fixture("opencode_cli_idle_splash.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_idle_splash.ansi.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_processing_returns_processing(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("opencode_cli_processing.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("opencode_cli_processing.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_processing_ansi_returns_processing(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_ansi_fixture("opencode_cli_processing.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_processing.ansi.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_completed_returns_completed(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_fixture("opencode_cli_completed.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("opencode_cli_completed.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_completed_ansi_returns_completed(self, mock_tmux):
-        mock_tmux.get_history.return_value = load_ansi_fixture("opencode_cli_completed.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_completed.ansi.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_permission_ansi_returns_waiting_user_answer(self, mock_tmux):
         # ANSI fixture required: plain text loses the △ Permission required overlay.
-        mock_tmux.get_history.return_value = load_ansi_fixture("opencode_cli_permission.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_permission.ansi.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_idle_post_completion_returns_idle(self, mock_tmux):
         # Use plain fixture — ANSI variant reuses the completed frame (see OPENCODE_FIXTURES.md).
-        mock_tmux.get_history.return_value = load_fixture("opencode_cli_idle_post_completion.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("opencode_cli_idle_post_completion.txt")
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_empty_output_returns_error(self, mock_tmux):
-        mock_tmux.get_history.return_value = ""
+        mock_tmux.return_value.get_history.return_value = ""
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_none_output_returns_error(self, mock_tmux):
-        mock_tmux.get_history.return_value = None
+        mock_tmux.return_value.get_history.return_value = None
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_unknown_output_returns_error_fallback(self, mock_tmux):
         """Non-empty output with no recognizable pattern → ERROR fallback.
 
         Exercises the final ``return TerminalStatus.ERROR`` at the end of
         get_status(), distinct from the early return on empty/None output.
         """
-        mock_tmux.get_history.return_value = "random text without any tui markers"
+        mock_tmux.return_value.get_history.return_value = "random text without any tui markers"
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.ERROR
 
@@ -186,7 +186,7 @@ class TestGetStatusFromFixtures:
 class TestStaleEscInterruptGuard:
     """Verify position-aware guard: esc interrupt on earlier line + idle footer on later line → IDLE."""
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_stale_esc_interrupt_returns_idle(self, mock_tmux):
         # Synthetic: esc interrupt on line 0 (old frame), ctrl+p commands on line 2 (new frame).
         stale_output = (
@@ -194,22 +194,22 @@ class TestStaleEscInterruptGuard:
             "\n"
             "                  ctrl+p commands    • OpenCode 1.14.19"
         )
-        mock_tmux.get_history.return_value = stale_output
+        mock_tmux.return_value.get_history.return_value = stale_output
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_same_line_esc_and_idle_returns_processing(self, mock_tmux):
         # esc interrupt and ctrl+p commands on the same footer line → PROCESSING (normal case).
         same_line_output = (
             "   some content here\n"
             "   ⬝⬝⬝⬝  esc interrupt                     tab agents  ctrl+p commands    • OpenCode"
         )
-        mock_tmux.get_history.return_value = same_line_output
+        mock_tmux.return_value.get_history.return_value = same_line_output
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_stale_esc_followed_by_full_completion_returns_completed(self, mock_tmux):
         # Stale esc interrupt line, then full completion marker + idle footer → COMPLETED.
         stale_to_completed = (
@@ -221,7 +221,7 @@ class TestStaleEscInterruptGuard:
             "\n"
             "                  ctrl+p commands    • OpenCode 1.14.19"
         )
-        mock_tmux.get_history.return_value = stale_to_completed
+        mock_tmux.return_value.get_history.return_value = stale_to_completed
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.COMPLETED
 
@@ -342,7 +342,7 @@ class TestExtractLastMessage:
 class TestInitialize:
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_success_returns_true(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = True
@@ -351,7 +351,7 @@ class TestInitialize:
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_uses_120s_timeout(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = True
@@ -362,39 +362,39 @@ class TestInitialize:
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_sends_agent_flag(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = True
         provider = make_provider(agent_profile="developer")
         provider.initialize()
-        sent_cmd = mock_tmux.send_keys.call_args[0][2]
+        sent_cmd = mock_tmux.return_value.send_keys.call_args[0][2]
         assert "--agent developer" in sent_cmd
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_includes_model_when_set(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = True
         provider = make_provider(model="anthropic/claude-sonnet-4-6")
         provider.initialize()
-        sent_cmd = mock_tmux.send_keys.call_args[0][2]
+        sent_cmd = mock_tmux.return_value.send_keys.call_args[0][2]
         assert "--model anthropic/claude-sonnet-4-6" in sent_cmd
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_no_model_flag_when_unset(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = True
         provider = make_provider(model=None)
         provider.initialize()
-        sent_cmd = mock_tmux.send_keys.call_args[0][2]
+        sent_cmd = mock_tmux.return_value.send_keys.call_args[0][2]
         assert "--model" not in sent_cmd
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_raises_on_shell_timeout(self, mock_tmux, mock_shell):
         mock_shell.return_value = False
         provider = make_provider()
@@ -403,7 +403,7 @@ class TestInitialize:
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_raises_on_opencode_timeout(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = False
@@ -413,13 +413,13 @@ class TestInitialize:
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.opencode_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_initialize_sets_env_vars_in_command(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = True
         provider = make_provider()
         provider.initialize()
-        sent_cmd = mock_tmux.send_keys.call_args[0][2]
+        sent_cmd = mock_tmux.return_value.send_keys.call_args[0][2]
         assert "OPENCODE_DISABLE_AUTOUPDATE=1" in sent_cmd
         assert "OPENCODE_DISABLE_MOUSE=1" in sent_cmd
         assert "OPENCODE_CLIENT=cao" in sent_cmd

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -106,25 +106,33 @@ class TestGetStatusFromFixtures:
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_idle_splash_returns_idle(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = load_fixture("opencode_cli_idle_splash.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "opencode_cli_idle_splash.txt"
+        )
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_idle_splash_ansi_returns_idle(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_idle_splash.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture(
+            "opencode_cli_idle_splash.ansi.txt"
+        )
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_processing_returns_processing(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = load_fixture("opencode_cli_processing.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "opencode_cli_processing.txt"
+        )
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.PROCESSING
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_processing_ansi_returns_processing(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_processing.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture(
+            "opencode_cli_processing.ansi.txt"
+        )
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.PROCESSING
 
@@ -136,21 +144,27 @@ class TestGetStatusFromFixtures:
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_completed_ansi_returns_completed(self, mock_tmux):
-        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_completed.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture(
+            "opencode_cli_completed.ansi.txt"
+        )
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.COMPLETED
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_permission_ansi_returns_waiting_user_answer(self, mock_tmux):
         # ANSI fixture required: plain text loses the △ Permission required overlay.
-        mock_tmux.return_value.get_history.return_value = load_ansi_fixture("opencode_cli_permission.ansi.txt")
+        mock_tmux.return_value.get_history.return_value = load_ansi_fixture(
+            "opencode_cli_permission.ansi.txt"
+        )
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     def test_idle_post_completion_returns_idle(self, mock_tmux):
         # Use plain fixture — ANSI variant reuses the completed frame (see OPENCODE_FIXTURES.md).
-        mock_tmux.return_value.get_history.return_value = load_fixture("opencode_cli_idle_post_completion.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "opencode_cli_idle_post_completion.txt"
+        )
         provider = make_provider()
         assert provider.get_status() == TerminalStatus.IDLE
 

--- a/test/providers/test_permission_prompt_detection.py
+++ b/test/providers/test_permission_prompt_detection.py
@@ -51,7 +51,9 @@ class TestPermissionPromptActive:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p1_active_empty_prompt(self, mock_tmux):
         """P1: Permission prompt shown, empty idle prompt on next line, unanswered."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_permission_active_empty.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_permission_active_empty.txt"
+        )
         provider = make_provider("cao-internal-docs-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
@@ -111,7 +113,9 @@ class TestPermissionPromptStale:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p5_answered_y_agent_idle(self, mock_tmux):
         """P5: User answered y, agent ran tool, now idle again."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_permission_stale_answered.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "kiro_cli_permission_stale_answered.txt"
+        )
         provider = make_provider("cao-workspace-expert")
         status = provider.get_status()
         assert status != TerminalStatus.WAITING_USER_ANSWER
@@ -172,14 +176,18 @@ class TestNonPermissionCases:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n2_idle_trailing_text(self, mock_tmux):
         """N2: Idle with trailing text after prompt."""
-        mock_tmux.return_value.get_history.return_value = "[developer] 24% λ > send message back to supervisor?"
+        mock_tmux.return_value.get_history.return_value = (
+            "[developer] 24% λ > send message back to supervisor?"
+        )
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n3_idle_what_would_you_like(self, mock_tmux):
         """N3: Idle with 'What would you like to do next?' trailing text."""
-        mock_tmux.return_value.get_history.return_value = "[developer] 11% > What would you like to do next?"
+        mock_tmux.return_value.get_history.return_value = (
+            "[developer] 11% > What would you like to do next?"
+        )
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.IDLE
 
@@ -226,7 +234,9 @@ class TestPermissionPromptEdgeCases:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_permission_same_line_as_idle(self, mock_tmux):
         """Original fixture format: [y/n/t]: and idle prompt on same line."""
-        mock_tmux.return_value.get_history.return_value = "Allow this action? [y/n/t]: [developer] 10% λ > "
+        mock_tmux.return_value.get_history.return_value = (
+            "Allow this action? [y/n/t]: [developer] 10% λ > "
+        )
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
@@ -260,7 +270,9 @@ class TestPermissionPromptEdgeCases:
     @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_no_permission_prompt_in_output(self, mock_tmux):
         """No permission prompt at all — should not affect idle detection."""
-        mock_tmux.return_value.get_history.return_value = "> Here is my response\n\n" "[developer] 22% λ > "
+        mock_tmux.return_value.get_history.return_value = (
+            "> Here is my response\n\n" "[developer] 22% λ > "
+        )
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.COMPLETED
 

--- a/test/providers/test_permission_prompt_detection.py
+++ b/test/providers/test_permission_prompt_detection.py
@@ -48,35 +48,35 @@ def make_provider(agent_profile="developer"):
 class TestPermissionPromptActive:
     """Cases where permission prompt is active — should return WAITING_USER_ANSWER."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p1_active_empty_prompt(self, mock_tmux):
         """P1: Permission prompt shown, empty idle prompt on next line, unanswered."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_permission_active_empty.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_permission_active_empty.txt")
         provider = make_provider("cao-internal-docs-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p2_active_trailing_text(self, mock_tmux):
         """P2: Permission prompt + idle prompt with trailing text, unanswered."""
-        mock_tmux.get_history.return_value = load_fixture(
+        mock_tmux.return_value.get_history.return_value = load_fixture(
             "kiro_cli_permission_active_trailing_text.txt"
         )
         provider = make_provider("cao-jira-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p3_active_injection_delivered(self, mock_tmux):
         """P3: Permission prompt + CAO injection message delivered during prompt."""
-        mock_tmux.get_history.return_value = load_fixture(
+        mock_tmux.return_value.get_history.return_value = load_fixture(
             "kiro_cli_permission_active_injection.txt"
         )
         provider = make_provider("cao-code-explorer-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p4_active_different_injection_text(self, mock_tmux):
         """P4: Permission prompt + different injected text on idle prompt."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Allow this action? Use 't' to trust (always allow) this tool "
             "for the session. [y/n/t]:\n\n"
             "[cao-workspace-expert] 22% λ > don't you have the internal search?"
@@ -84,19 +84,19 @@ class TestPermissionPromptActive:
         provider = make_provider("cao-workspace-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p8_active_partial_typing(self, mock_tmux):
         """P8: User typing partial text during permission prompt, no enter."""
-        mock_tmux.get_history.return_value = load_fixture(
+        mock_tmux.return_value.get_history.return_value = load_fixture(
             "kiro_cli_permission_active_partial_typing.txt"
         )
         provider = make_provider("cao-internal-docs-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p1_active_zero_idle_prompts_after(self, mock_tmux):
         """Permission prompt with no idle prompt after it at all."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Allow this action? Use 't' to trust (always allow) this tool "
             "for the session. [y/n/t]:\n"
         )
@@ -108,28 +108,28 @@ class TestPermissionPromptActive:
 class TestPermissionPromptStale:
     """Cases where permission prompt was answered — should NOT return WAITING_USER_ANSWER."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p5_answered_y_agent_idle(self, mock_tmux):
         """P5: User answered y, agent ran tool, now idle again."""
-        mock_tmux.get_history.return_value = load_fixture("kiro_cli_permission_stale_answered.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("kiro_cli_permission_stale_answered.txt")
         provider = make_provider("cao-workspace-expert")
         status = provider.get_status()
         assert status != TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p6_long_response_instead_of_ynt(self, mock_tmux):
         """P6: User typed long response instead of y/n/t, agent continued."""
-        mock_tmux.get_history.return_value = load_fixture(
+        mock_tmux.return_value.get_history.return_value = load_fixture(
             "kiro_cli_permission_stale_long_response.txt"
         )
         provider = make_provider("cao-query-decomposer-supervisor")
         status = provider.get_status()
         assert status != TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_p7_rerendered_prompts_then_answered(self, mock_tmux):
         """P7: Multiple [y/n/t]: re-renders during typing, then answered."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Allow this action? [y/n/t]:\n\n"
             "[developer] 16% λ > \n"
             "Allow this action? [y/n/t]:\n\n"
@@ -144,10 +144,10 @@ class TestPermissionPromptStale:
         status = provider.get_status()
         assert status != TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_stale_single_prompt_answered(self, mock_tmux):
         """Single permission prompt answered, 2 idle prompts after."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Allow this action? [y/n/t]:\n\n"
             "[developer] 10% λ > y\n\n"
             " - Completed in 1.5s\n\n"
@@ -162,40 +162,40 @@ class TestPermissionPromptStale:
 class TestNonPermissionCases:
     """Cases without permission prompts — existing detection should work."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n1_plain_idle(self, mock_tmux):
         """N1: Plain idle, no permission prompt."""
-        mock_tmux.get_history.return_value = "[developer] 22% λ > "
+        mock_tmux.return_value.get_history.return_value = "[developer] 22% λ > "
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n2_idle_trailing_text(self, mock_tmux):
         """N2: Idle with trailing text after prompt."""
-        mock_tmux.get_history.return_value = "[developer] 24% λ > send message back to supervisor?"
+        mock_tmux.return_value.get_history.return_value = "[developer] 24% λ > send message back to supervisor?"
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n3_idle_what_would_you_like(self, mock_tmux):
         """N3: Idle with 'What would you like to do next?' trailing text."""
-        mock_tmux.get_history.return_value = "[developer] 11% > What would you like to do next?"
+        mock_tmux.return_value.get_history.return_value = "[developer] 11% > What would you like to do next?"
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n4_running_tool(self, mock_tmux):
         """N4: Tool is executing, no idle prompt."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Searching for: system-privileges (*.toml) (using tool: grep)"
         )
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n6_completed_response(self, mock_tmux):
         """N6: Agent completed response, prompt shown after green arrow."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "[developer] 20% λ > user question\n"
             "> Complete response here\n"
             "[developer] 22% λ > "
@@ -203,19 +203,19 @@ class TestNonPermissionCases:
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_n9_message_received(self, mock_tmux):
         """N9: Inbox message delivered, agent idle."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "[developer] 12% > [Message from terminal 9445aa60] " "Hello from supervisor"
         )
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_empty_output(self, mock_tmux):
         """Empty output returns ERROR."""
-        mock_tmux.get_history.return_value = ""
+        mock_tmux.return_value.get_history.return_value = ""
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.ERROR
 
@@ -223,17 +223,17 @@ class TestNonPermissionCases:
 class TestPermissionPromptEdgeCases:
     """Edge cases for permission prompt detection."""
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_permission_same_line_as_idle(self, mock_tmux):
         """Original fixture format: [y/n/t]: and idle prompt on same line."""
-        mock_tmux.get_history.return_value = "Allow this action? [y/n/t]: [developer] 10% λ > "
+        mock_tmux.return_value.get_history.return_value = "Allow this action? [y/n/t]: [developer] 10% λ > "
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_multiple_active_prompts_last_unanswered(self, mock_tmux):
         """Multiple permission prompts, last one unanswered."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Allow this action? [y/n/t]:\n\n"
             "[developer] 10% λ > y\n\n"
             " - Completed in 1s\n\n"
@@ -244,10 +244,10 @@ class TestPermissionPromptEdgeCases:
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_permission_with_ansi_codes(self, mock_tmux):
         """Permission prompt with ANSI color codes (real terminal output)."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;244mAllow this action? Use '\x1b[38;5;13mt\x1b[38;5;244m' "
             "to trust (always allow) this tool for the session. "
             "[\x1b[38;5;13my\x1b[38;5;244m/\x1b[38;5;13mn\x1b[38;5;244m/"
@@ -257,14 +257,14 @@ class TestPermissionPromptEdgeCases:
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_no_permission_prompt_in_output(self, mock_tmux):
         """No permission prompt at all — should not affect idle detection."""
-        mock_tmux.get_history.return_value = "> Here is my response\n\n" "[developer] 22% λ > "
+        mock_tmux.return_value.get_history.return_value = "> Here is my response\n\n" "[developer] 22% λ > "
         provider = make_provider("developer")
         assert provider.get_status() == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_real_ansi_active_trailing_text(self, mock_tmux):
         """Real ANSI output: active prompt with trailing text and \\r redraw.
 
@@ -273,7 +273,7 @@ class TestPermissionPromptEdgeCases:
         The \\r redraw creates two idle prompt matches on the same line.
         Line-based counting correctly treats this as 1 line = active.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;244mAllow this action? Use '\x1b[38;5;13mt\x1b[38;5;244m' "
             "to trust (always allow) this tool for the session. "
             "[\x1b[38;5;13my\x1b[38;5;244m/\x1b[38;5;13mn\x1b[38;5;244m/"
@@ -289,14 +289,14 @@ class TestPermissionPromptEdgeCases:
         provider = make_provider("cao-jira-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_real_ansi_active_injection(self, mock_tmux):
         """Real ANSI output: active prompt with CAO injection delivered.
 
         From 0895b67b.log: injection message delivered during permission prompt
         via \\r redraw on same line.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;244mAllow this action? Use '\x1b[38;5;13mt\x1b[38;5;244m' "
             "to trust (always allow) this tool for the session. "
             "[\x1b[38;5;13my\x1b[38;5;244m/\x1b[38;5;13mn\x1b[38;5;244m/"
@@ -315,14 +315,14 @@ class TestPermissionPromptEdgeCases:
         provider = make_provider("cao-code-explorer-expert")
         assert provider.get_status() == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.kiro_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
     def test_real_ansi_stale_answered_y(self, mock_tmux):
         """Real ANSI output: permission answered with y, agent continued.
 
         From 4d9d97cf.log: user typed y via \\r redraw, tool completed,
         new prompt on separate \\n line.
         """
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;244mAllow this action? Use '\x1b[38;5;13mt\x1b[38;5;244m' "
             "to trust (always allow) this tool for the session. "
             "[\x1b[38;5;13my\x1b[38;5;244m/\x1b[38;5;13mn\x1b[38;5;244m/"

--- a/test/providers/test_q_cli_unit.py
+++ b/test/providers/test_q_cli_unit.py
@@ -24,7 +24,7 @@ class TestQCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.q_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.q_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_initialize_success(self, mock_tmux, mock_wait_status, mock_wait_shell):
         """Test successful initialization."""
         mock_wait_shell.return_value = True
@@ -35,13 +35,13 @@ class TestQCliProviderInitialization:
 
         assert result is True
         mock_wait_shell.assert_called_once()
-        mock_tmux.send_keys.assert_called_once_with(
+        mock_tmux.return_value.send_keys.assert_called_once_with(
             "test-session", "window-0", "q chat --agent developer"
         )
         mock_wait_status.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.q_cli.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_initialize_shell_timeout(self, mock_tmux, mock_wait_shell):
         """Test initialization with shell timeout."""
         mock_wait_shell.return_value = False
@@ -53,7 +53,7 @@ class TestQCliProviderInitialization:
 
     @patch("cli_agent_orchestrator.providers.q_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.q_cli.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_initialize_q_cli_timeout(self, mock_tmux, mock_wait_status, mock_wait_shell):
         """Test initialization with Q CLI timeout."""
         mock_wait_shell.return_value = True
@@ -78,82 +78,82 @@ class TestQCliProviderInitialization:
 class TestQCliProviderStatusDetection:
     """Test status detection logic."""
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_idle(self, mock_tmux):
         """Test IDLE status detection."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_idle_output.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_completed(self, mock_tmux):
         """Test COMPLETED status detection."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_completed_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_completed_output.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING status detection."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_processing_output.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
         """Test WAITING_USER_ANSWER status detection."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_permission_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_permission_output.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_error(self, mock_tmux):
         """Test ERROR status detection."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_error_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_error_output.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_with_empty_output(self, mock_tmux):
         """Test status detection with empty output."""
-        mock_tmux.get_history.return_value = ""
+        mock_tmux.return_value.get_history.return_value = ""
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_with_tail_lines(self, mock_tmux):
         """Test status detection with tail_lines parameter."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_idle_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_idle_output.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status(tail_lines=50)
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
+        mock_tmux.return_value.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_status_processing_response_started_no_final_prompt(self, mock_tmux):
         """Test status returns PROCESSING when response started but no final prompt."""
         # Response started (green arrow) but no idle prompt after it
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m user question\n"
             "\x1b[38;5;10m> \x1b[39mPartial response being generated..."
         )
@@ -163,11 +163,11 @@ class TestQCliProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_status_completed_prompt_after_response(self, mock_tmux):
         """Test status returns COMPLETED when prompt appears after response."""
         # Complete response with idle prompt after green arrow
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m user question\n"
             "\x1b[38;5;10m> \x1b[39mComplete response here\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
@@ -178,7 +178,7 @@ class TestQCliProviderStatusDetection:
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_extraction_succeeds_when_status_completed(self, mock_tmux):
         """Test extraction succeeds when status is COMPLETED."""
         output = (
@@ -186,7 +186,7 @@ class TestQCliProviderStatusDetection:
             "\x1b[38;5;10m> \x1b[39mComplete response here\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
         )
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
 
@@ -198,11 +198,11 @@ class TestQCliProviderStatusDetection:
         message = provider.extract_last_message_from_script(output)
         assert "Complete response here" in message
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_multiple_prompts_in_buffer_edge_case(self, mock_tmux):
         """Test with multiple prompts in buffer (edge case)."""
         # Multiple interactions in buffer - should use last response
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m first question\n"
             "\x1b[38;5;10m> \x1b[39mFirst response\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m second question\n"
@@ -216,15 +216,15 @@ class TestQCliProviderStatusDetection:
         assert status == TerminalStatus.COMPLETED
 
         # Verify extraction gets the last response
-        message = provider.extract_last_message_from_script(mock_tmux.get_history.return_value)
+        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
         assert "Second response" in message
         assert "First response" not in message
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_status_processing_multiple_green_arrows_no_final_prompt(self, mock_tmux):
         """Test PROCESSING status with multiple green arrows but no final prompt."""
         # Multiple responses but still processing (no final prompt after last arrow)
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[36m[developer]\x1b[35m>\x1b[39m question\n"
             "\x1b[38;5;10m> \x1b[39mFirst part of response\n"
             "\x1b[38;5;10m> \x1b[39mSecond part still generating..."
@@ -235,18 +235,18 @@ class TestQCliProviderStatusDetection:
 
         assert status == TerminalStatus.PROCESSING
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_status_idle_only_prompt_no_response(self, mock_tmux):
         """Test IDLE status when only prompt present, no response."""
         # Just the idle prompt, no green arrow response
-        mock_tmux.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m"
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m"
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_status_synchronization_guarantee(self, mock_tmux):
         """Test that COMPLETED status guarantees extraction will succeed."""
         test_cases = [
@@ -276,7 +276,7 @@ class TestQCliProviderStatusDetection:
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
 
         for output, expected_content in test_cases:
-            mock_tmux.get_history.return_value = output
+            mock_tmux.return_value.get_history.return_value = output
 
             # Status must be COMPLETED
             status = provider.get_status()
@@ -460,30 +460,30 @@ class TestQCliProviderRegexPatterns:
 class TestQCliProviderPromptPatterns:
     """Test various prompt pattern combinations."""
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_basic_prompt(self, mock_tmux):
         """Test basic prompt without extras."""
-        mock_tmux.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer]\x1b[35m>\x1b[39m "
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_prompt_with_percentage(self, mock_tmux):
         """Test prompt with usage percentage."""
-        mock_tmux.get_history.return_value = "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_prompt_with_special_profile_characters(self, mock_tmux):
         """Test prompt with special characters in profile name."""
-        mock_tmux.get_history.return_value = "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
 
         provider = QCliProvider("test1234", "test-session", "window-0", "code-reviewer_v2")
         status = provider.get_status()
@@ -494,21 +494,21 @@ class TestQCliProviderPromptPatterns:
 class TestQCliProviderHandoffScenarios:
     """Test handoff scenarios between agents."""
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_successful_status(self, mock_tmux):
         """Test COMPLETED status detection with successful handoff."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_handoff_successful.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_handoff_successful.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
 
         assert status == TerminalStatus.COMPLETED
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_successful_message_extraction(self, mock_tmux):
         """Test message extraction from successful handoff output."""
         output = load_fixture("q_cli_handoff_successful.txt")
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = QCliProvider("test1234", "test-session", "window-0", "supervisor")
         message = provider.extract_last_message_from_script(output)
@@ -520,21 +520,21 @@ class TestQCliProviderHandoffScenarios:
         assert "completed successfully" in message.lower()
         assert "developer agent" in message.lower()
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_error_status(self, mock_tmux):
         """Test ERROR status detection with failed handoff."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_handoff_error.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_handoff_error.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
 
         assert status == TerminalStatus.ERROR
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_error_message_extraction(self, mock_tmux):
         """Test message extraction from failed handoff output."""
         output = load_fixture("q_cli_handoff_error.txt")
-        mock_tmux.get_history.return_value = output
+        mock_tmux.return_value.get_history.return_value = output
 
         provider = QCliProvider("test1234", "test-session", "window-0", "supervisor")
 
@@ -545,17 +545,17 @@ class TestQCliProviderHandoffScenarios:
         assert "\x1b[" not in message
         assert "error" in message.lower() or "unable" in message.lower()
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_with_permission_prompt(self, mock_tmux):
         """Test WAITING_USER_ANSWER status during handoff requiring permission."""
-        mock_tmux.get_history.return_value = load_fixture("q_cli_handoff_with_permission.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_handoff_with_permission.txt")
 
         provider = QCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_message_preserves_content(self, mock_tmux):
         """Test that handoff message extraction preserves all content without truncation."""
         output = load_fixture("q_cli_handoff_successful.txt")
@@ -570,7 +570,7 @@ class TestQCliProviderHandoffScenarios:
         # Verify it's not truncated or corrupted
         assert len(message.split()) >= 8  # Should have multiple words
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_indices_not_corrupted(self, mock_tmux):
         """Test that ANSI code cleaning doesn't corrupt index-based extraction."""
         output = load_fixture("q_cli_handoff_successful.txt")
@@ -616,21 +616,21 @@ class TestQCliProviderEdgeCases:
 
         assert provider._initialized is False
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_long_agent_profile_name(self, mock_tmux):
         """Test with very long agent profile name."""
         long_profile = "very_long_agent_profile_name_that_exceeds_normal_length"
-        mock_tmux.get_history.return_value = f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
 
         provider = QCliProvider("test1234", "test-session", "window-0", long_profile)
         status = provider.get_status()
 
         assert status == TerminalStatus.IDLE
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_output_with_unicode_characters(self, mock_tmux):
         """Test handling of unicode characters in output."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;10m> \x1b[39mResponse with unicode: 日本語 café naïve 🚀\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
         )
@@ -641,30 +641,30 @@ class TestQCliProviderEdgeCases:
         assert status == TerminalStatus.COMPLETED
 
         # Test message extraction
-        message = provider.extract_last_message_from_script(mock_tmux.get_history.return_value)
+        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
         assert "日本語" in message
         assert "café" in message
         assert "🚀" in message
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_output_with_control_characters(self, mock_tmux):
         """Test handling of control characters."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "\x1b[38;5;10m> \x1b[39mResponse\x07with\x1bcontrol\x00chars\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
         )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
-        message = provider.extract_last_message_from_script(mock_tmux.get_history.return_value)
+        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
 
         # Control characters should be cleaned
         assert "\x07" not in message  # Bell
         assert "\x00" not in message  # Null
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_multiple_error_indicators(self, mock_tmux):
         """Test detection with multiple error indicators."""
-        mock_tmux.get_history.return_value = (
+        mock_tmux.return_value.get_history.return_value = (
             "Amazon Q is having trouble responding right now\n"
             "Amazon Q is having trouble responding right now\n"
             "\x1b[36m[developer]\x1b[35m>\x1b[39m"
@@ -684,7 +684,7 @@ class TestQCliProviderEdgeCases:
         assert provider.window_name == "window-0"
         assert provider._agent_profile == "developer"
 
-    @patch("cli_agent_orchestrator.providers.q_cli.tmux_client")
+    @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_whitespace_variations_in_prompt(self, mock_tmux):
         """Test various whitespace scenarios in prompts."""
         test_cases = [
@@ -697,6 +697,6 @@ class TestQCliProviderEdgeCases:
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
 
         for test_output in test_cases:
-            mock_tmux.get_history.return_value = test_output
+            mock_tmux.return_value.get_history.return_value = test_output
             status = provider.get_status()
             assert status == TerminalStatus.IDLE

--- a/test/providers/test_q_cli_unit.py
+++ b/test/providers/test_q_cli_unit.py
@@ -101,7 +101,9 @@ class TestQCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_processing(self, mock_tmux):
         """Test PROCESSING status detection."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_processing_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "q_cli_processing_output.txt"
+        )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -111,7 +113,9 @@ class TestQCliProviderStatusDetection:
     @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_get_status_waiting_user_answer(self, mock_tmux):
         """Test WAITING_USER_ANSWER status detection."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_permission_output.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "q_cli_permission_output.txt"
+        )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -147,7 +151,9 @@ class TestQCliProviderStatusDetection:
         status = provider.get_status(tail_lines=50)
 
         assert status == TerminalStatus.IDLE
-        mock_tmux.return_value.get_history.assert_called_once_with("test-session", "window-0", tail_lines=50)
+        mock_tmux.return_value.get_history.assert_called_once_with(
+            "test-session", "window-0", tail_lines=50
+        )
 
     @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_status_processing_response_started_no_final_prompt(self, mock_tmux):
@@ -216,7 +222,9 @@ class TestQCliProviderStatusDetection:
         assert status == TerminalStatus.COMPLETED
 
         # Verify extraction gets the last response
-        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
+        message = provider.extract_last_message_from_script(
+            mock_tmux.return_value.get_history.return_value
+        )
         assert "Second response" in message
         assert "First response" not in message
 
@@ -473,7 +481,9 @@ class TestQCliProviderPromptPatterns:
     @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_prompt_with_percentage(self, mock_tmux):
         """Test prompt with usage percentage."""
-        mock_tmux.return_value.get_history.return_value = "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = (
+            "\x1b[36m[developer] \x1b[32m75%\x1b[35m>\x1b[39m "
+        )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status()
@@ -483,7 +493,9 @@ class TestQCliProviderPromptPatterns:
     @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_prompt_with_special_profile_characters(self, mock_tmux):
         """Test prompt with special characters in profile name."""
-        mock_tmux.return_value.get_history.return_value = "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = (
+            "\x1b[36m[code-reviewer_v2]\x1b[35m>\x1b[39m "
+        )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "code-reviewer_v2")
         status = provider.get_status()
@@ -497,7 +509,9 @@ class TestQCliProviderHandoffScenarios:
     @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_successful_status(self, mock_tmux):
         """Test COMPLETED status detection with successful handoff."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_handoff_successful.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "q_cli_handoff_successful.txt"
+        )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
@@ -548,7 +562,9 @@ class TestQCliProviderHandoffScenarios:
     @patch("cli_agent_orchestrator.providers.q_cli.get_backend")
     def test_handoff_with_permission_prompt(self, mock_tmux):
         """Test WAITING_USER_ANSWER status during handoff requiring permission."""
-        mock_tmux.return_value.get_history.return_value = load_fixture("q_cli_handoff_with_permission.txt")
+        mock_tmux.return_value.get_history.return_value = load_fixture(
+            "q_cli_handoff_with_permission.txt"
+        )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "supervisor")
         status = provider.get_status()
@@ -620,7 +636,9 @@ class TestQCliProviderEdgeCases:
     def test_long_agent_profile_name(self, mock_tmux):
         """Test with very long agent profile name."""
         long_profile = "very_long_agent_profile_name_that_exceeds_normal_length"
-        mock_tmux.return_value.get_history.return_value = f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
+        mock_tmux.return_value.get_history.return_value = (
+            f"\x1b[36m[{long_profile}]\x1b[35m>\x1b[39m "
+        )
 
         provider = QCliProvider("test1234", "test-session", "window-0", long_profile)
         status = provider.get_status()
@@ -641,7 +659,9 @@ class TestQCliProviderEdgeCases:
         assert status == TerminalStatus.COMPLETED
 
         # Test message extraction
-        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
+        message = provider.extract_last_message_from_script(
+            mock_tmux.return_value.get_history.return_value
+        )
         assert "日本語" in message
         assert "café" in message
         assert "🚀" in message
@@ -655,7 +675,9 @@ class TestQCliProviderEdgeCases:
         )
 
         provider = QCliProvider("test1234", "test-session", "window-0", "developer")
-        message = provider.extract_last_message_from_script(mock_tmux.return_value.get_history.return_value)
+        message = provider.extract_last_message_from_script(
+            mock_tmux.return_value.get_history.return_value
+        )
 
         # Control characters should be cleaned
         assert "\x07" not in message  # Bell

--- a/test/services/test_flow_service.py
+++ b/test/services/test_flow_service.py
@@ -368,14 +368,14 @@ class TestExecuteFlow:
     @patch("cli_agent_orchestrator.services.flow_service.send_input")
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
     @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.get_backend")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_without_script(
         self,
         mock_db_get,
         mock_update_times,
-        mock_tmux_client,
+        mock_get_backend,
         mock_list_terminals,
         mock_create_terminal,
         mock_send_input,
@@ -405,7 +405,7 @@ Simple prompt without variables.
             next_run=datetime.now(),
         )
         mock_db_get.return_value = mock_flow
-        mock_tmux_client.session_exists.return_value = False
+        mock_get_backend.return_value.session_exists.return_value = False
 
         mock_terminal = MagicMock()
         mock_terminal.id = "terminal-123"
@@ -421,14 +421,14 @@ Simple prompt without variables.
     @patch("cli_agent_orchestrator.services.flow_service.send_input")
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
     @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.get_backend")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_with_script_execute_true(
         self,
         mock_db_get,
         mock_update_times,
-        mock_tmux_client,
+        mock_get_backend,
         mock_list_terminals,
         mock_create_terminal,
         mock_send_input,
@@ -463,7 +463,7 @@ Value is [[value]].
                 next_run=datetime.now(),
             )
             mock_db_get.return_value = mock_flow
-            mock_tmux_client.session_exists.return_value = False
+            mock_get_backend.return_value.session_exists.return_value = False
 
             # Mock script output
             mock_subprocess.return_value = MagicMock(
@@ -619,14 +619,14 @@ Prompt.
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
     @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
     @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.get_backend")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_skips_when_session_busy(
         self,
         mock_db_get,
         mock_update_times,
-        mock_tmux_client,
+        mock_get_backend,
         mock_list_terminals,
         mock_provider_manager,
         mock_create_terminal,
@@ -649,7 +649,7 @@ Prompt.
                 next_run=datetime.now(),
             )
         mock_db_get.return_value = mock_flow
-        mock_tmux_client.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = [{"id": "t1", "agent_profile": "developer"}]
         mock_provider = MagicMock()
         mock_provider.get_status.return_value = TerminalStatus.PROCESSING
@@ -659,21 +659,21 @@ Prompt.
 
         assert result is False
         mock_create_terminal.assert_not_called()
-        mock_tmux_client.kill_session.assert_not_called()
+        mock_get_backend.return_value.kill_session.assert_not_called()
 
     @patch("cli_agent_orchestrator.services.flow_service.delete_terminals_by_session")
     @patch("cli_agent_orchestrator.services.flow_service.send_input")
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
     @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
     @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.get_backend")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_kills_idle_session_and_proceeds(
         self,
         mock_db_get,
         mock_update_times,
-        mock_tmux_client,
+        mock_get_backend,
         mock_list_terminals,
         mock_provider_manager,
         mock_create_terminal,
@@ -697,7 +697,7 @@ Prompt.
                 next_run=datetime.now(),
             )
         mock_db_get.return_value = mock_flow
-        mock_tmux_client.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = [{"id": "t1"}]
         mock_provider = MagicMock()
         mock_provider.get_status.return_value = TerminalStatus.IDLE
@@ -709,7 +709,7 @@ Prompt.
         result = execute_flow("idle-flow")
 
         assert result is True
-        mock_tmux_client.kill_session.assert_called_once()
+        mock_get_backend.return_value.kill_session.assert_called_once()
         mock_provider_manager.cleanup_provider.assert_called_once_with("t1")
         mock_create_terminal.assert_called_once()
 
@@ -718,14 +718,14 @@ Prompt.
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
     @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
     @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.get_backend")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_handles_unknown_provider_as_non_busy(
         self,
         mock_db_get,
         mock_update_times,
-        mock_tmux_client,
+        mock_get_backend,
         mock_list_terminals,
         mock_provider_manager,
         mock_create_terminal,
@@ -749,7 +749,7 @@ Prompt.
                 next_run=datetime.now(),
             )
         mock_db_get.return_value = mock_flow
-        mock_tmux_client.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = [{"id": "t1"}]
         mock_provider_manager.get_provider.side_effect = ValueError("unknown terminal")
         mock_terminal = MagicMock()
@@ -759,7 +759,7 @@ Prompt.
         result = execute_flow("orphan-provider-flow")
 
         assert result is True
-        mock_tmux_client.kill_session.assert_called_once()
+        mock_get_backend.return_value.kill_session.assert_called_once()
         mock_create_terminal.assert_called_once()
 
     @patch("cli_agent_orchestrator.services.flow_service.delete_terminals_by_session")
@@ -767,14 +767,14 @@ Prompt.
     @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
     @patch("cli_agent_orchestrator.services.flow_service.provider_manager")
     @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.flow_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.flow_service.get_backend")
     @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
     @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
     def test_execute_flow_kills_orphaned_session(
         self,
         mock_db_get,
         mock_update_times,
-        mock_tmux_client,
+        mock_get_backend,
         mock_list_terminals,
         mock_provider_manager,
         mock_create_terminal,
@@ -798,7 +798,7 @@ Prompt.
                 next_run=datetime.now(),
             )
         mock_db_get.return_value = mock_flow
-        mock_tmux_client.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = []
         mock_terminal = MagicMock()
         mock_terminal.id = "terminal-123"
@@ -807,7 +807,7 @@ Prompt.
         result = execute_flow("empty-session-flow")
 
         assert result is True
-        mock_tmux_client.kill_session.assert_called_once()
+        mock_get_backend.return_value.kill_session.assert_called_once()
         mock_create_terminal.assert_called_once()
         mock_provider_manager.get_provider.assert_not_called()
 

--- a/test/services/test_herdr_inbox_registry.py
+++ b/test/services/test_herdr_inbox_registry.py
@@ -118,8 +118,7 @@ class TestModuleImport:
         attribute, so it actually exercises the import.
         """
         service_name = "cli_agent_orchestrator.services.herdr_inbox_service"
-        probe = textwrap.dedent(
-            f"""
+        probe = textwrap.dedent(f"""
             import sys
             import cli_agent_orchestrator.services.herdr_inbox_registry as r
             assert r.get_herdr_inbox_service() is None, "default should be None"
@@ -128,8 +127,7 @@ class TestModuleImport:
                 "TYPE_CHECKING guard was defeated"
             )
             print("OK")
-            """
-        )
+            """)
         result = subprocess.run(
             [sys.executable, "-c", probe],
             capture_output=True,

--- a/test/services/test_herdr_inbox_registry.py
+++ b/test/services/test_herdr_inbox_registry.py
@@ -1,0 +1,148 @@
+"""Tests for the HerdrInboxService registry.
+
+The registry stores its state in a module-level global
+(`_herdr_inbox_service`) that persists for the lifetime of the process. The
+`reset_registry` autouse fixture below resets that global before and after
+every test so the cases stay independent (no test depends on another's set()).
+"""
+
+import importlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from cli_agent_orchestrator.services import herdr_inbox_registry
+from cli_agent_orchestrator.services.herdr_inbox_registry import (
+    get_herdr_inbox_service,
+    set_herdr_inbox_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset the module-level singleton before and after each test.
+
+    Without this, a set() in one test leaks into the next and breaks the
+    "default is None" expectation. We reset on both sides so a test that runs
+    first sees a clean slate and a test that runs last does not pollute others.
+    """
+    herdr_inbox_registry._herdr_inbox_service = None
+    yield
+    herdr_inbox_registry._herdr_inbox_service = None
+
+
+class TestGetHerdrInboxService:
+    """Tests for get_herdr_inbox_service / default state."""
+
+    def test_get_returns_none_before_any_set(self):
+        """get() returns None when nothing has been set yet."""
+        assert get_herdr_inbox_service() is None
+
+    def test_module_default_is_none_on_fresh_import(self):
+        """The module-level default is genuinely None on a fresh import.
+
+        Reloading re-executes the module body, so this asserts the declared
+        default rather than the value the reset fixture happens to install.
+        """
+        reloaded = importlib.reload(herdr_inbox_registry)
+        assert reloaded.get_herdr_inbox_service() is None
+
+
+class TestSetHerdrInboxService:
+    """Tests for set_herdr_inbox_service round-trip and overwrite behavior."""
+
+    def test_set_then_get_round_trip(self):
+        """set() stores the exact object get() later returns (identity)."""
+        service = object()
+
+        set_herdr_inbox_service(service)  # type: ignore[arg-type]
+
+        assert get_herdr_inbox_service() is service
+
+    def test_set_twice_returns_latest_value(self):
+        """A second set() overwrites the first; get() returns the latest."""
+        first = object()
+        second = object()
+
+        set_herdr_inbox_service(first)  # type: ignore[arg-type]
+        set_herdr_inbox_service(second)  # type: ignore[arg-type]
+
+        result = get_herdr_inbox_service()
+        assert result is second
+        assert result is not first
+
+    def test_set_accepts_arbitrary_object_via_duck_typing(self):
+        """The forward-ref type hint is not enforced at runtime.
+
+        Any object is accepted and returned unchanged, so callers can inject a
+        test double (MagicMock, sentinel, or plain value) without subclassing
+        HerdrInboxService.
+        """
+        for sentinel in (object(), "a-string", 123, {"k": "v"}):
+            set_herdr_inbox_service(sentinel)  # type: ignore[arg-type]
+            assert get_herdr_inbox_service() is sentinel
+
+    def test_set_none_overwrites_back_to_unset(self):
+        """set(None) clears a previously configured service (no validation).
+
+        Adversarial: the signature advertises a HerdrInboxService, but None is
+        accepted and round-trips, indistinguishable from the never-set state.
+        """
+        set_herdr_inbox_service(object())  # type: ignore[arg-type]
+        assert get_herdr_inbox_service() is not None
+
+        set_herdr_inbox_service(None)  # type: ignore[arg-type]
+
+        assert get_herdr_inbox_service() is None
+
+
+class TestModuleImport:
+    """Tests guarding the TYPE_CHECKING import that breaks the circular dep."""
+
+    def test_registry_imports_without_importing_service(self):
+        """Importing the registry must not import HerdrInboxService at runtime.
+
+        The service import lives under a TYPE_CHECKING guard precisely to break
+        the registry <-> service circular import. If someone moves that import
+        to module scope, importing the registry would drag the service module
+        into sys.modules.
+
+        This MUST run in a fresh interpreter. In-process, the parent package
+        (`...services`) keeps a `herdr_inbox_service` attribute and the module
+        object lingers in sys.modules from earlier imports, so a same-process
+        pop() + re-import cannot prove the guard holds -- a module-scope
+        `from ...services import herdr_inbox_service` mutant would survive. A
+        clean subprocess has neither the cached module nor the package
+        attribute, so it actually exercises the import.
+        """
+        service_name = "cli_agent_orchestrator.services.herdr_inbox_service"
+        probe = textwrap.dedent(
+            f"""
+            import sys
+            import cli_agent_orchestrator.services.herdr_inbox_registry as r
+            assert r.get_herdr_inbox_service() is None, "default should be None"
+            assert "{service_name}" not in sys.modules, (
+                "registry import pulled in the service module -- the "
+                "TYPE_CHECKING guard was defeated"
+            )
+            print("OK")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"subprocess import probe failed:\n"
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        )
+        assert "OK" in result.stdout
+
+    def test_public_callables_present_after_import(self):
+        """Both public functions are importable and callable."""
+        reloaded = importlib.reload(herdr_inbox_registry)
+        assert callable(reloaded.get_herdr_inbox_service)
+        assert callable(reloaded.set_herdr_inbox_service)

--- a/test/services/test_inbox_service.py
+++ b/test/services/test_inbox_service.py
@@ -121,14 +121,18 @@ class TestCheckAndSendPendingMessages:
     @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
     @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
     def test_terminal_not_ready(self, mock_get_messages, mock_provider_manager):
-        """Test when terminal not ready."""
+        """Test when terminal not ready (PROCESSING, eager disabled -> skip)."""
         mock_message = MagicMock()
         mock_get_messages.return_value = [mock_message]
         mock_provider = MagicMock()
         mock_provider.get_status.return_value = TerminalStatus.PROCESSING
+        mock_provider.accepts_input_while_processing = False
         mock_provider_manager.get_provider.return_value = mock_provider
 
-        result = check_and_send_pending_messages("test-terminal")
+        # Pin the env-driven flag so the test is hermetic regardless of
+        # CAO_EAGER_INBOX_DELIVERY in the runner's environment.
+        with patch("cli_agent_orchestrator.services.inbox_service.EAGER_INBOX_DELIVERY", False):
+            result = check_and_send_pending_messages("test-terminal")
 
         assert result is False
 
@@ -221,7 +225,7 @@ class TestEagerInboxDelivery:
     """Tests for eager inbox delivery (CAO_EAGER_INBOX_DELIVERY).
 
     Covers the relaxed status gate in check_and_send_pending_messages() that
-    allows PROCESSING and WAITING_USER_ANSWER delivery when the env var is
+    allows PROCESSING delivery when the env var is
     enabled and the provider declares accepts_input_while_processing=True.
     """
 
@@ -323,14 +327,18 @@ class TestEagerInboxDelivery:
 
         assert result is False
 
-    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
     @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
     @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
     @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
     def test_delivery_waiting_user_answer_with_eager_enabled_and_capable_provider(
-        self, mock_get_messages, mock_pm, mock_ts, mock_update
+        self, mock_get_messages, mock_pm, mock_ts
     ):
-        """WAITING_USER_ANSWER + eager ON + capable provider -> delivers."""
+        """WAITING_USER_ANSWER -> stays pending, not eagerly delivered.
+
+        Even under the most delivery-favorable conditions (eager ON + capable
+        provider), WAITING_USER_ANSWER must not deliver: the agent is blocked on
+        a prompt and typing into it would answer the wrong question.
+        """
         mock_get_messages.return_value = [self._make_message()]
         provider = MagicMock()
         provider.get_status.return_value = TerminalStatus.WAITING_USER_ANSWER
@@ -340,8 +348,8 @@ class TestEagerInboxDelivery:
         with patch("cli_agent_orchestrator.services.inbox_service.EAGER_INBOX_DELIVERY", True):
             result = check_and_send_pending_messages("t1")
 
-        assert result is True
-        mock_ts.send_input.assert_called_once()
+        assert result is False
+        mock_ts.send_input.assert_not_called()
 
     @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
     @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")

--- a/test/services/test_inbox_service.py
+++ b/test/services/test_inbox_service.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from cli_agent_orchestrator.backends.base import TerminalNotFoundError
 from cli_agent_orchestrator.constants import INBOX_RECONCILE_GRACE_SECONDS
 from cli_agent_orchestrator.models.inbox import MessageStatus
 from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -219,6 +220,34 @@ class TestCheckAndSendPendingMessages:
 
         assert order[0] == ("update", (1, MessageStatus.DELIVERED))
         assert order[1][0] == "send"
+
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_resolution_failure_leaves_message_pending(
+        self, mock_get_messages, mock_provider_manager, mock_terminal_service, mock_update_status
+    ):
+        """A TerminalNotFoundError during send leaves the message PENDING, not FAILED.
+
+        Pane resolution can transiently fail (e.g. herdr pane not yet resolvable).
+        The message must remain pending for a later retry rather than being marked
+        FAILED or silently misrouted.
+        """
+        mock_message = MagicMock()
+        mock_message.id = 1
+        mock_message.message = "test message"
+        mock_get_messages.return_value = [mock_message]
+        mock_provider = MagicMock()
+        mock_provider.get_status.return_value = TerminalStatus.IDLE
+        mock_provider_manager.get_provider.return_value = mock_provider
+        mock_terminal_service.send_input.side_effect = TerminalNotFoundError("s:w")
+
+        result = check_and_send_pending_messages("test-terminal")
+
+        assert result is False
+        # Message stays pending: status is never updated to DELIVERED or FAILED
+        mock_update_status.assert_not_called()
 
 
 class TestEagerInboxDelivery:

--- a/test/services/test_inbox_service.py
+++ b/test/services/test_inbox_service.py
@@ -231,8 +231,9 @@ class TestCheckAndSendPendingMessages:
         """A TerminalNotFoundError during send leaves the message PENDING, not FAILED.
 
         Pane resolution can transiently fail (e.g. herdr pane not yet resolvable).
-        The message must remain pending for a later retry rather than being marked
-        FAILED or silently misrouted.
+        Status is optimistically set DELIVERED before send (to close the watchdog
+        re-entrancy race), so on a resolution failure it must be reset to PENDING
+        for a later retry — never left DELIVERED or marked FAILED.
         """
         mock_message = MagicMock()
         mock_message.id = 1
@@ -246,8 +247,9 @@ class TestCheckAndSendPendingMessages:
         result = check_and_send_pending_messages("test-terminal")
 
         assert result is False
-        # Message stays pending: status is never updated to DELIVERED or FAILED
-        mock_update_status.assert_not_called()
+        # Final status is PENDING (reset after the optimistic DELIVERED), never FAILED.
+        assert mock_update_status.call_args_list[-1] == call(1, MessageStatus.PENDING)
+        assert call(1, MessageStatus.FAILED) not in mock_update_status.call_args_list
 
 
 class TestEagerInboxDelivery:

--- a/test/services/test_plugin_event_emission.py
+++ b/test/services/test_plugin_event_emission.py
@@ -86,7 +86,9 @@ class TestSessionPluginEvents:
             call_order.append("dispatch")
 
         mock_tmux.return_value.session_exists.return_value = True
-        mock_tmux.return_value.kill_session.side_effect = lambda *_: call_order.append("kill_session")
+        mock_tmux.return_value.kill_session.side_effect = lambda *_: call_order.append(
+            "kill_session"
+        )
         mock_list_terminals.return_value = []
         mock_delete_terminals.side_effect = lambda *_: call_order.append("delete_terminals")
         registry.dispatch.side_effect = record_dispatch

--- a/test/services/test_plugin_event_emission.py
+++ b/test/services/test_plugin_event_emission.py
@@ -74,7 +74,7 @@ class TestSessionPluginEvents:
 
     @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_session")
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
     def test_delete_session_dispatches_post_kill_session_event_after_cleanup(
         self, mock_tmux, mock_list_terminals, mock_delete_terminals
     ):
@@ -85,8 +85,8 @@ class TestSessionPluginEvents:
         async def record_dispatch(*_args):
             call_order.append("dispatch")
 
-        mock_tmux.session_exists.return_value = True
-        mock_tmux.kill_session.side_effect = lambda *_: call_order.append("kill_session")
+        mock_tmux.return_value.session_exists.return_value = True
+        mock_tmux.return_value.kill_session.side_effect = lambda *_: call_order.append("kill_session")
         mock_list_terminals.return_value = []
         mock_delete_terminals.side_effect = lambda *_: call_order.append("delete_terminals")
         registry.dispatch.side_effect = record_dispatch
@@ -101,13 +101,15 @@ class TestSessionPluginEvents:
         assert event.session_id == "cao-demo"
         assert event.session_name == "cao-demo"
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_delete_session_does_not_dispatch_on_failure(self, mock_tmux):
-        """Missing sessions should raise without emitting events."""
+    @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_delete_session_does_not_dispatch_on_failure(self, mock_tmux, mock_list_terminals):
+        """Session deletion failures must not emit events."""
         registry = _registry_mock()
-        mock_tmux.session_exists.return_value = False
+        mock_tmux.return_value.session_exists.return_value = True
+        mock_list_terminals.side_effect = RuntimeError("db error")
 
-        with pytest.raises(ValueError, match="Session 'cao-missing' not found"):
+        with pytest.raises(RuntimeError, match="db error"):
             delete_session("cao-missing", registry=registry)
 
         registry.dispatch.assert_not_awaited()
@@ -121,7 +123,7 @@ class TestTerminalPluginEvents:
     @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     def test_create_terminal_dispatches_post_create_terminal_event_after_setup(
@@ -183,7 +185,7 @@ class TestTerminalPluginEvents:
     @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     def test_create_terminal_does_not_dispatch_on_failure(
@@ -223,7 +225,7 @@ class TestTerminalPluginEvents:
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal", return_value=True)
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_dispatches_post_kill_terminal_event_after_delete(
         self, mock_get_metadata, mock_tmux, mock_provider_manager, mock_db_delete_terminal
@@ -257,7 +259,7 @@ class TestTerminalPluginEvents:
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_does_not_dispatch_on_failure(
         self, mock_get_metadata, mock_tmux, mock_provider_manager, mock_db_delete_terminal
@@ -282,7 +284,7 @@ class TestMessagePluginEvents:
 
     @pytest.mark.parametrize("orchestration_type", ["send_message", "assign", "handoff"])
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_dispatches_post_send_message_event_for_each_orchestration_mode(
@@ -331,7 +333,7 @@ class TestMessagePluginEvents:
         assert event.message == "Hello from supervisor"
         assert event.orchestration_type == orchestration_type
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_does_not_dispatch_on_failure(

--- a/test/services/test_session_service.py
+++ b/test/services/test_session_service.py
@@ -105,7 +105,9 @@ class TestGetSession:
     def test_get_session_success(self, mock_get_backend, mock_list_terminals):
         """Test getting session successfully."""
         mock_get_backend.return_value.session_exists.return_value = True
-        mock_get_backend.return_value.list_sessions.return_value = [{"id": "cao-test", "name": "Test Session"}]
+        mock_get_backend.return_value.list_sessions.return_value = [
+            {"id": "cao-test", "name": "Test Session"}
+        ]
         mock_list_terminals.return_value = [{"id": "terminal1", "session": "cao-test"}]
 
         result = get_session("cao-test")

--- a/test/services/test_session_service.py
+++ b/test/services/test_session_service.py
@@ -52,10 +52,10 @@ class TestCreateSession:
 class TestListSessions:
     """Tests for list_sessions function."""
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_list_sessions_success(self, mock_tmux):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_list_sessions_success(self, mock_get_backend):
         """Test listing sessions successfully."""
-        mock_tmux.list_sessions.return_value = [
+        mock_get_backend.return_value.list_sessions.return_value = [
             {"id": "cao-session1", "name": "Session 1"},
             {"id": "cao-session2", "name": "Session 2"},
             {"id": "other-session", "name": "Other"},
@@ -66,19 +66,19 @@ class TestListSessions:
         assert len(result) == 2
         assert all(s["id"].startswith("cao-") for s in result)
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_list_sessions_empty(self, mock_tmux):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_list_sessions_empty(self, mock_get_backend):
         """Test listing sessions when none exist."""
-        mock_tmux.list_sessions.return_value = []
+        mock_get_backend.return_value.list_sessions.return_value = []
 
         result = list_sessions()
 
         assert result == []
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_list_sessions_no_cao_sessions(self, mock_tmux):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_list_sessions_no_cao_sessions(self, mock_get_backend):
         """Test listing sessions when no CAO sessions exist."""
-        mock_tmux.list_sessions.return_value = [
+        mock_get_backend.return_value.list_sessions.return_value = [
             {"id": "other-session1", "name": "Other 1"},
             {"id": "other-session2", "name": "Other 2"},
         ]
@@ -87,10 +87,10 @@ class TestListSessions:
 
         assert result == []
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_list_sessions_error(self, mock_tmux):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_list_sessions_error(self, mock_get_backend):
         """Test listing sessions with error."""
-        mock_tmux.list_sessions.side_effect = Exception("Tmux error")
+        mock_get_backend.return_value.list_sessions.side_effect = Exception("Tmux error")
 
         result = list_sessions()
 
@@ -101,40 +101,40 @@ class TestGetSession:
     """Tests for get_session function."""
 
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_get_session_success(self, mock_tmux, mock_list_terminals):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_get_session_success(self, mock_get_backend, mock_list_terminals):
         """Test getting session successfully."""
-        mock_tmux.session_exists.return_value = True
-        mock_tmux.list_sessions.return_value = [{"id": "cao-test", "name": "Test Session"}]
+        mock_get_backend.return_value.session_exists.return_value = True
+        mock_get_backend.return_value.list_sessions.return_value = [{"id": "cao-test", "name": "Test Session"}]
         mock_list_terminals.return_value = [{"id": "terminal1", "session": "cao-test"}]
 
         result = get_session("cao-test")
 
         assert result["session"]["id"] == "cao-test"
         assert len(result["terminals"]) == 1
-        mock_tmux.session_exists.assert_called_once_with("cao-test")
+        mock_get_backend.return_value.session_exists.assert_called_once_with("cao-test")
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_get_session_not_found(self, mock_tmux):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_get_session_not_found(self, mock_get_backend):
         """Test getting non-existent session."""
-        mock_tmux.session_exists.return_value = False
+        mock_get_backend.return_value.session_exists.return_value = False
 
         with pytest.raises(ValueError, match="Session 'cao-nonexistent' not found"):
             get_session("cao-nonexistent")
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_get_session_not_in_list(self, mock_tmux):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_get_session_not_in_list(self, mock_get_backend):
         """Test getting session that exists but not in list."""
-        mock_tmux.session_exists.return_value = True
-        mock_tmux.list_sessions.return_value = []
+        mock_get_backend.return_value.session_exists.return_value = True
+        mock_get_backend.return_value.list_sessions.return_value = []
 
         with pytest.raises(ValueError, match="Session 'cao-test' not found"):
             get_session("cao-test")
 
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_get_session_error(self, mock_tmux):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_get_session_error(self, mock_get_backend):
         """Test getting session with error."""
-        mock_tmux.session_exists.side_effect = Exception("Tmux error")
+        mock_get_backend.return_value.session_exists.side_effect = Exception("Tmux error")
 
         with pytest.raises(Exception, match="Tmux error"):
             get_session("cao-test")
@@ -146,12 +146,12 @@ class TestDeleteSession:
     @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_session")
     @patch("cli_agent_orchestrator.services.session_service.provider_manager")
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
     def test_delete_session_success(
-        self, mock_tmux, mock_list_terminals, mock_provider_manager, mock_delete_terminals
+        self, mock_get_backend, mock_list_terminals, mock_provider_manager, mock_delete_terminals
     ):
         """Test deleting session successfully."""
-        mock_tmux.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = [
             {"id": "terminal1"},
             {"id": "terminal2"},
@@ -160,27 +160,37 @@ class TestDeleteSession:
         result = delete_session("cao-test")
 
         assert result == {"deleted": ["cao-test"], "errors": []}
-        mock_tmux.kill_session.assert_called_once_with("cao-test")
+        mock_get_backend.return_value.kill_session.assert_called_once_with("cao-test")
         mock_delete_terminals.assert_called_once_with("cao-test")
         assert mock_provider_manager.cleanup_provider.call_count == 2
-
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_delete_session_not_found(self, mock_tmux):
-        """Test deleting non-existent session."""
-        mock_tmux.session_exists.return_value = False
-
-        with pytest.raises(ValueError, match="Session 'cao-nonexistent' not found"):
-            delete_session("cao-nonexistent")
 
     @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_session")
     @patch("cli_agent_orchestrator.services.session_service.provider_manager")
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_delete_session_when_backend_session_already_gone(
+        self, mock_get_backend, mock_list_terminals, mock_provider_manager, mock_delete_terminals
+    ):
+        """Backend session already gone — delete_session should not raise, not call kill_session,
+        but still call delete_terminals_by_session."""
+        mock_get_backend.return_value.session_exists.return_value = False
+        mock_list_terminals.return_value = [{"id": "terminal1"}]
+
+        result = delete_session("cao-test")
+
+        assert result == {"deleted": ["cao-test"], "errors": []}
+        mock_get_backend.return_value.kill_session.assert_not_called()
+        mock_delete_terminals.assert_called_once_with("cao-test")
+
+    @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.session_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
     def test_delete_session_no_terminals(
-        self, mock_tmux, mock_list_terminals, mock_provider_manager, mock_delete_terminals
+        self, mock_get_backend, mock_list_terminals, mock_provider_manager, mock_delete_terminals
     ):
         """Test deleting session with no terminals."""
-        mock_tmux.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = []
 
         result = delete_session("cao-test")
@@ -189,10 +199,10 @@ class TestDeleteSession:
         mock_provider_manager.cleanup_provider.assert_not_called()
 
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
-    def test_delete_session_error(self, mock_tmux, mock_list_terminals):
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_delete_session_error(self, mock_get_backend, mock_list_terminals):
         """Test deleting session with error."""
-        mock_tmux.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.side_effect = Exception("Database error")
 
         with pytest.raises(Exception, match="Database error"):
@@ -201,12 +211,12 @@ class TestDeleteSession:
     @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_session")
     @patch("cli_agent_orchestrator.services.session_service.provider_manager")
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
     def test_delete_session_continues_when_provider_cleanup_fails(
-        self, mock_tmux, mock_list_terminals, mock_provider_manager, mock_delete_terminals
+        self, mock_get_backend, mock_list_terminals, mock_provider_manager, mock_delete_terminals
     ):
         """Test that delete_session continues even when provider cleanup fails for some terminals."""
-        mock_tmux.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = [
             {"id": "terminal1"},
             {"id": "terminal2"},
@@ -224,7 +234,7 @@ class TestDeleteSession:
 
         # Session should still be deleted despite provider cleanup failure
         assert result == {"deleted": ["cao-test"], "errors": []}
-        mock_tmux.kill_session.assert_called_once_with("cao-test")
+        mock_get_backend.return_value.kill_session.assert_called_once_with("cao-test")
         mock_delete_terminals.assert_called_once_with("cao-test")
         # All three provider cleanups were attempted
         assert mock_provider_manager.cleanup_provider.call_count == 3
@@ -232,12 +242,12 @@ class TestDeleteSession:
     @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_session")
     @patch("cli_agent_orchestrator.services.session_service.provider_manager")
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
-    @patch("cli_agent_orchestrator.services.session_service.tmux_client")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
     def test_delete_session_cleans_up_provider_for_each_terminal(
-        self, mock_tmux, mock_list_terminals, mock_provider_manager, mock_delete_terminals
+        self, mock_get_backend, mock_list_terminals, mock_provider_manager, mock_delete_terminals
     ):
         """Test that delete_session calls cleanup_provider for every terminal in the session."""
-        mock_tmux.session_exists.return_value = True
+        mock_get_backend.return_value.session_exists.return_value = True
         mock_list_terminals.return_value = [
             {"id": "term-aaa"},
             {"id": "term-bbb"},

--- a/test/services/test_terminal_service.py
+++ b/test/services/test_terminal_service.py
@@ -13,7 +13,7 @@ from cli_agent_orchestrator.services.terminal_service import (
 class TestTerminalServiceWorkingDirectory:
     """Test terminal service working directory functionality."""
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_working_directory_success(self, mock_get_metadata, mock_tmux_client):
         """Test successful working directory retrieval."""
@@ -36,7 +36,7 @@ class TestTerminalServiceWorkingDirectory:
             "test-session", "test-window"
         )
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_working_directory_terminal_not_found(self, mock_get_metadata, mock_tmux_client):
         """Test ValueError when terminal not found."""
@@ -51,7 +51,7 @@ class TestTerminalServiceWorkingDirectory:
         mock_get_metadata.assert_called_once_with(terminal_id)
         mock_tmux_client.get_pane_working_directory.assert_not_called()
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_working_directory_returns_none(self, mock_get_metadata, mock_tmux_client):
         """Test when pane has no working directory."""
@@ -73,7 +73,7 @@ class TestTerminalServiceWorkingDirectory:
             "test-session", "test-window"
         )
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_working_directory_returns_directory_from_tmux_pane(
         self, mock_get_metadata, mock_tmux_client
@@ -97,7 +97,7 @@ class TestTerminalServiceWorkingDirectory:
             "cao-workspace", "developer-xyz"
         )
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_working_directory_raises_for_nonexistent_terminal(
         self, mock_get_metadata, mock_tmux_client
@@ -117,7 +117,7 @@ class TestSendSpecialKey:
     """Tests for send_special_key function."""
 
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_special_key_sends_key_via_tmux_client(
         self, mock_get_metadata, mock_tmux_client, mock_update_last_active
@@ -141,7 +141,7 @@ class TestSendSpecialKey:
         mock_update_last_active.assert_called_once_with(terminal_id)
 
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_special_key_ctrl_c(
         self, mock_get_metadata, mock_tmux_client, mock_update_last_active
@@ -163,7 +163,7 @@ class TestSendSpecialKey:
             "cao-session", "reviewer-efgh", "C-c"
         )
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_special_key_terminal_not_found(self, mock_get_metadata, mock_tmux_client):
         """Test that send_special_key raises ValueError when terminal not found."""
@@ -176,7 +176,7 @@ class TestSendSpecialKey:
 
         mock_tmux_client.send_special_key.assert_not_called()
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_special_key_propagates_tmux_errors(self, mock_get_metadata, mock_tmux_client):
         """Test that send_special_key propagates exceptions from tmux client."""
@@ -193,7 +193,7 @@ class TestSendSpecialKey:
             send_special_key(terminal_id, "Escape")
 
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_special_key_escape(
         self, mock_get_metadata, mock_tmux_client, mock_update_last_active

--- a/test/services/test_terminal_service_coverage.py
+++ b/test/services/test_terminal_service_coverage.py
@@ -15,7 +15,7 @@ class TestCreateTerminalCleanup:
     """Test error cleanup paths in create_terminal."""
 
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
@@ -60,7 +60,7 @@ class TestCreateTerminalCleanup:
         mock_tmux.kill_session.assert_called_once()
 
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
@@ -105,7 +105,7 @@ class TestCreateTerminalCleanup:
         mock_tmux.kill_session.assert_not_called()
 
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
@@ -149,7 +149,7 @@ class TestCreateTerminalCleanup:
             )
 
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
@@ -201,7 +201,7 @@ class TestCreateTerminalSessionCleanupGuard:
     """
 
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
@@ -239,7 +239,7 @@ class TestCreateTerminalSessionCleanupGuard:
         mock_tmux.kill_session.assert_not_called()
 
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
@@ -288,7 +288,7 @@ class TestDeleteTerminal:
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal", return_value=True)
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_full_path(self, mock_meta, mock_tmux, mock_pm, mock_db_del):
         """Delete should stop pipe-pane, kill window, cleanup provider, delete DB record."""
@@ -305,7 +305,7 @@ class TestDeleteTerminal:
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal", return_value=True)
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_pipe_pane_failure_continues(
         self, mock_meta, mock_tmux, mock_pm, mock_db_del
@@ -323,7 +323,7 @@ class TestDeleteTerminal:
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal", return_value=True)
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_kill_window_failure_continues(
         self, mock_meta, mock_tmux, mock_pm, mock_db_del
@@ -341,7 +341,7 @@ class TestDeleteTerminal:
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_db_failure_raises(self, mock_meta, mock_tmux, mock_pm, mock_db_del):
         """DB delete failure should propagate."""

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -26,7 +26,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -112,7 +112,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -145,7 +145,7 @@ class TestCreateTerminal:
         assert result.id == "test1234"
         mock_tmux.create_window.assert_called_once()
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -163,7 +163,7 @@ class TestCreateTerminal:
         with pytest.raises(ValueError, match="not found"):
             create_terminal("kiro_cli", "developer", session_name="cao-nonexistent")
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -184,7 +184,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -242,7 +242,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -286,7 +286,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -335,7 +335,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -373,7 +373,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -411,7 +411,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -499,7 +499,7 @@ class TestGetTerminal:
 class TestGetWorkingDirectory:
     """Tests for get_working_directory function."""
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_working_directory_success(self, mock_get_metadata, mock_tmux):
         """Test getting working directory successfully."""
@@ -527,7 +527,7 @@ class TestSendInput:
 
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_success(self, mock_get_metadata, mock_tmux, mock_pm, mock_update):
         """Test sending input successfully."""
@@ -637,7 +637,7 @@ class TestSendInput:
 class TestGetOutput:
     """Tests for get_output function."""
 
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_output_full(self, mock_get_metadata, mock_tmux):
         """Test getting full output."""
@@ -652,7 +652,7 @@ class TestGetOutput:
         assert result == "full terminal output"
 
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_output_last(self, mock_get_metadata, mock_tmux, mock_provider_manager):
         """Test getting last message."""
@@ -678,7 +678,7 @@ class TestGetOutput:
             get_output("nonexistent")
 
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_get_output_last_no_provider(self, mock_get_metadata, mock_tmux, mock_provider_manager):
         """Test getting last message when provider not found."""
@@ -692,13 +692,135 @@ class TestGetOutput:
         with pytest.raises(ValueError, match="Provider not found"):
             get_output("test1234", OutputMode.LAST)
 
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_get_output_last_escalates_and_finds_marker(
+        self, mock_get_metadata, mock_tmux, mock_provider_manager
+    ):
+        """Escalating fetch: marker not found at 200 lines, found at 500."""
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_tmux.get_history.return_value = "output"
+        mock_provider = MagicMock(spec=[
+            "extract_last_message_from_script",
+            "extraction_retries",
+        ])  # no extraction_tail_lines attribute → escalation path
+        mock_provider.extract_last_message_from_script.side_effect = [
+            ValueError("no marker"),  # 200-line attempt fails
+            "found at 500",  # 500-line attempt succeeds
+        ]
+        mock_provider_manager.get_provider.return_value = mock_provider
+
+        result = get_output("test1234", OutputMode.LAST)
+
+        assert result == "found at 500"
+        assert mock_tmux.get_history.call_count == 2
+
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_get_output_last_escalates_all_steps_then_partial(
+        self, mock_get_metadata, mock_tmux, mock_provider_manager
+    ):
+        """Escalating fetch: marker never found — returns PARTIAL RESPONSE prefix."""
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_tmux.get_history.return_value = "raw tail content"
+        mock_provider = MagicMock(spec=[
+            "extract_last_message_from_script",
+            "extraction_retries",
+        ])  # no extraction_tail_lines attribute → escalation path
+        mock_provider.extract_last_message_from_script.side_effect = ValueError("no marker")
+        mock_provider_manager.get_provider.return_value = mock_provider
+
+        result = get_output("test1234", OutputMode.LAST)
+
+        assert result.startswith("[PARTIAL RESPONSE")
+        assert "raw tail content" in result
+        # 4 escalation steps + 1 full_history attempt = 5 total
+        assert mock_tmux.get_history.call_count == 5
+        # Last call must use full_history=True
+        _, last_kwargs = mock_tmux.get_history.call_args
+        assert last_kwargs.get("full_history") is True
+
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_get_output_last_full_history_fallback_finds_marker(
+        self, mock_get_metadata, mock_tmux, mock_provider_manager
+    ):
+        """After all escalation steps fail, full_history=True recovers the marker."""
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_provider = MagicMock(spec=[
+            "extract_last_message_from_script",
+            "extraction_retries",
+        ])  # no extraction_tail_lines attribute → escalation path
+
+        # Tail-based reads fail (marker too far back), full_history read succeeds
+        def history_side_effect(*args, **kwargs):
+            if kwargs.get("full_history"):
+                return "full scrollback with ⏺ marker"
+            return "raw tail content without marker"
+
+        mock_tmux.get_history.side_effect = history_side_effect
+
+        def extract_side_effect(output):
+            if "full scrollback" in output:
+                return "recovered response"
+            raise ValueError("no marker")
+
+        mock_provider.extract_last_message_from_script.side_effect = extract_side_effect
+        mock_provider_manager.get_provider.return_value = mock_provider
+
+        result = get_output("test1234", OutputMode.LAST)
+
+        assert result == "recovered response"
+        assert mock_tmux.get_history.call_count == 5  # 4 steps + 1 full_history
+        _, last_kwargs = mock_tmux.get_history.call_args
+        assert last_kwargs.get("full_history") is True
+
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_get_output_last_fixed_extraction_tail_lines_skips_escalation(
+        self, mock_get_metadata, mock_tmux, mock_provider_manager
+    ):
+        """Providers that declare extraction_tail_lines bypass escalation entirely."""
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_tmux.get_history.return_value = "output"
+        mock_provider = MagicMock()
+        mock_provider.extraction_tail_lines = 2000  # provider pins depth
+        mock_provider.extraction_retries = 0
+        mock_provider.extract_last_message_from_script.return_value = "found"
+        mock_provider_manager.get_provider.return_value = mock_provider
+
+        result = get_output("test1234", OutputMode.LAST)
+
+        assert result == "found"
+        # Only one history call at the fixed depth, no escalation steps
+        assert mock_tmux.get_history.call_count == 1
+        mock_tmux.get_history.assert_called_once_with(
+            "cao-session", "developer-abcd", tail_lines=2000
+        )
+
 
 class TestDeleteTerminal:
     """Tests for delete_terminal function."""
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_success(
         self, mock_get_metadata, mock_tmux, mock_provider_manager, mock_db_delete
@@ -718,7 +840,7 @@ class TestDeleteTerminal:
 
     @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_delete_terminal_pipe_pane_error(
         self, mock_get_metadata, mock_tmux, mock_provider_manager, mock_db_delete

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -704,10 +704,12 @@ class TestGetOutput:
             "tmux_window": "developer-abcd",
         }
         mock_tmux.get_history.return_value = "output"
-        mock_provider = MagicMock(spec=[
-            "extract_last_message_from_script",
-            "extraction_retries",
-        ])  # no extraction_tail_lines attribute → escalation path
+        mock_provider = MagicMock(
+            spec=[
+                "extract_last_message_from_script",
+                "extraction_retries",
+            ]
+        )  # no extraction_tail_lines attribute → escalation path
         mock_provider.extract_last_message_from_script.side_effect = [
             ValueError("no marker"),  # 200-line attempt fails
             "found at 500",  # 500-line attempt succeeds
@@ -731,10 +733,12 @@ class TestGetOutput:
             "tmux_window": "developer-abcd",
         }
         mock_tmux.get_history.return_value = "raw tail content"
-        mock_provider = MagicMock(spec=[
-            "extract_last_message_from_script",
-            "extraction_retries",
-        ])  # no extraction_tail_lines attribute → escalation path
+        mock_provider = MagicMock(
+            spec=[
+                "extract_last_message_from_script",
+                "extraction_retries",
+            ]
+        )  # no extraction_tail_lines attribute → escalation path
         mock_provider.extract_last_message_from_script.side_effect = ValueError("no marker")
         mock_provider_manager.get_provider.return_value = mock_provider
 
@@ -759,10 +763,12 @@ class TestGetOutput:
             "tmux_session": "cao-session",
             "tmux_window": "developer-abcd",
         }
-        mock_provider = MagicMock(spec=[
-            "extract_last_message_from_script",
-            "extraction_retries",
-        ])  # no extraction_tail_lines attribute → escalation path
+        mock_provider = MagicMock(
+            spec=[
+                "extract_last_message_from_script",
+                "extraction_retries",
+            ]
+        )  # no extraction_tail_lines attribute → escalation path
 
         # Tail-based reads fail (marker too far back), full_history read succeeds
         def history_side_effect(*args, **kwargs):

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -63,7 +63,7 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
@@ -552,7 +552,7 @@ class TestSendInput:
 
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_blocks_assign_when_provider_waits_for_user_answer(
         self, mock_get_metadata, mock_tmux, mock_pm, mock_update
@@ -574,7 +574,7 @@ class TestSendInput:
 
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_blocked_message_uses_enum_value(
         self, mock_get_metadata, mock_tmux, mock_pm, mock_update
@@ -598,7 +598,7 @@ class TestSendInput:
 
     @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.services.terminal_service.tmux_client")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_allows_manual_answer_when_provider_waits_for_user_answer(
         self, mock_get_metadata, mock_tmux, mock_pm, mock_update

--- a/test/services/test_terminal_service_inbox_registration.py
+++ b/test/services/test_terminal_service_inbox_registration.py
@@ -1,0 +1,236 @@
+"""Unit tests for the herdr inbox registration/unregistration wiring in terminal_service.
+
+These tests verify the wiring between terminal lifecycle functions and the herdr inbox
+service, in isolation from real tmux/herdr:
+
+- create_terminal: registers the new terminal with the herdr inbox service when one is
+  available (herdr path), skips registration when the service is None (tmux path), and
+  never lets a registration failure tear down an otherwise-successful terminal.
+- delete_terminal: unregisters from the herdr inbox service when available and is a
+  no-op against the service when it is None.
+
+Note on signature: create_terminal's real signature is
+    create_terminal(provider, agent_profile, session_name=None, new_session=False,
+                    working_directory=None, allowed_tools=None, registry=None)
+so the keyword arguments below follow the implementation, not the (stale) task brief.
+"""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.models.provider import ProviderType
+from cli_agent_orchestrator.models.terminal import Terminal
+from cli_agent_orchestrator.services.terminal_service import (
+    create_terminal,
+    delete_terminal,
+)
+
+# Fixed identifiers used across the tests so assertions can be exact.
+TERMINAL_ID = "term-abc123"
+SESSION_NAME = "cao-test-session"
+WINDOW_NAME = "developer-wxyz"
+PANE_ID = "%42"
+
+# Module path prefix for patch targets (all dependencies are imported into the
+# terminal_service namespace, so they are patched there, not at their origin).
+_TS = "cli_agent_orchestrator.services.terminal_service."
+
+
+@pytest.fixture
+def create_mocks():
+    """Patch every external dependency of create_terminal and yield the mocks.
+
+    get_backend() returns a process-wide singleton in production, so a single MagicMock
+    backs every get_backend() call here; session_exists/create_window/get_pane_id/pipe_pane
+    are configured on that one object via ``get_backend.return_value``.
+
+    Defaults model the happy path on the herdr branch:
+    - existing tmux session (session_exists -> True), so new_session=False succeeds
+    - load_agent_profile -> None, which skips allowed-tools resolution and model lookup
+    - provider creates cleanly; shell_baseline is a MagicMock (not str) so it is treated
+      as None and update_terminal_shell_command is never called
+    - get_herdr_inbox_service -> a live mock service
+    """
+    with contextlib.ExitStack() as stack:
+
+        def p(name):
+            return stack.enter_context(patch(_TS + name))
+
+        m = SimpleNamespace(
+            get_herdr_inbox_service=p("get_herdr_inbox_service"),
+            get_backend=p("get_backend"),
+            db_create_terminal=p("db_create_terminal"),
+            provider_manager=p("provider_manager"),
+            generate_terminal_id=p("generate_terminal_id"),
+            generate_session_name=p("generate_session_name"),
+            generate_window_name=p("generate_window_name"),
+            load_agent_profile=p("load_agent_profile"),
+            build_skill_catalog=p("build_skill_catalog"),
+            dispatch_plugin_event=p("dispatch_plugin_event"),
+            update_terminal_shell_command=p("update_terminal_shell_command"),
+            # TERMINAL_LOG_DIR is a Path; a MagicMock supports `/` (__truediv__),
+            # .touch(), and str(), so log-file setup becomes a no-op.
+            TERMINAL_LOG_DIR=p("TERMINAL_LOG_DIR"),
+        )
+
+        m.generate_terminal_id.return_value = TERMINAL_ID
+        m.generate_window_name.return_value = "developer-base"
+        m.load_agent_profile.return_value = None
+
+        backend = m.get_backend.return_value
+        backend.session_exists.return_value = True
+        backend.create_window.return_value = WINDOW_NAME
+        backend.get_pane_id.return_value = PANE_ID
+
+        service = MagicMock()
+        m.get_herdr_inbox_service.return_value = service
+        m.service = service
+        m.backend = backend
+
+        yield m
+
+
+class TestCreateTerminalHerdrRegistration:
+    """create_terminal -> herdr inbox registration wiring."""
+
+    def test_create_terminal_registers_with_herdr_inbox(self, create_mocks):
+        """When a herdr inbox service exists, the new terminal is registered with it."""
+        # Arrange
+        m = create_mocks
+
+        # Act
+        terminal = create_terminal(
+            provider="claude_code",
+            agent_profile="developer",
+            session_name=SESSION_NAME,
+        )
+
+        # Assert: pane id resolved for the created window, then registered with is_kiro=False
+        m.backend.get_pane_id.assert_called_once_with(TERMINAL_ID, SESSION_NAME, WINDOW_NAME)
+        m.service.register_terminal.assert_called_once_with(TERMINAL_ID, PANE_ID, False)
+        assert isinstance(terminal, Terminal)
+        assert terminal.id == TERMINAL_ID
+
+    def test_create_terminal_no_registration_when_service_none(self, create_mocks):
+        """On the tmux path (service is None) no registration is attempted."""
+        # Arrange
+        m = create_mocks
+        m.get_herdr_inbox_service.return_value = None
+
+        # Act
+        terminal = create_terminal(
+            provider="claude_code",
+            agent_profile="developer",
+            session_name=SESSION_NAME,
+        )
+
+        # Assert: guard short-circuits before pane lookup or registration
+        m.backend.get_pane_id.assert_not_called()
+        m.service.register_terminal.assert_not_called()
+        assert isinstance(terminal, Terminal)
+        assert terminal.id == TERMINAL_ID
+
+    def test_create_terminal_registration_failure_does_not_kill_terminal(self, create_mocks):
+        """A registration failure is swallowed; the terminal is still created and returned."""
+        # Arrange: pane id lookup blows up (e.g. TerminalNotFoundError) inside the
+        # registration block. The inner try/except must contain it.
+        m = create_mocks
+        m.backend.get_pane_id.side_effect = RuntimeError("pane not found")
+
+        # Act
+        terminal = create_terminal(
+            provider="claude_code",
+            agent_profile="developer",
+            session_name=SESSION_NAME,
+        )
+
+        # Assert: creation succeeded and no exception propagated
+        assert isinstance(terminal, Terminal)
+        assert terminal.id == TERMINAL_ID
+        # registration never completed (failed before the register call)
+        m.service.register_terminal.assert_not_called()
+        # the outer failure-cleanup path was NOT triggered -> terminal not torn down
+        m.backend.kill_session.assert_not_called()
+        m.provider_manager.cleanup_provider.assert_not_called()
+
+    def test_create_terminal_kiro_provider_sets_is_kiro_true(self, create_mocks):
+        """A kiro_cli provider registers with is_kiro=True."""
+        # Arrange
+        m = create_mocks
+
+        # Act
+        create_terminal(
+            provider=ProviderType.KIRO_CLI.value,
+            agent_profile="developer",
+            session_name=SESSION_NAME,
+        )
+
+        # Assert
+        m.service.register_terminal.assert_called_once_with(TERMINAL_ID, PANE_ID, True)
+
+
+@pytest.fixture
+def delete_mocks():
+    """Patch delete_terminal's dependencies and yield the mocks.
+
+    get_terminal_metadata -> None so the scrollback-snapshot / stop-pipe-pane / kill-window
+    block (which needs the backend) is skipped, keeping these tests focused on the herdr
+    unregistration wiring. db_delete_terminal -> True so delete_terminal returns True.
+    """
+    with contextlib.ExitStack() as stack:
+
+        def p(name):
+            return stack.enter_context(patch(_TS + name))
+
+        m = SimpleNamespace(
+            get_herdr_inbox_service=p("get_herdr_inbox_service"),
+            get_terminal_metadata=p("get_terminal_metadata"),
+            provider_manager=p("provider_manager"),
+            db_delete_terminal=p("db_delete_terminal"),
+            dispatch_plugin_event=p("dispatch_plugin_event"),
+        )
+
+        m.get_terminal_metadata.return_value = None
+        m.db_delete_terminal.return_value = True
+
+        service = MagicMock()
+        m.get_herdr_inbox_service.return_value = service
+        m.service = service
+
+        yield m
+
+
+class TestDeleteTerminalHerdrUnregistration:
+    """delete_terminal -> herdr inbox unregistration wiring."""
+
+    def test_delete_terminal_unregisters_from_herdr_inbox(self, delete_mocks):
+        """When a herdr inbox service exists, the terminal is unregistered from it."""
+        # Arrange
+        m = delete_mocks
+
+        # Act
+        result = delete_terminal(TERMINAL_ID)
+
+        # Assert
+        m.service.unregister_terminal.assert_called_once_with(TERMINAL_ID)
+        assert result is True
+
+    def test_delete_terminal_no_unregistration_when_service_none(self, delete_mocks):
+        """On the tmux path (service is None) no unregister call is made.
+
+        If the None-guard were missing, the code would call unregister_terminal on None
+        and raise AttributeError; a clean True return proves the guard holds.
+        """
+        # Arrange
+        m = delete_mocks
+        m.get_herdr_inbox_service.return_value = None
+
+        # Act
+        result = delete_terminal(TERMINAL_ID)
+
+        # Assert
+        m.service.unregister_terminal.assert_not_called()
+        assert result is True


### PR DESCRIPTION
## Summary

  Adds [herdr](https://herdr.dev/) as a first-class terminal backend alongside the existing tmux backend.

  ### What is herdr?

  [herdr](https://herdr.dev/) is a terminal-native agent runtime and multiplexer designed specifically for AI coding agents. Unlike tmux, which CAO
  polls via `capture-pane` and regex to detect idle state, herdr exposes a Unix socket (JSON-RPC) that emits real-time agent status events
  (`working`, `idle`, `done`, `blocked`). This eliminates polling entirely for inbox delivery: CAO subscribes to pane events and delivers messages
  the instant an agent goes idle.

  herdr also tracks agent session identity natively (each pane knows its Claude session UUID), enabling accurate status reporting without heuristic
  output analysis.

  ### Changes

  **Core additions:**

  - `backends/` abstraction layer -- `TerminalBackend` ABC, `TmuxBackend` wrapper, `HerdrBackend` implementation, `BackendFactory` (reads
  `terminal_backend` from `~/.aws/cli-agent-orchestrator/config.json`), singleton registry. All services depend only on the ABC -- no concrete
  backend references outside `backends/`.
  - `HerdrBackend` -- full tmux-equivalent over herdr CLI: workspace/tab lifecycle, live label-based pane resolution (never caches stale pane IDs),
  pane output streaming, native `agent_status` polling via `herdr pane get`.
  - `HerdrInboxService` -- event-driven inbox delivery via herdr Unix socket. Subscribes per-pane on registration; delivers on `idle`/`done` status
  events. Includes exponential backoff reconnect with reconciliation on reconnect.
  - Eager inbox delivery (`inbox_service.py`) -- providers that buffer input during processing (e.g. claude_code) receive pending messages
  immediately on `send_input()`, not at the next IDLE poll. Benefits both backends.
  - `docs/herdr.md` -- setup, configuration, and troubleshooting guide.

  **Reliability fixes (found during local testing):**

  - Reconnect storm fix -- `_socket_loop()` previously reset backoff right after TCP connect. `_resubscribe_all()` with stale pane IDs caused
  ECONNRESET, triggering a tight reconnect loop (106K socket events/day observed). Fixed: run `_reconcile()` before `_resubscribe_all()`, reset
  backoff only after full setup completes.
  - Lifecycle events -- subscribes to `pane.closed` and `workspace.closed` globally; real-time map + DB cleanup eliminates ghost entries that
  previously caused "session already exists" errors on re-launch.
  - Startup DB cleanup -- `_startup_db_cleanup()` runs unconditionally at server start, before any pane registration. Cross-checks all DB terminals
  against live herdr tabs and removes ghost records from prior server runs. Fixes `cao session list` silently dropping sessions when their oldest
  DB terminal is a ghost (returns 500, caught, session dropped).
  - `GET /terminals/{id}` -- `TerminalNotFoundError` from the backend now returns 404 instead of 500.

  **Test coverage:** 101 new tests across `test/backends/`, `test_lifespan_inbox.py`, `test_herdr_inbox_registry.py`, and `test_inbox_service.py`.

  ## Test plan

  - [x] `uv run pytest --no-cov test/backends/ -v` -- all backend tests pass
  - [x] `uv run pytest --no-cov test/api/test_lifespan_inbox.py -v` -- inbox lifespan tests pass
  - [x] `uv run pytest --no-cov test/services/test_inbox_service.py -v` -- inbox service tests pass
  - [x] Set `terminal_backend: "herdr"` in `~/.aws/cli-agent-orchestrator/config.json`, launch a session with `cao launch --agents developer`,
  verify terminals appear in `cao session list`
  - [x] Restart cao-server with ghost DB records present; startup log shows `Startup DB cleanup: removed N ghost terminal(s)` and session list
  displays correctly