### PR TITLE
feat(skills): discover skills from extra_skill_dirs (mirror extra_agent_dirs)

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -59,6 +59,24 @@ Add additional directories that are scanned for agent profiles across all provid
 }
 ```
 
+## Skill Directories
+
+CAO discovers skills (loaded on demand via the `load_skill` MCP tool) by scanning, in order (first match wins):
+
+1. **Global skill store** — `~/.aws/cli-agent-orchestrator/skills/`
+2. **Extra custom directories** — User-added paths (`extra_skill_dirs`)
+
+This mirrors agent-profile resolution: a skill in the global store is not shadowed by one with the same name in a later extra directory. `extra_skill_dirs` lets you keep a project's skills in the project repo (e.g. `<repo>/.cao/skills`) and register the directory, instead of copying or symlinking each skill into the global store.
+
+```json
+{
+  "extra_skill_dirs": [
+    "/path/to/team-shared-skills",
+    "/path/to/project-specific-skills"
+  ]
+}
+```
+
 ## settings.json Format
 
 ```json
@@ -70,7 +88,8 @@ Add additional directories that are scanned for agent profiles across all provid
     "codex": "~/.aws/cli-agent-orchestrator/agent-store",
     "cao_installed": "~/.aws/cli-agent-orchestrator/agent-context"
   },
-  "extra_agent_dirs": []
+  "extra_agent_dirs": [],
+  "extra_skill_dirs": []
 }
 ```
 
@@ -82,6 +101,8 @@ Add additional directories that are scanned for agent profiles across all provid
 | `POST` | `/settings/agent-dirs` | Update agent directories |
 | `GET` | `/settings/extra-agent-dirs` | Get extra custom directories |
 | `POST` | `/settings/extra-agent-dirs` | Set extra custom directories |
+| `GET` | `/settings/skill-dirs` | Get the global skill store path and extra skill directories |
+| `POST` | `/settings/skill-dirs` | Set extra custom skill directories |
 
 See [api.md](api.md) for the full API reference.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -99,8 +99,6 @@ This mirrors agent-profile resolution: a skill in the global store is not shadow
 |--------|----------|-------------|
 | `GET` | `/settings/agent-dirs` | Get current agent directories (merged with defaults) |
 | `POST` | `/settings/agent-dirs` | Update agent directories |
-| `GET` | `/settings/extra-agent-dirs` | Get extra custom directories |
-| `POST` | `/settings/extra-agent-dirs` | Set extra custom directories |
 | `GET` | `/settings/skill-dirs` | Get the global skill store path and extra skill directories |
 | `POST` | `/settings/skill-dirs` | Set extra custom skill directories |
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,7 +6,7 @@ Skills are reusable blocks of instructional content — domain knowledge, conven
 
 Skills are loaded lazily: only the skill name and description are injected into the agent's prompt at launch. The full content is retrieved on demand when the agent decides it needs it, preserving context window budget.
 
-All skills live in a single directory: `~/.aws/cli-agent-orchestrator/skills/`. There is no distinction between built-in and user-created skills — you can edit, replace, or remove any skill, including the defaults.
+The global skill store lives at `~/.aws/cli-agent-orchestrator/skills/`. There is no distinction between built-in and user-created skills — you can edit, replace, or remove any skill, including the defaults. In addition to the global store, CAO can discover skills from extra directories you register (for example a project's own skills folder) — see [Extra Skill Directories](#extra-skill-directories) below.
 
 ## When to Use Skills
 
@@ -97,6 +97,18 @@ CAO ships with two builtin skills:
 |-------|-------------|
 | `cao-supervisor-protocols` | Multi-agent orchestration patterns for supervisors: `assign`, `handoff`, idle-based message delivery |
 | `cao-worker-protocols` | Worker-side callback and completion rules for assigned and handed-off tasks |
+
+## Extra Skill Directories
+
+Beyond the global store, CAO can discover skills from extra directories you register via the `extra_skill_dirs` setting. This mirrors `extra_agent_dirs` for agent profiles.
+
+Unlike `cao skills add`, which **copies** a skill folder into the global store, an extra directory is **scanned in place** — nothing is copied. This lets you keep a project's skills in the project repo (e.g. `<repo>/.cao/skills`) and register that directory, so the skills stay canonical in their source location: edits are picked up on the next terminal creation, there is no second copy to keep in sync, and the skills are version-controlled alongside the project rather than re-added after every change.
+
+Each registered directory is scanned one level deep — every immediate subfolder that contains a `SKILL.md` is treated as a skill, and subfolders without one are ignored. A registered path may therefore be a broad project root; only its skill subfolders are picked up.
+
+**Resolution order.** Directories are searched global store first, then `extra_skill_dirs` in the configured order. The first *valid* match for a given name wins, so a skill in the global store is never shadowed by a same-named skill in a later extra directory, and an invalid (unloadable) folder does not shadow a later valid one of the same name — `cao skills list` and `load_skill` resolve a name to the same skill.
+
+**Configuration.** Extra skill directories are stored under `extra_skill_dirs` in `~/.aws/cli-agent-orchestrator/settings.json` and managed through the `/settings/skill-dirs` API. See [settings.md](./settings.md#skill-directories) for the request/response format.
 
 ## How Agents Discover Skills
 

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -432,6 +432,7 @@ class SkillDirsUpdate(BaseModel):
 @app.post("/settings/skill-dirs")
 async def set_skill_dirs_endpoint(body: SkillDirsUpdate) -> Dict:
     """Update user-added extra skill directories."""
+    from cli_agent_orchestrator.constants import SKILLS_DIR
     from cli_agent_orchestrator.services.settings_service import (
         get_extra_skill_dirs,
         set_extra_skill_dirs,
@@ -440,7 +441,10 @@ async def set_skill_dirs_endpoint(body: SkillDirsUpdate) -> Dict:
     result_extra: List[str] = []
     if body.extra_dirs is not None:
         result_extra = set_extra_skill_dirs(body.extra_dirs)
-    return {"extra_dirs": result_extra or get_extra_skill_dirs()}
+    return {
+        "skills_dir": str(SKILLS_DIR),
+        "extra_dirs": result_extra or get_extra_skill_dirs(),
+    }
 
 
 @app.get("/skills/{name}", response_model=SkillContentResponse)

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -416,6 +416,33 @@ async def set_agent_dirs_endpoint(body: AgentDirsUpdate) -> Dict:
     }
 
 
+@app.get("/settings/skill-dirs")
+async def get_skill_dirs_endpoint() -> Dict:
+    """Get the global skill store path and user-added extra skill directories."""
+    from cli_agent_orchestrator.constants import SKILLS_DIR
+    from cli_agent_orchestrator.services.settings_service import get_extra_skill_dirs
+
+    return {"skills_dir": str(SKILLS_DIR), "extra_dirs": get_extra_skill_dirs()}
+
+
+class SkillDirsUpdate(BaseModel):
+    extra_dirs: Optional[List[str]] = None
+
+
+@app.post("/settings/skill-dirs")
+async def set_skill_dirs_endpoint(body: SkillDirsUpdate) -> Dict:
+    """Update user-added extra skill directories."""
+    from cli_agent_orchestrator.services.settings_service import (
+        get_extra_skill_dirs,
+        set_extra_skill_dirs,
+    )
+
+    result_extra: List[str] = []
+    if body.extra_dirs is not None:
+        result_extra = set_extra_skill_dirs(body.extra_dirs)
+    return {"extra_dirs": result_extra or get_extra_skill_dirs()}
+
+
 @app.get("/skills/{name}", response_model=SkillContentResponse)
 async def get_skill_content(name: str) -> SkillContentResponse:
     """Return the full Markdown body for an installed skill."""

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -137,3 +137,19 @@ def set_extra_agent_dirs(dirs: List[str]) -> List[str]:
     settings["extra_agent_dirs"] = extra_agent_dirs
     _save(settings)
     return extra_agent_dirs
+
+
+def get_extra_skill_dirs() -> List[str]:
+    """Get extra skill scan directories (user-added custom paths)."""
+    settings = _load()
+    dirs = settings.get("extra_skill_dirs", [])
+    return dirs if isinstance(dirs, list) else []
+
+
+def set_extra_skill_dirs(dirs: List[str]) -> List[str]:
+    """Set extra skill scan directories."""
+    settings = _load()
+    extra_skill_dirs = [d for d in dirs if d.strip()]
+    settings["extra_skill_dirs"] = extra_skill_dirs
+    _save(settings)
+    return extra_skill_dirs

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -140,16 +140,23 @@ def set_extra_agent_dirs(dirs: List[str]) -> List[str]:
 
 
 def get_extra_skill_dirs() -> List[str]:
-    """Get extra skill scan directories (user-added custom paths)."""
+    """Get extra skill scan directories (user-added custom paths).
+
+    Filters to non-empty strings so malformed persisted data (e.g. a manually
+    edited ``settings.json`` storing ``null`` or numbers) cannot later raise a
+    ``TypeError`` from ``Path(extra)`` and break skill listing/loading.
+    """
     settings = _load()
     dirs = settings.get("extra_skill_dirs", [])
-    return dirs if isinstance(dirs, list) else []
+    if not isinstance(dirs, list):
+        return []
+    return [d.strip() for d in dirs if isinstance(d, str) and d.strip()]
 
 
 def set_extra_skill_dirs(dirs: List[str]) -> List[str]:
     """Set extra skill scan directories."""
     settings = _load()
-    extra_skill_dirs = [d for d in dirs if d.strip()]
+    extra_skill_dirs = [d.strip() for d in dirs if isinstance(d, str) and d.strip()]
     settings["extra_skill_dirs"] = extra_skill_dirs
     _save(settings)
     return extra_skill_dirs

--- a/src/cli_agent_orchestrator/utils/skills.py
+++ b/src/cli_agent_orchestrator/utils/skills.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import frontmatter
 from pydantic import ValidationError
@@ -70,38 +70,71 @@ def _load_skill_folder(skill_path: Path) -> Tuple[SkillMetadata, str]:
     return metadata, content
 
 
+def _skill_search_dirs() -> List[Path]:
+    """Return skill store directories in resolution order.
+
+    The global skill store (``SKILLS_DIR``) is searched first, followed by any
+    user-added directories from the ``extra_skill_dirs`` setting. This mirrors
+    agent-profile resolution (global store first, then extra user directories),
+    so a skill in the global store is never shadowed by a later extra directory.
+    """
+    from cli_agent_orchestrator.services.settings_service import get_extra_skill_dirs
+
+    dirs: List[Path] = [SKILLS_DIR]
+    dirs.extend(Path(extra) for extra in get_extra_skill_dirs())
+    return dirs
+
+
+def _resolve_skill_path(skill_name: str) -> Path:
+    """Locate a skill folder across the global store and extra directories.
+
+    Returns the first ``<dir>/<skill_name>`` that contains a ``SKILL.md``. When
+    nothing matches, falls back to ``SKILLS_DIR / skill_name`` so callers raise a
+    ``FileNotFoundError`` that references the canonical global path.
+    """
+    for directory in _skill_search_dirs():
+        candidate = directory / skill_name
+        if (candidate / "SKILL.md").is_file():
+            return candidate
+    return SKILLS_DIR / skill_name
+
+
 def load_skill_metadata(name: str) -> SkillMetadata:
     """Load validated metadata for a single installed skill."""
     skill_name = validate_skill_name(name)
-    skill_path = SKILLS_DIR / skill_name
-    metadata, _ = _load_skill_folder(skill_path)
+    metadata, _ = _load_skill_folder(_resolve_skill_path(skill_name))
     return metadata
 
 
 def load_skill_content(name: str) -> str:
     """Load the Markdown body content for a single installed skill."""
     skill_name = validate_skill_name(name)
-    skill_path = SKILLS_DIR / skill_name
-    _, content = _load_skill_folder(skill_path)
+    _, content = _load_skill_folder(_resolve_skill_path(skill_name))
     return content
 
 
 def list_skills() -> List[SkillMetadata]:
-    """Return all valid skills from the local skill store sorted by name."""
-    if not SKILLS_DIR.exists():
-        return []
+    """Return all valid skills from the global store and extra directories.
 
-    skills: List[SkillMetadata] = []
-    for item in SKILLS_DIR.iterdir():
-        if not item.is_dir():
+    Directories are scanned in resolution order (global store first, then
+    ``extra_skill_dirs``); the first occurrence of a skill name wins, so a skill
+    in the global store is not shadowed by one in a later extra directory.
+    Invalid skill folders are skipped. The result is sorted by name.
+    """
+    skills_by_name: Dict[str, SkillMetadata] = {}
+    for directory in _skill_search_dirs():
+        if not directory.exists():
             continue
+        for item in directory.iterdir():
+            if not item.is_dir() or item.name in skills_by_name:
+                continue
+            try:
+                metadata, _ = _load_skill_folder(item)
+                skills_by_name[item.name] = metadata
+            except Exception as exc:
+                logger.warning("Skipping invalid skill folder '%s': %s", item, exc)
 
-        try:
-            skills.append(load_skill_metadata(item.name))
-        except Exception as exc:
-            logger.warning("Skipping invalid skill folder '%s': %s", item, exc)
-
-    return sorted(skills, key=lambda skill: skill.name)
+    return sorted(skills_by_name.values(), key=lambda skill: skill.name)
 
 
 def build_skill_catalog() -> str:

--- a/src/cli_agent_orchestrator/utils/skills.py
+++ b/src/cli_agent_orchestrator/utils/skills.py
@@ -123,10 +123,16 @@ def list_skills() -> List[SkillMetadata]:
     """
     skills_by_name: Dict[str, SkillMetadata] = {}
     for directory in _skill_search_dirs():
-        if not directory.exists():
+        if not directory.is_dir():
             continue
         for item in directory.iterdir():
             if not item.is_dir() or item.name in skills_by_name:
+                continue
+            # extra_skill_dirs may point at a broad project root, so only treat a
+            # subdirectory as a skill when it actually contains a SKILL.md;
+            # unrelated folders are skipped silently. A folder that has a
+            # SKILL.md but fails to load is still reported below.
+            if not (item / "SKILL.md").is_file():
                 continue
             try:
                 metadata, _ = _load_skill_folder(item)

--- a/src/cli_agent_orchestrator/utils/skills.py
+++ b/src/cli_agent_orchestrator/utils/skills.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import frontmatter
 from pydantic import ValidationError
@@ -88,15 +88,31 @@ def _skill_search_dirs() -> List[Path]:
 def _resolve_skill_path(skill_name: str) -> Path:
     """Locate a skill folder across the global store and extra directories.
 
-    Returns the first ``<dir>/<skill_name>`` that contains a ``SKILL.md``. When
-    nothing matches, falls back to ``SKILLS_DIR / skill_name`` so callers raise a
-    ``FileNotFoundError`` that references the canonical global path.
+    Returns the first ``<dir>/<skill_name>`` that loads as a *valid* skill, so
+    resolution stays consistent with :func:`list_skills` ("first valid match
+    wins"): an earlier folder that contains a ``SKILL.md`` but fails to load no
+    longer shadows a later valid folder of the same name. Without this, the
+    injected catalog could advertise a skill (from a later dir) that the
+    subsequent ``load_skill`` call then fails to resolve.
+
+    When no candidate loads cleanly, falls back to the first folder that does
+    contain a ``SKILL.md`` so the caller re-raises the underlying validation
+    error, or ultimately to ``SKILLS_DIR / skill_name`` so the error references
+    the canonical global path.
     """
+    first_with_skill_md: Optional[Path] = None
     for directory in _skill_search_dirs():
         candidate = directory / skill_name
-        if (candidate / "SKILL.md").is_file():
-            return candidate
-    return SKILLS_DIR / skill_name
+        if not (candidate / "SKILL.md").is_file():
+            continue
+        if first_with_skill_md is None:
+            first_with_skill_md = candidate
+        try:
+            _load_skill_folder(candidate)
+        except Exception:
+            continue
+        return candidate
+    return first_with_skill_md if first_with_skill_md is not None else SKILLS_DIR / skill_name
 
 
 def load_skill_metadata(name: str) -> SkillMetadata:
@@ -117,9 +133,11 @@ def list_skills() -> List[SkillMetadata]:
     """Return all valid skills from the global store and extra directories.
 
     Directories are scanned in resolution order (global store first, then
-    ``extra_skill_dirs``); the first occurrence of a skill name wins, so a skill
-    in the global store is not shadowed by one in a later extra directory.
-    Invalid skill folders are skipped. The result is sorted by name.
+    ``extra_skill_dirs``); the first *valid* occurrence of a skill name wins, so
+    a skill in the global store is not shadowed by one in a later extra
+    directory. Invalid skill folders are skipped without reserving the name,
+    which matches :func:`_resolve_skill_path` ("first valid match wins"). The
+    result is sorted by name.
     """
     skills_by_name: Dict[str, SkillMetadata] = {}
     for directory in _skill_search_dirs():

--- a/src/cli_agent_orchestrator/utils/skills.py
+++ b/src/cli_agent_orchestrator/utils/skills.py
@@ -85,47 +85,47 @@ def _skill_search_dirs() -> List[Path]:
     return dirs
 
 
-def _resolve_skill_path(skill_name: str) -> Path:
-    """Locate a skill folder across the global store and extra directories.
+def _resolve_skill(skill_name: str) -> Tuple[SkillMetadata, str]:
+    """Load a skill by name from the global store or extra directories.
 
-    Returns the first ``<dir>/<skill_name>`` that loads as a *valid* skill, so
-    resolution stays consistent with :func:`list_skills` ("first valid match
-    wins"): an earlier folder that contains a ``SKILL.md`` but fails to load no
-    longer shadows a later valid folder of the same name. Without this, the
-    injected catalog could advertise a skill (from a later dir) that the
-    subsequent ``load_skill`` call then fails to resolve.
+    Scans the search dirs in resolution order and returns the first
+    ``<dir>/<skill_name>`` that loads as a *valid* skill ("first valid match
+    wins"), so resolution stays consistent with :func:`list_skills`: an earlier
+    folder that contains a ``SKILL.md`` but fails to load no longer shadows a
+    later valid folder of the same name. Without this, the injected catalog
+    could advertise a skill (from a later dir) that the subsequent ``load_skill``
+    call then fails to resolve.
 
-    When no candidate loads cleanly, falls back to the first folder that does
-    contain a ``SKILL.md`` so the caller re-raises the underlying validation
-    error, or ultimately to ``SKILLS_DIR / skill_name`` so the error references
-    the canonical global path.
+    The matched folder is parsed exactly once. When no candidate loads cleanly,
+    the error from the first folder that contains a ``SKILL.md`` is re-raised so
+    the underlying validation failure is surfaced; if no folder contains a
+    ``SKILL.md`` at all, a ``FileNotFoundError`` referencing the canonical global
+    path is raised instead.
     """
-    first_with_skill_md: Optional[Path] = None
+    first_error: Optional[Exception] = None
     for directory in _skill_search_dirs():
         candidate = directory / skill_name
         if not (candidate / "SKILL.md").is_file():
             continue
-        if first_with_skill_md is None:
-            first_with_skill_md = candidate
         try:
-            _load_skill_folder(candidate)
-        except Exception:
-            continue
-        return candidate
-    return first_with_skill_md if first_with_skill_md is not None else SKILLS_DIR / skill_name
+            return _load_skill_folder(candidate)
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
+    return _load_skill_folder(SKILLS_DIR / skill_name)
 
 
 def load_skill_metadata(name: str) -> SkillMetadata:
     """Load validated metadata for a single installed skill."""
-    skill_name = validate_skill_name(name)
-    metadata, _ = _load_skill_folder(_resolve_skill_path(skill_name))
+    metadata, _ = _resolve_skill(validate_skill_name(name))
     return metadata
 
 
 def load_skill_content(name: str) -> str:
     """Load the Markdown body content for a single installed skill."""
-    skill_name = validate_skill_name(name)
-    _, content = _load_skill_folder(_resolve_skill_path(skill_name))
+    _, content = _resolve_skill(validate_skill_name(name))
     return content
 
 
@@ -136,7 +136,7 @@ def list_skills() -> List[SkillMetadata]:
     ``extra_skill_dirs``); the first *valid* occurrence of a skill name wins, so
     a skill in the global store is not shadowed by one in a later extra
     directory. Invalid skill folders are skipped without reserving the name,
-    which matches :func:`_resolve_skill_path` ("first valid match wins"). The
+    which matches :func:`_resolve_skill` ("first valid match wins"). The
     result is sorted by name.
     """
     skills_by_name: Dict[str, SkillMetadata] = {}

--- a/test/api/test_settings_api.py
+++ b/test/api/test_settings_api.py
@@ -217,7 +217,9 @@ class TestSetSkillDirsEndpoint:
             )
 
         assert response.status_code == 200
-        assert response.json()["extra_dirs"] == ["/new/skills"]
+        data = response.json()
+        assert "skills_dir" in data
+        assert data["extra_dirs"] == ["/new/skills"]
 
     def test_empty_body_returns_existing(self, client):
         """POST /settings/skill-dirs with empty body returns existing extra dirs."""

--- a/test/api/test_settings_api.py
+++ b/test/api/test_settings_api.py
@@ -166,3 +166,66 @@ class TestSetAgentDirsEndpoint:
         data = response.json()
         assert data["agent_dirs"] == {}
         assert data["extra_dirs"] == []
+
+
+class TestGetSkillDirsEndpoint:
+    """Tests for GET /settings/skill-dirs endpoint."""
+
+    def test_returns_skills_dir_and_extra_dirs(self, client):
+        """GET /settings/skill-dirs returns the global store path and extra_dirs."""
+        with patch(
+            "cli_agent_orchestrator.services.settings_service.get_extra_skill_dirs",
+            return_value=["/extra/skills1", "/extra/skills2"],
+        ):
+            response = client.get("/settings/skill-dirs")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "skills_dir" in data
+        assert data["extra_dirs"] == ["/extra/skills1", "/extra/skills2"]
+
+    def test_returns_empty_extra_dirs_when_none(self, client):
+        """GET /settings/skill-dirs returns empty extra_dirs when none configured."""
+        with patch(
+            "cli_agent_orchestrator.services.settings_service.get_extra_skill_dirs",
+            return_value=[],
+        ):
+            response = client.get("/settings/skill-dirs")
+
+        assert response.status_code == 200
+        assert response.json()["extra_dirs"] == []
+
+
+class TestSetSkillDirsEndpoint:
+    """Tests for POST /settings/skill-dirs endpoint."""
+
+    def test_updates_extra_dirs(self, client):
+        """POST /settings/skill-dirs updates extra_dirs and returns them."""
+        with (
+            patch(
+                "cli_agent_orchestrator.services.settings_service.set_extra_skill_dirs",
+                return_value=["/new/skills"],
+            ),
+            patch(
+                "cli_agent_orchestrator.services.settings_service.get_extra_skill_dirs",
+                return_value=["/new/skills"],
+            ),
+        ):
+            response = client.post(
+                "/settings/skill-dirs",
+                json={"extra_dirs": ["/new/skills"]},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["extra_dirs"] == ["/new/skills"]
+
+    def test_empty_body_returns_existing(self, client):
+        """POST /settings/skill-dirs with empty body returns existing extra dirs."""
+        with patch(
+            "cli_agent_orchestrator.services.settings_service.get_extra_skill_dirs",
+            return_value=[],
+        ):
+            response = client.post("/settings/skill-dirs", json={})
+
+        assert response.status_code == 200
+        assert response.json()["extra_dirs"] == []

--- a/test/cli/commands/test_skills.py
+++ b/test/cli/commands/test_skills.py
@@ -11,6 +11,21 @@ from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.utils.skill_injection import refresh_agent_json_prompt
 
 
+@pytest.fixture(autouse=True)
+def _default_no_extra_skill_dirs(monkeypatch):
+    """Default ``extra_skill_dirs`` to empty for every test.
+
+    These tests patch only ``SKILLS_DIR``; without this they would read the
+    developer's real ``settings.json`` and pick up any ``extra_skill_dirs``
+    there (e.g. a project registered for live skill discovery), making
+    "empty store" assertions flaky on a configured machine.
+    """
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_extra_skill_dirs",
+        lambda: [],
+    )
+
+
 def _create_skill(folder: Path, name: str, description: str, body: str = "# Skill\n\nBody") -> None:
     """Create a skill folder with SKILL.md and optional content."""
     folder.mkdir(parents=True, exist_ok=True)

--- a/test/services/test_settings_service.py
+++ b/test/services/test_settings_service.py
@@ -12,8 +12,10 @@ from cli_agent_orchestrator.services.settings_service import (
     _save,
     get_agent_dirs,
     get_extra_agent_dirs,
+    get_extra_skill_dirs,
     set_agent_dirs,
     set_extra_agent_dirs,
+    set_extra_skill_dirs,
 )
 
 
@@ -201,3 +203,59 @@ class TestSetExtraAgentDirs:
         set_extra_agent_dirs(["/something"])
         set_extra_agent_dirs([])
         assert get_extra_agent_dirs() == []
+
+
+class TestGetExtraSkillDirs:
+    """Tests for get_extra_skill_dirs function."""
+
+    def test_returns_empty_list_when_none_set(self, settings_file):
+        """get_extra_skill_dirs returns [] when no extra dirs configured."""
+        result = get_extra_skill_dirs()
+        assert result == []
+
+    def test_returns_saved_extra_dirs(self, settings_file):
+        """get_extra_skill_dirs returns the saved list."""
+        settings_file.write_text(json.dumps({"extra_skill_dirs": ["/a", "/b"]}))
+        result = get_extra_skill_dirs()
+        assert result == ["/a", "/b"]
+
+
+class TestSetExtraSkillDirs:
+    """Tests for set_extra_skill_dirs function."""
+
+    def test_saves_and_returns_dirs(self, settings_file):
+        """set_extra_skill_dirs saves dirs and returns them."""
+        result = set_extra_skill_dirs(["/dir1", "/dir2"])
+        assert result == ["/dir1", "/dir2"]
+
+    def test_strips_empty_strings(self, settings_file):
+        """set_extra_skill_dirs removes empty or whitespace-only strings."""
+        result = set_extra_skill_dirs(["/valid", "", "  ", "/also-valid"])
+        assert result == ["/valid", "/also-valid"]
+
+    def test_persists_to_disk(self, settings_file):
+        """set_extra_skill_dirs persists to disk so get_extra_skill_dirs reads it."""
+        set_extra_skill_dirs(["/persisted"])
+        assert get_extra_skill_dirs() == ["/persisted"]
+
+    def test_replaces_previous_list(self, settings_file):
+        """set_extra_skill_dirs replaces the entire previous list."""
+        set_extra_skill_dirs(["/first"])
+        set_extra_skill_dirs(["/second"])
+        assert get_extra_skill_dirs() == ["/second"]
+
+    def test_empty_list_clears_previous(self, settings_file):
+        """Setting an empty list clears all extra dirs."""
+        set_extra_skill_dirs(["/something"])
+        set_extra_skill_dirs([])
+        assert get_extra_skill_dirs() == []
+
+
+class TestExtraAgentAndSkillDirsAreIndependent:
+    """The agent and skill extra-dir lists are stored under separate keys."""
+
+    def test_independent_keys(self, settings_file):
+        set_extra_agent_dirs(["/agents"])
+        set_extra_skill_dirs(["/skills"])
+        assert get_extra_agent_dirs() == ["/agents"]
+        assert get_extra_skill_dirs() == ["/skills"]

--- a/test/services/test_settings_service.py
+++ b/test/services/test_settings_service.py
@@ -219,6 +219,17 @@ class TestGetExtraSkillDirs:
         result = get_extra_skill_dirs()
         assert result == ["/a", "/b"]
 
+    def test_filters_non_string_and_empty_entries(self, settings_file):
+        """Malformed persisted entries (null/numbers/blank) are dropped, not returned.
+
+        Otherwise Path(extra) in _skill_search_dirs() would raise TypeError and
+        break skill listing/loading.
+        """
+        settings_file.write_text(
+            json.dumps({"extra_skill_dirs": ["/valid", None, 123, "", "  ", "/also-valid"]})
+        )
+        assert get_extra_skill_dirs() == ["/valid", "/also-valid"]
+
 
 class TestSetExtraSkillDirs:
     """Tests for set_extra_skill_dirs function."""
@@ -231,6 +242,11 @@ class TestSetExtraSkillDirs:
     def test_strips_empty_strings(self, settings_file):
         """set_extra_skill_dirs removes empty or whitespace-only strings."""
         result = set_extra_skill_dirs(["/valid", "", "  ", "/also-valid"])
+        assert result == ["/valid", "/also-valid"]
+
+    def test_ignores_non_string_entries(self, settings_file):
+        """Non-string entries are dropped rather than crashing on .strip()."""
+        result = set_extra_skill_dirs(["/valid", None, 123, "/also-valid"])
         assert result == ["/valid", "/also-valid"]
 
     def test_persists_to_disk(self, settings_file):

--- a/test/utils/test_skills.py
+++ b/test/utils/test_skills.py
@@ -288,6 +288,44 @@ class TestExtraSkillDirs:
         with pytest.raises(FileNotFoundError, match="Skill folder does not exist"):
             load_skill_metadata("nope")
 
+    def test_invalid_earlier_skill_does_not_shadow_valid_extra(self, tmp_path, monkeypatch):
+        """A broken same-named folder in an earlier dir must not hide a valid later one.
+
+        ``list_skills`` already skips the invalid folder and advertises the
+        valid extra-dir skill; ``_resolve_skill_path`` must agree so ``load_skill``
+        succeeds for the same name ("first valid match wins").
+        """
+        global_dir = tmp_path / "global"
+        # Invalid: folder name does not match the declared skill name.
+        broken = global_dir / "task"
+        broken.mkdir(parents=True)
+        (broken / "SKILL.md").write_text("---\nname: other\ndescription: Broken\n---\n\nBody\n")
+        extra = tmp_path / "project"
+        _write_skill(extra / "task", "task", "Project task", body="# Task\n\nSteps.")
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        # list and load must agree: both resolve to the valid extra-dir skill.
+        assert "task" in [skill.name for skill in list_skills()]
+        assert load_skill_metadata("task").description == "Project task"
+        assert load_skill_content("task") == "# Task\n\nSteps."
+
+    def test_invalid_only_skill_surfaces_validation_error(self, tmp_path, monkeypatch):
+        """When the only same-named folder is invalid, the real validation error is raised.
+
+        The fallback preserves the meaningful error instead of degrading to a
+        generic "Skill folder does not exist".
+        """
+        global_dir = tmp_path / "global"
+        broken = global_dir / "task"
+        broken.mkdir(parents=True)
+        (broken / "SKILL.md").write_text("---\nname: other\ndescription: Broken\n---\n\nBody\n")
+        extra = tmp_path / "project"
+        extra.mkdir()
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        with pytest.raises(ValueError, match="does not match skill name"):
+            load_skill_metadata("task")
+
 
 class TestValidateSkillFolder:
     """Tests for validate_skill_folder."""

--- a/test/utils/test_skills.py
+++ b/test/utils/test_skills.py
@@ -25,6 +25,29 @@ def _write_skill(folder: Path, name: str, description: str, body: str = "# Title
     return skill_file
 
 
+@pytest.fixture(autouse=True)
+def _default_no_extra_skill_dirs(monkeypatch):
+    """Default ``extra_skill_dirs`` to empty for every test.
+
+    Existing tests patch only ``SKILLS_DIR``; without this they would read the
+    developer's real ``settings.json``. Tests that exercise extra dirs override
+    this via ``_use_skill_dirs``.
+    """
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_extra_skill_dirs",
+        lambda: [],
+    )
+
+
+def _use_skill_dirs(monkeypatch, global_dir, extra_dirs):
+    """Point skill resolution at a global store plus a list of extra directories."""
+    monkeypatch.setattr("cli_agent_orchestrator.utils.skills.SKILLS_DIR", global_dir)
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_extra_skill_dirs",
+        lambda: [str(d) for d in extra_dirs],
+    )
+
+
 class TestLoadSkillMetadata:
     """Tests for load_skill_metadata."""
 
@@ -179,6 +202,78 @@ class TestListSkills:
         assert [skill.name for skill in skills] == ["valid-skill"]
         assert "Skipping invalid skill folder" in caplog.text
         assert "broken-skill" in caplog.text
+
+
+class TestExtraSkillDirs:
+    """Resolving skills from ``extra_skill_dirs`` (mirrors ``extra_agent_dirs``)."""
+
+    def test_load_metadata_from_extra_dir(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        extra = tmp_path / "project"
+        _write_skill(extra / "task", "task", "Project task workflow")
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        metadata = load_skill_metadata("task")
+
+        assert metadata == SkillMetadata(name="task", description="Project task workflow")
+
+    def test_load_content_from_extra_dir(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        extra = tmp_path / "project"
+        _write_skill(extra / "task", "task", "Project task", body="# Task\n\nSteps.")
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        assert load_skill_content("task") == "# Task\n\nSteps."
+
+    def test_global_store_takes_precedence_over_extra_dir(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / "global"
+        _write_skill(global_dir / "task", "task", "Global task")
+        extra = tmp_path / "project"
+        _write_skill(extra / "task", "task", "Project task")
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        assert load_skill_metadata("task").description == "Global task"
+
+    def test_list_includes_global_and_extra_dirs(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / "global"
+        _write_skill(global_dir / "alpha", "alpha", "Global alpha")
+        extra = tmp_path / "project"
+        _write_skill(extra / "beta", "beta", "Project beta")
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        assert [skill.name for skill in list_skills()] == ["alpha", "beta"]
+
+    def test_list_dedups_with_global_winning_over_extra(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / "global"
+        _write_skill(global_dir / "task", "task", "Global task")
+        extra = tmp_path / "project"
+        _write_skill(extra / "task", "task", "Project task")
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        skills = list_skills()
+
+        assert [skill.name for skill in skills] == ["task"]
+        assert skills[0].description == "Global task"
+
+    def test_list_skips_missing_extra_dir(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / "global"
+        _write_skill(global_dir / "alpha", "alpha", "Global alpha")
+        missing = tmp_path / "does-not-exist"
+        _use_skill_dirs(monkeypatch, global_dir, [missing])
+
+        assert [skill.name for skill in list_skills()] == ["alpha"]
+
+    def test_missing_skill_falls_back_to_global_path_error(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        extra = tmp_path / "project"
+        extra.mkdir()
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        with pytest.raises(FileNotFoundError, match="Skill folder does not exist"):
+            load_skill_metadata("nope")
 
 
 class TestValidateSkillFolder:

--- a/test/utils/test_skills.py
+++ b/test/utils/test_skills.py
@@ -257,6 +257,19 @@ class TestExtraSkillDirs:
         assert [skill.name for skill in skills] == ["task"]
         assert skills[0].description == "Global task"
 
+    def test_list_skips_non_skill_subdir_silently(self, tmp_path, monkeypatch, caplog):
+        global_dir = tmp_path / "global"
+        _write_skill(global_dir / "alpha", "alpha", "Global alpha")
+        extra = tmp_path / "project"
+        _write_skill(extra / "task", "task", "Project task")
+        (extra / "node_modules").mkdir(parents=True)  # unrelated folder, no SKILL.md
+        _use_skill_dirs(monkeypatch, global_dir, [extra])
+
+        skills = list_skills()
+
+        assert [skill.name for skill in skills] == ["alpha", "task"]
+        assert "node_modules" not in caplog.text
+
     def test_list_skips_missing_extra_dir(self, tmp_path, monkeypatch):
         global_dir = tmp_path / "global"
         _write_skill(global_dir / "alpha", "alpha", "Global alpha")


### PR DESCRIPTION
## Summary

Skills can only be loaded from the single global skill store (`~/.aws/cli-agent-orchestrator/skills/`), so the only way to make a project's skills available to the running CAO server is to copy or symlink each skill folder into that global directory. Agent profiles already solve the equivalent problem via the `extra_agent_dirs` setting — this PR adds the symmetric **`extra_skill_dirs`** so skills get the same first-class, project-friendly discovery.

## Motivation

`extra_agent_dirs` lets you keep agent profiles in a project repo and register the directory once; CAO then discovers them live. Skills had no equivalent, so project-local skills required a per-skill symlink farm into the global store (brittle, and `cao skills add` *copies* rather than links). Adding the mirror setting removes that asymmetry and the symlink workaround.

## What changed

- **`settings_service`** — `get_extra_skill_dirs` / `set_extra_skill_dirs` (mirror of the existing `*_extra_agent_dirs` pair).
- **`utils/skills`** — `load_skill_metadata`, `load_skill_content`, and `list_skills` now resolve across the global store **first**, then each `extra_skill_dirs` entry. First match wins, so a global skill is never shadowed by an extra directory; `list_skills` dedups by name and skips invalid folders.
- **API** — `GET` / `POST /settings/skill-dirs` (mirror of `/settings/agent-dirs`).
- **docs/settings.md** — documents the setting and the endpoints.
- **tests** — `settings_service`, `utils/skills`, `api/settings`, plus an autouse fixture in the skills-CLI tests so the existing "empty store" assertions don't read a developer's real `extra_skill_dirs`.

## Scope / compatibility

Discovery parity only. Resolution stays global/flat, and behavior is unchanged when `extra_skill_dirs` is empty (the default). Directories are scanned live on each request, exactly like `extra_agent_dirs`. Project-scoped *visibility* (per agent / per project) is intentionally out of scope and can build on this later.

## Testing

- `pytest` — full suite green.
- `black` / `isort` — clean.
