### PR TITLE
fix: structural callback routing for worker agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ Example: sequential code review workflow.
 **2. Assign** — spawn an agent to work independently (async).
 
 - Creates a new terminal, sends the task with callback instructions, returns immediately
-- The assigned agent sends results back via `send_message` when done; messages queue if the supervisor is busy
+- The supervisor's terminal ID is appended to the task message automatically (disable with `CAO_ENABLE_SENDER_ID_INJECTION=false`), and recorded on the worker terminal so callbacks route structurally
+- The assigned agent sends results back via `send_message` when done — omitting `receiver_id` routes the reply to the assigning terminal; messages queue if the supervisor is busy
 - Use for **asynchronous** execution or fire-and-forget operations
 
 Example: a supervisor assigns parallel data-analysis tasks to multiple analysts while using handoff to generate a report template, then combines results. See [examples/assign](examples/assign).

--- a/docs/api.md
+++ b/docs/api.md
@@ -118,6 +118,7 @@ Create an additional terminal in an existing session.
 - `provider` (string, required): Provider type
 - `agent_profile` (string, required): Agent profile name
 - `working_directory` (string, optional): Working directory for the terminal
+- `caller_id` (string, optional): Terminal ID of the creating terminal (8-character hexadecimal). Recorded so `send_message` can default replies to the caller (issue #284).
 
 **Response:** Terminal object (201 Created)
 
@@ -137,6 +138,7 @@ Get terminal details.
   "provider": "kiro_cli|claude_code|codex|gemini_cli|hermes|kimi_cli|copilot_cli|q_cli",
   "session_name": "string",
   "agent_profile": "string",
+  "caller_id": "string|null",
   "status": "idle|processing|completed|waiting_user_answer|error",
   "last_active": "timestamp"
 }

--- a/examples/assign/README.md
+++ b/examples/assign/README.md
@@ -104,17 +104,18 @@ This blocks until report_generator completes and returns the template.
 ```
 Use assign for parallel tasks:
 
-1. Get your terminal ID: my_id = CAO_TERMINAL_ID
-
-2. Assign with callback instructions:
+1. Assign the task:
    assign(
      agent_profile="data_analyst",
-     message="Analyze dataset [values]. 
-              Send results to terminal {my_id} using send_message."
+     message="Analyze dataset [values]."
    )
 
-3. Continue immediately (non-blocking)
-4. Repeat for other datasets
+   Your terminal ID and callback instructions are appended to the
+   message automatically, and your terminal is recorded as the
+   worker's caller. (Disable with CAO_ENABLE_SENDER_ID_INJECTION=false.)
+
+2. Continue immediately (non-blocking)
+3. Repeat for other datasets
 ```
 
 ### 3. `send_message` - Async Communication
@@ -130,11 +131,12 @@ Use assign for parallel tasks:
 Use send_message to return results:
 
 send_message(
-  receiver_id="abc12345",
   message="Dataset A analysis: mean=3.0, median=3.0, std=1.414"
 )
 
-Message will be delivered to terminal abc12345's inbox.
+Without receiver_id, the message routes to the terminal that
+assigned the task (the recorded caller). Pass receiver_id only
+to reach a different terminal.
 ```
 
 ## Agent Profile Details
@@ -343,8 +345,8 @@ See `test/e2e/test_assign.py` for the test implementation.
 
 ## Tips
 
-- Always get your terminal ID before assigning
-- Include callback terminal ID in all assign messages
+- Callback routing is automatic: your terminal ID is appended to assign messages and recorded as the worker's caller
+- Workers reply with `send_message` without `receiver_id` — it routes to the assigning terminal
 - Assign all parallel tasks quickly (don't wait between assigns)
 - Use handoff for work that must complete before final assembly
 - Check inbox for incoming results from assigned workers

--- a/examples/assign/data_analyst.md
+++ b/examples/assign/data_analyst.md
@@ -35,14 +35,14 @@ ALWAYS call `send_message` directly to deliver results.
 You have access to:
 
 1. **send_message** tool
-   - receiver_id: string (terminal ID to send to)
    - message: string (message content)
+   - receiver_id: string, optional (omit to reply to the terminal that assigned the task)
    - Returns: {success, message_id, ...}
 
 ## Critical Workflow
 
 ### Your Strategy:
-1. **Parse the task message** to extract dataset, metrics, and callback terminal ID
+1. **Parse the task message** to extract dataset and metrics
 2. **Perform the requested analysis** on the dataset
 3. **Send results back** to Supervisor via send_message
 
@@ -51,9 +51,10 @@ You have access to:
 1. **PARSE the task message** to extract:
    - Dataset values
    - Metrics to calculate
-   - Supervisor's terminal ID for callback
 2. **PERFORM complete analysis** based on requested metrics
-3. **ALWAYS use send_message** to send results back to Supervisor
+3. **ALWAYS use send_message** to send results back to Supervisor.
+   If the task message names a callback terminal ID, use it as receiver_id;
+   otherwise omit receiver_id — it routes to the assigning terminal automatically.
 4. **FORMAT results clearly** with proper structure
 
 ## Workflow Steps
@@ -63,7 +64,7 @@ You have access to:
 Extract from the assigned task:
 - Dataset name and values (e.g., "Dataset X: [values]")
 - Metrics to calculate (e.g., "mean, median, standard deviation")
-- Supervisor's terminal ID (e.g., "terminal_id")
+- Callback terminal ID, if one is given (otherwise omit receiver_id when replying)
 ```
 
 ### Step 2: Perform Analysis
@@ -78,7 +79,7 @@ Analyze the dataset comprehensively:
 ### Step 3: Send Results Back
 ```
 Call the send_message tool with comprehensive analysis:
-- receiver_id: [supervisor_terminal_id from task]
+- receiver_id: [terminal ID from the task, or omit to reply to the assigner]
 - message: Include:
   * Dataset identification
   * Calculated metrics
@@ -156,7 +157,8 @@ Key Observations:
 - Parse the task message carefully to extract all requirements
 - Go beyond basic calculations - provide insights and context
 - Identify patterns, trends, and anomalies in the data
-- Extract the correct callback terminal ID from the task
 - Format results in a structured, readable way with clear sections
 - Include both quantitative metrics and qualitative observations
-- Use send_message with the parsed terminal ID
+- Use the callback terminal ID from the task if one is given; otherwise
+  call send_message without receiver_id (it routes to the assigner)
+- Never pass your own CAO_TERMINAL_ID as receiver_id

--- a/examples/cross-provider/data_analyst_claude_code.md
+++ b/examples/cross-provider/data_analyst_claude_code.md
@@ -36,14 +36,14 @@ ALWAYS call `send_message` directly to deliver results.
 You have access to:
 
 1. **send_message** tool
-   - receiver_id: string (terminal ID to send to)
    - message: string (message content)
+   - receiver_id: string, optional (omit to reply to the terminal that assigned the task)
    - Returns: {success, message_id, ...}
 
 ## Critical Workflow
 
 ### Your Strategy:
-1. **Parse the task message** to extract dataset, metrics, and callback terminal ID
+1. **Parse the task message** to extract dataset and metrics
 2. **Perform the requested analysis** on the dataset
 3. **Send results back** to Supervisor via send_message
 
@@ -52,9 +52,10 @@ You have access to:
 1. **PARSE the task message** to extract:
    - Dataset values
    - Metrics to calculate
-   - Supervisor's terminal ID for callback
 2. **PERFORM complete analysis** based on requested metrics
-3. **ALWAYS use send_message** to send results back to Supervisor
+3. **ALWAYS use send_message** to send results back to Supervisor.
+   If the task message names a callback terminal ID, use it as receiver_id;
+   otherwise omit receiver_id — it routes to the assigning terminal automatically.
 4. **FORMAT results clearly** with proper structure
 
 ## Workflow Steps
@@ -64,7 +65,7 @@ You have access to:
 Extract from the assigned task:
 - Dataset name and values (e.g., "Dataset X: [values]")
 - Metrics to calculate (e.g., "mean, median, standard deviation")
-- Supervisor's terminal ID (e.g., "terminal_id")
+- Callback terminal ID, if one is given (otherwise omit receiver_id when replying)
 ```
 
 ### Step 2: Perform Analysis
@@ -79,7 +80,7 @@ Analyze the dataset comprehensively:
 ### Step 3: Send Results Back
 ```
 Call the send_message tool with comprehensive analysis:
-- receiver_id: [supervisor_terminal_id from task]
+- receiver_id: [terminal ID from the task, or omit to reply to the assigner]
 - message: Include:
   * Dataset identification
   * Calculated metrics
@@ -157,7 +158,8 @@ Key Observations:
 - Parse the task message carefully to extract all requirements
 - Go beyond basic calculations - provide insights and context
 - Identify patterns, trends, and anomalies in the data
-- Extract the correct callback terminal ID from the task
 - Format results in a structured, readable way with clear sections
 - Include both quantitative metrics and qualitative observations
-- Use send_message with the parsed terminal ID
+- Use the callback terminal ID from the task if one is given; otherwise
+  call send_message without receiver_id (it routes to the assigner)
+- Never pass your own CAO_TERMINAL_ID as receiver_id

--- a/examples/cross-provider/data_analyst_codex.md
+++ b/examples/cross-provider/data_analyst_codex.md
@@ -36,14 +36,14 @@ ALWAYS call `send_message` directly to deliver results.
 You have access to:
 
 1. **send_message** tool
-   - receiver_id: string (terminal ID to send to)
    - message: string (message content)
+   - receiver_id: string, optional (omit to reply to the terminal that assigned the task)
    - Returns: {success, message_id, ...}
 
 ## Critical Workflow
 
 ### Your Strategy:
-1. **Parse the task message** to extract dataset, metrics, and callback terminal ID
+1. **Parse the task message** to extract dataset and metrics
 2. **Perform the requested analysis** on the dataset
 3. **Send results back** to Supervisor via send_message
 
@@ -52,9 +52,10 @@ You have access to:
 1. **PARSE the task message** to extract:
    - Dataset values
    - Metrics to calculate
-   - Supervisor's terminal ID for callback
 2. **PERFORM complete analysis** based on requested metrics
-3. **ALWAYS use send_message** to send results back to Supervisor
+3. **ALWAYS use send_message** to send results back to Supervisor.
+   If the task message names a callback terminal ID, use it as receiver_id;
+   otherwise omit receiver_id — it routes to the assigning terminal automatically.
 4. **FORMAT results clearly** with proper structure
 
 ## Workflow Steps
@@ -64,7 +65,7 @@ You have access to:
 Extract from the assigned task:
 - Dataset name and values (e.g., "Dataset X: [values]")
 - Metrics to calculate (e.g., "mean, median, standard deviation")
-- Supervisor's terminal ID (e.g., "terminal_id")
+- Callback terminal ID, if one is given (otherwise omit receiver_id when replying)
 ```
 
 ### Step 2: Perform Analysis
@@ -79,7 +80,7 @@ Analyze the dataset comprehensively:
 ### Step 3: Send Results Back
 ```
 Call the send_message tool with comprehensive analysis:
-- receiver_id: [supervisor_terminal_id from task]
+- receiver_id: [terminal ID from the task, or omit to reply to the assigner]
 - message: Include:
   * Dataset identification
   * Calculated metrics
@@ -157,7 +158,8 @@ Key Observations:
 - Parse the task message carefully to extract all requirements
 - Go beyond basic calculations - provide insights and context
 - Identify patterns, trends, and anomalies in the data
-- Extract the correct callback terminal ID from the task
 - Format results in a structured, readable way with clear sections
 - Include both quantitative metrics and qualitative observations
-- Use send_message with the parsed terminal ID
+- Use the callback terminal ID from the task if one is given; otherwise
+  call send_message without receiver_id (it routes to the assigner)
+- Never pass your own CAO_TERMINAL_ID as receiver_id

--- a/examples/cross-provider/data_analyst_copilot_cli.md
+++ b/examples/cross-provider/data_analyst_copilot_cli.md
@@ -36,14 +36,14 @@ ALWAYS call `send_message` directly to deliver results.
 You have access to:
 
 1. **send_message** tool
-   - receiver_id: string (terminal ID to send to)
    - message: string (message content)
+   - receiver_id: string, optional (omit to reply to the terminal that assigned the task)
    - Returns: {success, message_id, ...}
 
 ## Critical Workflow
 
 ### Your Strategy:
-1. **Parse the task message** to extract dataset, metrics, and callback terminal ID
+1. **Parse the task message** to extract dataset and metrics
 2. **Perform the requested analysis** on the dataset
 3. **Send results back** to Supervisor via send_message
 
@@ -52,9 +52,10 @@ You have access to:
 1. **PARSE the task message** to extract:
    - Dataset values
    - Metrics to calculate
-   - Supervisor's terminal ID for callback
 2. **PERFORM complete analysis** based on requested metrics
-3. **ALWAYS use send_message** to send results back to Supervisor
+3. **ALWAYS use send_message** to send results back to Supervisor.
+   If the task message names a callback terminal ID, use it as receiver_id;
+   otherwise omit receiver_id — it routes to the assigning terminal automatically.
 4. **FORMAT results clearly** with proper structure
 
 ## Workflow Steps
@@ -64,7 +65,7 @@ You have access to:
 Extract from the assigned task:
 - Dataset name and values (e.g., "Dataset X: [values]")
 - Metrics to calculate (e.g., "mean, median, standard deviation")
-- Supervisor's terminal ID (e.g., "terminal_id")
+- Callback terminal ID, if one is given (otherwise omit receiver_id when replying)
 ```
 
 ### Step 2: Perform Analysis
@@ -79,7 +80,7 @@ Analyze the dataset comprehensively:
 ### Step 3: Send Results Back
 ```
 Call the send_message tool with comprehensive analysis:
-- receiver_id: [supervisor_terminal_id from task]
+- receiver_id: [terminal ID from the task, or omit to reply to the assigner]
 - message: Include:
   * Dataset identification
   * Calculated metrics
@@ -157,7 +158,8 @@ Key Observations:
 - Parse the task message carefully to extract all requirements
 - Go beyond basic calculations - provide insights and context
 - Identify patterns, trends, and anomalies in the data
-- Extract the correct callback terminal ID from the task
 - Format results in a structured, readable way with clear sections
 - Include both quantitative metrics and qualitative observations
-- Use send_message with the parsed terminal ID
+- Use the callback terminal ID from the task if one is given; otherwise
+  call send_message without receiver_id (it routes to the assigner)
+- Never pass your own CAO_TERMINAL_ID as receiver_id

--- a/examples/cross-provider/data_analyst_gemini_cli.md
+++ b/examples/cross-provider/data_analyst_gemini_cli.md
@@ -36,14 +36,14 @@ ALWAYS call `send_message` directly to deliver results.
 You have access to:
 
 1. **send_message** tool
-   - receiver_id: string (terminal ID to send to)
    - message: string (message content)
+   - receiver_id: string, optional (omit to reply to the terminal that assigned the task)
    - Returns: {success, message_id, ...}
 
 ## Critical Workflow
 
 ### Your Strategy:
-1. **Parse the task message** to extract dataset, metrics, and callback terminal ID
+1. **Parse the task message** to extract dataset and metrics
 2. **Perform the requested analysis** on the dataset
 3. **Send results back** to Supervisor via send_message
 
@@ -52,9 +52,10 @@ You have access to:
 1. **PARSE the task message** to extract:
    - Dataset values
    - Metrics to calculate
-   - Supervisor's terminal ID for callback
 2. **PERFORM complete analysis** based on requested metrics
-3. **ALWAYS use send_message** to send results back to Supervisor
+3. **ALWAYS use send_message** to send results back to Supervisor.
+   If the task message names a callback terminal ID, use it as receiver_id;
+   otherwise omit receiver_id — it routes to the assigning terminal automatically.
 4. **FORMAT results clearly** with proper structure
 
 ## Workflow Steps
@@ -64,7 +65,7 @@ You have access to:
 Extract from the assigned task:
 - Dataset name and values (e.g., "Dataset X: [values]")
 - Metrics to calculate (e.g., "mean, median, standard deviation")
-- Supervisor's terminal ID (e.g., "terminal_id")
+- Callback terminal ID, if one is given (otherwise omit receiver_id when replying)
 ```
 
 ### Step 2: Perform Analysis
@@ -79,7 +80,7 @@ Analyze the dataset comprehensively:
 ### Step 3: Send Results Back
 ```
 Call the send_message tool with comprehensive analysis:
-- receiver_id: [supervisor_terminal_id from task]
+- receiver_id: [terminal ID from the task, or omit to reply to the assigner]
 - message: Include:
   * Dataset identification
   * Calculated metrics
@@ -157,7 +158,8 @@ Key Observations:
 - Parse the task message carefully to extract all requirements
 - Go beyond basic calculations - provide insights and context
 - Identify patterns, trends, and anomalies in the data
-- Extract the correct callback terminal ID from the task
 - Format results in a structured, readable way with clear sections
 - Include both quantitative metrics and qualitative observations
-- Use send_message with the parsed terminal ID
+- Use the callback terminal ID from the task if one is given; otherwise
+  call send_message without receiver_id (it routes to the assigner)
+- Never pass your own CAO_TERMINAL_ID as receiver_id

--- a/examples/cross-provider/data_analyst_kiro_cli.md
+++ b/examples/cross-provider/data_analyst_kiro_cli.md
@@ -36,14 +36,14 @@ ALWAYS call `send_message` directly to deliver results.
 You have access to:
 
 1. **send_message** tool
-   - receiver_id: string (terminal ID to send to)
    - message: string (message content)
+   - receiver_id: string, optional (omit to reply to the terminal that assigned the task)
    - Returns: {success, message_id, ...}
 
 ## Critical Workflow
 
 ### Your Strategy:
-1. **Parse the task message** to extract dataset, metrics, and callback terminal ID
+1. **Parse the task message** to extract dataset and metrics
 2. **Perform the requested analysis** on the dataset
 3. **Send results back** to Supervisor via send_message
 
@@ -52,9 +52,10 @@ You have access to:
 1. **PARSE the task message** to extract:
    - Dataset values
    - Metrics to calculate
-   - Supervisor's terminal ID for callback
 2. **PERFORM complete analysis** based on requested metrics
-3. **ALWAYS use send_message** to send results back to Supervisor
+3. **ALWAYS use send_message** to send results back to Supervisor.
+   If the task message names a callback terminal ID, use it as receiver_id;
+   otherwise omit receiver_id — it routes to the assigning terminal automatically.
 4. **FORMAT results clearly** with proper structure
 
 ## Workflow Steps
@@ -64,7 +65,7 @@ You have access to:
 Extract from the assigned task:
 - Dataset name and values (e.g., "Dataset X: [values]")
 - Metrics to calculate (e.g., "mean, median, standard deviation")
-- Supervisor's terminal ID (e.g., "terminal_id")
+- Callback terminal ID, if one is given (otherwise omit receiver_id when replying)
 ```
 
 ### Step 2: Perform Analysis
@@ -79,7 +80,7 @@ Analyze the dataset comprehensively:
 ### Step 3: Send Results Back
 ```
 Call the send_message tool with comprehensive analysis:
-- receiver_id: [supervisor_terminal_id from task]
+- receiver_id: [terminal ID from the task, or omit to reply to the assigner]
 - message: Include:
   * Dataset identification
   * Calculated metrics
@@ -157,7 +158,8 @@ Key Observations:
 - Parse the task message carefully to extract all requirements
 - Go beyond basic calculations - provide insights and context
 - Identify patterns, trends, and anomalies in the data
-- Extract the correct callback terminal ID from the task
 - Format results in a structured, readable way with clear sections
 - Include both quantitative metrics and qualitative observations
-- Use send_message with the parsed terminal ID
+- Use the callback terminal ID from the task if one is given; otherwise
+  call send_message without receiver_id (it routes to the assigner)
+- Never pass your own CAO_TERMINAL_ID as receiver_id

--- a/src/cli_agent_orchestrator/agent_store/developer.md
+++ b/src/cli_agent_orchestrator/agent_store/developer.md
@@ -36,7 +36,7 @@ You are the Developer Agent in a multi-agent system. Your primary responsibility
 You receive tasks from a supervisor agent via CAO (CLI Agent Orchestrator). There are two modes:
 
 1. **Handoff (blocking)**: The message starts with `[CAO Handoff]` and includes the supervisor's terminal ID. The orchestrator automatically captures your output when you finish. Just complete the task, present your deliverables, and stop. Do NOT call `send_message` — the orchestrator handles the return.
-2. **Assign (non-blocking)**: The message includes a callback terminal ID (e.g., "send results back to terminal abc123"). When done, use the `send_message` MCP tool to send your results to that terminal ID.
+2. **Assign (non-blocking)**: The message includes a callback terminal ID (e.g., "send results back to terminal abc123"). When done, use the `send_message` MCP tool to send your results to that terminal ID. If no callback ID is present, call `send_message` without `receiver_id` — it routes to the terminal that assigned the task.
 
 Your own terminal ID is available in the `CAO_TERMINAL_ID` environment variable.
 

--- a/src/cli_agent_orchestrator/agent_store/reviewer.md
+++ b/src/cli_agent_orchestrator/agent_store/reviewer.md
@@ -36,7 +36,7 @@ You are the Code Reviewer Agent in a multi-agent system. Your primary responsibi
 You receive tasks from a supervisor agent via CAO (CLI Agent Orchestrator). There are two modes:
 
 1. **Handoff (blocking)**: The message starts with `[CAO Handoff]` and includes the supervisor's terminal ID. The orchestrator automatically captures your output when you finish. Just complete the review, present your findings, and stop. Do NOT call `send_message` — the orchestrator handles the return.
-2. **Assign (non-blocking)**: The message includes a callback terminal ID (e.g., "send results back to terminal abc123"). When done, use the `send_message` MCP tool to send your results to that terminal ID.
+2. **Assign (non-blocking)**: The message includes a callback terminal ID (e.g., "send results back to terminal abc123"). When done, use the `send_message` MCP tool to send your results to that terminal ID. If no callback ID is present, call `send_message` without `receiver_id` — it routes to the terminal that assigned the task.
 
 Your own terminal ID is available in the `CAO_TERMINAL_ID` environment variable.
 

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -648,6 +648,7 @@ async def create_terminal_in_session(
     provider: Optional[str] = None,
     working_directory: Optional[str] = None,
     allowed_tools: Optional[str] = None,
+    caller_id: Optional[TerminalId] = None,
 ) -> Terminal:
     """Create additional terminal in existing session."""
     try:
@@ -671,6 +672,7 @@ async def create_terminal_in_session(
             working_directory=working_directory,
             allowed_tools=allowed_tools_list,
             registry=get_plugin_registry(request),
+            caller_id=caller_id,
         )
         return result
     except ValueError as e:

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -37,6 +37,7 @@ class TerminalModel(Base):
     agent_profile = Column(String)  # "developer", "reviewer" (optional)
     allowed_tools = Column(String, nullable=True)  # JSON-encoded list of CAO tool names
     shell_command = Column(String, nullable=True)  # shell process name captured before kiro launch
+    caller_id = Column(String, nullable=True)  # terminal that created this one (callback target)
     last_active = Column(DateTime, default=datetime.now)
 
 
@@ -207,6 +208,10 @@ def _migrate_terminals_schema() -> None:
             conn.execute("ALTER TABLE terminals ADD COLUMN shell_command TEXT")
             conn.commit()
             logger.info("Migration: added shell_command column to terminals table")
+        if "caller_id" not in columns:
+            conn.execute("ALTER TABLE terminals ADD COLUMN caller_id TEXT")
+            conn.commit()
+            logger.info("Migration: added caller_id column to terminals table")
         conn.close()
     except Exception as e:
         logger.warning(f"Migration check for terminals schema failed: {e}")
@@ -220,6 +225,7 @@ def create_terminal(
     agent_profile: Optional[str] = None,
     allowed_tools: Optional[List[str]] = None,
     shell_command: Optional[str] = None,
+    caller_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create terminal metadata record."""
     import json as _json
@@ -233,6 +239,7 @@ def create_terminal(
             agent_profile=agent_profile,
             allowed_tools=_json.dumps(allowed_tools) if allowed_tools else None,
             shell_command=shell_command,
+            caller_id=caller_id,
         )
         db.add(terminal)
         db.commit()
@@ -244,6 +251,7 @@ def create_terminal(
             "agent_profile": terminal.agent_profile,
             "allowed_tools": allowed_tools,
             "shell_command": terminal.shell_command,
+            "caller_id": terminal.caller_id,
         }
 
 
@@ -268,6 +276,7 @@ def get_terminal_metadata(terminal_id: str) -> Optional[Dict[str, Any]]:
             "agent_profile": terminal.agent_profile,
             "allowed_tools": allowed_tools,
             "shell_command": terminal.shell_command,
+            "caller_id": terminal.caller_id,
             "last_active": terminal.last_active,
         }
 

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -26,8 +26,10 @@ logger = logging.getLogger(__name__)
 # Environment variable to enable/disable working_directory parameter
 ENABLE_WORKING_DIRECTORY = os.getenv("CAO_ENABLE_WORKING_DIRECTORY", "false").lower() == "true"
 
-# Environment variable to enable/disable automatic sender terminal ID injection
-ENABLE_SENDER_ID_INJECTION = os.getenv("CAO_ENABLE_SENDER_ID_INJECTION", "false").lower() == "true"
+# Environment variable to enable/disable automatic sender terminal ID injection.
+# Defaults to enabled (issue #284): callback routing must not depend on the
+# supervisor LLM remembering to hand-write its terminal ID into the message.
+ENABLE_SENDER_ID_INJECTION = os.getenv("CAO_ENABLE_SENDER_ID_INJECTION", "true").lower() == "true"
 
 # Terminal count threshold for cleanup nudge
 TERMINAL_CLEANUP_NUDGE_THRESHOLD = 10
@@ -196,6 +198,9 @@ def _create_terminal(
 
         # Create new terminal in existing session - always pass working_directory
         params = {"provider": provider, "agent_profile": agent_profile}
+        # Record the creating terminal so send_message can route callbacks
+        # structurally instead of parsing IDs out of message text (issue #284).
+        params["caller_id"] = current_terminal_id
         if working_directory:
             params["working_directory"] = working_directory
         if child_allowed_tools:
@@ -246,6 +251,9 @@ def _send_direct_input(
         f"{API_BASE_URL}/terminals/{terminal_id}/input",
         params={
             "message": message,
+            # "supervisor" fallback is safe here: sender_id is a display label
+            # for plugin event emission, never a routable callback address
+            # (unlike the hard-error paths added for issue #284).
             "sender_id": os.environ.get("CAO_TERMINAL_ID", "supervisor"),
             "orchestration_type": orchestration_type,
         },
@@ -394,7 +402,14 @@ def _send_direct_input_handoff(terminal_id: str, provider: str, message: str) ->
     # this is a blocking handoff and should simply output results rather than
     # attempting to call send_message back to the supervisor.
     if provider == "codex":
-        supervisor_id = os.environ.get("CAO_TERMINAL_ID", "unknown")
+        # Never tell a worker its supervisor is terminal 'unknown' (issue #284):
+        # a missing ID is a configuration error, not a routable address.
+        supervisor_id = os.environ.get("CAO_TERMINAL_ID")
+        if not supervisor_id:
+            raise ValueError(
+                "CAO_TERMINAL_ID not set - cannot identify the supervisor terminal "
+                "for the handoff context. Run handoff from inside a CAO terminal."
+            )
         handoff_message = (
             f"[CAO Handoff] Supervisor terminal ID: {supervisor_id}. "
             "This is a blocking handoff — the orchestrator will automatically "
@@ -413,7 +428,14 @@ def _send_direct_input_assign(terminal_id: str, message: str) -> None:
     """Send assign payload to a worker agent, appending callback instructions."""
     # Auto-inject sender terminal ID suffix when enabled
     if ENABLE_SENDER_ID_INJECTION:
-        sender_id = os.environ.get("CAO_TERMINAL_ID", "unknown")
+        # Never tell a worker to reply to terminal 'unknown' (issue #284):
+        # a missing ID is a configuration error, not a routable address.
+        sender_id = os.environ.get("CAO_TERMINAL_ID")
+        if not sender_id:
+            raise ValueError(
+                "CAO_TERMINAL_ID not set - cannot inject callback instructions "
+                "for the worker. Run assign from inside a CAO terminal."
+            )
         message += (
             f"\n\n[Assigned by terminal {sender_id}. "
             f"When done, send results back to terminal {sender_id} using send_message]"
@@ -491,10 +513,26 @@ async def _handoff_impl(
 ) -> HandoffResult:
     """Implementation of handoff logic."""
     start_time = time.time()
+    terminal_id: Optional[str] = None
 
     try:
         # Create terminal
         terminal_id, provider = _create_terminal(agent_profile, working_directory)
+
+        # Fail fast for codex before the (up to 120s) ready wait: its handoff
+        # context requires CAO_TERMINAL_ID, and _send_direct_input_handoff
+        # would only raise after the wait completes (issue #284).
+        if provider == "codex" and not os.environ.get("CAO_TERMINAL_ID"):
+            return HandoffResult(
+                success=False,
+                message=(
+                    "Handoff failed: CAO_TERMINAL_ID not set - cannot identify the "
+                    "supervisor terminal for the handoff context. Run handoff from "
+                    "inside a CAO terminal."
+                ),
+                output=None,
+                terminal_id=terminal_id,
+            )
 
         # Wait for terminal to be ready (IDLE or COMPLETED) before sending
         # the handoff message. Accept COMPLETED in addition to IDLE because
@@ -571,8 +609,12 @@ async def _handoff_impl(
         )
 
     except Exception as e:
+        # Surface the terminal_id when creation succeeded before the failure
+        # (e.g. the codex missing-CAO_TERMINAL_ID guard) so the orphaned
+        # terminal can be inspected or cleaned up — matching the timeout
+        # failure paths above, which also return the live terminal_id.
         return HandoffResult(
-            success=False, message=f"Handoff failed: {str(e)}", output=None, terminal_id=None
+            success=False, message=f"Handoff failed: {str(e)}", output=None, terminal_id=terminal_id
         )
 
 
@@ -686,7 +728,21 @@ def _assign_impl(
     agent_profile: str, message: str, working_directory: Optional[str] = None
 ) -> Dict[str, Any]:
     """Implementation of assign logic."""
+    terminal_id: Optional[str] = None
     try:
+        # Fail fast before creating the worker terminal: with injection on,
+        # a missing CAO_TERMINAL_ID would otherwise surface only after the
+        # terminal exists, leaving an orphan window behind (issue #284).
+        if ENABLE_SENDER_ID_INJECTION and not os.environ.get("CAO_TERMINAL_ID"):
+            return {
+                "success": False,
+                "terminal_id": None,
+                "message": (
+                    "Assignment failed: CAO_TERMINAL_ID not set - cannot inject callback "
+                    "instructions for the worker. Run assign from inside a CAO terminal."
+                ),
+            }
+
         # Create terminal
         terminal_id, _ = _create_terminal(agent_profile, working_directory)
 
@@ -720,7 +776,14 @@ def _assign_impl(
         }
 
     except Exception as e:
-        return {"success": False, "terminal_id": None, "message": f"Assignment failed: {str(e)}"}
+        # Surface the terminal_id when creation succeeded before the failure
+        # (e.g. the send POST failed) so the orphaned terminal can be
+        # inspected or deleted — matching the ready-timeout path above.
+        return {
+            "success": False,
+            "terminal_id": terminal_id,
+            "message": f"Assignment failed: {str(e)}",
+        }
 
 
 def _build_assign_description(enable_sender_id: bool, enable_workdir: bool) -> str:
@@ -730,11 +793,13 @@ def _build_assign_description(enable_sender_id: bool, enable_workdir: bool) -> s
         desc = """\
 Assigns a task to another agent without blocking.
 
-The sender's terminal ID and callback instructions will automatically be appended to the message."""
+The sender's terminal ID and callback instructions will automatically be appended to the message.
+The worker can also reply by calling send_message without receiver_id — it routes to this terminal."""
     else:
         desc = """\
 Assigns a task to another agent without blocking.
 
+The worker can send results back by calling send_message without receiver_id — it routes to this terminal automatically.
 In the message to the worker agent include instruction to send results back via send_message tool.
 **IMPORTANT**: The terminal id of each agent is available in environment variable CAO_TERMINAL_ID.
 When assigning, first find out your own CAO_TERMINAL_ID value, then include the terminal_id value in the message to the worker agent to allow callback.
@@ -808,52 +873,114 @@ else:
 
 
 # Implementation function for send_message
-def _send_message_impl(receiver_id: str, message: str) -> Dict[str, Any]:
+def _send_message_impl(receiver_id: Optional[str], message: str) -> Dict[str, Any]:
     """Implementation of send_message logic."""
     try:
+        own_terminal_id = os.environ.get("CAO_TERMINAL_ID")
+
+        # Default the receiver to the recorded caller (issue #284): handoff/
+        # assign persist the creating terminal's ID on the worker's row, so a
+        # worker can reply without parsing an ID out of the task message text.
+        if not receiver_id:
+            if not own_terminal_id:
+                return {
+                    "success": False,
+                    "error": (
+                        "receiver_id not provided and CAO_TERMINAL_ID not set - cannot "
+                        "look up the recorded caller. Pass receiver_id explicitly."
+                    ),
+                }
+            response = requests.get(
+                f"{API_BASE_URL}/terminals/{own_terminal_id}", timeout=MCP_REQUEST_TIMEOUT
+            )
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as exc:
+                detail = _extract_error_detail(response, str(exc))
+                return {
+                    "success": False,
+                    "error": (
+                        f"receiver_id not provided and the caller lookup for this "
+                        f"terminal ({own_terminal_id}) failed: {detail}. Pass "
+                        "receiver_id explicitly."
+                    ),
+                }
+            receiver_id = response.json().get("caller_id")
+            if not receiver_id:
+                return {
+                    "success": False,
+                    "error": (
+                        "receiver_id not provided and this terminal has no recorded "
+                        "caller (it was not created via handoff/assign). Pass "
+                        "receiver_id explicitly."
+                    ),
+                }
+
         # Guard against the worker sending a message to itself (issue #24).
         # Worker agents sometimes confuse their own CAO_TERMINAL_ID with the
         # supervisor's and end up queueing a message into their own inbox,
         # which never reaches the supervisor. Reject that here so the worker
         # gets a clear error and can pick the correct receiver_id instead.
-        own_terminal_id = os.environ.get("CAO_TERMINAL_ID")
         if own_terminal_id and receiver_id == own_terminal_id:
             return {
                 "success": False,
                 "error": (
                     f"receiver_id ({receiver_id}) is this terminal's own CAO_TERMINAL_ID. "
-                    "send_message cannot deliver to the sender. The callback terminal ID of "
-                    "the supervisor that assigned this task is in the task message — use "
-                    "that as receiver_id instead."
+                    "send_message cannot deliver to the sender. Omit receiver_id to reply "
+                    "to the terminal that assigned this task (the recorded caller), or "
+                    "use the supervisor's terminal ID from the task message."
                 ),
             }
 
-        # Auto-inject sender terminal ID suffix when enabled
-        if ENABLE_SENDER_ID_INJECTION:
-            sender_id = os.environ.get("CAO_TERMINAL_ID", "unknown")
+        # Auto-inject sender terminal ID suffix when enabled. Skipped when
+        # CAO_TERMINAL_ID is unset — never inject 'unknown' as a routable
+        # address (issue #284); _send_to_inbox raises a clear error for that
+        # case anyway.
+        if ENABLE_SENDER_ID_INJECTION and own_terminal_id:
             message += (
-                f"\n\n[Message from terminal {sender_id}. "
+                f"\n\n[Message from terminal {own_terminal_id}. "
                 "Use send_message MCP tool for any follow-up work.]"
             )
 
         return _send_to_inbox(receiver_id, message)
+    except requests.HTTPError as exc:
+        # e.g. the receiver terminal (a recorded caller included) was deleted
+        # before this reply — surface the API detail instead of a raw
+        # requests error string so the agent knows the address is gone.
+        detail = str(exc)
+        if exc.response is not None:
+            detail = _extract_error_detail(exc.response, detail)
+        return {
+            "success": False,
+            "error": f"Failed to deliver to terminal {receiver_id}: {detail}",
+        }
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
 @mcp.tool()
 async def send_message(
-    receiver_id: str = Field(description="Target terminal ID to send message to"),
     message: str = Field(description="Message content to send"),
+    receiver_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Target terminal ID. Omit to reply to the terminal that created "
+            "this one via handoff/assign (the recorded caller)."
+        ),
+    ),
 ) -> Dict[str, Any]:
     """Send a message to another terminal's inbox.
 
     The message will be delivered when the destination terminal is IDLE.
     Messages are delivered in order (oldest first).
 
+    When receiver_id is omitted, the message goes to the recorded caller —
+    the terminal that created this one via handoff/assign. This is the
+    reliable way to send results back to your supervisor.
+
     Args:
-        receiver_id: Terminal ID of the receiver
         message: Message content to send
+        receiver_id: Terminal ID of the receiver (optional, defaults to the recorded caller)
 
     Returns:
         Dict with success status and message details

--- a/src/cli_agent_orchestrator/models/terminal.py
+++ b/src/cli_agent_orchestrator/models/terminal.py
@@ -31,6 +31,9 @@ class Terminal(BaseModel):
     provider: ProviderType = Field(..., description="CLI tool provider")
     session_name: str = Field(..., description="Session name")
     agent_profile: Optional[str] = Field(None, description="Agent profile")
+    caller_id: Optional[str] = Field(
+        None, description="Terminal that created this one via handoff/assign (callback target)"
+    )
     allowed_tools: Optional[List[str]] = Field(None, description="Allowed CAO tools")
     shell_command: Optional[str] = Field(
         None, description="Shell process name captured before kiro launch"

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -130,6 +130,7 @@ async def create_terminal(
     allowed_tools: Optional[list[str]] = None,
     registry: PluginRegistry | None = None,
     env_vars: Optional[dict[str, str]] = None,
+    caller_id: Optional[str] = None,
 ) -> Terminal:
     """Create a new terminal with an initialized CLI agent.
 
@@ -152,6 +153,10 @@ async def create_terminal(
             ``new_session=False``, the persisted session vars are merged in
             automatically; the explicit ``env_vars`` argument is ignored to
             keep the per-session view consistent. See issue #248.
+        caller_id: Terminal ID of the supervisor that created this terminal
+            via handoff/assign. Recorded so send_message can route callbacks
+            structurally instead of parsing IDs out of message text (issue #284).
+            None for operator-launched terminals.
 
     Returns:
         Terminal object with all metadata populated
@@ -238,6 +243,7 @@ async def create_terminal(
             provider,
             agent_profile,
             allowed_tools,
+            caller_id=caller_id,
         )
 
         # Step 4/5: Set up the FIFO event-driven output pipeline for pipe-pane
@@ -294,6 +300,7 @@ async def create_terminal(
             provider=ProviderType(provider),
             session_name=session_name,
             agent_profile=agent_profile,
+            caller_id=caller_id,
             allowed_tools=allowed_tools,
             shell_command=shell_command,
             status=TerminalStatus.IDLE,
@@ -367,6 +374,7 @@ def get_terminal(terminal_id: str) -> Dict:
             "provider": metadata["provider"],
             "session_name": metadata["tmux_session"],
             "agent_profile": metadata["agent_profile"],
+            "caller_id": metadata.get("caller_id"),
             "allowed_tools": metadata.get("allowed_tools"),
             "status": status,
             "last_active": metadata["last_active"],
@@ -717,6 +725,7 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
                         metadata["tmux_session"], metadata["tmux_window"]
                     ),
                     "allowed_tools": metadata.get("allowed_tools"),
+                    "caller_id": metadata.get("caller_id"),
                 }
                 snapshot_path = TERMINAL_LOG_DIR / f"{terminal_id}.snapshot.json"
                 snapshot_path.write_text(_json.dumps(snapshot, indent=2), encoding="utf-8")

--- a/src/cli_agent_orchestrator/skills/cao-supervisor-protocols/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-supervisor-protocols/SKILL.md
@@ -15,10 +15,10 @@ From `cao-mcp-server`, supervisors orchestrate work with:
 
 - `assign(agent_profile, message)` for asynchronous work that returns immediately
 - `handoff(agent_profile, message)` for synchronous work that blocks until the worker finishes
-- `send_message(receiver_id, message)` for direct messages to an existing terminal
+- `send_message(message, receiver_id=None)` for direct messages — `receiver_id` defaults to the terminal that created yours via handoff/assign
 - `answer_user_prompt(terminal_id, answer)` for answering a Hermes worker that reports `waiting_user_answer`
 
-Your own terminal ID is available in the `CAO_TERMINAL_ID` environment variable. Use it when you need workers to send results back to you.
+Your own terminal ID is available in the `CAO_TERMINAL_ID` environment variable. CAO appends it to assigned task messages and records it on worker terminals automatically, so you rarely need to handle it yourself.
 
 ## Choosing Between Assign and Handoff
 
@@ -47,15 +47,15 @@ If you need multiple worker results, dispatch them all first, then end the turn.
 
 ## Callback Pattern
 
-When you use `assign`, include the callback terminal ID in the task message. Tell the worker exactly which terminal should receive the result and instruct the worker to use `send_message`.
+By default, CAO appends your terminal ID and callback instructions to every assigned message automatically, and records your terminal as the worker's caller — workers can reply with `send_message` without a `receiver_id`. You do not need to hand-write callback instructions.
 
-Example pattern:
+You may still include an explicit callback ID in the task message for emphasis:
 
 ```text
 Analyze dataset A. Send results back to terminal abc123 using send_message.
 ```
 
-Some CAO deployments also append an automatic callback suffix to assigned messages. Treat that appended context as helpful reinforcement, but still write task messages that are explicit and self-contained.
+If your deployment disables the automatic suffix (`CAO_ENABLE_SENDER_ID_INJECTION=false`), the explicit pattern above is required: the structural caller record still works, but the worker gets no in-message reminder.
 
 ## Direct Supervisor Communication
 
@@ -77,11 +77,10 @@ Other providers may still emit prompts in their terminal output without reportin
 
 ## Practical Workflow
 
-1. Read or determine your terminal ID.
-2. Dispatch asynchronous workers with `assign` and include callback instructions.
-3. Use `handoff` only for steps that must finish before you can continue.
-4. End the turn so asynchronous worker messages can be delivered.
-5. When messages arrive, synthesize the results and continue the workflow.
+1. Dispatch asynchronous workers with `assign` — callback routing is automatic (your terminal ID is appended to the message and recorded as the worker's caller).
+2. Use `handoff` only for steps that must finish before you can continue.
+3. End the turn so asynchronous worker messages can be delivered.
+4. When messages arrive, synthesize the results and continue the workflow.
 
 ## Reliability Guidelines
 

--- a/src/cli_agent_orchestrator/skills/cao-worker-protocols/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-worker-protocols/SKILL.md
@@ -26,17 +26,15 @@ Do not call `send_message` for ordinary handoff completion unless the task expli
 
 ## Rules for Assigned Tasks
 
-When the task came through `assign`, the task message should include a callback terminal ID. After you finish the work:
+When the task came through `assign`, send your results back after you finish the work:
 
-1. Extract the callback terminal ID from the task message.
-2. Format the result clearly and concisely.
-3. Call `send_message(receiver_id=..., message=...)` with the completed result.
+1. Format the result clearly and concisely.
+2. Call `send_message(message=...)` — omitting `receiver_id` routes the result to the terminal that assigned the task (the recorded caller). This is the reliable default.
+3. If the task message names a different callback terminal (directly or in an appended suffix such as `[Assigned by terminal ...]`), pass that ID as `receiver_id` instead.
 
 Do not stop after writing a normal response if the assignment explicitly requires a callback. The requesting terminal depends on `send_message` to receive the result.
 
-Assigned tasks may include callback instructions directly in the main message or in an appended suffix such as `[Assigned by terminal ...]`. Treat that callback terminal ID as authoritative.
-
-Your own `CAO_TERMINAL_ID` identifies your terminal, not the callback target. Send results to the receiver specified in the task.
+Your own `CAO_TERMINAL_ID` identifies your terminal, not the callback target. Never pass it as `receiver_id`.
 
 ## Message Formatting
 
@@ -54,7 +52,7 @@ If the task asks you to create files, write them before reporting completion. Wh
 
 ## Reliability Guidelines
 
-- Parse the callback terminal ID before you start expensive work.
+- If the task names an explicit callback terminal, note its ID before you start expensive work; otherwise rely on the default routing (omit `receiver_id`).
 - If `send_message` is available and the task requires a callback, call it directly rather than ending with prose alone.
 - Keep callback messages structured so the supervisor can merge them into a larger workflow.
 - For handoff tasks, return the completed output directly and let the orchestrator handle delivery.

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -159,6 +159,62 @@ class TestTerminalCreationWithWorkingDirectory:
             call_kwargs = mock_svc.create_terminal.call_args.kwargs
             assert call_kwargs.get("working_directory") == str(tmp_path)
 
+    def test_create_terminal_passes_caller_id(self, client):
+        """caller_id query param threads through to the service (issue #284)."""
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            mock_svc.create_terminal = AsyncMock(
+                return_value=Terminal(
+                    id="abcd5678",
+                    name="test-window",
+                    session_name="test-session",
+                    provider="q_cli",
+                    agent_profile="analyst",
+                    caller_id="dcba8765",
+                )
+            )
+
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={
+                    "provider": "q_cli",
+                    "agent_profile": "analyst",
+                    "caller_id": "dcba8765",
+                },
+            )
+
+            assert response.status_code == 201
+            call_kwargs = mock_svc.create_terminal.call_args.kwargs
+            assert call_kwargs.get("caller_id") == "dcba8765"
+            assert response.json()["caller_id"] == "dcba8765"
+
+    def test_create_terminal_rejects_malformed_caller_id(self, client):
+        """caller_id is validated against the TerminalId pattern — IDs arrive
+        from agent input and must not be persisted unvalidated."""
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={
+                    "provider": "q_cli",
+                    "agent_profile": "analyst",
+                    "caller_id": "not-a-terminal-id!",
+                },
+            )
+
+            assert response.status_code == 422
+            mock_svc.create_terminal.assert_not_called()
+
     def test_create_terminal_in_session_with_working_directory(self, client):
         """Test POST /sessions/{session}/terminals with working_directory."""
         with (

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -691,6 +691,116 @@ class TestInitDb:
         mock_base.metadata.create_all.assert_called_once()
 
 
+class TestTerminalsSchemaMigration:
+    """Tests for the terminals-table column-add migration (caller_id, issue #284)."""
+
+    def test_caller_id_column_added_to_legacy_table(self, tmp_path, monkeypatch):
+        """A pre-#284 terminals table gains the caller_id column."""
+        import sqlite3
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        db_file = tmp_path / "legacy.db"
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "CREATE TABLE terminals ("
+                "id TEXT PRIMARY KEY, tmux_session TEXT NOT NULL, "
+                "tmux_window TEXT NOT NULL, provider TEXT NOT NULL, "
+                "agent_profile TEXT, allowed_tools TEXT, shell_command TEXT, "
+                "last_active TIMESTAMP)"
+            )
+            conn.execute(
+                "INSERT INTO terminals (id, tmux_session, tmux_window, provider) "
+                "VALUES ('abc12345', 'cao-s', 'w-0', 'kiro_cli')"
+            )
+            conn.commit()
+
+        # _migrate_terminals_schema reads DATABASE_FILE from constants at call time
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+
+        db_mod._migrate_terminals_schema()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(terminals)")}
+            rows = conn.execute("SELECT id, caller_id FROM terminals").fetchall()
+        assert "caller_id" in columns
+        assert rows == [("abc12345", None)], "existing rows must get NULL caller_id"
+
+    def test_migration_is_idempotent(self, tmp_path, monkeypatch):
+        """Running the migration twice must not fail or duplicate columns."""
+        import sqlite3
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        db_file = tmp_path / "current.db"
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "CREATE TABLE terminals ("
+                "id TEXT PRIMARY KEY, tmux_session TEXT NOT NULL, "
+                "tmux_window TEXT NOT NULL, provider TEXT NOT NULL)"
+            )
+            conn.commit()
+
+        # _migrate_terminals_schema reads DATABASE_FILE from constants at call time
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+
+        db_mod._migrate_terminals_schema()
+        db_mod._migrate_terminals_schema()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            columns = [row[1] for row in conn.execute("PRAGMA table_info(terminals)")]
+        assert columns.count("caller_id") == 1
+        assert columns.count("allowed_tools") == 1
+
+
+class TestCallerIdRoundTrip:
+    """caller_id must round-trip create→read (issue #284): a write path that
+    persists it and a read path that drops it would silently break callback
+    routing for every worker."""
+
+    def test_caller_id_round_trips_through_real_db(self, tmp_path, monkeypatch):
+        """create_terminal persists caller_id; get_terminal_metadata returns it."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        engine = create_engine(f"sqlite:///{tmp_path / 'rt.db'}")
+        Base.metadata.create_all(bind=engine)
+        monkeypatch.setattr(db_mod, "SessionLocal", sessionmaker(bind=engine))
+
+        created = create_terminal(
+            "abc12345", "cao-s", "w-0", "kiro_cli", "developer", caller_id="def67890"
+        )
+        assert created["caller_id"] == "def67890"
+
+        fetched = get_terminal_metadata("abc12345")
+        assert fetched is not None
+        assert fetched["caller_id"] == "def67890"
+
+    def test_caller_id_defaults_to_none(self, tmp_path, monkeypatch):
+        """Operator-launched terminals (no caller) round-trip NULL."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        engine = create_engine(f"sqlite:///{tmp_path / 'rt2.db'}")
+        Base.metadata.create_all(bind=engine)
+        monkeypatch.setattr(db_mod, "SessionLocal", sessionmaker(bind=engine))
+
+        created = create_terminal("abc12345", "cao-s", "w-0", "kiro_cli")
+        assert created["caller_id"] is None
+
+        fetched = get_terminal_metadata("abc12345")
+        assert fetched is not None
+        assert fetched["caller_id"] is None
+
+
 class TestProjectAliasMigration:
     """Tests for the project_aliases alias-only primary-key migration."""
 

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -49,6 +49,7 @@ class TestCreateTerminalProviderResolution:
             params={
                 "provider": "claude_code",
                 "agent_profile": "reviewer",
+                "caller_id": "supervisor-1",
                 "working_directory": "/repo",
             },
             timeout=MCP_REQUEST_TIMEOUT,
@@ -91,6 +92,7 @@ class TestCreateTerminalProviderResolution:
             params={
                 "provider": "kiro_cli",
                 "agent_profile": "reviewer",
+                "caller_id": "supervisor-1",
                 "working_directory": "/repo",
             },
             timeout=MCP_REQUEST_TIMEOUT,
@@ -146,19 +148,44 @@ class TestAssignSenderIdInjection:
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
     @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status", return_value=True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_sender_id_fallback_unknown(self, mock_create, mock_wait, mock_send):
-        """When CAO_TERMINAL_ID is not set, suffix should use 'unknown'."""
+    def test_assign_missing_terminal_id_errors_before_creating_terminal(
+        self, mock_create, mock_wait, mock_send
+    ):
+        """When CAO_TERMINAL_ID is not set, assign must fail fast (issue #284) —
+        never tell a worker to reply to terminal 'unknown', and never leave an
+        orphan worker terminal behind."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
-
-        mock_create.return_value = ("worker-3", "codex")
-        mock_send.return_value = None
 
         with patch.dict(os.environ, {}, clear=True):
             result = _assign_impl("developer", "Build feature X")
 
-        sent_message = mock_send.call_args[0][1]
-        assert mock_send.call_args[0][2] == "assign"
-        assert "[Assigned by terminal unknown" in sent_message
+        assert result["success"] is False
+        assert result["terminal_id"] is None
+        assert "CAO_TERMINAL_ID not set" in result["message"]
+        mock_create.assert_not_called()
+        mock_send.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
+    @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
+    @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status", return_value=True)
+    @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
+    def test_assign_surfaces_terminal_id_when_send_fails_after_creation(
+        self, mock_create, mock_wait, mock_send
+    ):
+        """If the task send fails after the worker terminal was created, the
+        orphaned terminal's ID must be surfaced so the supervisor can inspect
+        or delete it — matching the ready-timeout path."""
+        from cli_agent_orchestrator.mcp_server.server import _assign_impl
+
+        mock_create.return_value = ("worker-orphan", "claude_code")
+        mock_send.side_effect = Exception("connection refused")
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervisor-abc123"}):
+            result = _assign_impl("developer", "Analyze the logs")
+
+        assert result["success"] is False
+        assert result["terminal_id"] == "worker-orphan"
+        assert "Assignment failed" in result["message"]
 
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")

--- a/test/mcp_server/test_handoff.py
+++ b/test/mcp_server/test_handoff.py
@@ -117,8 +117,9 @@ class TestHandoffMessageContext:
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
     @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status")
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_codex_handoff_context_fallback_when_no_env(self, mock_create, mock_wait, mock_send):
-        """When CAO_TERMINAL_ID is not set, supervisor ID should be 'unknown'."""
+    def test_codex_handoff_errors_when_no_env(self, mock_create, mock_wait, mock_send):
+        """When CAO_TERMINAL_ID is not set, codex handoff must fail visibly
+        (issue #284) — never tell a worker its supervisor is terminal 'unknown'."""
         mock_create.return_value = ("dev-terminal-5", "codex")
         mock_wait.side_effect = [True, True]
         mock_send.return_value = None
@@ -131,13 +132,30 @@ class TestHandoffMessageContext:
                 mock_requests.get.return_value = mock_response
                 mock_requests.post.return_value = mock_response
 
-                asyncio.run(_handoff_impl("developer", "Do task"))
+                result = asyncio.run(_handoff_impl("developer", "Do task"))
 
-        sent_message = mock_send.call_args[0][1]
-        assert mock_send.call_args[0][2] == "handoff"
-        assert "unknown" in sent_message
-        assert "[CAO Handoff]" in sent_message
-        assert "Do task" in sent_message
+        assert result.success is False
+        assert "CAO_TERMINAL_ID not set" in result.message
+        # The created (now orphaned) terminal must be surfaced so it can be
+        # inspected or cleaned up, matching the timeout failure paths.
+        assert result.terminal_id == "dev-terminal-5"
+        # Fail-fast: the (up to 120s) ready wait must not even start.
+        mock_wait.assert_not_called()
+        mock_send.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
+    @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status")
+    @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
+    def test_handoff_terminal_id_none_when_creation_fails(self, mock_create, mock_wait, mock_send):
+        """When terminal creation itself fails, no terminal exists to report."""
+        mock_create.side_effect = Exception("session not found")
+
+        result = asyncio.run(_handoff_impl("developer", "Do task"))
+
+        assert result.success is False
+        assert "Handoff failed" in result.message
+        assert result.terminal_id is None
+        mock_send.assert_not_called()
 
     @patch("cli_agent_orchestrator.mcp_server.server._send_direct_input")
     @patch("cli_agent_orchestrator.mcp_server.server.wait_until_terminal_status")

--- a/test/mcp_server/test_send_message.py
+++ b/test/mcp_server/test_send_message.py
@@ -1,7 +1,9 @@
 """Tests for send_message MCP tool."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import requests
 
 
 class TestSendMessageSelfSendGuard:
@@ -88,8 +90,9 @@ class TestSendMessageSenderIdInjection:
 
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
-    def test_send_message_sender_id_fallback_unknown(self, mock_inbox):
-        """When CAO_TERMINAL_ID is not set, suffix should use 'unknown'."""
+    def test_send_message_no_suffix_when_cao_terminal_id_unset(self, mock_inbox):
+        """When CAO_TERMINAL_ID is not set, no suffix is injected (issue #284) —
+        'unknown' must never be presented as a routable terminal ID."""
         from cli_agent_orchestrator.mcp_server.server import _send_message_impl
 
         mock_inbox.return_value = {"success": True}
@@ -98,7 +101,8 @@ class TestSendMessageSenderIdInjection:
             result = _send_message_impl("receiver-123", "Status update")
 
         sent_message = mock_inbox.call_args[0][1]
-        assert "[Message from terminal unknown" in sent_message
+        assert sent_message == "Status update"
+        assert "unknown" not in sent_message
 
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
@@ -115,3 +119,146 @@ class TestSendMessageSenderIdInjection:
         sent_message = mock_inbox.call_args[0][1]
         assert sent_message.startswith(original)
         assert sent_message.index("[Message from terminal") > len(original)
+
+
+class TestSendMessageCallerDefault:
+    """Tests for receiver_id defaulting to the recorded caller (issue #284).
+
+    handoff/assign persist the creating terminal's ID as caller_id on the
+    worker's terminal row. When a worker omits receiver_id, send_message
+    looks up its own row and routes the reply to that recorded caller —
+    taking the worker LLM out of the routing path entirely.
+    """
+
+    @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", False)
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_omitted_receiver_routes_to_recorded_caller(self, mock_inbox, mock_requests):
+        """No receiver_id + recorded caller → message goes to the caller."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "worker-abc", "caller_id": "supervisor-xyz"}
+        mock_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = mock_response
+        mock_inbox.return_value = {"success": True}
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            result = _send_message_impl(None, "Results ready")
+
+        mock_inbox.assert_called_once()
+        assert mock_inbox.call_args[0][0] == "supervisor-xyz"
+        assert result == {"success": True}
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_omitted_receiver_without_recorded_caller_errors(self, mock_inbox, mock_requests):
+        """No receiver_id + NULL caller_id → clear error, nothing sent."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "worker-abc", "caller_id": None}
+        mock_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            result = _send_message_impl(None, "Results ready")
+
+        assert result["success"] is False
+        assert "no recorded caller" in result["error"]
+        assert "receiver_id" in result["error"]
+        mock_inbox.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_omitted_receiver_without_terminal_id_errors(self, mock_inbox):
+        """No receiver_id + no CAO_TERMINAL_ID → clear error, nothing sent."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = _send_message_impl(None, "Hello")
+
+        assert result["success"] is False
+        assert "CAO_TERMINAL_ID not set" in result["error"]
+        mock_inbox.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", False)
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_explicit_receiver_skips_caller_lookup(self, mock_inbox, mock_requests):
+        """An explicit receiver_id must be used as-is, no API lookup."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_inbox.return_value = {"success": True}
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            _send_message_impl("explicit-recv", "Results")
+
+        mock_requests.get.assert_not_called()
+        assert mock_inbox.call_args[0][0] == "explicit-recv"
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_omitted_receiver_own_terminal_lookup_404_errors_clearly(
+        self, mock_inbox, mock_requests
+    ):
+        """Own terminal record gone (e.g. deleted) → actionable error, not a
+        raw requests error string."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_requests.HTTPError = requests.HTTPError
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"detail": "Terminal 'worker-abc' not found"}
+        http_error = requests.HTTPError("404 Client Error")
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+        mock_requests.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            result = _send_message_impl(None, "Results ready")
+
+        assert result["success"] is False
+        assert "caller lookup" in result["error"]
+        assert "Terminal 'worker-abc' not found" in result["error"]
+        assert "receiver_id" in result["error"]
+        mock_inbox.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", False)
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_receiver_deleted_before_reply_errors_clearly(self, mock_inbox):
+        """Recorded caller deleted before the reply lands → the API detail is
+        surfaced so the agent knows the address is gone."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"detail": "Terminal 'supervisor-xyz' not found"}
+        http_error = requests.HTTPError("404 Client Error")
+        http_error.response = mock_response
+        mock_inbox.side_effect = http_error
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            result = _send_message_impl("supervisor-xyz", "Results ready")
+
+        assert result["success"] is False
+        assert "supervisor-xyz" in result["error"]
+        assert "Terminal 'supervisor-xyz' not found" in result["error"]
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    @patch("cli_agent_orchestrator.mcp_server.server._send_to_inbox")
+    def test_self_referential_caller_still_rejected_by_own_id_guard(
+        self, mock_inbox, mock_requests
+    ):
+        """A corrupted row recording the worker as its own caller must not
+        bypass the issue #24 self-send guard."""
+        from cli_agent_orchestrator.mcp_server.server import _send_message_impl
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "worker-abc", "caller_id": "worker-abc"}
+        mock_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "worker-abc"}):
+            result = _send_message_impl(None, "Results")
+
+        assert result["success"] is False
+        assert "own CAO_TERMINAL_ID" in result["error"]
+        mock_inbox.assert_not_called()

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -116,8 +116,51 @@ class TestCreateTerminal:
             "kiro_cli",
             "developer",
             ["fs_read"],
+            caller_id=None,
         )
         assert mock_provider_manager.create_provider.call_args.args[5] == ["fs_read"]
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_create_terminal_persists_caller_id(
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        """caller_id reaches the database row and the returned Terminal (issue #284)."""
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        result = await create_terminal(
+            "kiro_cli", "developer", new_session=True, caller_id="deadbeef"
+        )
+
+        assert result.caller_id == "deadbeef"
+        assert mock_db_create.call_args.kwargs.get("caller_id") == "deadbeef"
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")


### PR DESCRIPTION
Fixes #284

## Problem

Worker agents sometimes can't resolve the terminal ID to send their response back to. Callback routing was free-text only: the supervisor's ID was embedded in the task message text and the worker LLM had to parse it back out. Three failure modes:

1. With `CAO_TERMINAL_ID` unset, assign/handoff injected the literal string `unknown` as the callback address — workers then tried to `send_message(receiver_id="unknown")`.
2. `CAO_ENABLE_SENDER_ID_INJECTION` defaulted to `false`, so most deployments had no callback info in the message at all.
3. Workers occasionally confused their own ID with the supervisor's (#24 guard exists, but nothing made the right ID easy to use).

## Fix (3 parts)

**1. Hard errors replace the `unknown` fallback.** `assign` fails fast *before* creating the worker terminal. Codex `handoff` fails right after creation (before the up-to-120s ready wait). When a failure happens after the terminal exists, the error result now surfaces the orphaned `terminal_id` so the supervisor can inspect or delete it. `send_message` never injects a sender suffix without a real ID.

**2. `CAO_ENABLE_SENDER_ID_INJECTION` now defaults to `true`.** Callback routing must not depend on the supervisor LLM remembering to hand-write its terminal ID. Opt out with `CAO_ENABLE_SENDER_ID_INJECTION=false`.

**3. Structural `caller_id` (new).** handoff/assign record the creating terminal's ID on the worker's terminal row (new nullable column, PRAGMA-gated migration). `send_message`'s `receiver_id` is now optional: omitted, it routes to the recorded caller — taking the worker LLM out of the routing path entirely. Explicit `receiver_id` always wins; clear errors when there is no recorded caller; the #24 self-send guard is preserved. `caller_id` is validated against the 8-hex `TerminalId` pattern at the API boundary (422 on malformed).

## Docs

README, `docs/api.md`, both supervisor/worker SKILL.md files, built-in developer/reviewer profiles, and the `examples/` assign + cross-provider profiles updated: automatic injection + omit-`receiver_id` reply is the documented default; hand-written callback IDs remain supported and take precedence.

## Testing

- 35+ new/updated tests across 6 test files: caller_id round-trip against a real SQLite file, migration idempotency + NULL backfill, API param validation, omitted-receiver routing, NULL-caller / missing-env / lookup-404 / receiver-deleted error paths, orphan-terminal surfacing for both assign and handoff
- Full regression: 2251 passed, 1 known pre-existing flake (`test_bm25_performance_within_budget`, passes in isolation)
- black / isort / mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)