### PR TITLE
fix(kiro): detect kiro 2.8.x TUI idle state after MCP server init

### DIFF
--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -14,6 +14,7 @@ from cli_agent_orchestrator.constants import (
     PROVIDERS,
     SERVER_HOST,
     SERVER_PORT,
+    SESSION_CREATE_TIMEOUT,
 )
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.utils.terminal import (
@@ -287,7 +288,10 @@ def launch(
         # Forwarded env vars travel in the JSON body so values (which may
         # contain secrets) don't end up in cao-server's HTTP access log.
         # See issue #248.
-        post_kwargs: dict = {"params": params, "timeout": MCP_REQUEST_TIMEOUT}
+        # Session creation blocks while the provider initializes (~30-40s for
+        # TUI providers like kiro_cli). Use a longer timeout than the default
+        # MCP_REQUEST_TIMEOUT (30s) to avoid client-side read timeouts.
+        post_kwargs: dict = {"params": params, "timeout": SESSION_CREATE_TIMEOUT}
         if forwarded_env:
             post_kwargs["json"] = {"env_vars": forwarded_env}
 

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -185,6 +185,12 @@ API_BASE_URL = f"http://{SERVER_HOST}:{SERVER_PORT}"
 # Default timeout (seconds) for HTTP calls to the CAO API server.
 MCP_REQUEST_TIMEOUT = 30
 
+# Timeout (seconds) for session/terminal creation requests. Provider
+# initialization (TUI startup, MCP server loading) can take 30-60s depending
+# on the number of configured MCP servers. This must be greater than the
+# server-side provider init timeout (currently 30s + 10s shell wait).
+SESSION_CREATE_TIMEOUT = int(os.environ.get("CAO_SESSION_CREATE_TIMEOUT", "120"))
+
 
 # Operators can extend network allowlists via the env vars handled below.
 # Same comma-separated pattern as ``CAO_PROFILE_ALLOWED_HOSTS`` in install_service.

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -10,7 +10,7 @@ import requests
 from fastmcp import FastMCP
 from pydantic import Field
 
-from cli_agent_orchestrator.constants import API_BASE_URL, DEFAULT_PROVIDER, MCP_REQUEST_TIMEOUT
+from cli_agent_orchestrator.constants import API_BASE_URL, DEFAULT_PROVIDER, MCP_REQUEST_TIMEOUT, SESSION_CREATE_TIMEOUT
 from cli_agent_orchestrator.mcp_server.models import HandoffResult
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -209,7 +209,7 @@ def _create_terminal(
         response = requests.post(
             f"{API_BASE_URL}/sessions/{session_name}/terminals",
             params=params,
-            timeout=MCP_REQUEST_TIMEOUT,
+            timeout=SESSION_CREATE_TIMEOUT,
         )
         response.raise_for_status()
         terminal = response.json()
@@ -226,7 +226,7 @@ def _create_terminal(
             params["working_directory"] = working_directory
 
         response = requests.post(
-            f"{API_BASE_URL}/sessions", params=params, timeout=MCP_REQUEST_TIMEOUT
+            f"{API_BASE_URL}/sessions", params=params, timeout=SESSION_CREATE_TIMEOUT
         )
         response.raise_for_status()
         terminal = response.json()

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -18,6 +18,7 @@ The provider detects the following terminal states:
 """
 
 import logging
+import os
 import re
 import shlex
 from typing import Optional
@@ -61,13 +62,14 @@ IDLE_PROMPT_PATTERN_LOG = r"\x1b\[38;5;\d+m\[.+?\].*\x1b\[38;5;\d+m>\s*\x1b\[\d*
 # New TUI Patterns (Kiro CLI without --legacy-ui)
 # =============================================================================
 
-# New TUI idle prompt: "Ask a question or describe a task ↵"
-# Case-insensitive match; comma between "question" and "or" is optional
-# (older versions used lowercase with comma, v1.29+ uses capitalized without)
-NEW_TUI_IDLE_PATTERN = r"[Aa]sk a question,? or describe a task"
+# New TUI idle prompt: "Ask a question or describe a task ↵" (≤2.7.x)
+# kiro-cli 2.8.x replaced the input placeholder with a status-bar format:
+#   "saga · auto · ◔ 3%   ~/.aws/cli-agent-orchestrator · (main)"
+# Match either form so both old and new kiro versions are supported.
+NEW_TUI_IDLE_PATTERN = r"[Aa]sk a question,? or describe a task|· (?:auto|manual) · ◔"
 
 # New TUI IDLE prompt pattern for log files (with ANSI codes)
-NEW_TUI_IDLE_PATTERN_LOG = r"[Aa]sk a question,? or describe a task"
+NEW_TUI_IDLE_PATTERN_LOG = r"[Aa]sk a question,? or describe a task|· (?:auto|manual) · ◔"
 
 # TUI separator line: horizontal bar (────) used to delimit sections.
 # Require 20+ chars to avoid matching short markdown separators in agent output.
@@ -91,11 +93,23 @@ TUI_PROCESSING_PATTERN = r"Kiro is working"
 # is interactive, so a paste sent during this window is absorbed by the
 # pre-prompt boot screen and silently dropped (observed during e2e
 # allowed-tools tests).
+#
+# Note: kiro-cli 2.8.x replaced "● Initializing..." with "Initializing ·
+# type to queue a message", which does NOT match this pattern. In 2.8.x the
+# old idle prompt ("Ask a question or describe a task") only appears as part
+# of the final screen render (66 chars before the true idle state), so it no
+# longer needs to be suppressed — it reliably indicates kiro is interactive.
 TUI_INITIALIZING_PATTERN = r"Initializing\.\.\.|\d+ of \d+ mcp servers initialized\.\s*ctrl-c to start chatting now"  # noqa: E501
 
 # TUI permission prompt: shown instead of legacy [y/n/t] format.
 # Requires all three options together to avoid false positives on "Yes"/"No" in agent output.
 TUI_PERMISSION_PATTERN = r"Yes\s+No\s+Always [Aa]llow"
+
+# Seconds to wait for the kiro TUI to reach IDLE during initialization.
+# kiro-cli 2.8.x takes 40-60s to initialize with many MCP servers; the old
+# 30s default was too short, causing every session to fall back to --legacy-ui.
+# Override via CAO_KIRO_TUI_INIT_TIMEOUT env var.
+TUI_INIT_TIMEOUT = float(os.environ.get("CAO_KIRO_TUI_INIT_TIMEOUT", "90"))
 
 # =============================================================================
 # Error Detection
@@ -261,7 +275,7 @@ class KiroCliProvider(BaseProvider):
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
         # message that get_status() interprets as a completed response.
         if not await wait_until_status(
-            self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=30.0
+            self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=TUI_INIT_TIMEOUT
         ):
             if yolo:
                 # Yolo already launched with --legacy-ui; no further fallback.
@@ -285,7 +299,7 @@ class KiroCliProvider(BaseProvider):
             status_monitor.notify_input_sent(self.terminal_id)
             get_backend().send_keys(self.session_name, self.window_name, legacy_command)
             if not await wait_until_status(
-                self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=30.0
+                self.terminal_id, {TerminalStatus.IDLE, TerminalStatus.COMPLETED}, timeout=TUI_INIT_TIMEOUT
             ):
                 raise TimeoutError("Kiro CLI initialization timed out with TUI and `--legacy-ui`")
 
@@ -343,7 +357,10 @@ class KiroCliProvider(BaseProvider):
         if init_matches:
             last_init_pos = init_matches[-1].end()
             real_idle_after_init = any(m.start() > last_init_pos for m in old_idle_matches)
-            if not real_idle_after_init:
+            # kiro-cli 2.8.x TUI never shows [agent] > prompts; check the new
+            # "· auto · ◔" idle indicator too so init doesn't block detection.
+            new_tui_idle_after_init = any(m.start() > last_init_pos for m in new_tui_idle_matches)
+            if not real_idle_after_init and not new_tui_idle_after_init:
                 return TerminalStatus.PROCESSING
 
         # Check 2: Look for TUI "Kiro is working" ghost text.


### PR DESCRIPTION
## Problem

kiro-cli 2.8.x changed two things that broke CAO's TUI initialization detection:

1. **New idle indicator**: replaced the input placeholder (`Ask a question or describe a task`) with a status-bar format: `agent · auto · ◔ N%` (with RGB ANSI color codes on the `·` and `◔` chars).

2. **Init progress lines**: during MCP server boot, kiro 2.8.x prints `Initializing...` once per server. With many MCP servers these lines fill the 8 KB rolling buffer. The `init_matches` guard in `get_status()` looked for a real `[agent] >` idle prompt *after* the last init match to decide that boot was done — but kiro 2.8.x TUI never emits that legacy prompt style. The guard therefore always returned `PROCESSING`, causing every session to time out and fall back to `--legacy-ui`.

## Root cause (get_status lines 356-361 before this fix)

```python
init_matches = list(re.finditer(TUI_INITIALIZING_PATTERN, clean_output))
if init_matches:
    last_init_pos = init_matches[-1].end()
    real_idle_after_init = any(m.start() > last_init_pos for m in old_idle_matches)
    if not real_idle_after_init:   # ← always True for kiro 2.8.x TUI
        return TerminalStatus.PROCESSING
```

`old_idle_matches` uses the legacy `[agent] >` pattern, which is always empty in kiro 2.8.x TUI mode. `new_tui_idle_matches` was not checked here.

## Changes

- **`NEW_TUI_IDLE_PATTERN`**: extended to match the kiro 2.8.x status-bar (`· (?:auto|manual) · ◔`) in addition to the legacy placeholder. `strip_terminal_escapes()` correctly strips the RGB ANSI codes (`\x1b[38;2;R;G;Bm`) before pattern matching.
- **`get_status()` init guard**: also checks `new_tui_idle_matches` after `last_init_pos`, so kiro 2.8.x TUI sessions reach `IDLE` without timeout.
- **`TUI_INIT_TIMEOUT`**: extracted from hard-coded `30.0` to a named constant (default `90s`, configurable via `CAO_KIRO_TUI_INIT_TIMEOUT` env var) to support environments with many MCP servers.

## Result

With this fix, a kiro 2.8.x session with many MCP servers reaches `IDLE` in ~7–10s and uses the TUI interface as intended, instead of timing out and falling back to `--legacy-ui`.

## Testing

Tested locally with kiro-cli 2.8.1 and CAO 2.2.0 reinstalled from this branch:

```
2026-06-22 11:04:16 - wait_until_status [d9dfcfd9]: waiting for {idle, completed}, timeout=90.0s
2026-06-22 11:04:23 - Terminal d9dfcfd9 status changed: idle   ← 7.5s, TUI mode, no legacy-ui fallback
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)