### PR TITLE
fix(codex): handle v0.136+ TUI footer and skip MCP tool-call markers …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
-## [2.2.0] - 2026-06-01
+## [2.2.0] - 2026-06-04
 
 ### Highlights
 
@@ -51,6 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+
+- codex: detect v0.136+ TUI footer (`model · path` without `N% left`) so handoff/assign workers reliably reach COMPLETED instead of pinning at IDLE
+
+- codex: skip `• Called <tool>(...)` MCP tool-call markers during last-message extraction so skill body text (including `[CAO Handoff]`) no longer leaks into worker output
+
+- ci: stop TestPyPI squats breaking the release smoke test by installing the package with `--no-deps` and resolving deps from PyPI alone (#270)
+
+- kiro_cli: treat MCP-server boot screen as PROCESSING and gate shell-baseline IDLE on `_initialized` to fix paste-into-boot-screen race that dropped the first message after launch (#268)
 
 - mcp: reject `send_message` when `receiver_id` equals sender (#263)
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -39,7 +39,10 @@ ASSISTANT_PREFIX_PATTERN = r"^(?:(?:assistant|codex|agent)\s*:|[^\S\n]*•)"
 # "• Called cao-mcp-server.load_skill({...})". The body that follows
 # (└ ... lines) is the tool's return value, not the model's reply.
 # Used to skip these markers when locating the actual response start.
-MCP_TOOL_CALL_PATTERN = r"^[^\S\n]*•\s+Called\s+\S+"
+# The "<server>.<tool>(" shape (identifier.identifier followed by an open
+# paren) is required so legitimate model bullets like "• Called attention
+# to the bug" don't get filtered as tool calls.
+MCP_TOOL_CALL_PATTERN = r"^[^\S\n]*•\s+Called\s+[\w-]+\.[\w-]+\("
 # Match user input: "You ..." (label style) or "› text" (Codex interactive prompt).
 # The "›[^\S\n]*\S" alternative requires a non-whitespace character on the same line
 # to distinguish user input ("› what is your role?") from the empty idle prompt ("› ").
@@ -113,6 +116,27 @@ def _compute_tui_footer_cutoff(all_lines: list) -> int:
             break
 
     return len("\n".join(all_lines[:footer_start_idx]))
+
+
+def _find_assistant_marker(text: str) -> Optional[re.Match]:
+    """Find the first ASSISTANT_PREFIX_PATTERN match in ``text`` whose line
+    is not an MCP tool-call marker.
+
+    Codex emits ``• Called <server>.<tool>(...)`` when invoking an MCP tool;
+    that bullet matches ASSISTANT_PREFIX_PATTERN but is followed by tool
+    output, not the model's reply. Anchoring on it would conflate tool
+    output with the model response (status: false COMPLETED;
+    extraction: skill-body leak).
+    """
+    for m in re.finditer(ASSISTANT_PREFIX_PATTERN, text, re.IGNORECASE | re.MULTILINE):
+        line_end = text.find("\n", m.start())
+        if line_end == -1:
+            line_end = len(text)
+        line = text[m.start() : line_end]
+        if re.match(MCP_TOOL_CALL_PATTERN, line):
+            continue
+        return m
+    return None
 
 
 class ProviderError(Exception):
@@ -332,13 +356,10 @@ class CodexProvider(BaseProvider):
                 last_user = match
 
         output_after_last_user = clean_output[last_user.start() :] if last_user else clean_output
+        # Skip MCP tool-call markers — those mark "model invoked a tool", not
+        # "model has replied", and shouldn't gate WAITING/ERROR detection.
         assistant_after_last_user = bool(
-            last_user
-            and re.search(
-                ASSISTANT_PREFIX_PATTERN,
-                output_after_last_user,
-                re.IGNORECASE | re.MULTILINE,
-            )
+            last_user and _find_assistant_marker(output_after_last_user) is not None
         )
 
         # Check trust prompt early — the trust menu uses › which matches the idle prompt
@@ -384,13 +405,12 @@ class CodexProvider(BaseProvider):
             if re.search(TUI_PROGRESS_PATTERN, tail_output, re.MULTILINE):
                 return TerminalStatus.PROCESSING
 
-            # Consider COMPLETED only if we see an assistant marker after the last user message.
+            # Consider COMPLETED only if we see an assistant marker (skipping
+            # MCP tool-call markers) after the last user message. Without the
+            # tool-call filter, "• Called <server>.<tool>(...)" emitted before
+            # the model has actually replied would trip COMPLETED prematurely.
             if last_user is not None:
-                if re.search(
-                    ASSISTANT_PREFIX_PATTERN,
-                    clean_output[last_user.start() :],
-                    re.IGNORECASE | re.MULTILINE,
-                ):
+                if _find_assistant_marker(clean_output[last_user.start() :]) is not None:
                     return TerminalStatus.COMPLETED
 
                 return TerminalStatus.IDLE
@@ -439,25 +459,11 @@ class CodexProvider(BaseProvider):
             last_user = user_matches[-1]
 
             # Find the first assistant response marker (• or assistant:) after
-            # the user message, skipping "• Called <tool>(...)" MCP tool call
-            # markers — those are followed by tool output, not the model's
-            # reply. Anchoring on a tool call marker would pull tool output
-            # (e.g. skill body text) into the extracted response.
-            asst_after_user = None
-            for m in re.finditer(
-                ASSISTANT_PREFIX_PATTERN,
-                clean_output[last_user.start() :],
-                re.IGNORECASE | re.MULTILINE,
-            ):
-                line_start = last_user.start() + m.start()
-                line_end = clean_output.find("\n", line_start)
-                if line_end == -1:
-                    line_end = len(clean_output)
-                line = clean_output[line_start:line_end]
-                if re.match(MCP_TOOL_CALL_PATTERN, line):
-                    continue
-                asst_after_user = m
-                break
+            # the user message, skipping "• Called <server>.<tool>(...)" MCP
+            # tool call markers — those are followed by tool output, not the
+            # model's reply. Anchoring on a tool call marker would pull tool
+            # output (e.g. skill body text) into the extracted response.
+            asst_after_user = _find_assistant_marker(clean_output[last_user.start() :])
 
             if asst_after_user:
                 response_start = last_user.start() + asst_after_user.start()

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -118,7 +118,7 @@ def _compute_tui_footer_cutoff(all_lines: list) -> int:
     return len("\n".join(all_lines[:footer_start_idx]))
 
 
-def _find_assistant_marker(text: str) -> Optional[re.Match]:
+def _find_assistant_marker(text: str) -> Optional[re.Match[str]]:
     """Find the first ASSISTANT_PREFIX_PATTERN match in ``text`` whose line
     is not an MCP tool-call marker.
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -507,7 +507,7 @@ class CodexProvider(BaseProvider):
             line_end = clean_output.find("\n", m.start())
             if line_end == -1:
                 line_end = len(clean_output)
-            line = clean_output[m.start():line_end]
+            line = clean_output[m.start() : line_end]
             if re.match(MCP_TOOL_CALL_PATTERN, line):
                 continue
             matches.append(m)

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -31,7 +31,15 @@ IDLE_PROMPT_TAIL_LINES = 5
 IDLE_PROMPT_PATTERN_LOG = r"\? for shortcuts"
 # Match assistant response start: "assistant:/codex:/agent:" (label style from synthetic
 # test fixtures) or "•" bullet point (real Codex interactive output format).
-ASSISTANT_PREFIX_PATTERN = r"^(?:(?:assistant|codex|agent)\s*:|\s*•)"
+# [^\S\n]* matches horizontal whitespace only (not newlines) so the match anchors
+# on the actual bullet line — using \s* would let the match start on a blank
+# line above the bullet, breaking per-line tool-call filtering downstream.
+ASSISTANT_PREFIX_PATTERN = r"^(?:(?:assistant|codex|agent)\s*:|[^\S\n]*•)"
+# MCP tool call marker emitted by Codex when invoking a tool, e.g.
+# "• Called cao-mcp-server.load_skill({...})". The body that follows
+# (└ ... lines) is the tool's return value, not the model's reply.
+# Used to skip these markers when locating the actual response start.
+MCP_TOOL_CALL_PATTERN = r"^[^\S\n]*•\s+Called\s+\S+"
 # Match user input: "You ..." (label style) or "› text" (Codex interactive prompt).
 # The "›[^\S\n]*\S" alternative requires a non-whitespace character on the same line
 # to distinguish user input ("› what is your role?") from the empty idle prompt ("› ").
@@ -50,7 +58,10 @@ ERROR_PATTERN = r"^(?:Error:|ERROR:|Traceback \(most recent call last\):|panic:)
 # Used to detect when the bottom lines contain TUI chrome rather than user input.
 # v0.110 and earlier: "? for shortcuts" and "N% context left"
 # v0.111+: "model · N% left · path" (PR #13202 restored draft footer hints)
-TUI_FOOTER_PATTERN = r"(?:\?\s+for shortcuts|context left|\d+%\s+left)"
+# v0.136+: "model · path" (the "N% left" segment was removed)
+# The "·\s+[~/]" alternative anchors on the path component of the footer,
+# which is shared across v0.111 and v0.136 status bars.
+TUI_FOOTER_PATTERN = r"(?:\?\s+for shortcuts|context left|\d+%\s+left|·\s+[~/])"
 # Codex TUI progress spinner: "• Working (0s • esc to interrupt)",
 # "• Thinking (2s ...)", "• Starting script creation (10s • esc to interrupt)".
 # The prefix text varies but the "(Ns • esc to interrupt)" format is consistent.
@@ -428,13 +439,26 @@ class CodexProvider(BaseProvider):
             last_user = user_matches[-1]
 
             # Find the first assistant response marker (• or assistant:) after
-            # the user message. This correctly skips multi-line user messages
-            # that wrap across several lines in the Codex TUI.
-            asst_after_user = re.search(
+            # the user message, skipping "• Called <tool>(...)" MCP tool call
+            # markers — those are followed by tool output, not the model's
+            # reply. Anchoring on a tool call marker would pull tool output
+            # (e.g. skill body text) into the extracted response.
+            asst_after_user = None
+            for m in re.finditer(
                 ASSISTANT_PREFIX_PATTERN,
                 clean_output[last_user.start() :],
                 re.IGNORECASE | re.MULTILINE,
-            )
+            ):
+                line_start = last_user.start() + m.start()
+                line_end = clean_output.find("\n", line_start)
+                if line_end == -1:
+                    line_end = len(clean_output)
+                line = clean_output[line_start:line_end]
+                if re.match(MCP_TOOL_CALL_PATTERN, line):
+                    continue
+                asst_after_user = m
+                break
+
             if asst_after_user:
                 response_start = last_user.start() + asst_after_user.start()
             else:
@@ -473,9 +497,20 @@ class CodexProvider(BaseProvider):
                 return response_text.strip()
 
         # Fallback: assistant marker based extraction (no user message found).
-        matches = list(
+        # Filter out "• Called <tool>(...)" MCP tool call markers so we anchor
+        # on the model's actual reply, not tool output.
+        all_matches = list(
             re.finditer(ASSISTANT_PREFIX_PATTERN, clean_output, re.IGNORECASE | re.MULTILINE)
         )
+        matches = []
+        for m in all_matches:
+            line_end = clean_output.find("\n", m.start())
+            if line_end == -1:
+                line_end = len(clean_output)
+            line = clean_output[m.start():line_end]
+            if re.match(MCP_TOOL_CALL_PATTERN, line):
+                continue
+            matches.append(m)
 
         if not matches:
             raise ValueError("No Codex response found - no assistant marker detected")

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -696,6 +696,45 @@ class TestCodexBulletFormatStatusDetection:
         assert status == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    def test_get_status_idle_when_only_tool_call_after_user(self, mock_tmux):
+        """IDLE when the only "•" bullet after the user prompt is an MCP
+        tool-call marker — the model hasn't actually replied yet.
+
+        Regression for the Copilot review on PR #274 that flagged COMPLETED
+        being satisfied by a tool-call marker. A "• Called <server>.<tool>(...)"
+        bullet must not trip COMPLETED on its own.
+        """
+        mock_tmux.get_history.return_value = (
+            "› [CAO Handoff] do task\n"
+            '• Called cao-mcp-server.load_skill({"name":"cao-worker-protocols"})\n'
+            "  └ skill body text\n"
+            "\n"
+            "› \n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    def test_get_status_completed_when_real_reply_after_tool_call(self, mock_tmux):
+        """COMPLETED when a real "•" reply follows the MCP tool-call marker."""
+        mock_tmux.get_history.return_value = (
+            "› [CAO Handoff] do task\n"
+            '• Called cao-mcp-server.load_skill({"name":"cao-worker-protocols"})\n'
+            "  └ skill body text\n"
+            "• Done — created the function.\n"
+            "\n"
+            "› \n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
     def test_get_status_completed_bullet_with_code_block(self, mock_tmux):
         """COMPLETED with • response containing code blocks."""
         mock_tmux.get_history.return_value = (
@@ -1185,6 +1224,26 @@ class TestCodexBulletFormatExtraction:
         assert "created the function" in message
         assert "skill body text" not in message
         assert "list_terminals" not in message
+
+    def test_extract_does_not_filter_called_as_english_word(self):
+        """A model bullet starting "• Called <english word>" must NOT be filtered.
+
+        The MCP tool-call pattern requires a "<server>.<tool>(" shape.
+        Bullets like "• Called attention to the bug" are real model replies
+        and must survive extraction. Regression for the Copilot review on
+        PR #274 that flagged the previous loose pattern.
+        """
+        output = (
+            "› what did you do?\n"
+            "• Called attention to the import bug in main.py and fixed it.\n"
+            "\n"
+            "› \n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        message = provider.extract_last_message_from_script(output)
+
+        assert "Called attention to the import bug" in message
 
 
 class TestCodexV0111Extraction:

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -1119,7 +1119,7 @@ class TestCodexBulletFormatExtraction:
         """
         output = (
             "› [CAO Handoff] Create a Python function called 'add_numbers'.\n"
-            "• Called cao-mcp-server.load_skill({\"name\":\"cao-worker-protocols\"})\n"
+            '• Called cao-mcp-server.load_skill({"name":"cao-worker-protocols"})\n'
             "  └ # CAO Worker Protocols\n"
             "\n"
             "    Use this skill when acting as a worker agent.\n"
@@ -1149,7 +1149,7 @@ class TestCodexBulletFormatExtraction:
         output = (
             "› [CAO Handoff] do task\n"
             "\n"
-            "• Called cao-mcp-server.load_skill({\"name\":\"cao-worker-protocols\"})\n"
+            '• Called cao-mcp-server.load_skill({"name":"cao-worker-protocols"})\n'
             "  └ skill body with [CAO Handoff] reference\n"
             "\n"
             "• def add_numbers(a, b):\n"
@@ -1169,10 +1169,10 @@ class TestCodexBulletFormatExtraction:
         """Multiple consecutive tool calls before the final response."""
         output = (
             "› do the task\n"
-            "• Called cao-mcp-server.load_skill({\"name\":\"foo\"})\n"
+            '• Called cao-mcp-server.load_skill({"name":"foo"})\n'
             "  └ skill body text\n"
             "• Called cao-mcp-server.list_terminals({})\n"
-            "  └ [{\"id\":\"abc\"}]\n"
+            '  └ [{"id":"abc"}]\n'
             "• Done — created the function.\n"
             "\n"
             "› \n"

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -904,6 +904,93 @@ class TestCodexV0111FooterFormat:
         assert status == TerminalStatus.PROCESSING
 
 
+class TestCodexV0136FooterFormat:
+    """Tests for Codex v0.136.0+ TUI footer format.
+
+    v0.136 dropped the "N% left" segment from the status bar; the footer is now
+    just "model · path". Without an updated TUI_FOOTER_PATTERN the suggestion
+    hint line ("› Run /review on my current changes") is mistaken for a real
+    user message, which hides any preceding • assistant response and keeps the
+    terminal status pinned at IDLE forever.
+    """
+
+    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    def test_get_status_completed_v0136_footer(self, mock_tmux):
+        """COMPLETED with v0.136 footer (suggestion hint must not mask the • response)."""
+        mock_tmux.get_history.return_value = (
+            "› Create a Python function called 'greet'.\n"
+            "• def greet(name):\n"
+            '      return f"Hello, {name}!"\n'
+            "\n"
+            "› Run /review on my current changes\n"
+            "\n"
+            "  openai.gpt-5.5 medium · ~/project\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    def test_get_status_idle_v0136_footer(self, mock_tmux):
+        """IDLE with v0.136 footer format (no user message, no response yet)."""
+        mock_tmux.get_history.return_value = (
+            "╭───────────────────────────────────────────╮\n"
+            "│ >_ OpenAI Codex (v0.136.0)                │\n"
+            "│ model: openai.gpt-5.5 medium              │\n"
+            "│ directory: ~/project                      │\n"
+            "╰───────────────────────────────────────────╯\n"
+            "\n"
+            "› Find and fix a bug in @filename\n"
+            "\n"
+            "  openai.gpt-5.5 medium · ~/project\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    def test_get_status_processing_v0136_spinner(self, mock_tmux):
+        """PROCESSING when TUI shows spinner with v0.136 footer."""
+        mock_tmux.get_history.return_value = (
+            "› [CAO Handoff] Do the task.\n"
+            "\n"
+            "• Working (0s • esc to interrupt)\n"
+            "\n"
+            "› Find and fix a bug in @filename\n"
+            "\n"
+            "  openai.gpt-5.5 medium · ~/project\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status()
+
+        assert status == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.codex.tmux_client")
+    def test_extract_last_message_v0136_footer(self, mock_tmux):
+        """extract_last_message_from_script ignores v0.136 suggestion-hint footer."""
+        script_output = (
+            "› Create a Python function called 'greet'.\n"
+            "• def greet(name):\n"
+            '      return f"Hello, {name}!"\n'
+            "\n"
+            "› Run /review on my current changes\n"
+            "\n"
+            "  openai.gpt-5.5 medium · ~/project\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        message = provider.extract_last_message_from_script(script_output)
+
+        assert "def greet(name):" in message
+        assert "Hello, {name}!" in message
+        assert "Run /review" not in message
+
+
 class TestCodexProviderMessageExtraction:
     def test_extract_last_message_success(self):
         output = load_fixture("codex_completed_output.txt")
@@ -1021,6 +1108,83 @@ class TestCodexBulletFormatExtraction:
         message = provider.extract_last_message_from_script(output)
 
         assert "I've fixed the import issue" in message
+
+    def test_extract_skips_mcp_tool_call_marker(self):
+        """`• Called <tool>(...)` markers must not be treated as the response start.
+
+        Codex emits "• Called cao-mcp-server.load_skill({...})" when invoking an
+        MCP tool, followed by "└ <tool output>". The next "•" line is the actual
+        model reply. Anchoring on the tool-call marker would pull tool output
+        (e.g. skill body containing "[CAO Handoff]") into the extracted output.
+        """
+        output = (
+            "› [CAO Handoff] Create a Python function called 'add_numbers'.\n"
+            "• Called cao-mcp-server.load_skill({\"name\":\"cao-worker-protocols\"})\n"
+            "  └ # CAO Worker Protocols\n"
+            "\n"
+            "    Use this skill when acting as a worker agent.\n"
+            "    For example, Codex workers receive a `[CAO Handoff]` prefix.\n"
+            "\n"
+            "• def add_numbers(a, b):\n"
+            "      return a + b\n"
+            "\n"
+            "› \n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        message = provider.extract_last_message_from_script(output)
+
+        assert "def add_numbers(a, b):" in message
+        assert "return a + b" in message
+        assert "[CAO Handoff]" not in message
+        assert "CAO Worker Protocols" not in message
+        assert "Called cao-mcp-server" not in message
+
+    def test_extract_skips_tool_call_with_blank_separators(self):
+        """Tool-call filtering must work when blank lines separate the tool call
+        from later content. The ASSISTANT_PREFIX_PATTERN must anchor on the
+        bullet line itself — not on a preceding blank line — otherwise the
+        per-line tool-call check sees an empty line and is bypassed.
+        """
+        output = (
+            "› [CAO Handoff] do task\n"
+            "\n"
+            "• Called cao-mcp-server.load_skill({\"name\":\"cao-worker-protocols\"})\n"
+            "  └ skill body with [CAO Handoff] reference\n"
+            "\n"
+            "• def add_numbers(a, b):\n"
+            "      return a + b\n"
+            "\n"
+            "› \n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        message = provider.extract_last_message_from_script(output)
+
+        assert "def add_numbers(a, b):" in message
+        assert "[CAO Handoff]" not in message
+        assert "skill body" not in message
+
+    def test_extract_skips_multiple_tool_calls(self):
+        """Multiple consecutive tool calls before the final response."""
+        output = (
+            "› do the task\n"
+            "• Called cao-mcp-server.load_skill({\"name\":\"foo\"})\n"
+            "  └ skill body text\n"
+            "• Called cao-mcp-server.list_terminals({})\n"
+            "  └ [{\"id\":\"abc\"}]\n"
+            "• Done — created the function.\n"
+            "\n"
+            "› \n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        message = provider.extract_last_message_from_script(output)
+
+        assert "Done" in message
+        assert "created the function" in message
+        assert "skill body text" not in message
+        assert "list_terminals" not in message
 
 
 class TestCodexV0111Extraction:


### PR DESCRIPTION
…in extraction

Two bugs in CodexProvider, both surfaced by the e2e suite on codex 0.136+:

1. TUI footer detection — codex 0.136 dropped the "N% left" segment; the footer is now just "model · path". TUI_FOOTER_PATTERN never matched, so get_status() couldn't distinguish the suggestion hint ("› Run /review on my current changes") from a real user message and pinned terminals at IDLE forever. Pattern extended to anchor on "·\s+[~/]".

2. extract_last_message_from_script() anchored on the first "•" after the user prompt, which can be a "• Called <mcp_server>.<tool>(...)" tool-call marker. The lines that follow are tool output, not the model's reply, so when codex called load_skill before responding the extracted message leaked the cao-worker-protocols skill body (which mentions "[CAO Handoff]") into the test output. Now iterates "•" matches and skips MCP_TOOL_CALL_PATTERN. Also tightened ASSISTANT_PREFIX_PATTERN from "\s*•" to "[^\S\n]*•" so the match anchors on the bullet line itself, not a preceding blank line.

Verified end-to-end: 11/12 codex e2e pass (1 xfailed expected), 81/81 unit tests including 3 new regressions for the v0.136 footer and tool-call marker filtering.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
