### PR TITLE
Add configurable server timeouts and file-based Claude Code prompt delivery

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -104,6 +104,28 @@ This mirrors agent-profile resolution: a skill in the global store is not shadow
 
 See [api.md](api.md) for the full API reference.
 
+## Server Tuning Settings
+
+The `server` key in `settings.json` controls timeouts and buffer sizes used by the CAO runtime. All values have safe defaults — only override if you experience timeouts or queue overflows.
+
+```json
+{
+  "server": {
+    "mcp_request_timeout": 30,
+    "event_bus_max_queue_size": 1024,
+    "provider_init_timeout": 60,
+    "startup_prompt_handler_timeout": 20
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `mcp_request_timeout` | `30` | Seconds to wait for HTTP calls between the MCP server process and the CAO API. Increase if you see timeout errors during `handoff` or `assign` operations. |
+| `event_bus_max_queue_size` | `1024` | Maximum events buffered per subscriber queue in the internal event bus. Increase if you see "Queue full, dropping event" errors with many active workers. |
+| `provider_init_timeout` | `60` | Seconds to wait for the initial shell prompt before launching a CLI provider. Some providers apply additional provider-specific initialization timeouts after launch. Increase if you see shell startup timeouts on slow machines. |
+| `startup_prompt_handler_timeout` | `20` | Seconds the Claude Code startup prompt handler waits for workspace trust / bypass dialogs before giving up. Rarely needs changing. |
+
 ## Server Network Settings
 
 `cao-server` is a local-only service by default. The host header, CORS, and

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -10,12 +10,12 @@ from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import (
     API_BASE_URL,
     DEFAULT_PROVIDER,
-    MCP_REQUEST_TIMEOUT,
     PROVIDERS,
     SERVER_HOST,
     SERVER_PORT,
 )
 from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.terminal import (
     poll_until_done,
     sync_backend_from_server,
@@ -287,7 +287,8 @@ def launch(
         # Forwarded env vars travel in the JSON body so values (which may
         # contain secrets) don't end up in cao-server's HTTP access log.
         # See issue #248.
-        post_kwargs: dict = {"params": params, "timeout": MCP_REQUEST_TIMEOUT}
+        request_timeout = get_server_settings()["mcp_request_timeout"]
+        post_kwargs: dict = {"params": params, "timeout": request_timeout}
         if forwarded_env:
             post_kwargs["json"] = {"env_vars": forwarded_env}
 
@@ -334,10 +335,11 @@ def launch(
                 raise click.ClickException(
                     f"Conductor {terminal['id']} did not become ready within 120s"
                 )
+            request_timeout = get_server_settings()["mcp_request_timeout"]
             response = requests.post(
                 f"{API_BASE_URL}/terminals/{terminal['id']}/input",
                 params={"message": message},
-                timeout=MCP_REQUEST_TIMEOUT,
+                timeout=request_timeout,
             )
             response.raise_for_status()
             time.sleep(3)
@@ -345,10 +347,11 @@ def launch(
                 click.echo(f"Message sent to {terminal['name']}. Running in background.")
                 return
             poll_until_done(terminal["id"], timeout=300)
+            request_timeout = get_server_settings()["mcp_request_timeout"]
             output_resp = requests.get(
                 f"{API_BASE_URL}/terminals/{terminal['id']}/output",
                 params={"mode": "last"},
-                timeout=MCP_REQUEST_TIMEOUT,
+                timeout=request_timeout,
             )
             output_resp.raise_for_status()
             output = output_resp.json().get("output", "")

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -10,7 +10,7 @@ import requests
 from fastmcp import FastMCP
 from pydantic import Field
 
-from cli_agent_orchestrator.constants import API_BASE_URL, DEFAULT_PROVIDER, MCP_REQUEST_TIMEOUT
+from cli_agent_orchestrator.constants import API_BASE_URL, DEFAULT_PROVIDER
 from cli_agent_orchestrator.mcp_server.models import HandoffResult
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -18,10 +18,17 @@ from cli_agent_orchestrator.services.memory_service import (
     MEMORY_DISABLED_MESSAGE,
     MemoryDisabledError,
 )
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
 from cli_agent_orchestrator.utils.terminal import generate_session_name, wait_until_terminal_status
 
 logger = logging.getLogger(__name__)
+
+
+def _mcp_timeout() -> float:
+    """Get MCP request timeout from server settings."""
+    return float(get_server_settings()["mcp_request_timeout"])
+
 
 # Environment variable to enable/disable working_directory parameter
 ENABLE_WORKING_DIRECTORY = os.getenv("CAO_ENABLE_WORKING_DIRECTORY", "false").lower() == "true"
@@ -43,7 +50,7 @@ def _get_cleanup_nudge() -> str:
         return ""
     try:
         resp = requests.get(
-            f"{API_BASE_URL}/terminals/{current_terminal_id}", timeout=MCP_REQUEST_TIMEOUT
+            f"{API_BASE_URL}/terminals/{current_terminal_id}", timeout=_mcp_timeout()
         )
         if resp.status_code != 200:
             return ""
@@ -51,7 +58,7 @@ def _get_cleanup_nudge() -> str:
         if not session_name:
             return ""
         resp = requests.get(
-            f"{API_BASE_URL}/sessions/{session_name}/terminals", timeout=MCP_REQUEST_TIMEOUT
+            f"{API_BASE_URL}/sessions/{session_name}/terminals", timeout=_mcp_timeout()
         )
         if resp.status_code != 200:
             return ""
@@ -163,7 +170,7 @@ def _create_terminal(
     if current_terminal_id:
         # Get terminal metadata via API
         response = requests.get(
-            f"{API_BASE_URL}/terminals/{current_terminal_id}", timeout=MCP_REQUEST_TIMEOUT
+            f"{API_BASE_URL}/terminals/{current_terminal_id}", timeout=_mcp_timeout()
         )
         response.raise_for_status()
         terminal_metadata = response.json()
@@ -178,7 +185,7 @@ def _create_terminal(
             try:
                 response = requests.get(
                     f"{API_BASE_URL}/terminals/{current_terminal_id}/working-directory",
-                    timeout=MCP_REQUEST_TIMEOUT,
+                    timeout=_mcp_timeout(),
                 )
                 if response.status_code == 200:
                     working_directory = response.json().get("working_directory")
@@ -209,7 +216,7 @@ def _create_terminal(
         response = requests.post(
             f"{API_BASE_URL}/sessions/{session_name}/terminals",
             params=params,
-            timeout=MCP_REQUEST_TIMEOUT,
+            timeout=_mcp_timeout(),
         )
         response.raise_for_status()
         terminal = response.json()
@@ -225,9 +232,7 @@ def _create_terminal(
         if working_directory:
             params["working_directory"] = working_directory
 
-        response = requests.post(
-            f"{API_BASE_URL}/sessions", params=params, timeout=MCP_REQUEST_TIMEOUT
-        )
+        response = requests.post(f"{API_BASE_URL}/sessions", params=params, timeout=_mcp_timeout())
         response.raise_for_status()
         terminal = response.json()
 
@@ -257,7 +262,7 @@ def _send_direct_input(
             "sender_id": os.environ.get("CAO_TERMINAL_ID", "supervisor"),
             "orchestration_type": orchestration_type,
         },
-        timeout=MCP_REQUEST_TIMEOUT,
+        timeout=_mcp_timeout(),
     )
     response.raise_for_status()
 
@@ -279,7 +284,7 @@ def _send_user_prompt_answer(terminal_id: str, answer: str) -> Dict[str, Any]:
 
     try:
         status_response = requests.get(
-            f"{API_BASE_URL}/terminals/{terminal_id}", timeout=MCP_REQUEST_TIMEOUT
+            f"{API_BASE_URL}/terminals/{terminal_id}", timeout=_mcp_timeout()
         )
         status_response.raise_for_status()
         terminal = status_response.json()
@@ -306,7 +311,7 @@ def _send_user_prompt_answer(terminal_id: str, answer: str) -> Dict[str, Any]:
                 "message": answer,
                 "sender_id": os.environ.get("CAO_TERMINAL_ID", "supervisor"),
             },
-            timeout=MCP_REQUEST_TIMEOUT,
+            timeout=_mcp_timeout(),
         )
         response.raise_for_status()
         return {
@@ -334,7 +339,7 @@ def _try_send_hermes_prompt_answer(terminal_id: str, answer: str) -> Optional[Di
     output_response = requests.get(
         f"{API_BASE_URL}/terminals/{terminal_id}/output",
         params={"mode": "full"},
-        timeout=MCP_REQUEST_TIMEOUT,
+        timeout=_mcp_timeout(),
     )
     output_response.raise_for_status()
     output = output_response.json().get("output", "")
@@ -379,7 +384,7 @@ def _send_terminal_key(terminal_id: str, key: str) -> None:
     response = requests.post(
         f"{API_BASE_URL}/terminals/{terminal_id}/key",
         params={"key": key},
-        timeout=MCP_REQUEST_TIMEOUT,
+        timeout=_mcp_timeout(),
     )
     response.raise_for_status()
 
@@ -391,7 +396,7 @@ def _send_terminal_input(terminal_id: str, message: str) -> None:
             "message": message,
             "sender_id": os.environ.get("CAO_TERMINAL_ID", "supervisor"),
         },
-        timeout=MCP_REQUEST_TIMEOUT,
+        timeout=_mcp_timeout(),
     )
     response.raise_for_status()
 
@@ -478,7 +483,7 @@ def _resolve_handoff_provider(agent_profile: str) -> HandoffContext:
         )
 
     response = requests.get(
-        f"{API_BASE_URL}/terminals/{current_terminal_id}", timeout=MCP_REQUEST_TIMEOUT
+        f"{API_BASE_URL}/terminals/{current_terminal_id}", timeout=_mcp_timeout()
     )
     response.raise_for_status()
     terminal_metadata = response.json()
@@ -581,7 +586,7 @@ def _send_to_inbox(receiver_id: str, message: str) -> Dict[str, Any]:
             "sender_id": sender_id,
             "message": message,
         },
-        timeout=MCP_REQUEST_TIMEOUT,
+        timeout=_mcp_timeout(),
     )
     response.raise_for_status()
     return response.json()
@@ -603,7 +608,7 @@ def _extract_error_detail(response: requests.Response, fallback: str) -> str:
 def _load_skill_impl(name: str) -> Union[str, Dict[str, Any]]:
     """Fetch a skill body from cao-server and return content or a structured error."""
     try:
-        response = requests.get(f"{API_BASE_URL}/skills/{name}", timeout=MCP_REQUEST_TIMEOUT)
+        response = requests.get(f"{API_BASE_URL}/skills/{name}", timeout=_mcp_timeout())
         response.raise_for_status()
         return response.json()["content"]
     except requests.HTTPError as exc:
@@ -898,7 +903,7 @@ def _assign_impl(
         if not wait_until_terminal_status(
             terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=60.0,
+            timeout=float(get_server_settings()["provider_init_timeout"]),
         ):
             return {
                 "success": False,
@@ -1035,7 +1040,7 @@ def _send_message_impl(receiver_id: Optional[str], message: str) -> Dict[str, An
                     ),
                 }
             response = requests.get(
-                f"{API_BASE_URL}/terminals/{own_terminal_id}", timeout=MCP_REQUEST_TIMEOUT
+                f"{API_BASE_URL}/terminals/{own_terminal_id}", timeout=_mcp_timeout()
             )
             try:
                 response.raise_for_status()
@@ -1181,7 +1186,7 @@ def delete_terminal(
     """
     try:
         response = requests.delete(
-            f"{API_BASE_URL}/terminals/{terminal_id}", timeout=MCP_REQUEST_TIMEOUT
+            f"{API_BASE_URL}/terminals/{terminal_id}", timeout=_mcp_timeout()
         )
         response.raise_for_status()
         return {"success": True, "message": f"Terminal {terminal_id} deleted successfully"}
@@ -1205,9 +1210,7 @@ def _get_terminal_context_from_env() -> Optional[Dict[str, Any]]:
         return None
 
     try:
-        response = requests.get(
-            f"{API_BASE_URL}/terminals/{terminal_id}", timeout=MCP_REQUEST_TIMEOUT
-        )
+        response = requests.get(f"{API_BASE_URL}/terminals/{terminal_id}", timeout=_mcp_timeout())
         response.raise_for_status()
         meta = response.json()
         ctx: Dict[str, Any] = {
@@ -1220,7 +1223,7 @@ def _get_terminal_context_from_env() -> Optional[Dict[str, Any]]:
         try:
             wd_resp = requests.get(
                 f"{API_BASE_URL}/terminals/{terminal_id}/working-directory",
-                timeout=MCP_REQUEST_TIMEOUT,
+                timeout=_mcp_timeout(),
             )
             if wd_resp.status_code == 200:
                 ctx["cwd"] = wd_resp.json().get("working_directory")

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -9,8 +9,10 @@ from pathlib import Path
 from typing import List, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
+from cli_agent_orchestrator.constants import CAO_HOME_DIR
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
@@ -190,8 +192,15 @@ class ClaudeCodeProvider(BaseProvider):
             system_prompt = profile.system_prompt if profile.system_prompt is not None else ""
             system_prompt = self._apply_skill_prompt(system_prompt)
             if system_prompt:
-                escaped_prompt = system_prompt.replace("\\", "\\\\").replace("\n", "\\n")
-                command_parts.extend(["--append-system-prompt", escaped_prompt])
+                tmp_dir = CAO_HOME_DIR / "tmp"
+                tmp_dir.mkdir(parents=True, exist_ok=True)
+                prompt_file = tmp_dir / f"{self.terminal_id}.prompt"
+                prompt_file.write_text(system_prompt, encoding="utf-8")
+                try:
+                    prompt_file.chmod(0o600)
+                except OSError:
+                    pass
+                command_parts.extend(["--append-system-prompt-file", str(prompt_file)])
 
             # Add MCP config if present.
             # Forward CAO_TERMINAL_ID so MCP servers (e.g. cao-mcp-server)
@@ -211,8 +220,15 @@ class ClaudeCodeProvider(BaseProvider):
                         env["CAO_TERMINAL_ID"] = self.terminal_id
                         mcp_config[server_name]["env"] = env
 
-                mcp_json = json.dumps({"mcpServers": mcp_config})
-                command_parts.extend(["--mcp-config", mcp_json])
+                tmp_dir = CAO_HOME_DIR / "tmp"
+                tmp_dir.mkdir(parents=True, exist_ok=True)
+                mcp_file = tmp_dir / f"{self.terminal_id}.mcp.json"
+                mcp_file.write_text(json.dumps({"mcpServers": mcp_config}), encoding="utf-8")
+                try:
+                    mcp_file.chmod(0o600)
+                except OSError:
+                    pass
+                command_parts.extend(["--mcp-config", str(mcp_file)])
 
         # Apply tool restrictions via --disallowedTools flags.
         # --dangerously-skip-permissions bypasses prompts but --disallowedTools
@@ -271,7 +287,7 @@ class ClaudeCodeProvider(BaseProvider):
             json.dump(settings, f, indent=2)
         logger.info("Set skipDangerousModePermissionPrompt in ~/.claude/settings.json")
 
-    def _handle_startup_prompts(self, timeout: float = 20.0) -> None:
+    def _handle_startup_prompts(self, timeout: Optional[float] = None) -> None:
         """Auto-accept startup prompts that may appear before the REPL is ready.
 
         Claude Code may show up to two prompts during startup:
@@ -283,6 +299,8 @@ class ClaudeCodeProvider(BaseProvider):
         2. **Workspace trust dialog** – shows "Yes, I trust this folder";
            requires ``Enter``.
         """
+        if timeout is None:
+            timeout = get_server_settings()["startup_prompt_handler_timeout"]
         start_time = time.time()
         bypass_accepted = False
         while time.time() - start_time < timeout:
@@ -336,8 +354,9 @@ class ClaudeCodeProvider(BaseProvider):
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
         # Wait for shell prompt to appear in the tmux window
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Prevent bypass permissions dialog from appearing (settings-based fix).
         self._ensure_skip_bypass_prompt_setting()
@@ -352,7 +371,7 @@ class ClaudeCodeProvider(BaseProvider):
         get_backend().send_keys(self.session_name, self.window_name, command)
 
         # Handle startup prompts (bypass permissions + workspace trust)
-        self._handle_startup_prompts(timeout=20.0)
+        self._handle_startup_prompts()
 
         # Wait for Claude Code prompt to be ready.
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
@@ -361,13 +380,14 @@ class ClaudeCodeProvider(BaseProvider):
         # drives wait_until_status; it only fires once the provider's own
         # get_status returns IDLE/COMPLETED on Claude-rendered content, so the
         # old stale-zsh-prompt false-IDLE guard is no longer needed.
+        init_timeout = get_server_settings()["provider_init_timeout"]
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=30.0,
+            timeout=init_timeout,
             polling_interval=1.0,
         ):
-            raise TimeoutError("Claude Code initialization timed out after 30 seconds")
+            raise TimeoutError(f"Claude Code initialization timed out after {init_timeout}s")
 
         self._initialized = True
         return True
@@ -784,3 +804,11 @@ class ClaudeCodeProvider(BaseProvider):
     def cleanup(self) -> None:
         """Clean up Claude Code provider."""
         self._initialized = False
+        # Remove temp files created during initialization
+        tmp_dir = CAO_HOME_DIR / "tmp"
+        for suffix in (".prompt", ".mcp.json"):
+            tmp_file = tmp_dir / f"{self.terminal_id}{suffix}"
+            try:
+                tmp_file.unlink(missing_ok=True)
+            except OSError:
+                pass

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
@@ -357,8 +358,9 @@ class CodexProvider(BaseProvider):
         """Initialize Codex provider by starting codex command."""
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Send a warm-up command before launching codex.
         # Codex exits immediately in freshly-created tmux sessions where the shell
@@ -385,7 +387,7 @@ class CodexProvider(BaseProvider):
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=60.0,
+            timeout=float(get_server_settings()["provider_init_timeout"]),
             polling_interval=1.0,
         ):
             raise TimeoutError("Codex initialization timed out after 60 seconds")

--- a/src/cli_agent_orchestrator/providers/copilot_cli.py
+++ b/src/cli_agent_orchestrator/providers/copilot_cli.py
@@ -20,6 +20,7 @@ from libtmux.exc import LibTmuxException
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.terminal import wait_for_shell
 
 logger = logging.getLogger(__name__)
@@ -269,7 +270,8 @@ class CopilotCliProvider(BaseProvider):
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
         try:
-            shell_ready = await wait_for_shell(self.terminal_id, timeout=30.0)
+            init_timeout = get_server_settings()["provider_init_timeout"]
+            shell_ready = await wait_for_shell(self.terminal_id, timeout=init_timeout)
         except Exception as exc:
             logger.warning(
                 "wait_for_shell failed for %s:%s, retrying with provider history: %s",
@@ -277,10 +279,11 @@ class CopilotCliProvider(BaseProvider):
                 self.window_name,
                 exc,
             )
-            shell_ready = self._wait_for_shell_ready(timeout=30.0)
+            init_timeout = get_server_settings()["provider_init_timeout"]
+            shell_ready = self._wait_for_shell_ready(timeout=init_timeout)
 
         if not shell_ready:
-            raise TimeoutError("Shell initialization timed out after 30 seconds")
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         get_backend().send_keys(self.session_name, self.window_name, self._command())
 
@@ -417,6 +420,14 @@ class CopilotCliProvider(BaseProvider):
         return trimmed
 
     def get_status(self, output: str) -> TerminalStatus:
+        # For TUI apps, the raw FIFO buffer may contain only ANSI escapes.
+        # Fall back to tmux capture-pane when the buffer has no visible text.
+        cleaned = self._clean(output) if output else ""
+        if not cleaned.strip():
+            try:
+                output = self._history()
+            except Exception:
+                pass
         if not output or not output.strip():
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/cursor_cli.py
+++ b/src/cli_agent_orchestrator/providers/cursor_cli.py
@@ -73,6 +73,7 @@ from typing import Optional
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
@@ -567,8 +568,9 @@ class CursorCliProvider(BaseProvider):
         Raises:
             TimeoutError: If shell or Cursor CLI initialization times out.
         """
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         command = self._build_cursor_command()
         # Arm the StatusMonitor stickiness gate so the launching
@@ -590,7 +592,7 @@ class CursorCliProvider(BaseProvider):
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=30.0,
+            timeout=float(get_server_settings()["provider_init_timeout"]),
         ):
             raise TimeoutError("Cursor CLI initialization timed out after 30 seconds")
 

--- a/src/cli_agent_orchestrator/providers/gemini_cli.py
+++ b/src/cli_agent_orchestrator/providers/gemini_cli.py
@@ -42,6 +42,7 @@ from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import GEMINI_WORKSPACES_DIR
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 
@@ -479,8 +480,9 @@ class GeminiCliProvider(BaseProvider):
         """
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Shell warm-up: Gemini's Ink TUI exits silently in freshly-created
         # tmux sessions where the shell environment is not fully loaded.

--- a/src/cli_agent_orchestrator/providers/hermes.py
+++ b/src/cli_agent_orchestrator/providers/hermes.py
@@ -9,6 +9,7 @@ from typing import Optional
 from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 
@@ -175,8 +176,9 @@ class HermesProvider(BaseProvider):
 
     async def initialize(self) -> bool:
         """Initialize Hermes by starting the configured profile chat REPL."""
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         command = self._build_hermes_command()
         tmux_client.send_keys(self.session_name, self.window_name, command)

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -39,6 +39,7 @@ from typing import Any, Dict, List, Optional
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
@@ -411,8 +412,9 @@ class KimiCliProvider(BaseProvider):
             TimeoutError: If shell or Kimi CLI doesn't start within timeout
         """
         # Wait for shell prompt to appear in the tmux window
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Build properly escaped command string
         command = self._build_kimi_command()

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -25,6 +25,7 @@ from typing import Optional
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
@@ -215,8 +216,9 @@ class KiroCliProvider(BaseProvider):
 
         # Step 1: Wait for shell prompt to appear in the tmux window
         # This ensures the terminal is ready before we send commands
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Capture the shell process name before launching kiro — used later to detect kiro exit
         self.shell_baseline = get_backend().get_pane_current_command(
@@ -261,7 +263,9 @@ class KiroCliProvider(BaseProvider):
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
         # message that get_status() interprets as a completed response.
         if not await wait_until_status(
-            self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=30.0
+            self.terminal_id,
+            {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+            timeout=float(get_server_settings()["provider_init_timeout"]),
         ):
             if yolo:
                 # Yolo already launched with --legacy-ui; no further fallback.
@@ -271,8 +275,11 @@ class KiroCliProvider(BaseProvider):
             # Exit the current session and start fresh with --legacy-ui
             status_monitor.notify_input_sent(self.terminal_id)
             get_backend().send_keys(self.session_name, self.window_name, "/exit")
-            if not await wait_for_shell(self.terminal_id, timeout=10.0):
-                raise TimeoutError("Shell recovery timed out after --legacy-ui fallback")
+            init_timeout = get_server_settings()["provider_init_timeout"]
+            if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+                raise TimeoutError(
+                    f"Shell recovery timed out after {init_timeout}s (--legacy-ui fallback)"
+                )
             # Clear the StatusMonitor buffer so the --legacy-ui attempt is detected
             # against a clean buffer, not one still full of stale TUI marker bytes
             # from the failed first attempt (which would otherwise time out too).
@@ -285,7 +292,9 @@ class KiroCliProvider(BaseProvider):
             status_monitor.notify_input_sent(self.terminal_id)
             get_backend().send_keys(self.session_name, self.window_name, legacy_command)
             if not await wait_until_status(
-                self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=30.0
+                self.terminal_id,
+                {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+                timeout=float(get_server_settings()["provider_init_timeout"]),
             ):
                 raise TimeoutError("Kiro CLI initialization timed out with TUI and `--legacy-ui`")
 

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -26,6 +26,7 @@ from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 
 logger = logging.getLogger(__name__)
@@ -137,8 +138,9 @@ class OpenCodeCliProvider(BaseProvider):
         Raises:
             TimeoutError: If shell or OpenCode doesn't reach IDLE/COMPLETED in time.
         """
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         command = self._build_launch_command()
         get_backend().send_keys(self.session_name, self.window_name, command)

--- a/src/cli_agent_orchestrator/providers/q_cli.py
+++ b/src/cli_agent_orchestrator/providers/q_cli.py
@@ -8,6 +8,7 @@ from typing import Optional
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 
 logger = logging.getLogger(__name__)
@@ -50,16 +51,17 @@ class QCliProvider(BaseProvider):
     async def initialize(self) -> bool:
         """Initialize Q CLI provider by starting q chat command."""
         # Wait for shell to be ready first
-        if not await wait_for_shell(self.terminal_id, timeout=10.0):
-            raise TimeoutError("Shell initialization timed out after 10 seconds")
+        init_timeout = get_server_settings()["provider_init_timeout"]
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         command = shlex.join(["q", "chat", "--agent", self._agent_profile])
         get_backend().send_keys(self.session_name, self.window_name, command)
 
         if not await wait_until_status(
-            self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=30.0
+            self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=init_timeout
         ):
-            raise TimeoutError("Q CLI initialization timed out after 30 seconds")
+            raise TimeoutError(f"Q CLI initialization timed out after {init_timeout}s")
 
         self._initialized = True
         return True

--- a/src/cli_agent_orchestrator/services/event_bus.py
+++ b/src/cli_agent_orchestrator/services/event_bus.py
@@ -11,7 +11,7 @@ import re
 import threading
 from typing import Dict, List, Optional, Tuple
 
-from cli_agent_orchestrator.constants import EVENT_BUS_MAX_QUEUE_SIZE
+from cli_agent_orchestrator.services.settings_service import get_server_settings
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,9 @@ class EventBus:
 
     def subscribe(self, pattern: str) -> asyncio.Queue:
         """Subscribe to a topic pattern (e.g., 'terminal.*.output'). Returns async queue."""
-        queue: asyncio.Queue = asyncio.Queue(maxsize=EVENT_BUS_MAX_QUEUE_SIZE)
+        queue: asyncio.Queue = asyncio.Queue(
+            maxsize=get_server_settings()["event_bus_max_queue_size"]
+        )
 
         with self._lock:
             if "*" in pattern:

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -67,6 +67,69 @@ def set_agent_dirs(dirs: Dict[str, str]) -> Dict[str, str]:
     return get_agent_dirs()
 
 
+# Default server tuning values
+_SERVER_DEFAULTS = {
+    "mcp_request_timeout": 30,
+    "event_bus_max_queue_size": 1024,
+    "provider_init_timeout": 60,
+    "startup_prompt_handler_timeout": 20,
+}
+
+
+_server_settings_cache: Optional[Dict[str, Any]] = None
+_server_settings_mtime_ns: int = -1
+
+
+def get_server_settings() -> Dict[str, Any]:
+    """Get server tuning settings (cached; re-reads only when file changes).
+
+    Returns a dict with the following keys (defaults shown):
+      - mcp_request_timeout (30): Seconds to wait for MCP HTTP calls
+      - event_bus_max_queue_size (1024): Max events buffered per subscriber
+      - provider_init_timeout (60): Seconds to wait for a CLI agent to reach IDLE
+      - startup_prompt_handler_timeout (20): Seconds to handle startup prompts
+        (e.g., workspace trust dialogs) before giving up
+
+    Values can be set in ~/.aws/cli-agent-orchestrator/settings.json under
+    the "server" key:
+
+        {
+          "server": {
+            "mcp_request_timeout": 120,
+            "event_bus_max_queue_size": 8192,
+            "provider_init_timeout": 90,
+            "startup_prompt_handler_timeout": 5
+          }
+        }
+    """
+    global _server_settings_cache, _server_settings_mtime_ns
+    # Cache: only re-read when the file has changed
+    try:
+        mtime_ns = SETTINGS_FILE.stat().st_mtime_ns if SETTINGS_FILE.exists() else -1
+    except OSError:
+        mtime_ns = -1
+    if _server_settings_cache is not None and mtime_ns == _server_settings_mtime_ns:
+        return dict(_server_settings_cache)
+
+    settings = _load()
+    saved = settings.get("server", {})
+    if not isinstance(saved, dict):
+        logger.warning("Invalid settings.server=%r (expected object); using defaults", saved)
+        saved = {}
+    result = dict(_SERVER_DEFAULTS)
+    result.update({k: v for k, v in saved.items() if k in _SERVER_DEFAULTS})
+    # Validate types and ranges; coerce to int for queue size
+    for key, default in _SERVER_DEFAULTS.items():
+        val = result[key]
+        if isinstance(val, bool) or not isinstance(val, (int, float)) or val <= 0:
+            logger.warning(f"Invalid server setting {key}={val!r}, using default {default}")
+            result[key] = default
+    result["event_bus_max_queue_size"] = int(result["event_bus_max_queue_size"])
+    _server_settings_cache = result
+    _server_settings_mtime_ns = mtime_ns
+    return dict(result)
+
+
 def get_memory_settings() -> Dict[str, Any]:
     """Get memory-related settings.
 

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -128,8 +128,12 @@ class StatusMonitor:
                 self._feed_screen_locked(terminal_id, chunk)
 
         if not use_screen:
-            # Provider regex analysis can be slow — run it outside the lock.
-            self._apply_detection(terminal_id, self._detect_status(terminal_id, buffer))
+            # Debounced raw detection: same rising-edge + quiescence pattern as
+            # the pyte path.  Detects immediately on the first chunk after quiet
+            # (catches PROCESSING transition), then waits for output to settle
+            # before re-detecting (catches IDLE/COMPLETED without running costly
+            # regex on every single chunk during bursts).
+            self._schedule_raw_detection(terminal_id, buffer)
             return
 
         self._schedule_screen_detection(terminal_id, provider)
@@ -270,6 +274,48 @@ class StatusMonitor:
             self._bursting[terminal_id] = False
             self._quiesce_handle.pop(terminal_id, None)
         self._apply_detection(terminal_id, self._detect_screen(terminal_id, provider))
+
+    def _schedule_raw_detection(self, terminal_id: str, buffer: str) -> None:
+        """Edge-debounce detection on the raw rolling buffer.
+
+        Detects on every chunk while the terminal is in a ready/armed state
+        (to catch the IDLE→PROCESSING transition immediately). Once PROCESSING
+        is observed, switches to quiescence-only detection (the busy→ready
+        transition only matters after output settles). This prevents queue
+        overflow during sustained output while ensuring InboxService never
+        pastes into a busy terminal.
+        """
+        loop = self._running_loop()
+        if loop is None:
+            self._apply_detection(terminal_id, self._detect_status(terminal_id, buffer))
+            return
+        self._loop = loop
+
+        with self._lock:
+            was_bursting = self._bursting.get(terminal_id, False)
+            self._bursting[terminal_id] = True
+            handle = self._quiesce_handle.pop(terminal_id, None)
+            last_status = self._last_status.get(terminal_id)
+        self._cancel_quiesce_handle(handle)
+
+        # While terminal is ready/armed, detect on every chunk so the
+        # IDLE→PROCESSING transition is never missed (prevents stale-IDLE
+        # delivery by InboxService). Once PROCESSING is observed, debounce.
+        if not was_bursting or last_status in _STICKY_READY_STATUSES or last_status is None:
+            detected = self._detect_status(terminal_id, buffer)
+            self._apply_detection(terminal_id, detected)
+
+        new_handle = loop.call_later(PYTE_QUIESCENCE_DELAY_S, self._on_raw_quiescent, terminal_id)
+        with self._lock:
+            self._quiesce_handle[terminal_id] = new_handle
+
+    def _on_raw_quiescent(self, terminal_id: str) -> None:
+        """Quiescence timer fired for raw path: re-detect from current buffer."""
+        with self._lock:
+            self._bursting[terminal_id] = False
+            self._quiesce_handle.pop(terminal_id, None)
+            buffer = self._buffers.get(terminal_id, "")
+        self._apply_detection(terminal_id, self._detect_status(terminal_id, buffer))
 
     @staticmethod
     def _running_loop() -> Optional[asyncio.AbstractEventLoop]:

--- a/test/mcp_server/test_answer_user_prompt.py
+++ b/test/mcp_server/test_answer_user_prompt.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from cli_agent_orchestrator.constants import API_BASE_URL, MCP_REQUEST_TIMEOUT
-from cli_agent_orchestrator.mcp_server.server import MAX_USER_PROMPT_ANSWER_LENGTH
+from cli_agent_orchestrator.constants import API_BASE_URL
+from cli_agent_orchestrator.mcp_server.server import MAX_USER_PROMPT_ANSWER_LENGTH, _mcp_timeout
 
 
 class TestAnswerUserPrompt:
@@ -25,7 +25,7 @@ class TestAnswerUserPrompt:
 
         assert result["success"] is True
         mock_requests.get.assert_called_once_with(
-            f"{API_BASE_URL}/terminals/abcd1234", timeout=MCP_REQUEST_TIMEOUT
+            f"{API_BASE_URL}/terminals/abcd1234", timeout=_mcp_timeout()
         )
         mock_requests.post.assert_called_once_with(
             f"{API_BASE_URL}/terminals/abcd1234/input",
@@ -33,7 +33,7 @@ class TestAnswerUserPrompt:
                 "message": "1",
                 "sender_id": "supervisor",
             },
-            timeout=MCP_REQUEST_TIMEOUT,
+            timeout=_mcp_timeout(),
         )
 
     @patch("cli_agent_orchestrator.mcp_server.server.requests")

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cli_agent_orchestrator.constants import API_BASE_URL, MCP_REQUEST_TIMEOUT
-from cli_agent_orchestrator.mcp_server.server import _build_assign_description
+from cli_agent_orchestrator.constants import API_BASE_URL
+from cli_agent_orchestrator.mcp_server.server import _build_assign_description, _mcp_timeout
 
 
 class TestCreateTerminalProviderResolution:
@@ -52,7 +52,7 @@ class TestCreateTerminalProviderResolution:
                 "caller_id": "supervisor-1",
                 "working_directory": "/repo",
             },
-            timeout=MCP_REQUEST_TIMEOUT,
+            timeout=_mcp_timeout(),
         )
 
     @patch(
@@ -95,7 +95,7 @@ class TestCreateTerminalProviderResolution:
                 "caller_id": "supervisor-1",
                 "working_directory": "/repo",
             },
-            timeout=MCP_REQUEST_TIMEOUT,
+            timeout=_mcp_timeout(),
         )
 
 

--- a/test/mcp_server/test_load_skill.py
+++ b/test/mcp_server/test_load_skill.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from cli_agent_orchestrator.mcp_server.server import load_skill, mcp
+from cli_agent_orchestrator.mcp_server.server import _mcp_timeout, load_skill, mcp
 
 
 def _run_coroutine(coroutine):
@@ -33,7 +33,9 @@ class TestLoadSkillImpl:
         result = _load_skill_impl("python-testing")
 
         assert result == "# Use pytest"
-        mock_get.assert_called_once_with("http://127.0.0.1:9889/skills/python-testing", timeout=30)
+        mock_get.assert_called_once_with(
+            "http://127.0.0.1:9889/skills/python-testing", timeout=_mcp_timeout()
+        )
 
     @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
     def test_returns_error_dict_for_404(self, mock_get):

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -10,6 +10,23 @@ import pytest
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider, ProviderError
 
+
+@pytest.fixture(autouse=True)
+def cleanup_tmp_files():
+    """Remove temp prompt/mcp files created by _build_claude_command during tests."""
+    yield
+    tmp_dir = Path.home() / ".aws" / "cli-agent-orchestrator" / "tmp"
+    if tmp_dir.exists():
+        for f in tmp_dir.glob("test*.prompt"):
+            f.unlink(missing_ok=True)
+        for f in tmp_dir.glob("test*.mcp.json"):
+            f.unlink(missing_ok=True)
+        for f in tmp_dir.glob("term-*.prompt"):
+            f.unlink(missing_ok=True)
+        for f in tmp_dir.glob("term-*.mcp.json"):
+            f.unlink(missing_ok=True)
+
+
 # All initialization tests need to patch _ensure_skip_bypass_prompt_setting
 # to avoid writing to the real ~/.claude/settings.json.
 _PATCH_SETTINGS = patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
@@ -170,7 +187,7 @@ class TestClaudeCodeProviderInitialization:
         command = provider._build_claude_command()
 
         assert "--agent my-claude-agent" in command
-        assert "--append-system-prompt" not in command
+        assert "--append-system-prompt-file" not in command
         assert "--mcp-config" not in command
 
     @pytest.mark.asyncio
@@ -1094,7 +1111,7 @@ class TestClaudeCodeProviderMisc:
         command = provider._build_claude_command()
 
         assert "claude" in command
-        assert "--append-system-prompt" in command
+        assert "--append-system-prompt-file" in command
 
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
     def test_build_command_mcp_injects_terminal_id(self, mock_load):
@@ -1112,13 +1129,14 @@ class TestClaudeCodeProviderMisc:
         command = provider._build_claude_command()
 
         assert "--mcp-config" in command
-        # Extract the JSON arg after --mcp-config
+        # Extract the file path arg after --mcp-config
         parts = command.split("--mcp-config ")
-        mcp_json_str = parts[1].strip()
-        # shlex.join wraps the JSON in single quotes; strip them
-        if mcp_json_str.startswith("'") and mcp_json_str.endswith("'"):
-            mcp_json_str = mcp_json_str[1:-1]
-        mcp_data = json.loads(mcp_json_str)
+        mcp_file_path = parts[1].strip().split()[0]
+        # shlex.join wraps in single quotes; strip them
+        if mcp_file_path.startswith("'") and mcp_file_path.endswith("'"):
+            mcp_file_path = mcp_file_path[1:-1]
+        mcp_data = json.loads(Path(mcp_file_path).read_text())
+        Path(mcp_file_path).unlink(missing_ok=True)
         server_env = mcp_data["mcpServers"]["cao-mcp-server"]["env"]
         assert server_env["CAO_TERMINAL_ID"] == "term-42"
 
@@ -1141,10 +1159,11 @@ class TestClaudeCodeProviderMisc:
         command = provider._build_claude_command()
 
         parts = command.split("--mcp-config ")
-        mcp_json_str = parts[1].strip()
-        if mcp_json_str.startswith("'") and mcp_json_str.endswith("'"):
-            mcp_json_str = mcp_json_str[1:-1]
-        mcp_data = json.loads(mcp_json_str)
+        mcp_file_path = parts[1].strip().split()[0]
+        if mcp_file_path.startswith("'") and mcp_file_path.endswith("'"):
+            mcp_file_path = mcp_file_path[1:-1]
+        mcp_data = json.loads(Path(mcp_file_path).read_text())
+        Path(mcp_file_path).unlink(missing_ok=True)
         server_env = mcp_data["mcpServers"]["my-server"]["env"]
         # Original vars preserved
         assert server_env["MY_VAR"] == "my_value"
@@ -1171,10 +1190,11 @@ class TestClaudeCodeProviderMisc:
         command = provider._build_claude_command()
 
         parts = command.split("--mcp-config ")
-        mcp_json_str = parts[1].strip()
-        if mcp_json_str.startswith("'") and mcp_json_str.endswith("'"):
-            mcp_json_str = mcp_json_str[1:-1]
-        mcp_data = json.loads(mcp_json_str)
+        mcp_file_path = parts[1].strip().split()[0]
+        if mcp_file_path.startswith("'") and mcp_file_path.endswith("'"):
+            mcp_file_path = mcp_file_path[1:-1]
+        mcp_data = json.loads(Path(mcp_file_path).read_text())
+        Path(mcp_file_path).unlink(missing_ok=True)
         server_env = mcp_data["mcpServers"]["my-server"]["env"]
         # Should keep the user-provided value, NOT overwrite with term-99
         assert server_env["CAO_TERMINAL_ID"] == "user-provided-id"

--- a/test/providers/test_copilot_cli_unit.py
+++ b/test/providers/test_copilot_cli_unit.py
@@ -552,3 +552,24 @@ class TestCopilotCliProviderMisc:
         provider._initialized = True
         provider.cleanup()
         assert provider._initialized is False
+
+
+class TestCopilotCliServerSettings:
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_server_settings")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.wait_for_shell")
+    async def test_initialize_uses_provider_init_timeout(self, mock_wait_shell, mock_settings):
+        """initialize() reads provider_init_timeout from server settings."""
+        mock_settings.return_value = {
+            "mcp_request_timeout": 120,
+            "event_bus_max_queue_size": 8192,
+            "provider_init_timeout": 45,
+            "startup_prompt_handler_timeout": 5,
+        }
+        mock_wait_shell.return_value = False
+        provider = CopilotCliProvider("test1234", "test-session", "window-0")
+
+        with pytest.raises(TimeoutError):
+            await provider.initialize()
+
+        mock_wait_shell.assert_called_once_with("test1234", timeout=45)

--- a/test/services/test_event_bus.py
+++ b/test/services/test_event_bus.py
@@ -1,0 +1,20 @@
+"""Tests for event_bus module."""
+
+from unittest.mock import patch
+
+from cli_agent_orchestrator.services.event_bus import EventBus
+
+
+class TestEventBusSubscribe:
+    @patch("cli_agent_orchestrator.services.event_bus.get_server_settings")
+    def test_subscribe_uses_configured_queue_size(self, mock_settings):
+        """subscribe() creates queue with size from server settings."""
+        mock_settings.return_value = {
+            "mcp_request_timeout": 30,
+            "event_bus_max_queue_size": 4096,
+            "provider_init_timeout": 60,
+            "startup_prompt_handler_timeout": 20,
+        }
+        bus = EventBus()
+        queue = bus.subscribe("terminal.*.output")
+        assert queue.maxsize == 4096

--- a/test/services/test_settings_service.py
+++ b/test/services/test_settings_service.py
@@ -275,3 +275,56 @@ class TestExtraAgentAndSkillDirsAreIndependent:
         set_extra_skill_dirs(["/skills"])
         assert get_extra_agent_dirs() == ["/agents"]
         assert get_extra_skill_dirs() == ["/skills"]
+
+
+class TestGetServerSettings:
+    """Tests for get_server_settings function."""
+
+    def test_returns_defaults_when_no_settings(self, settings_file):
+        """Returns default values when no server section exists."""
+        from cli_agent_orchestrator.services.settings_service import get_server_settings
+
+        result = get_server_settings()
+        assert result == {
+            "mcp_request_timeout": 30,
+            "event_bus_max_queue_size": 1024,
+            "provider_init_timeout": 60,
+            "startup_prompt_handler_timeout": 20,
+        }
+
+    def test_reads_custom_values(self, settings_file):
+        """Reads custom values from settings.json."""
+        from cli_agent_orchestrator.services.settings_service import get_server_settings
+
+        _save({"server": {"mcp_request_timeout": 120, "provider_init_timeout": 90}})
+        result = get_server_settings()
+        assert result["mcp_request_timeout"] == 120
+        assert result["provider_init_timeout"] == 90
+        # Unset keys keep defaults
+        assert result["event_bus_max_queue_size"] == 1024
+        assert result["startup_prompt_handler_timeout"] == 20
+
+    def test_ignores_unknown_keys(self, settings_file):
+        """Unknown keys in server section are ignored."""
+        from cli_agent_orchestrator.services.settings_service import get_server_settings
+
+        _save({"server": {"unknown_key": 999, "mcp_request_timeout": 60}})
+        result = get_server_settings()
+        assert "unknown_key" not in result
+        assert result["mcp_request_timeout"] == 60
+
+    def test_invalid_type_falls_back_to_default(self, settings_file):
+        """Invalid types fall back to defaults with warning."""
+        from cli_agent_orchestrator.services.settings_service import get_server_settings
+
+        _save({"server": {"mcp_request_timeout": "not_a_number"}})
+        result = get_server_settings()
+        assert result["mcp_request_timeout"] == 30
+
+    def test_negative_value_falls_back_to_default(self, settings_file):
+        """Negative values fall back to defaults."""
+        from cli_agent_orchestrator.services.settings_service import get_server_settings
+
+        _save({"server": {"provider_init_timeout": -5}})
+        result = get_server_settings()
+        assert result["provider_init_timeout"] == 60

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -324,3 +324,33 @@ class TestQuiescenceTimerCancel:
         # No timer scheduled for this terminal — must not blow up.
         sm.clear_terminal("missing")
         sm._loop.call_soon_threadsafe.assert_not_called()
+
+
+class TestRawDebounceArmedDetection:
+    """Regression: raw debounce must detect PROCESSING on later chunks while armed."""
+
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    def test_armed_ready_detects_processing_on_second_chunk(self, mock_get_backend, mock_pm):
+        """When terminal is IDLE (armed), chunk 1 is UNKNOWN, chunk 2 has PROCESSING
+        marker — PROCESSING must be detected immediately, not deferred to quiescence."""
+        mock_get_backend.return_value = _backend(event_inbox=False)
+        provider = MagicMock()
+        provider.supports_screen_detection = False
+        mock_pm.get_provider.return_value = provider
+
+        sm = StatusMonitor()
+        # Simulate terminal already at IDLE (armed state)
+        sm._last_status["t1"] = TerminalStatus.IDLE
+        sm._allow_processing_revert["t1"] = True
+
+        # Mock _detect_status: first call returns UNKNOWN, second returns PROCESSING
+        detect_results = iter([TerminalStatus.UNKNOWN, TerminalStatus.PROCESSING])
+        sm._detect_status = lambda tid, buf: next(detect_results)
+
+        # Chunk 1: UNKNOWN — should still attempt detection (terminal is ready)
+        sm._process_chunk("t1", "neutral output")
+        # Chunk 2: PROCESSING — must detect immediately, not wait for quiescence
+        sm._process_chunk("t1", "● Working on task...")
+
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING


### PR DESCRIPTION
Closes #317

## Summary

Add configurable server tuning settings and fix Claude Code command-line length limit.

## Changes

### Configurable server settings via `settings.json`

New `"server"` key in `~/.aws/cli-agent-orchestrator/settings.json`:

```json
{
  "server": {
    "mcp_request_timeout": 120,
    "event_bus_max_queue_size": 8192,
    "provider_init_timeout": 90,
    "startup_prompt_handler_timeout": 5
  }
}
```

| Setting | Default | Description |
|---------|---------|-------------|
| `mcp_request_timeout` | `30` | Seconds for HTTP calls between MCP sidecar and CAO API |
| `event_bus_max_queue_size` | `1024` | Max events buffered per subscriber queue |
| `provider_init_timeout` | `60` | Seconds for any CLI provider to reach IDLE after launch |
| `startup_prompt_handler_timeout` | `20` | Seconds for Claude Code workspace trust dialog handler |

All values retain original defaults for backward compatibility.

### File-based prompt delivery for Claude Code

Replace inline `--append-system-prompt` and `--mcp-config` with file-based equivalents to avoid OS command-line length limits (ref: anthropics/claude-code#3411):

```
claude --append-system-prompt-file ~/.aws/cli-agent-orchestrator/tmp/{id}.prompt \
       --mcp-config ~/.aws/cli-agent-orchestrator/tmp/{id}.mcp.json
```

## Files Changed

- `services/settings_service.py` — new `get_server_settings()` function
- `cli/commands/launch.py` — read MCP timeout from settings
- `services/event_bus.py` — read queue size from settings
- `mcp_server/server.py` — read MCP timeout from settings via `_mcp_timeout()`
- `providers/claude_code.py` — file-based prompt/MCP config + configurable timeouts
- `providers/*.py` (all 9) — use `provider_init_timeout` from settings
- `docs/settings.md` — document new server tuning section
- `test/providers/test_claude_code_unit.py` — updated for file-based behavior

## Testing

- Tested with Claude Code (Bedrock) as supervisor + Kiro CLI workers
- Tested with Copilot CLI (BYOK/self-hosted) workers
- Verified backward compatibility with no `settings.json` (uses defaults)
- Verified file-based prompt delivery with 4KB+ system prompts