### PR TITLE
feat(web): add optional Session Name field to the Spawn Agent dialog

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -107,7 +107,7 @@ export const api = {
   listSessions: () => fetchJSON<Session[]>('/sessions'),
   getSession: (name: string) => fetchJSON<SessionDetail>(`/sessions/${name}`),
   createSession: (provider: string, agentProfile: string, sessionName?: string, workingDirectory?: string) =>
-    fetchJSON<Terminal>(`/sessions?provider=${provider}&agent_profile=${agentProfile}${sessionName ? `&session_name=${encodeURIComponent(sessionName)}` : ''}${workingDirectory ? `&working_directory=${encodeURIComponent(workingDirectory)}` : ''}`, { method: 'POST', timeoutMs: 90000 }),
+    fetchJSON<Terminal>(`/sessions?provider=${encodeURIComponent(provider)}&agent_profile=${encodeURIComponent(agentProfile)}${sessionName ? `&session_name=${encodeURIComponent(sessionName)}` : ''}${workingDirectory ? `&working_directory=${encodeURIComponent(workingDirectory)}` : ''}`, { method: 'POST', timeoutMs: 90000 }),
   deleteSession: (name: string) => fetchJSON<{ success: boolean; deleted: string[]; errors: any[] }>(`/sessions/${name}`, { method: 'DELETE' }),
 
   // Terminals
@@ -123,7 +123,7 @@ export const api = {
   getWorkingDirectory: (id: string) =>
     fetchJSON<{ working_directory: string | null }>(`/terminals/${id}/working-directory`),
   addTerminalToSession: (sessionName: string, provider: string, agentProfile: string, workingDirectory?: string) =>
-    fetchJSON<Terminal>(`/sessions/${sessionName}/terminals?provider=${provider}&agent_profile=${agentProfile}${workingDirectory ? `&working_directory=${encodeURIComponent(workingDirectory)}` : ''}`, { method: 'POST', timeoutMs: 90000 }),
+    fetchJSON<Terminal>(`/sessions/${sessionName}/terminals?provider=${encodeURIComponent(provider)}&agent_profile=${encodeURIComponent(agentProfile)}${workingDirectory ? `&working_directory=${encodeURIComponent(workingDirectory)}` : ''}`, { method: 'POST', timeoutMs: 90000 }),
 
   // Inbox
   getInboxMessages: (terminalId: string, limit?: number, status?: string) =>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -107,7 +107,7 @@ export const api = {
   listSessions: () => fetchJSON<Session[]>('/sessions'),
   getSession: (name: string) => fetchJSON<SessionDetail>(`/sessions/${name}`),
   createSession: (provider: string, agentProfile: string, sessionName?: string, workingDirectory?: string) =>
-    fetchJSON<Terminal>(`/sessions?provider=${provider}&agent_profile=${agentProfile}${sessionName ? `&session_name=${sessionName}` : ''}${workingDirectory ? `&working_directory=${encodeURIComponent(workingDirectory)}` : ''}`, { method: 'POST', timeoutMs: 90000 }),
+    fetchJSON<Terminal>(`/sessions?provider=${provider}&agent_profile=${agentProfile}${sessionName ? `&session_name=${encodeURIComponent(sessionName)}` : ''}${workingDirectory ? `&working_directory=${encodeURIComponent(workingDirectory)}` : ''}`, { method: 'POST', timeoutMs: 90000 }),
   deleteSession: (name: string) => fetchJSON<{ success: boolean; deleted: string[]; errors: any[] }>(`/sessions/${name}`, { method: 'DELETE' }),
 
   // Terminals

--- a/web/src/components/AgentPanel.tsx
+++ b/web/src/components/AgentPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useStore } from '../store'
 import { api, AgentProfileInfo, ProviderInfo } from '../api'
-import { Bot, Play, Trash2, ChevronRight, Terminal as TermIcon, Monitor, Package, FolderOpen, Search, Mail, Plus, LogOut, Send, FileText, X } from 'lucide-react'
+import { Bot, Play, Trash2, ChevronRight, Terminal as TermIcon, Monitor, Package, FolderOpen, Tag, Search, Mail, Plus, LogOut, Send, FileText, X } from 'lucide-react'
 import { TerminalView } from './TerminalView'
 import { ConfirmModal } from './ConfirmModal'
 import { InboxPanel } from './InboxPanel'
@@ -45,6 +45,7 @@ export function AgentPanel() {
   const [sessionSearch, setSessionSearch] = useState('')
   const [inboxTerminalId, setInboxTerminalId] = useState<string | null>(null)
   const [workingDirectory, setWorkingDirectory] = useState('')
+  const [sessionName, setSessionName] = useState('')
   const [terminalWorkDirs, setTerminalWorkDirs] = useState<Record<string, string | null>>({})
   const [showAddAgent, setShowAddAgent] = useState(false)
   const [addProvider, setAddProvider] = useState('kiro_cli')
@@ -138,11 +139,12 @@ export function AgentPanel() {
   const handleCreate = async () => {
     if (!profile.trim()) return
     setCreating(true)
-    await createSession(provider, profile.trim(), workingDirectory.trim() || undefined)
+    await createSession(provider, profile.trim(), workingDirectory.trim() || undefined, sessionName.trim() || undefined)
     setCreating(false)
     setShowSpawnModal(false)
     setProfile('')
     setWorkingDirectory('')
+    setSessionName('')
   }
 
   const openTerminal = (terminalId: string, provider?: string, agentProfile?: string | null) => {
@@ -561,6 +563,21 @@ export function AgentPanel() {
                     className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2.5 focus:border-emerald-500 focus:outline-none"
                   />
                 )}
+              </div>
+
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">Session Name <span className="text-gray-600">(optional)</span></label>
+                <div className="relative">
+                  <Tag size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
+                  <input
+                    type="text"
+                    value={sessionName}
+                    onChange={e => setSessionName(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && handleCreate()}
+                    placeholder="my-session (or a random id like cao-a1b2c3d4)"
+                    className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg pl-9 pr-3 py-2.5 focus:border-emerald-500 focus:outline-none"
+                  />
+                </div>
               </div>
 
               <div>

--- a/web/src/components/AgentPanel.tsx
+++ b/web/src/components/AgentPanel.tsx
@@ -25,6 +25,10 @@ export function AgentPanel() {
   const [provider, setProvider] = useState('kiro_cli')
   const [profile, setProfile] = useState('')
   const [creating, setCreating] = useState(false)
+  // Synchronous in-flight lock: prevents a second submit (rapid double-click or
+  // Enter in the form inputs, which bypass the button's disabled state) from
+  // firing before the `creating` state re-renders and creating a duplicate session.
+  const creatingRef = useRef(false)
   const [liveTerminal, setLiveTerminal] = useState<{ id: string; provider?: string; agentProfile?: string | null } | null>(null)
   const [profiles, setProfiles] = useState<AgentProfileInfo[]>([])
   const [loadingProfiles, setLoadingProfiles] = useState(true)
@@ -137,14 +141,19 @@ export function AgentPanel() {
   }, [activeSessionDetail?.terminals.map(t => t.id).join(',')])
 
   const handleCreate = async () => {
-    if (!profile.trim()) return
+    if (creatingRef.current || !profile.trim()) return
+    creatingRef.current = true
     setCreating(true)
-    await createSession(provider, profile.trim(), workingDirectory.trim() || undefined, sessionName.trim() || undefined)
-    setCreating(false)
-    setShowSpawnModal(false)
-    setProfile('')
-    setWorkingDirectory('')
-    setSessionName('')
+    try {
+      await createSession(provider, profile.trim(), workingDirectory.trim() || undefined, sessionName.trim() || undefined)
+      setShowSpawnModal(false)
+      setProfile('')
+      setWorkingDirectory('')
+      setSessionName('')
+    } finally {
+      setCreating(false)
+      creatingRef.current = false
+    }
   }
 
   const openTerminal = (terminalId: string, provider?: string, agentProfile?: string | null) => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -21,7 +21,7 @@ interface Store {
 
   fetchSessions: () => Promise<void>
   selectSession: (name: string | null) => Promise<void>
-  createSession: (provider: string, agentProfile: string, workingDirectory?: string) => Promise<void>
+  createSession: (provider: string, agentProfile: string, workingDirectory?: string, sessionName?: string) => Promise<void>
   deleteSession: (name: string) => Promise<void>
   showSnackbar: (snackbar: Snackbar) => void
   hideSnackbar: () => void
@@ -72,9 +72,9 @@ export const useStore = create<Store>((set, get) => ({
     }
   },
 
-  createSession: async (provider, agentProfile, workingDirectory) => {
+  createSession: async (provider, agentProfile, workingDirectory, sessionName) => {
     try {
-      await api.createSession(provider, agentProfile, undefined, workingDirectory)
+      await api.createSession(provider, agentProfile, sessionName, workingDirectory)
       get().showSnackbar({ type: 'success', message: 'Session created' })
       await get().fetchSessions()
     } catch (e: any) {

--- a/web/src/test/api.test.ts
+++ b/web/src/test/api.test.ts
@@ -85,6 +85,15 @@ describe('API wrapper', () => {
     )
   })
 
+  it('createSession includes session name (url-encoded) when provided', async () => {
+    mockResponse({ id: 't1' })
+    await api.createSession('kiro_cli', 'developer', 'my session/1')
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('session_name=my%20session%2F1'),
+      expect.any(Object)
+    )
+  })
+
   it('deleteSession sends DELETE', async () => {
     mockResponse({ success: true, deleted: [], errors: [] })
     await api.deleteSession('s1')

--- a/web/src/test/api.test.ts
+++ b/web/src/test/api.test.ts
@@ -94,6 +94,15 @@ describe('API wrapper', () => {
     )
   })
 
+  it('createSession url-encodes provider and agent_profile', async () => {
+    mockResponse({ id: 't1' })
+    await api.createSession('kiro_cli', 'my agent/v2')
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('agent_profile=my%20agent%2Fv2'),
+      expect.any(Object)
+    )
+  })
+
   it('deleteSession sends DELETE', async () => {
     mockResponse({ success: true, deleted: [], errors: [] })
     await api.deleteSession('s1')


### PR DESCRIPTION
## Summary

The Spawn Agent dialog in the web UI had no way to set a session name, so every web-created session got an auto-generated `cao-<hash>` name (8 hex chars from a UUID). That generated id is the only label the session list shows and searches by, and there is no rename — so the spawn dialog is the one place to give a session a readable identity. The backend `POST /sessions` and the CLI `--session-name` already accept a custom name; this just exposes it in the UI.

## What changed

- **AgentPanel** — add an optional "Session Name" input to the Spawn dialog (with a tag icon, mirroring the Working Directory field) and pass it to `createSession`.
- **store** — thread `sessionName` through `createSession` (it was hardcoded to `undefined`).
- **api** — URL-encode `session_name` in the query string (matching `working_directory`).
- **test** — `createSession` includes the URL-encoded `session_name`.

## Behavior

- Empty field → unchanged: the backend auto-generates `cao-<hash>` exactly as before.
- Filled → the session is created with that name; the backend validates it (`validate_tmux_name`) and prefixes `cao-` if missing, identical to `cao launch --session-name` and the API. A duplicate name surfaces the backend error in the existing snackbar.

<img width="585" height="699" alt="Screenshot 2026-06-05 at 16 51 53" src="https://github.com/user-attachments/assets/8956733a-199e-4aba-aff7-949973b9fc2b" />

This brings the web UI to parity with the CLI's `--session-name`.

## Testing

- `npm test` (vitest) — green.
- `npm run build` (tsc + vite) — clean.
