### PR TITLE
feat(memory): Web UI support for the memory system

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -267,6 +267,106 @@ Send a message to another terminal's inbox.
 
 ---
 
+## Memory
+
+REST mirror of the `cao memory` CLI. All `/memory` endpoints return `404` with
+`"Memory system is disabled"` when `memory.enabled` is false in settings.json;
+use `GET /settings/memory` to discover the enabled state (e.g. for hiding UI).
+
+Keys must match `^[a-z0-9-]{1,60}$` and `scope_id` must match
+`^[a-zA-Z0-9._-]{1,128}$`; malformed values return `422`.
+
+Because the server's working directory is not the user's project, project scope
+is addressed by an explicit `scope_id` query parameter (the resolved project
+ID). This intentionally diverges from the MCP `memory_forget` tool, which
+resolves context from the calling terminal.
+
+Known inconsistency: the internal `GET /terminals/{id}/memory-context` endpoint
+predates this contract and returns an empty `200` (not `404`) when memory is
+disabled.
+
+### GET /settings/memory
+Return whether the memory subsystem is enabled.
+
+**Response:**
+```json
+{
+  "enabled": true
+}
+```
+
+### GET /memory
+List stored memories across all projects (the CLI's `cao memory list --all`).
+
+**Parameters:**
+- `scope` (string, optional): Filter by scope (`global`, `project`, `session`, `agent`)
+- `type` (string, optional): Filter by memory type (`user`, `feedback`, `project`, `reference`)
+- `scope_id` (string, optional): Filter to one project/session/agent
+- `limit` (integer, optional): Max results, 1–100 (default: 50)
+
+**Response:**
+```json
+[
+  {
+    "key": "string",
+    "scope": "string",
+    "scope_id": "string|null",
+    "memory_type": "string",
+    "tags": "string",
+    "created_at": "timestamp",
+    "updated_at": "timestamp"
+  }
+]
+```
+
+`scope_id` is the project ID for project memories, the session/agent ID for
+those scopes, and `null` for global.
+
+### GET /memory/{key}
+Show a memory by key (first match wins when the same key exists in several
+scopes; narrow with `scope`/`scope_id`).
+
+**Parameters:**
+- `scope` (string, optional): Scope to search in
+- `scope_id` (string, optional): Project/session/agent to search in
+
+**Response:** the list entry shape plus `"content"` (the latest wiki section).
+`404` if no exact key match.
+
+### DELETE /memory/{key}
+Delete a memory by key.
+
+**Parameters:**
+- `scope` (string, optional): Scope of the memory (default: `project`)
+- `scope_id` (string): Required for `project`, `session`, and `agent` scopes (`400` if missing)
+
+**Response:**
+```json
+{
+  "success": true
+}
+```
+
+`404` if the key does not exist in the scope.
+
+### DELETE /memory
+Clear all memories in a scope. Best-effort: deletion continues past
+per-item failures and reports how many were removed.
+
+**Parameters:**
+- `scope` (string, required): Scope to clear
+- `scope_id` (string): Required for `project`, `session`, and `agent` scopes (`400` if missing)
+
+**Response:**
+```json
+{
+  "success": true,
+  "deleted_count": 3
+}
+```
+
+---
+
 ## Error Responses
 
 All endpoints return standard HTTP status codes:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -12,6 +12,7 @@ import struct
 import subprocess
 import termios
 from contextlib import asynccontextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Dict, List, Optional, cast
 
@@ -54,6 +55,12 @@ from cli_agent_orchestrator.constants import (
 )
 from cli_agent_orchestrator.models.flow import Flow
 from cli_agent_orchestrator.models.inbox import MessageStatus, OrchestrationType
+from cli_agent_orchestrator.models.memory import (
+    MemoryKey,
+    MemoryScope,
+    MemoryScopeId,
+    MemoryType,
+)
 from cli_agent_orchestrator.models.terminal import Terminal, TerminalId
 from cli_agent_orchestrator.plugins import PluginRegistry
 from cli_agent_orchestrator.providers.manager import provider_manager
@@ -171,6 +178,26 @@ class InstallAgentProfileRequest(BaseModel):
     source: str
     provider: str = DEFAULT_PROVIDER
     env_vars: Optional[Dict[str, str]] = None
+
+
+class MemorySummary(BaseModel):
+    """Memory list entry. Excludes file_path (absolute server filesystem path)."""
+
+    key: str
+    scope: str
+    scope_id: Optional[str] = Field(
+        description="Native for session/agent, derived from storage path for project, None for global"
+    )
+    memory_type: str
+    tags: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class MemoryDetail(MemorySummary):
+    """Full memory view — adds the latest wiki section content."""
+
+    content: str
 
 
 class CreateFlowRequest(BaseModel):
@@ -450,6 +477,14 @@ async def get_agent_dirs_endpoint() -> Dict:
 class AgentDirsUpdate(BaseModel):
     agent_dirs: Optional[Dict[str, str]] = None
     extra_dirs: Optional[List[str]] = None
+
+
+@app.get("/settings/memory")
+async def get_memory_settings_endpoint() -> Dict:
+    """Return whether the memory subsystem is enabled (for UI feature discovery)."""
+    from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+    return {"enabled": is_memory_enabled()}
 
 
 @app.post("/settings/agent-dirs")
@@ -1246,6 +1281,231 @@ async def run_flow(name: str) -> Dict:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to execute flow: {str(e)}",
         )
+
+
+# ── Memory endpoints ─────────────────────────────────────────────────
+# REST mirror of `cao memory list/show/delete/clear` (issue #286). The server
+# has no meaningful cwd, so project scope is addressed by an explicit scope_id
+# query param instead of terminal_context — passing a client cwd would be
+# routed through resolve_project_id(), whose CAO_PROJECT_ID override applies
+# unconditionally and could silently target the wrong project.
+
+
+def _get_memory_service():
+    """Build a MemoryService (lazy import mirrors the circular-import guard
+    in memory_service._is_memory_enabled; module-level factory so tests can
+    patch it like the CLI's _get_memory_service)."""
+    from cli_agent_orchestrator.services.memory_service import MemoryService
+
+    return MemoryService()
+
+
+def _require_memory_enabled() -> None:
+    """Raise 404 when the memory subsystem is disabled.
+
+    recall() silently returns [] when disabled, so the gate must be explicit
+    rather than inferred from empty results.
+    """
+    from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+    if not is_memory_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Memory system is disabled"
+        )
+
+
+def _memory_scope_id(mem, base_dir: Path) -> Optional[str]:
+    """Resolve the response scope_id for a recalled memory.
+
+    session/agent results carry scope_id natively; project membership is only
+    recoverable from the storage path (base_dir/<project_id>/wiki/project/...);
+    global has none.
+    """
+    if mem.scope_id:
+        return str(mem.scope_id)
+    if mem.scope != MemoryScope.PROJECT.value:
+        return None
+    try:
+        relative = Path(mem.file_path).resolve().relative_to(base_dir.resolve())
+        return relative.parts[0]
+    except (ValueError, IndexError):
+        return None
+
+
+def _memory_matches_scope_id(mem, scope_id: str, base_dir: Path) -> bool:
+    """True when a recalled memory belongs to the given scope_id (global always matches)."""
+    if mem.scope == MemoryScope.GLOBAL.value:
+        return True
+    return _memory_scope_id(mem, base_dir) == scope_id
+
+
+def _to_memory_summary(mem, base_dir: Path) -> MemorySummary:
+    return MemorySummary(
+        key=mem.key,
+        scope=mem.scope,
+        scope_id=_memory_scope_id(mem, base_dir),
+        memory_type=mem.memory_type,
+        tags=mem.tags,
+        created_at=mem.created_at,
+        updated_at=mem.updated_at,
+    )
+
+
+@app.get("/memory", response_model=List[MemorySummary])
+async def list_memories_endpoint(
+    scope: Optional[MemoryScope] = None,
+    memory_type: Optional[MemoryType] = Query(default=None, alias="type"),
+    scope_id: Optional[MemoryScopeId] = None,
+    limit: int = Query(default=50, ge=1, le=100),
+) -> List[MemorySummary]:
+    """List stored memories across all projects (mirrors `cao memory list --all`)."""
+    _require_memory_enabled()
+    svc = _get_memory_service()
+    try:
+        # Internal limit 1000: recall truncates BEFORE the scope_id filter
+        # below, so filtering a small page could return an under-filled result.
+        # metadata mode: no query to rank, and it avoids the BM25 path.
+        memories = await svc.recall(
+            scope=scope.value if scope else None,
+            memory_type=memory_type.value if memory_type else None,
+            limit=1000,
+            scan_all=True,
+            search_mode="metadata",
+        )
+        if scope_id is not None:
+            memories = [m for m in memories if _memory_matches_scope_id(m, scope_id, svc.base_dir)]
+        return [_to_memory_summary(m, svc.base_dir) for m in memories[:limit]]
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list memories: {str(e)}",
+        )
+
+
+@app.get("/memory/{key}", response_model=MemoryDetail)
+async def get_memory_endpoint(
+    key: MemoryKey,
+    scope: Optional[MemoryScope] = None,
+    scope_id: Optional[MemoryScopeId] = None,
+) -> MemoryDetail:
+    """Show a memory by key (mirrors `cao memory show`; first match wins)."""
+    _require_memory_enabled()
+    svc = _get_memory_service()
+    try:
+        memories = await svc.recall(
+            query=key,
+            scope=scope.value if scope else None,
+            limit=1000,
+            scan_all=True,
+            search_mode="metadata",
+        )
+        for mem in memories:
+            if mem.key != key:
+                continue
+            if scope_id is not None and not _memory_matches_scope_id(mem, scope_id, svc.base_dir):
+                continue
+            return MemoryDetail(
+                content=mem.content,
+                **_to_memory_summary(mem, svc.base_dir).model_dump(),
+            )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Memory '{key}' not found"
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get memory: {str(e)}",
+        )
+
+
+@app.delete("/memory/{key}")
+async def delete_memory_endpoint(
+    key: MemoryKey,
+    scope: MemoryScope = MemoryScope.PROJECT,
+    scope_id: Optional[MemoryScopeId] = None,
+) -> Dict:
+    """Delete a memory by key (mirrors `cao memory delete`).
+
+    Unlike the MCP memory_forget tool (which resolves context from
+    CAO_TERMINAL_ID), non-global scopes require an explicit scope_id.
+    """
+    from cli_agent_orchestrator.services.memory_service import MemoryDisabledError
+
+    _require_memory_enabled()
+    if scope != MemoryScope.GLOBAL and scope_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"scope '{scope.value}' requires scope_id",
+        )
+    svc = _get_memory_service()
+    try:
+        deleted = await svc.forget(key=key, scope=scope.value, scope_id=scope_id)
+    except MemoryDisabledError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Memory system is disabled"
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to delete memory: {str(e)}",
+        )
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Memory '{key}' not found in scope '{scope.value}'",
+        )
+    return {"success": True}
+
+
+@app.delete("/memory")
+async def clear_memories_endpoint(
+    scope: MemoryScope,
+    scope_id: Optional[MemoryScopeId] = None,
+) -> Dict:
+    """Clear all memories in a scope (mirrors `cao memory clear`).
+
+    Best-effort per-item loop (warn-and-continue), reporting deleted_count —
+    deliberately not all-or-nothing.
+    """
+    from cli_agent_orchestrator.services.memory_service import MemoryDisabledError
+
+    _require_memory_enabled()
+    if scope != MemoryScope.GLOBAL and scope_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"scope '{scope.value}' requires scope_id",
+        )
+    svc = _get_memory_service()
+    try:
+        memories = await svc.recall(
+            scope=scope.value, limit=1000, scan_all=True, search_mode="metadata"
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to clear memories: {str(e)}",
+        )
+    if scope_id is not None:
+        memories = [m for m in memories if _memory_matches_scope_id(m, scope_id, svc.base_dir)]
+
+    deleted_count = 0
+    for mem in memories:
+        try:
+            # session/agent results carry scope_id natively; project results
+            # need the query param (their recalled scope_id is None).
+            if await svc.forget(key=mem.key, scope=scope.value, scope_id=mem.scope_id or scope_id):
+                deleted_count += 1
+        except MemoryDisabledError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Memory system is disabled"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to delete memory '{mem.key}' during clear: {e}")
+    return {"success": True, "deleted_count": deleted_count}
 
 
 # Static file serving for built web UI.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -1333,9 +1333,11 @@ def _memory_scope_id(mem, base_dir: Path) -> Optional[str]:
 
 
 def _memory_matches_scope_id(mem, scope_id: str, base_dir: Path) -> bool:
-    """True when a recalled memory belongs to the given scope_id (global always matches)."""
-    if mem.scope == MemoryScope.GLOBAL.value:
-        return True
+    """True when a recalled memory belongs to the given scope_id.
+
+    Global memories have no scope_id (resolved as None), so they never match —
+    scope_id strictly narrows to one project/session/agent.
+    """
     return _memory_scope_id(mem, base_dir) == scope_id
 
 
@@ -1504,7 +1506,7 @@ async def clear_memories_endpoint(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Memory system is disabled"
             )
         except Exception as e:
-            logger.warning(f"Failed to delete memory '{mem.key}' during clear: {e}")
+            logger.warning("Failed to delete memory %r during clear: %s", mem.key, e)
     return {"success": True, "deleted_count": deleted_count}
 
 

--- a/src/cli_agent_orchestrator/models/memory.py
+++ b/src/cli_agent_orchestrator/models/memory.py
@@ -28,8 +28,8 @@ MemoryKey = Annotated[
 
 def _reject_all_dots(value: str) -> str:
     """Reject '.', '..', '...' so traversal tokens 422 at the boundary instead
-    of relying on the get_wiki_path guard deeper down. A validator rather than
-    a lookahead because pydantic-core's regex engine has no look-around."""
+    of relying on the get_wiki_path guard deeper down."""
+    _reject_control_chars(value)
     if set(value) == {"."}:
         raise ValueError("scope_id must not consist solely of dots")
     return value

--- a/src/cli_agent_orchestrator/models/memory.py
+++ b/src/cli_agent_orchestrator/models/memory.py
@@ -2,9 +2,38 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Annotated, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    Field,
+    StringConstraints,
+    field_validator,
+)
+
+# Mirrors the CLI validation rule (cli/commands/memory.py) — reject-first, so
+# malformed keys 422 at the API layer instead of being silently sanitized.
+# Length-bounded pattern avoids Python's `$`-matches-before-trailing-newline quirk.
+MemoryKey = Annotated[str, StringConstraints(pattern=r"^[a-z0-9-]{1,60}$")]
+
+
+def _reject_all_dots(value: str) -> str:
+    """Reject '.', '..', '...' so traversal tokens 422 at the boundary instead
+    of relying on the get_wiki_path guard deeper down. A validator rather than
+    a lookahead because pydantic-core's regex engine has no look-around."""
+    if set(value) == {"."}:
+        raise ValueError("scope_id must not consist solely of dots")
+    return value
+
+
+# Same charset as _PROJECT_ID_OVERRIDE_PATTERN in memory_service.py; also valid
+# for session/agent scope_ids (which pass _sanitize_scope_id).
+MemoryScopeId = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-zA-Z0-9._-]{1,128}$"),
+    AfterValidator(_reject_all_dots),
+]
 
 
 class MemoryScope(str, Enum):

--- a/src/cli_agent_orchestrator/models/memory.py
+++ b/src/cli_agent_orchestrator/models/memory.py
@@ -12,11 +12,13 @@ from pydantic import (
     field_validator,
 )
 
+
 def _reject_control_chars(value: str) -> str:
     """Reject control characters to prevent newline/NULL bypasses of `$`-anchored regexes."""
     if any(ch in value for ch in ("\n", "\r", "\x00")):
         raise ValueError("must not contain control characters")
     return value
+
 
 # Mirrors the CLI validation rule (cli/commands/memory.py) — reject-first, so
 # malformed keys 422 at the API layer instead of being silently sanitized.
@@ -25,6 +27,7 @@ MemoryKey = Annotated[
     StringConstraints(pattern=r"^[a-z0-9-]{1,60}$"),
     AfterValidator(_reject_control_chars),
 ]
+
 
 def _reject_all_dots(value: str) -> str:
     """Reject '.', '..', '...' so traversal tokens 422 at the boundary instead

--- a/src/cli_agent_orchestrator/models/memory.py
+++ b/src/cli_agent_orchestrator/models/memory.py
@@ -12,11 +12,19 @@ from pydantic import (
     field_validator,
 )
 
+def _reject_control_chars(value: str) -> str:
+    """Reject control characters to prevent newline/NULL bypasses of `$`-anchored regexes."""
+    if any(ch in value for ch in ("\n", "\r", "\x00")):
+        raise ValueError("must not contain control characters")
+    return value
+
 # Mirrors the CLI validation rule (cli/commands/memory.py) — reject-first, so
 # malformed keys 422 at the API layer instead of being silently sanitized.
-# Length-bounded pattern avoids Python's `$`-matches-before-trailing-newline quirk.
-MemoryKey = Annotated[str, StringConstraints(pattern=r"^[a-z0-9-]{1,60}$")]
-
+MemoryKey = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-z0-9-]{1,60}$"),
+    AfterValidator(_reject_control_chars),
+]
 
 def _reject_all_dots(value: str) -> str:
     """Reject '.', '..', '...' so traversal tokens 422 at the boundary instead

--- a/test/api/test_memory_api.py
+++ b/test/api/test_memory_api.py
@@ -145,6 +145,17 @@ class TestListMemories:
         assert client.get("/memory?scope_id=.").status_code == 422
         mock_service.recall.assert_not_awaited()
 
+    def test_list_scope_id_excludes_globals(self, client, mock_service):
+        """scope_id strictly narrows: global memories (scope_id=None) never match."""
+        mock_service.recall.return_value = [
+            _make_memory(key="global-one", scope="global"),
+            _make_memory(key="mine", scope="project", project_dir="proj-mine"),
+        ]
+        response = client.get("/memory?scope_id=proj-mine")
+
+        assert response.status_code == 200
+        assert [m["key"] for m in response.json()] == ["mine"]
+
     def test_list_filters_session_by_native_scope_id(self, client, mock_service):
         mock_service.recall.return_value = [
             _make_memory(key="s-one", scope="session", scope_id="sess-1"),

--- a/test/api/test_memory_api.py
+++ b/test/api/test_memory_api.py
@@ -1,0 +1,370 @@
+"""Tests for memory REST endpoints (issue #286).
+
+Endpoint logic is isolated by patching the _get_memory_service factory
+(mirroring test/cli/commands/test_memory.py) and the is_memory_enabled
+gate at the seam the endpoints read.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.models.memory import Memory
+
+MEMORY_BASE = Path("/home/user/.aws/cli-agent-orchestrator/memory")
+
+FACTORY_TARGET = "cli_agent_orchestrator.api.main._get_memory_service"
+ENABLED_TARGET = "cli_agent_orchestrator.services.settings_service.is_memory_enabled"
+
+
+def _make_memory(
+    key="test-key",
+    scope="global",
+    scope_id=None,
+    memory_type="project",
+    tags="",
+    content="Test content.",
+    project_dir="global",
+):
+    """Build a Memory with a realistic on-disk file_path.
+
+    Layout (memory_service.get_wiki_path): base/<container>/wiki/<scope>[/<scope_id>]/<key>.md
+    where container is the project id for project scope and "global" otherwise.
+    """
+    if scope in ("session", "agent") and scope_id:
+        file_path = MEMORY_BASE / "global" / "wiki" / scope / scope_id / f"{key}.md"
+    else:
+        file_path = MEMORY_BASE / project_dir / "wiki" / scope / f"{key}.md"
+    return Memory(
+        id=f"{scope}:{key}",
+        key=key,
+        memory_type=memory_type,
+        scope=scope,
+        scope_id=scope_id,
+        file_path=str(file_path),
+        tags=tags,
+        created_at=datetime(2026, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc),
+        content=content,
+    )
+
+
+@pytest.fixture
+def mock_service():
+    """Patch the module-level factory with a service mock (async recall/forget)."""
+    svc = MagicMock()
+    svc.base_dir = MEMORY_BASE
+    svc.recall = AsyncMock(return_value=[])
+    svc.forget = AsyncMock(return_value=True)
+    with patch(FACTORY_TARGET, return_value=svc):
+        yield svc
+
+
+class TestMemorySettingsEndpoint:
+    """Tests for GET /settings/memory."""
+
+    def test_enabled(self, client):
+        with patch(ENABLED_TARGET, return_value=True):
+            response = client.get("/settings/memory")
+        assert response.status_code == 200
+        assert response.json() == {"enabled": True}
+
+    def test_disabled(self, client):
+        with patch(ENABLED_TARGET, return_value=False):
+            response = client.get("/settings/memory")
+        assert response.status_code == 200
+        assert response.json() == {"enabled": False}
+
+
+class TestListMemories:
+    """Tests for GET /memory."""
+
+    def test_list_success(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="alpha", scope="global"),
+            _make_memory(key="beta", scope="project", project_dir="proj-abc123"),
+        ]
+        response = client.get("/memory")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [m["key"] for m in data] == ["alpha", "beta"]
+        # project scope_id is derived from the storage path; global has none
+        assert data[0]["scope_id"] is None
+        assert data[1]["scope_id"] == "proj-abc123"
+        # file_path must never leak into the response
+        assert "file_path" not in data[0]
+
+    def test_list_recall_args(self, client, mock_service):
+        """recall uses internal limit 1000 + scan_all + metadata; response sliced to user limit."""
+        mock_service.recall.return_value = [_make_memory(key=f"key-{i}") for i in range(5)]
+        response = client.get("/memory?limit=3&scope=global&type=feedback")
+
+        assert response.status_code == 200
+        assert len(response.json()) == 3
+        mock_service.recall.assert_awaited_once_with(
+            scope="global",
+            memory_type="feedback",
+            limit=1000,
+            scan_all=True,
+            search_mode="metadata",
+        )
+
+    def test_list_filters_project_by_scope_id(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="mine", scope="project", project_dir="proj-mine"),
+            _make_memory(key="other", scope="project", project_dir="proj-other"),
+        ]
+        response = client.get("/memory?scope=project&scope_id=proj-mine")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [m["key"] for m in data] == ["mine"]
+
+    def test_list_slices_after_scope_id_filter(self, client, mock_service):
+        """The user limit applies to the FILTERED set, not the raw recall page."""
+        mock_service.recall.return_value = [
+            # interleave non-matching first so a slice-before-filter would
+            # return too few matching rows
+            mem
+            for i in range(5)
+            for mem in (
+                _make_memory(key=f"other-{i}", scope="project", project_dir="proj-other"),
+                _make_memory(key=f"mine-{i}", scope="project", project_dir="proj-mine"),
+            )
+        ]
+        response = client.get("/memory?scope=project&scope_id=proj-mine&limit=3")
+
+        assert response.status_code == 200
+        assert [m["key"] for m in response.json()] == ["mine-0", "mine-1", "mine-2"]
+
+    def test_list_dot_only_scope_id_returns_422(self, client, mock_service):
+        assert client.get("/memory?scope_id=..").status_code == 422
+        assert client.get("/memory?scope_id=.").status_code == 422
+        mock_service.recall.assert_not_awaited()
+
+    def test_list_filters_session_by_native_scope_id(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="s-one", scope="session", scope_id="sess-1"),
+            _make_memory(key="s-two", scope="session", scope_id="sess-2"),
+        ]
+        response = client.get("/memory?scope=session&scope_id=sess-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [m["key"] for m in data] == ["s-one"]
+        assert data[0]["scope_id"] == "sess-1"
+
+    def test_list_disabled_returns_404(self, client, mock_service):
+        with patch(ENABLED_TARGET, return_value=False):
+            response = client.get("/memory")
+        assert response.status_code == 404
+        assert "disabled" in response.json()["detail"]
+
+    def test_list_invalid_scope_returns_422(self, client, mock_service):
+        assert client.get("/memory?scope=bogus").status_code == 422
+
+    def test_list_invalid_limit_returns_422(self, client, mock_service):
+        assert client.get("/memory?limit=0").status_code == 422
+        assert client.get("/memory?limit=101").status_code == 422
+
+    def test_list_server_error_returns_500(self, client, mock_service):
+        mock_service.recall.side_effect = Exception("storage exploded")
+        response = client.get("/memory")
+        assert response.status_code == 500
+        assert "Failed to list memories" in response.json()["detail"]
+
+
+class TestGetMemory:
+    """Tests for GET /memory/{key}."""
+
+    def test_get_success(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="my-key", content="Full content here.")
+        ]
+        response = client.get("/memory/my-key")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["key"] == "my-key"
+        assert data["content"] == "Full content here."
+        assert "file_path" not in data
+        mock_service.recall.assert_awaited_once_with(
+            query="my-key",
+            scope=None,
+            limit=1000,
+            scan_all=True,
+            search_mode="metadata",
+        )
+
+    def test_get_exact_match_only(self, client, mock_service):
+        """Substring recall hits that aren't exact key matches are skipped."""
+        mock_service.recall.return_value = [_make_memory(key="my-key-extended")]
+        response = client.get("/memory/my-key")
+        assert response.status_code == 404
+        assert "Memory 'my-key' not found" in response.json()["detail"]
+
+    def test_get_narrows_by_scope_id(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="dup", scope="project", project_dir="proj-other"),
+            _make_memory(key="dup", scope="project", project_dir="proj-mine"),
+        ]
+        response = client.get("/memory/dup?scope=project&scope_id=proj-mine")
+
+        assert response.status_code == 200
+        assert response.json()["scope_id"] == "proj-mine"
+
+    def test_get_not_found(self, client, mock_service):
+        response = client.get("/memory/missing-key")
+        assert response.status_code == 404
+        assert "Memory 'missing-key' not found" in response.json()["detail"]
+
+    def test_get_invalid_keys_return_422(self, client, mock_service):
+        # uppercase, underscore, overlong — all rejected pre-handler
+        assert client.get("/memory/BadKey").status_code == 422
+        assert client.get("/memory/bad_key").status_code == 422
+        assert client.get(f"/memory/{'a' * 61}").status_code == 422
+        # encoded traversal never routes to the handler (404 from Starlette,
+        # not from our not-found path) — the property that matters is that
+        # the service is never reached
+        assert client.get("/memory/%2E%2E%2Fetc").status_code == 404
+        mock_service.recall.assert_not_awaited()
+
+    def test_get_disabled_returns_404(self, client, mock_service):
+        with patch(ENABLED_TARGET, return_value=False):
+            response = client.get("/memory/my-key")
+        assert response.status_code == 404
+        assert "disabled" in response.json()["detail"]
+
+    def test_get_server_error_returns_500(self, client, mock_service):
+        mock_service.recall.side_effect = Exception("boom")
+        response = client.get("/memory/my-key")
+        assert response.status_code == 500
+        assert "Failed to get memory" in response.json()["detail"]
+
+
+class TestDeleteMemory:
+    """Tests for DELETE /memory/{key}."""
+
+    def test_delete_global_success(self, client, mock_service):
+        response = client.delete("/memory/my-key?scope=global")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+        mock_service.forget.assert_awaited_once_with(key="my-key", scope="global", scope_id=None)
+
+    def test_delete_project_with_scope_id(self, client, mock_service):
+        response = client.delete("/memory/my-key?scope=project&scope_id=proj-abc")
+
+        assert response.status_code == 200
+        mock_service.forget.assert_awaited_once_with(
+            key="my-key", scope="project", scope_id="proj-abc"
+        )
+
+    def test_delete_project_without_scope_id_returns_400(self, client, mock_service):
+        """Default scope is project (CLI parity) and non-global scopes need scope_id."""
+        response = client.delete("/memory/my-key")
+        assert response.status_code == 400
+        assert "requires scope_id" in response.json()["detail"]
+        mock_service.forget.assert_not_awaited()
+
+    def test_delete_not_found(self, client, mock_service):
+        mock_service.forget.return_value = False
+        response = client.delete("/memory/my-key?scope=global")
+        assert response.status_code == 404
+        assert "not found in scope 'global'" in response.json()["detail"]
+
+    def test_delete_invalid_key_returns_422(self, client, mock_service):
+        assert client.delete("/memory/Bad_Key?scope=global").status_code == 422
+        mock_service.forget.assert_not_awaited()
+
+    def test_delete_dot_only_scope_id_returns_422(self, client, mock_service):
+        """Traversal tokens are rejected at the boundary, not by the path guard."""
+        assert client.delete("/memory/my-key?scope=project&scope_id=..").status_code == 422
+        assert client.delete("/memory/my-key?scope=project&scope_id=.").status_code == 422
+        mock_service.forget.assert_not_awaited()
+
+    def test_delete_disabled_returns_404(self, client, mock_service):
+        with patch(ENABLED_TARGET, return_value=False):
+            response = client.delete("/memory/my-key?scope=global")
+        assert response.status_code == 404
+        assert "disabled" in response.json()["detail"]
+
+    def test_delete_server_error_returns_500(self, client, mock_service):
+        mock_service.forget.side_effect = Exception("boom")
+        response = client.delete("/memory/my-key?scope=global")
+        assert response.status_code == 500
+        assert "Failed to delete memory" in response.json()["detail"]
+
+
+class TestClearMemories:
+    """Tests for DELETE /memory (clear by scope)."""
+
+    def test_clear_global_success(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="one"),
+            _make_memory(key="two"),
+        ]
+        response = client.delete("/memory?scope=global")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "deleted_count": 2}
+        assert mock_service.forget.await_count == 2
+
+    def test_clear_requires_scope(self, client, mock_service):
+        assert client.delete("/memory").status_code == 422
+
+    def test_clear_project_without_scope_id_returns_400(self, client, mock_service):
+        response = client.delete("/memory?scope=project")
+        assert response.status_code == 400
+        assert "requires scope_id" in response.json()["detail"]
+
+    def test_clear_project_filters_and_passes_scope_id(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="mine", scope="project", project_dir="proj-mine"),
+            _make_memory(key="other", scope="project", project_dir="proj-other"),
+        ]
+        response = client.delete("/memory?scope=project&scope_id=proj-mine")
+
+        assert response.status_code == 200
+        assert response.json()["deleted_count"] == 1
+        mock_service.forget.assert_awaited_once_with(
+            key="mine", scope="project", scope_id="proj-mine"
+        )
+
+    def test_clear_session_passes_native_scope_id(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="s-one", scope="session", scope_id="sess-1"),
+        ]
+        response = client.delete("/memory?scope=session&scope_id=sess-1")
+
+        assert response.status_code == 200
+        mock_service.forget.assert_awaited_once_with(
+            key="s-one", scope="session", scope_id="sess-1"
+        )
+
+    def test_clear_continues_past_per_item_failure(self, client, mock_service):
+        mock_service.recall.return_value = [
+            _make_memory(key="one"),
+            _make_memory(key="two"),
+        ]
+        mock_service.forget.side_effect = [Exception("boom"), True]
+        response = client.delete("/memory?scope=global")
+
+        assert response.status_code == 200
+        assert response.json()["deleted_count"] == 1
+        assert mock_service.forget.await_count == 2
+
+    def test_clear_disabled_returns_404(self, client, mock_service):
+        with patch(ENABLED_TARGET, return_value=False):
+            response = client.delete("/memory?scope=global")
+        assert response.status_code == 404
+        assert "disabled" in response.json()["detail"]
+
+    def test_clear_recall_error_returns_500(self, client, mock_service):
+        mock_service.recall.side_effect = Exception("boom")
+        response = client.delete("/memory?scope=global")
+        assert response.status_code == 500
+        assert "Failed to clear memories" in response.json()["detail"]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,19 +1,23 @@
 import { useEffect, useState, Suspense } from 'react'
+import { api } from './api'
 import { useStore } from './store'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { DashboardHome } from './components/DashboardHome'
 import { AgentPanel } from './components/AgentPanel'
 import { FlowsPanel } from './components/FlowsPanel'
+import { MemoryPanel } from './components/MemoryPanel'
 import { SettingsPanel } from './components/SettingsPanel'
-import { Bot, Home, Clock, Settings, CheckCircle, XCircle, Info, Wifi, WifiOff } from 'lucide-react'
+import { Bot, Home, Clock, Settings, Brain, CheckCircle, XCircle, Info, Wifi, WifiOff } from 'lucide-react'
 
-type TabKey = 'home' | 'agents' | 'flows' | 'settings'
+type TabKey = 'home' | 'agents' | 'flows' | 'settings' | 'memory'
 
+// Memory appended last so Alt+N numbering of existing tabs never shifts
 const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
   { key: 'home', label: 'Home', icon: <Home size={16} /> },
   { key: 'agents', label: 'Agents', icon: <Bot size={16} /> },
   { key: 'flows', label: 'Flows', icon: <Clock size={16} /> },
   { key: 'settings', label: 'Settings', icon: <Settings size={16} /> },
+  { key: 'memory', label: 'Memory', icon: <Brain size={16} /> },
 ]
 
 function Snackbar() {
@@ -49,25 +53,32 @@ function Snackbar() {
 
 export default function App() {
   const [tab, setTab] = useState<TabKey>('home')
+  // Default false (fail-closed): a dead backend hides the tab rather than showing a broken panel
+  const [memoryEnabled, setMemoryEnabled] = useState(false)
   const { sessions, connected, fetchSessions } = useStore()
+
+  const visibleTabs = TABS.filter(t => t.key !== 'memory' || memoryEnabled)
 
   useEffect(() => {
     fetchSessions()
+    api.getMemoryStatus()
+      .then(s => setMemoryEnabled(s.enabled))
+      .catch(() => {})
     const interval = setInterval(fetchSessions, 10000)
     return () => clearInterval(interval)
   }, [])
 
-  // Keyboard shortcuts: Alt+1-4
+  // Keyboard shortcuts: Alt+1-N over the visible tabs
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.altKey && e.key >= '1' && e.key <= String(TABS.length)) {
+      if (e.altKey && e.key >= '1' && e.key <= String(visibleTabs.length)) {
         e.preventDefault()
-        setTab(TABS[parseInt(e.key) - 1].key)
+        setTab(visibleTabs[parseInt(e.key) - 1].key)
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [])
+  }, [memoryEnabled])
 
   return (
     <div className="min-h-screen bg-[#0f0f14] text-gray-200">
@@ -100,7 +111,7 @@ export default function App() {
       <div className="border-b border-gray-800">
         <div className="max-w-7xl mx-auto px-6">
           <nav className="flex gap-1 py-2" role="tablist">
-            {TABS.map((t, i) => (
+            {visibleTabs.map((t, i) => (
               <button
                 key={t.key}
                 role="tab"
@@ -134,6 +145,7 @@ export default function App() {
             {tab === 'agents' && <AgentPanel />}
             {tab === 'flows' && <FlowsPanel />}
             {tab === 'settings' && <SettingsPanel />}
+            {tab === 'memory' && <MemoryPanel />}
           </Suspense>
         </ErrorBoundary>
       </main>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -89,6 +89,24 @@ export interface ProviderInfo {
   installed: boolean
 }
 
+export interface MemoryStatus {
+  enabled: boolean
+}
+
+export interface MemorySummary {
+  key: string
+  scope: string
+  scope_id: string | null
+  memory_type: string
+  tags: string
+  created_at: string
+  updated_at: string
+}
+
+export interface MemoryDetail extends MemorySummary {
+  content: string
+}
+
 export const api = {
   // Agent Profiles & Providers
   listProfiles: () => fetchJSON<AgentProfileInfo[]>('/agents/profiles'),
@@ -144,4 +162,27 @@ export const api = {
   enableFlow: (name: string) => fetchJSON<{ success: boolean }>(`/flows/${name}/enable`, { method: 'POST' }),
   disableFlow: (name: string) => fetchJSON<{ success: boolean }>(`/flows/${name}/disable`, { method: 'POST' }),
   runFlow: (name: string) => fetchJSON<{ executed: boolean }>(`/flows/${name}/run`, { method: 'POST', timeoutMs: 90000 }),
+
+  // Memory
+  getMemoryStatus: () => fetchJSON<MemoryStatus>('/settings/memory'),
+  listMemories: (filters?: { scope?: string; type?: string; scopeId?: string; limit?: number }) => {
+    const params = [
+      filters?.scope ? `scope=${encodeURIComponent(filters.scope)}` : '',
+      filters?.type ? `type=${encodeURIComponent(filters.type)}` : '',
+      filters?.scopeId ? `scope_id=${encodeURIComponent(filters.scopeId)}` : '',
+      filters?.limit ? `limit=${filters.limit}` : '',
+    ].filter(Boolean).join('&')
+    return fetchJSON<MemorySummary[]>(`/memory${params ? `?${params}` : ''}`)
+  },
+  getMemory: (key: string, scope?: string, scopeId?: string) => {
+    const params = [
+      scope ? `scope=${encodeURIComponent(scope)}` : '',
+      scopeId ? `scope_id=${encodeURIComponent(scopeId)}` : '',
+    ].filter(Boolean).join('&')
+    return fetchJSON<MemoryDetail>(`/memory/${encodeURIComponent(key)}${params ? `?${params}` : ''}`)
+  },
+  deleteMemory: (key: string, scope: string, scopeId?: string) =>
+    fetchJSON<{ success: boolean }>(`/memory/${encodeURIComponent(key)}?scope=${encodeURIComponent(scope)}${scopeId ? `&scope_id=${encodeURIComponent(scopeId)}` : ''}`, { method: 'DELETE' }),
+  clearMemories: (scope: string, scopeId?: string) =>
+    fetchJSON<{ success: boolean; deleted_count: number }>(`/memory?scope=${encodeURIComponent(scope)}${scopeId ? `&scope_id=${encodeURIComponent(scopeId)}` : ''}`, { method: 'DELETE' }),
 }

--- a/web/src/components/MemoryPanel.tsx
+++ b/web/src/components/MemoryPanel.tsx
@@ -1,0 +1,318 @@
+import { useState, useEffect } from 'react'
+import { api, MemorySummary, MemoryDetail } from '../api'
+import { useStore } from '../store'
+import { ConfirmModal } from './ConfirmModal'
+import { Brain, Search, Trash2, ChevronDown, ChevronRight } from 'lucide-react'
+import { CustomSelect } from './CustomSelect'
+
+const SCOPE_OPTIONS = [
+  { value: '', label: 'All scopes' },
+  { value: 'global', label: 'global' },
+  { value: 'project', label: 'project' },
+  { value: 'session', label: 'session' },
+  { value: 'agent', label: 'agent' },
+]
+
+const TYPE_OPTIONS = [
+  { value: '', label: 'All types' },
+  { value: 'user', label: 'user' },
+  { value: 'feedback', label: 'feedback' },
+  { value: 'project', label: 'project' },
+  { value: 'reference', label: 'reference' },
+]
+
+const SCOPE_PILL: Record<string, string> = {
+  global: 'bg-blue-900/50 text-blue-400',
+  project: 'bg-emerald-900/50 text-emerald-400',
+  session: 'bg-yellow-900/50 text-yellow-400',
+  agent: 'bg-purple-900/50 text-purple-400',
+}
+
+// Keys are unique only within (scope, scope_id), so rows need a composite id
+function rowId(m: MemorySummary): string {
+  return `${m.scope}:${m.scope_id ?? ''}:${m.key}`
+}
+
+export function MemoryPanel() {
+  const { showSnackbar } = useStore()
+
+  // Memory list state
+  const [memories, setMemories] = useState<MemorySummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [scopeFilter, setScopeFilter] = useState('')
+  const [typeFilter, setTypeFilter] = useState('')
+  const [search, setSearch] = useState('')
+
+  // Expanded detail state; detail is keyed by row id so a slow fetch for a
+  // previously-expanded row can't land under the currently-expanded one
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+  const [detail, setDetail] = useState<{ id: string; data: MemoryDetail } | null>(null)
+
+  // Delete / clear confirmation state
+  const [pendingDelete, setPendingDelete] = useState<MemorySummary | null>(null)
+  const [pendingClear, setPendingClear] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const fetchMemories = async () => {
+    try {
+      const data = await api.listMemories({
+        scope: scopeFilter || undefined,
+        type: typeFilter || undefined,
+      })
+      setMemories(data)
+    } catch {
+      setMemories([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchMemories()
+  }, [scopeFilter, typeFilter])
+
+  const handleExpand = async (m: MemorySummary) => {
+    const id = rowId(m)
+    if (expandedKey === id) {
+      setExpandedKey(null)
+      return
+    }
+    setExpandedKey(id)
+    setDetail(null)
+    try {
+      const d = await api.getMemory(m.key, m.scope, m.scope_id ?? undefined)
+      // A stale slow fetch must not clobber the detail of a row expanded later
+      setExpandedKey(current => {
+        if (current === id) setDetail({ id, data: d })
+        return current
+      })
+    } catch (e: any) {
+      showSnackbar({ type: 'error', message: e.message || 'Failed to load memory' })
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!pendingDelete) return
+    setBusy(true)
+    try {
+      await api.deleteMemory(pendingDelete.key, pendingDelete.scope, pendingDelete.scope_id ?? undefined)
+      showSnackbar({ type: 'success', message: `Memory "${pendingDelete.key}" deleted` })
+      await fetchMemories()
+    } catch (e: any) {
+      showSnackbar({ type: 'error', message: e.message || 'Failed to delete memory' })
+    } finally {
+      setBusy(false)
+      setPendingDelete(null)
+    }
+  }
+
+  const handleClear = async () => {
+    if (!pendingClear) return
+    setBusy(true)
+    let deleted = 0
+    let failures = 0
+    try {
+      if (pendingClear === 'global') {
+        const res = await api.clearMemories(pendingClear)
+        deleted = res.deleted_count
+      } else {
+        // Server requires scope_id for non-global scopes. Re-fetch the scope
+        // unfiltered (the view may be narrowed by a type filter or the default
+        // page size), then clear each scope_id best-effort (matching the
+        // server's own warn-and-continue semantics)
+        const scopeMemories = await api.listMemories({ scope: pendingClear, limit: 100 })
+        const scopeIds = [...new Set(
+          scopeMemories.filter(m => m.scope_id).map(m => m.scope_id as string)
+        )]
+        for (const scopeId of scopeIds) {
+          try {
+            const res = await api.clearMemories(pendingClear, scopeId)
+            deleted += res.deleted_count
+          } catch {
+            failures++
+          }
+        }
+      }
+      if (failures > 0) {
+        showSnackbar({ type: 'error', message: `Cleared ${deleted}, but ${failures} scope ID${failures === 1 ? '' : 's'} failed` })
+      } else {
+        showSnackbar({ type: 'success', message: `Cleared ${deleted} memor${deleted === 1 ? 'y' : 'ies'}` })
+      }
+    } catch (e: any) {
+      showSnackbar({ type: 'error', message: e.message || 'Failed to clear memories' })
+    } finally {
+      // Refetch even after failure — some deletions may already have landed
+      await fetchMemories()
+      setBusy(false)
+      setPendingClear(null)
+    }
+  }
+
+  if (loading) {
+    return <div className="text-gray-500 text-sm py-8 text-center">Loading memories...</div>
+  }
+
+  const filtered = memories.filter(m => !search || m.key.includes(search.toLowerCase()))
+
+  return (
+    <div className="space-y-6">
+      {/* Memory List */}
+      <div className="bg-gray-800/60 border border-gray-700/50 rounded-xl p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wide">
+            Memories ({filtered.length})
+          </h3>
+          <button
+            onClick={() => setPendingClear(scopeFilter)}
+            disabled={!scopeFilter}
+            className="flex items-center gap-2 bg-red-600 hover:bg-red-500 disabled:opacity-40 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+            title={scopeFilter ? `Clear all ${scopeFilter} memories` : 'Select a scope filter to enable'}
+          >
+            <Trash2 size={14} />
+            Clear scope…
+          </button>
+        </div>
+
+        {/* Filters */}
+        <div className="flex items-center gap-3 mb-4">
+          <CustomSelect
+            value={scopeFilter}
+            onChange={setScopeFilter}
+            options={SCOPE_OPTIONS}
+            className="w-40"
+          />
+          <CustomSelect
+            value={typeFilter}
+            onChange={setTypeFilter}
+            options={TYPE_OPTIONS}
+            className="w-40"
+          />
+          <div className="relative">
+            <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-500" />
+            <input
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Filter keys..."
+              className="bg-gray-900 border border-gray-700 text-gray-200 text-xs rounded-lg pl-8 pr-3 py-1.5 w-48 focus:border-emerald-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="text-center py-8">
+            <Brain size={32} className="mx-auto text-gray-600 mb-3" />
+            <p className="text-gray-500 text-sm">No memories stored.</p>
+            <p className="text-gray-600 text-xs mt-1">
+              Agents store memories as they work. Inspect them with the CLI: <code className="text-emerald-400">cao memory list</code>
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {filtered.map(m => (
+              <div key={rowId(m)} className="bg-gray-900/50 border border-gray-700/30 rounded-lg">
+                {/* Row header */}
+                <div
+                  className="flex items-center justify-between p-3 cursor-pointer hover:bg-gray-800/50 transition-colors"
+                  onClick={() => handleExpand(m)}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Brain size={14} className="text-gray-400 shrink-0" />
+                    <span className="text-sm text-gray-200 font-medium truncate">{m.key}</span>
+                    <span className={`text-xs px-2 py-0.5 rounded-full shrink-0 ${SCOPE_PILL[m.scope] || 'bg-gray-700 text-gray-400'}`}>
+                      {m.scope}
+                    </span>
+                    <span className="text-xs text-gray-500 shrink-0">{m.memory_type}</span>
+                    {m.tags && (
+                      <span className="text-xs text-gray-600 truncate">{m.tags}</span>
+                    )}
+                    <span className="text-xs text-gray-500 shrink-0">
+                      {new Date(m.updated_at).toLocaleString()}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-2 shrink-0 ml-3">
+                    {/* Delete */}
+                    <button
+                      onClick={e => { e.stopPropagation(); setPendingDelete(m) }}
+                      className="p-1.5 text-gray-500 hover:text-red-400 transition-colors rounded"
+                      title="Delete memory"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+
+                    {/* Expand chevron */}
+                    {expandedKey === rowId(m) ? (
+                      <ChevronDown size={14} className="text-gray-500" />
+                    ) : (
+                      <ChevronRight size={14} className="text-gray-500" />
+                    )}
+                  </div>
+                </div>
+
+                {/* Expanded details */}
+                {expandedKey === rowId(m) && (
+                  <div className="px-3 pb-3 text-xs text-gray-400 space-y-3 border-t border-gray-700/30 pt-3">
+                    <div className="grid grid-cols-2 gap-x-6 gap-y-1">
+                      <div>Created: <span className="text-gray-300">{new Date(m.created_at).toLocaleString()}</span></div>
+                      <div>Updated: <span className="text-gray-300">{new Date(m.updated_at).toLocaleString()}</span></div>
+                      {m.scope_id && (
+                        <div className="col-span-2">Scope ID: <span className="text-gray-300 font-mono">{m.scope_id}</span></div>
+                      )}
+                      {m.tags && (
+                        <div className="col-span-2">Tags: <span className="text-gray-300">{m.tags}</span></div>
+                      )}
+                    </div>
+                    {/* Plain text only — memory bodies are untrusted agent output */}
+                    {detail && detail.id === rowId(m) ? (
+                      <div className="bg-gray-950/60 border border-gray-700/30 rounded-lg p-3 text-sm text-gray-300 font-mono whitespace-pre-wrap leading-relaxed max-h-64 overflow-y-auto">
+                        {detail.data.content}
+                      </div>
+                    ) : (
+                      <div className="text-gray-500">Loading content...</div>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Delete Confirmation Modal */}
+      <ConfirmModal
+        open={!!pendingDelete}
+        title="Delete Memory"
+        message="This will permanently remove the memory and its history. This action cannot be undone."
+        details={pendingDelete ? [
+          { label: 'Key', value: pendingDelete.key },
+          { label: 'Scope', value: pendingDelete.scope },
+          { label: 'Scope ID', value: pendingDelete.scope_id || 'n/a' },
+          { label: 'Type', value: pendingDelete.memory_type },
+        ] : []}
+        confirmLabel="Delete Memory"
+        variant="danger"
+        loading={busy}
+        onConfirm={handleDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
+
+      {/* Clear Scope Confirmation Modal. No count shown: the server clears
+          the ENTIRE scope (all types, all pages), which can exceed what the
+          possibly-filtered view displays. */}
+      <ConfirmModal
+        open={!!pendingClear}
+        title="Clear Scope"
+        message="This will permanently remove every memory in the selected scope — including any not shown by the current type filter or search. This action cannot be undone."
+        details={pendingClear ? [
+          { label: 'Scope', value: pendingClear },
+        ] : []}
+        confirmLabel="Clear Scope"
+        variant="danger"
+        loading={busy}
+        onConfirm={handleClear}
+        onCancel={() => setPendingClear(null)}
+      />
+    </div>
+  )
+}

--- a/web/src/components/MemoryPanel.tsx
+++ b/web/src/components/MemoryPanel.tsx
@@ -303,7 +303,7 @@ export function MemoryPanel() {
       <ConfirmModal
         open={!!pendingClear}
         title="Clear Scope"
-        message="This will permanently remove every memory in the selected scope — including any not shown by the current type filter or search. This action cannot be undone."
+        message="This attempts to permanently remove all memories in the selected scope (best-effort) — including any not shown by the current type filter or search. This action cannot be undone."
         details={pendingClear ? [
           { label: 'Scope', value: pendingClear },
         ] : []}

--- a/web/src/test/api.test.ts
+++ b/web/src/test/api.test.ts
@@ -176,4 +176,82 @@ describe('API wrapper', () => {
     await api.deleteTerminal('t1')
     expect(mockFetch).toHaveBeenCalledWith('/terminals/t1', expect.objectContaining({ method: 'DELETE' }))
   })
+
+  it('getMemoryStatus fetches /settings/memory', async () => {
+    mockResponse({ enabled: true })
+    const result = await api.getMemoryStatus()
+    expect(result).toEqual({ enabled: true })
+    expect(mockFetch).toHaveBeenCalledWith('/settings/memory', expect.objectContaining({ signal: expect.any(AbortSignal) }))
+  })
+
+  it('listMemories fetches /memory without filters', async () => {
+    mockResponse([])
+    await api.listMemories()
+    expect(mockFetch).toHaveBeenCalledWith('/memory', expect.any(Object))
+  })
+
+  it('listMemories includes filters as query params', async () => {
+    mockResponse([])
+    await api.listMemories({ scope: 'project', type: 'reference', scopeId: 'my-proj', limit: 25 })
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/memory?scope=project&type=reference&scope_id=my-proj&limit=25',
+      expect.any(Object)
+    )
+  })
+
+  it('getMemory fetches /memory/{key} with scope and scope_id', async () => {
+    mockResponse({ key: 'my-key', scope: 'session', scope_id: 's1', memory_type: 'user', tags: '', created_at: '', updated_at: '', content: 'hello' })
+    const result = await api.getMemory('my-key', 'session', 's1')
+    expect(result.content).toBe('hello')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/memory/my-key?scope=session&scope_id=s1',
+      expect.any(Object)
+    )
+  })
+
+  it('getMemory encodes user strings in URL', async () => {
+    mockResponse({})
+    await api.getMemory('a b', 'project', 'p/1')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/memory/a%20b?scope=project&scope_id=p%2F1',
+      expect.any(Object)
+    )
+  })
+
+  it('deleteMemory sends DELETE with scope and scope_id', async () => {
+    mockResponse({ success: true })
+    await api.deleteMemory('my-key', 'project', 'my-proj')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/memory/my-key?scope=project&scope_id=my-proj',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('deleteMemory omits scope_id for global scope', async () => {
+    mockResponse({ success: true })
+    await api.deleteMemory('my-key', 'global')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/memory/my-key?scope=global',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('clearMemories sends DELETE with scope and scope_id', async () => {
+    mockResponse({ success: true, deleted_count: 3 })
+    const result = await api.clearMemories('session', 's 1')
+    expect(result.deleted_count).toBe(3)
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/memory?scope=session&scope_id=s%201',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('clearMemories omits scope_id for global scope', async () => {
+    mockResponse({ success: true, deleted_count: 0 })
+    await api.clearMemories('global')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/memory?scope=global',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
 })

--- a/web/src/test/memory-panel.test.tsx
+++ b/web/src/test/memory-panel.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryPanel } from '../components/MemoryPanel'
+
+const MEMORIES = [
+  {
+    key: 'project-conventions',
+    scope: 'project',
+    scope_id: 'my-proj',
+    memory_type: 'project',
+    tags: 'style,conventions',
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-10T00:00:00Z',
+  },
+  {
+    key: 'user-preferences',
+    scope: 'global',
+    scope_id: null,
+    memory_type: 'user',
+    tags: '',
+    created_at: '2026-06-02T00:00:00Z',
+    updated_at: '2026-06-11T00:00:00Z',
+  },
+]
+
+describe('MemoryPanel', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mockListResponse(data: unknown) {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(data),
+    })
+  }
+
+  it('renders memory rows after fetch', async () => {
+    mockListResponse(MEMORIES)
+    render(<MemoryPanel />)
+    expect(await screen.findByText('project-conventions')).toBeInTheDocument()
+    expect(screen.getByText('user-preferences')).toBeInTheDocument()
+    expect(screen.getByText('global')).toBeInTheDocument()
+    expect(screen.getByText('style,conventions')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no memories', async () => {
+    mockListResponse([])
+    render(<MemoryPanel />)
+    expect(await screen.findByText('No memories stored.')).toBeInTheDocument()
+  })
+
+  it('shows ConfirmModal when delete is clicked', async () => {
+    mockListResponse(MEMORIES)
+    render(<MemoryPanel />)
+    await screen.findByText('project-conventions')
+    const deleteButtons = screen.getAllByTitle('Delete memory')
+    fireEvent.click(deleteButtons[0])
+    await waitFor(() => {
+      expect(screen.getByText(/permanently remove the memory/i)).toBeInTheDocument()
+    })
+    // Modal details echo the row's key (row + modal both show it)
+    expect(screen.getAllByText('project-conventions').length).toBe(2)
+  })
+
+  it('disables Clear scope button when no scope filter is selected', async () => {
+    mockListResponse(MEMORIES)
+    render(<MemoryPanel />)
+    await screen.findByText('project-conventions')
+    const clearButton = screen.getByText('Clear scope…').closest('button')
+    expect(clearButton).toBeDisabled()
+  })
+
+  it('filters rows by key search client-side', async () => {
+    mockListResponse(MEMORIES)
+    render(<MemoryPanel />)
+    await screen.findByText('project-conventions')
+    fireEvent.change(screen.getByPlaceholderText('Filter keys...'), { target: { value: 'user-pref' } })
+    expect(screen.queryByText('project-conventions')).not.toBeInTheDocument()
+    expect(screen.getByText('user-preferences')).toBeInTheDocument()
+  })
+})

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       '/agents': { target: 'http://localhost:9889', changeOrigin: true },
       '/settings': { target: 'http://localhost:9889', changeOrigin: true },
       '/flows': { target: 'http://localhost:9889', changeOrigin: true },
+      '/memory': { target: 'http://localhost:9889', changeOrigin: true },
     },
   },
 })


### PR DESCRIPTION
Closes #286

## Summary

Adds Web UI support for the memory system: five REST endpoints mirroring the `cao memory` CLI, and a new **Memory** tab in the dashboard with browse, detail, delete, and clear-scope.

![Memory tab](placeholder-screenshot)

## REST endpoints

| Endpoint | Mirrors |
|---|---|
| `GET /settings/memory` | feature discovery (`{"enabled": bool}`) for tab hiding |
| `GET /memory` | `cao memory list --all` |
| `GET /memory/{key}` | `cao memory show` |
| `DELETE /memory/{key}` | `cao memory delete` |
| `DELETE /memory` | `cao memory clear` (returns `deleted_count`, best-effort) |

Thin wrappers over the existing async `MemoryService.recall()`/`forget()` — no new service-layer code.

## Design decisions

- **Explicit `scope_id` query param instead of a client cwd.** `resolve_project_id()` applies the server's `CAO_PROJECT_ID` override unconditionally before consulting cwd, so a client-supplied cwd could silently route to the wrong project. A regex-validated `scope_id` (`^[a-zA-Z0-9._-]{1,128}$`, all-dot values rejected) bypasses the resolver; non-global delete/clear require it (400 otherwise). This deliberately diverges from MCP `memory_forget`, which resolves context from `CAO_TERMINAL_ID` — documented in docs/api.md.
- **Explicit disabled gate → 404.** `recall()` silently returns `[]` when memory is disabled, so every `/memory` endpoint checks `is_memory_enabled()` explicitly. The UI hides the tab via `GET /settings/memory` (fail-closed: tab stays hidden if the fetch errors), so it never needs to distinguish disabled-404 from not-found-404.
- **Validated types at the boundary.** `MemoryKey` (`^[a-z0-9-]{1,60}$`, the CLI rule — reject-first, 422) and `MemoryScopeId` as Annotated StringConstraints types, following the `TerminalId` pattern.
- **Internal recall with `limit=1000, scan_all=True, search_mode="metadata"`**, filter by scope_id, then slice to the user limit (1–100) — `recall()` truncates before any endpoint-side filter could run.
- **Responses exclude `file_path`** (absolute server paths); project `scope_id` is derived from the storage path since recall populates it natively only for session/agent.
- **Plain-text detail rendering** — memory bodies are agent-written (prompt-injectable), so no markdown dependency.

## Web UI

`MemoryPanel` follows the FlowsPanel patterns: local state, fetch-on-mount + refetch-after-mutation, `CustomSelect` scope/type filters, client-side key search, lazy detail expand (stale-fetch race-guarded), delete and clear-scope behind `ConfirmModal`. Tab appended last so existing Alt+N shortcuts don't shift. New `/memory` Vite proxy entry.

## Testing

- 35 new API tests (`test/api/test_memory_api.py`): per-endpoint success/404/500 triplets, 422 validation (keys, scope, limit bounds, dot-only scope_id), 400 missing-scope_id, disabled-404 on every endpoint, scope_id filtering for project (path-derived) and session (native), filter-then-slice ordering
- 14 new web tests (api client methods incl. URL encoding; MemoryPanel render/empty/confirm states)
- Full suite: **2,271 passed, 0 failed**; mypy/black/isort clean; `tsc --noEmit` clean; production build OK
- Reviewed by three adversarial passes (design conformance, security, correctness) — security findings (dot-only scope_id traversal tokens) fixed with boundary validation + pinning tests

## Out of scope (per issue)

Create/edit from UI, live updates, Phase 3 views (lint/audit/cross-refs), markdown rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)