### PR TITLE
fix(claude_code): echoed system prompt false-matches idle, blocking workspace-trust dialog

### DIFF
--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -320,12 +320,21 @@ class ClaudeCodeProvider(BaseProvider):
                 get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 return
 
-            # 3) Claude Code fully started — no prompts needed
+            # 3) Claude Code fully started — no prompts needed.
+            #    The version banner is the ONLY reliable "ready" signal here: it
+            #    renders only once the REPL is up and cannot appear in the echoed
+            #    launch command. The old bare IDLE_PROMPT_PATTERN ("> "/"❯ ") check
+            #    was removed: the injected --append-system-prompt text contains
+            #    "> `memory_store`" (start of a line), which the echoed command
+            #    surfaces in the capture buffer within ~300ms and false-matches as
+            #    "idle". The handler then returned BEFORE the workspace-trust dialog
+            #    rendered, leaving it unaccepted; initialize() then blocked on
+            #    {IDLE, COMPLETED} for 30s and the session was killed. Trust/bypass
+            #    dialogs are handled explicitly above; if no banner ever appears the
+            #    loop just waits out its timeout and the downstream
+            #    wait_until_status() remains the real readiness gate.
             if re.search(r"Welcome to|Claude Code v\d+", clean_output):
                 logger.info("Claude Code started without prompts")
-                return
-            if re.search(IDLE_PROMPT_PATTERN, clean_output):
-                logger.info("Claude Code idle prompt detected, no prompts needed")
                 return
 
             time.sleep(1.0)

--- a/test/providers/test_claude_code_coverage.py
+++ b/test/providers/test_claude_code_coverage.py
@@ -1,7 +1,8 @@
 """Additional tests for ClaudeCodeProvider to cover uncovered branches.
 
 Covers: McpServer model_dump path, bypass permissions prompt handling,
-and idle prompt early return in _handle_startup_prompts.
+and the workspace-trust handling in _handle_startup_prompts (including the
+regression where the echoed launch command false-matched the idle prompt).
 """
 
 import re
@@ -66,16 +67,39 @@ class TestHandleStartupPromptsBranches:
             provider.session_name, provider.window_name, "Enter"
         )
 
+    @patch("cli_agent_orchestrator.providers.claude_code.time.sleep", lambda *a, **k: None)
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_idle_prompt_detected_early_return(self, mock_backend, provider):
-        """When idle prompt is visible, returns immediately without sending keys."""
-        from cli_agent_orchestrator.providers.claude_code import IDLE_PROMPT_PATTERN
+    def test_echoed_prompt_does_not_short_circuit_trust(self, mock_backend, provider):
+        """Regression: the injected --append-system-prompt contains a line that
+        starts with "> `memory_store`". The shell echoes the launch command into
+        the capture buffer ~300ms before the workspace-trust dialog renders, so
+        that "> " must NOT be treated as the idle prompt and end startup handling
+        early — otherwise the trust dialog is left unaccepted and initialize()
+        blocks on {IDLE, COMPLETED} until it times out and the session is killed.
 
-        mock_backend.get_history.return_value = "❯ "
+        First poll returns the echoed command (with the "> memory_store" marker
+        but no dialog yet); second poll returns the trust dialog. The handler must
+        accept the trust dialog (Enter) rather than returning on the first frame.
+        """
+        echoed_launch_cmd = (
+            "user@host:/tmp/proj$ claude --dangerously-skip-permissions "
+            "--append-system-prompt '## Memory\n"
+            "> `memory_store` and `memory_recall` are CAO's memory tools'"
+        )
+        trust_frame = (
+            "Quick safety check: Is this a project you created or one you trust?\n"
+            "❯ 1. Yes, I trust this folder\n"
+            "  2. No, exit\n"
+        )
+        mock_backend.get_history.side_effect = [echoed_launch_cmd, trust_frame]
 
-        provider._handle_startup_prompts(timeout=1.0)
+        provider._handle_startup_prompts(timeout=5.0)
 
-        # No exception means early return worked
+        # Trust dialog accepted via Enter — proves we did not early-return on the
+        # echoed "> memory_store" marker.
+        mock_backend.send_special_key.assert_called_once_with(
+            provider.session_name, provider.window_name, "Enter"
+        )
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_welcome_banner_detected_early_return(self, mock_backend, provider):


### PR DESCRIPTION
## Summary

`cao launch --provider claude_code` fails to initialize in any working directory that Claude Code has **not yet trusted**. The session is created, Claude starts, but CAO kills it after 30s with:

```
Claude Code initialization timed out after 30 seconds
```

## Reproduction

1. Point CAO at a fresh directory Claude Code hasn't seen before.
2. `cao launch --agents code_supervisor --provider claude_code --headless ...`
3. The tmux session spawns, Claude shows the **"Is this a project you created or one you trust?"** dialog, and CAO never accepts it → init times out → session killed.

(Pre-trusting the directory by launching `claude` there once and accepting the dialog works around it, which is what pointed to the root cause.)

## Root cause

`_handle_startup_prompts()` uses `IDLE_PROMPT_PATTERN = r"[>❯][\s\xa0]"` as an early-return "Claude is ready" signal. The supervisor system prompt injected via `--append-system-prompt` contains a line that **starts with** `` > `memory_store` `` (the memory-tools note). When the shell echoes the long launch command into the capture buffer, that `> ` appears ~300ms after launch — well before the trust dialog renders.

So the handler matches the echoed `> `, logs `Claude Code idle prompt detected, no prompts needed`, and returns **before the trust dialog exists**. `initialize()` then waits for `{IDLE, COMPLETED}`, but the trust dialog reads as `WAITING_USER_ANSWER`, so it never becomes idle → 30s timeout → `terminal_service` tears the session down.

Observed in the server log:

```
21:53:46,369  Claude Code idle prompt detected, no prompts needed   # 358ms after send — the echoed "> memory_store"
21:54:16,382  wait_until_status: timeout waiting for {completed, idle}
21:54:16,382  Failed to create terminal: Claude Code initialization timed out after 30 seconds
```

## Fix

Remove the bare `IDLE_PROMPT_PATTERN` early-return. The version banner (`Welcome to` / `Claude Code v\d+`) is the only "ready" signal that **cannot** appear in the echoed launch command, so it's kept; the trust and bypass dialogs are still handled explicitly above it; and `wait_until_status()` remains the real readiness gate. Note that anchoring the pattern to start-of-line would *not* help here, because the offending `> ` is itself at the start of a line in the injected prompt.

After the fix, the same launch in a fresh untrusted dir logs:

```
Workspace trust prompt detected, auto-accepting
status changed: idle -> processing
```

…and the worker runs to completion.

## Test

Added a regression test (`test_echoed_prompt_does_not_short_circuit_trust`) that returns the echoed command (with the `> memory_store` marker, no dialog) on the first poll and the trust dialog on the second, asserting the dialog is accepted via `Enter`. This fails on the old early-return and passes now. Full provider suite (114 tests) passes; `black`/`isort` clean.

## Environment

- CAO `2.2.0` (current `main`)
- Claude Code `2.1.183`

Happy to file a tracking issue per CONTRIBUTING if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)