### PR TITLE
fix(providers): harden Claude and OpenCode status detection

### DIFF
--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -64,8 +64,10 @@ FIFO_DIR.mkdir(parents=True, exist_ok=True)
 # Keeps trailing 8KB of terminal output for pattern matching
 STATE_BUFFER_MAX = 8192
 
-# Max events buffered per subscriber queue before dropping
-EVENT_BUS_MAX_QUEUE_SIZE = 1024
+# Max events buffered per subscriber queue before dropping. Claude's TUI startup
+# can emit thousands of small chunks in a short burst, so keep this comfortably
+# above the old 1024 default while still bounded.
+EVENT_BUS_MAX_QUEUE_SIZE = int(os.environ.get("CAO_EVENT_BUS_MAX_QUEUE_SIZE", "16384"))
 
 # pyte-rendered status detection. When enabled, the StatusMonitor feeds each
 # terminal's output through a pyte terminal emulator and runs detection against

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -13,6 +13,15 @@ from pathlib import Path
 
 from cli_agent_orchestrator.models.provider import ProviderType
 
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer env var, falling back when the value is invalid."""
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
 # =============================================================================
 # Session Configuration
 # =============================================================================
@@ -67,7 +76,7 @@ STATE_BUFFER_MAX = 8192
 # Max events buffered per subscriber queue before dropping. Claude's TUI startup
 # can emit thousands of small chunks in a short burst, so keep this comfortably
 # above the old 1024 default while still bounded.
-EVENT_BUS_MAX_QUEUE_SIZE = int(os.environ.get("CAO_EVENT_BUS_MAX_QUEUE_SIZE", "16384"))
+EVENT_BUS_MAX_QUEUE_SIZE = _env_int("CAO_EVENT_BUS_MAX_QUEUE_SIZE", 16384)
 
 # pyte-rendered status detection. When enabled, the StatusMonitor feeds each
 # terminal's output through a pyte terminal emulator and runs detection against

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -228,7 +228,7 @@ class ClaudeCodeProvider(BaseProvider):
                     mcp_file.chmod(0o600)
                 except OSError:
                     pass
-                command_parts.extend(["--mcp-config", str(mcp_file)])
+                command_parts.extend(["--mcp-config", str(mcp_file), "--strict-mcp-config"])
 
         # Apply tool restrictions via --disallowedTools flags.
         # --dangerously-skip-permissions bypasses prompts but --disallowedTools

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -20,7 +20,7 @@ The provider detects the following terminal states:
 import logging
 import re
 import shlex
-from typing import Optional
+from typing import List, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE
@@ -249,6 +249,70 @@ class OpenCodeCliProvider(BaseProvider):
             return TerminalStatus.IDLE
 
         # ── 5. UNKNOWN (fallback) ─────────────────────────────────────────────
+        return TerminalStatus.UNKNOWN
+
+    # ── Screen-based detection (pyte) ────────────────────────────────────────
+
+    supports_screen_detection = True
+
+    def get_status_from_screen(self, screen_lines: List[str]) -> TerminalStatus:
+        """Detect status from a pyte-composited viewport (escape-free rows).
+
+        The pyte screen represents the current terminal viewport without any
+        ANSI escape sequences, so the status markers are clean text — no
+        buffer-eviction or escape-stripping issues.
+
+        Precedence mirrors ``get_status``:
+        1. WAITING_USER_ANSWER — permission dialog heading
+        2. PROCESSING — ``esc interrupt`` footer
+        3. COMPLETED — completion marker followed by idle footer
+        4. IDLE — idle footer present
+        5. UNKNOWN — fallback
+        """
+        rows = [ln.rstrip() for ln in screen_lines if ln.strip()]
+        if not rows:
+            return TerminalStatus.UNKNOWN
+
+        # Join with newlines so multiline patterns work.
+        joined = "\n".join(rows)
+
+        # ── 1. WAITING_USER_ANSWER ───────────────────────────────────────
+        if re.search(PERMISSION_PROMPT_PATTERN, joined):
+            # Permission dialog replaces the normal footer; if idle footer
+            # also appears the user already dismissed it.
+            if not re.search(IDLE_FOOTER_PATTERN, joined):
+                return TerminalStatus.WAITING_USER_ANSWER
+
+        # ── 2. PROCESSING ───────────────────────────────────────────────
+        last_esc_line = -1
+        for i, row in enumerate(rows):
+            if re.search(PROCESSING_FOOTER_PATTERN, row):
+                last_esc_line = i
+
+        esc_is_stale = False
+        if last_esc_line >= 0:
+            later = rows[last_esc_line + 1 :]
+            has_idle_later = any(re.search(IDLE_FOOTER_PATTERN, row) for row in later)
+            has_completion_later = any(re.search(COMPLETION_MARKER_PATTERN, row) for row in later)
+            if not has_idle_later and not has_completion_later:
+                return TerminalStatus.PROCESSING
+            esc_is_stale = True
+
+        # ── 3. COMPLETED ────────────────────────────────────────────────
+        completion_matches = list(re.finditer(COMPLETION_MARKER_PATTERN, joined))
+        if completion_matches:
+            last_end = completion_matches[-1].end()
+            after = joined[last_end:]
+            if re.search(IDLE_FOOTER_PATTERN, after) and not re.search(r"▣", after):
+                return TerminalStatus.COMPLETED
+
+        # ── 4. IDLE ─────────────────────────────────────────────────────
+        if re.search(IDLE_FOOTER_PATTERN, joined) and (
+            not re.search(PROCESSING_FOOTER_PATTERN, joined) or esc_is_stale
+        ):
+            return TerminalStatus.IDLE
+
+        # ── 5. UNKNOWN (fallback) ───────────────────────────────────────
         return TerminalStatus.UNKNOWN
 
     def extract_last_message_from_script(self, script_output: str) -> str:

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -220,9 +220,30 @@ class StatusMonitor:
 
     def _detect_screen(self, terminal_id: str, provider) -> TerminalStatus:
         """Detect status from the terminal's composited pyte screen."""
+        fallback_buffer: Optional[str] = None
         with self._lock:
             scr = self._screens.get(terminal_id)
-            lines: List[str] = list(scr[0].display) if scr is not None else []
+            buffer = self._buffers.get(terminal_id, "")
+            try:
+                lines: List[str] = list(scr[0].display) if scr is not None else []
+            except Exception:
+                # pyte can transiently hold zero-length cell data while rendering
+                # complex TUI redraws. Fall back to raw-buffer detection instead of
+                # letting the quiescence callback tear down status monitoring.
+                logger.exception(
+                    "Error rendering screen status for %s; falling back to raw buffer",
+                    terminal_id,
+                )
+                fallback_buffer = buffer
+                lines = []
+        if fallback_buffer is not None:
+            if provider is None:
+                return TerminalStatus.UNKNOWN
+            try:
+                return provider.get_status(fallback_buffer)
+            except Exception:
+                logger.exception(f"Error detecting fallback status for {terminal_id}")
+                return TerminalStatus.UNKNOWN
         if not lines or provider is None:
             return TerminalStatus.UNKNOWN
         try:

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -242,7 +242,7 @@ class StatusMonitor:
             try:
                 return provider.get_status(fallback_buffer)
             except Exception:
-                logger.exception(f"Error detecting fallback status for {terminal_id}")
+                logger.exception("Error detecting fallback status for %s", terminal_id)
                 return TerminalStatus.UNKNOWN
         if not lines or provider is None:
             return TerminalStatus.UNKNOWN

--- a/src/cli_agent_orchestrator/utils/skills.py
+++ b/src/cli_agent_orchestrator/utils/skills.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 SKILL_CATALOG_INSTRUCTION = (
     "The following skills are available exclusively in this CAO orchestration context. "
-    "To load a skill's full content, use the `load_skill` MCP tool provided by the CAO MCP server. "
+    "To load a skill's full content, use the `mcp__cao-mcp-server__load_skill` tool (NOT the Skill command). "
     "These skills are not accessible through provider-native skill commands or directories."
 )
 

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1,6 +1,7 @@
 """Unit tests for Claude Code provider."""
 
 import json
+import shlex
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
@@ -30,6 +31,16 @@ def cleanup_tmp_files():
 # All initialization tests need to patch _ensure_skip_bypass_prompt_setting
 # to avoid writing to the real ~/.claude/settings.json.
 _PATCH_SETTINGS = patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
+
+
+def _extract_mcp_config(command: str) -> dict:
+    args = shlex.split(command)
+    assert "--strict-mcp-config" in args
+    mcp_file = Path(args[args.index("--mcp-config") + 1])
+    try:
+        return json.loads(mcp_file.read_text())
+    finally:
+        mcp_file.unlink(missing_ok=True)
 
 
 class TestClaudeCodeProviderInitialization:
@@ -1129,14 +1140,7 @@ class TestClaudeCodeProviderMisc:
         command = provider._build_claude_command()
 
         assert "--mcp-config" in command
-        # Extract the file path arg after --mcp-config
-        parts = command.split("--mcp-config ")
-        mcp_file_path = parts[1].strip().split()[0]
-        # shlex.join wraps in single quotes; strip them
-        if mcp_file_path.startswith("'") and mcp_file_path.endswith("'"):
-            mcp_file_path = mcp_file_path[1:-1]
-        mcp_data = json.loads(Path(mcp_file_path).read_text())
-        Path(mcp_file_path).unlink(missing_ok=True)
+        mcp_data = _extract_mcp_config(command)
         server_env = mcp_data["mcpServers"]["cao-mcp-server"]["env"]
         assert server_env["CAO_TERMINAL_ID"] == "term-42"
 
@@ -1158,12 +1162,7 @@ class TestClaudeCodeProviderMisc:
         provider = ClaudeCodeProvider("term-99", "test-session", "window-0", "test-agent")
         command = provider._build_claude_command()
 
-        parts = command.split("--mcp-config ")
-        mcp_file_path = parts[1].strip().split()[0]
-        if mcp_file_path.startswith("'") and mcp_file_path.endswith("'"):
-            mcp_file_path = mcp_file_path[1:-1]
-        mcp_data = json.loads(Path(mcp_file_path).read_text())
-        Path(mcp_file_path).unlink(missing_ok=True)
+        mcp_data = _extract_mcp_config(command)
         server_env = mcp_data["mcpServers"]["my-server"]["env"]
         # Original vars preserved
         assert server_env["MY_VAR"] == "my_value"
@@ -1189,12 +1188,7 @@ class TestClaudeCodeProviderMisc:
         provider = ClaudeCodeProvider("term-99", "test-session", "window-0", "test-agent")
         command = provider._build_claude_command()
 
-        parts = command.split("--mcp-config ")
-        mcp_file_path = parts[1].strip().split()[0]
-        if mcp_file_path.startswith("'") and mcp_file_path.endswith("'"):
-            mcp_file_path = mcp_file_path[1:-1]
-        mcp_data = json.loads(Path(mcp_file_path).read_text())
-        Path(mcp_file_path).unlink(missing_ok=True)
+        mcp_data = _extract_mcp_config(command)
         server_env = mcp_data["mcpServers"]["my-server"]["env"]
         # Should keep the user-provided value, NOT overwrite with term-99
         assert server_env["CAO_TERMINAL_ID"] == "user-provided-id"

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -164,6 +164,88 @@ class TestGetStatusFromFixtures:
         assert provider.get_status("random text without any tui markers") == TerminalStatus.UNKNOWN
 
 
+class TestGetStatusFromScreen:
+    """Pin OpenCode's pyte-rendered screen detector.
+
+    The screen path receives escape-free viewport rows, so it should classify the
+    same user-visible TUI markers without relying on the rolling raw buffer.
+    """
+
+    def test_idle_footer_returns_idle(self):
+        provider = make_provider()
+
+        assert provider.get_status_from_screen(["", "tab agents  ctrl+p commands  • OpenCode"]) == (
+            TerminalStatus.IDLE
+        )
+
+    def test_processing_footer_returns_processing(self):
+        provider = make_provider()
+
+        assert provider.get_status_from_screen(["⬝⬝⬝⬝  esc interrupt   ctrl+p commands"]) == (
+            TerminalStatus.PROCESSING
+        )
+
+    def test_stale_processing_footer_followed_by_idle_returns_idle(self):
+        provider = make_provider()
+
+        assert (
+            provider.get_status_from_screen(
+                [
+                    "⬝⬝⬝⬝  esc interrupt",
+                    "",
+                    "tab agents  ctrl+p commands  • OpenCode",
+                ]
+            )
+            == TerminalStatus.IDLE
+        )
+
+    def test_stale_processing_footer_followed_by_completion_returns_completed(self):
+        provider = make_provider()
+
+        assert (
+            provider.get_status_from_screen(
+                [
+                    "⬝⬝⬝⬝  esc interrupt",
+                    "Hello from OpenCode",
+                    "▣  Build · Big Pickle · 7.2s",
+                    "tab agents  ctrl+p commands  • OpenCode",
+                ]
+            )
+            == TerminalStatus.COMPLETED
+        )
+
+    def test_completion_marker_followed_by_idle_returns_completed(self):
+        provider = make_provider()
+
+        assert (
+            provider.get_status_from_screen(
+                [
+                    "Hello from OpenCode",
+                    "▣  Build · Big Pickle · 7.2s",
+                    "tab agents  ctrl+p commands  • OpenCode",
+                ]
+            )
+            == TerminalStatus.COMPLETED
+        )
+
+    def test_permission_prompt_without_idle_returns_waiting_user_answer(self):
+        provider = make_provider()
+
+        assert provider.get_status_from_screen(["△  Permission required", "Allow command?"]) == (
+            TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_blank_screen_returns_unknown(self):
+        provider = make_provider()
+
+        assert provider.get_status_from_screen(["", "   "]) == TerminalStatus.UNKNOWN
+
+    def test_unrecognized_nonblank_screen_returns_unknown(self):
+        provider = make_provider()
+
+        assert provider.get_status_from_screen(["OpenCode is repainting"]) == TerminalStatus.UNKNOWN
+
+
 # ---------------------------------------------------------------------------
 # (c)  Stale ``esc interrupt`` + idle footer on later line → IDLE
 # ---------------------------------------------------------------------------

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -85,6 +85,29 @@ class TestGetStatusEventInbox:
         assert sm.get_status("t1") == TerminalStatus.UNKNOWN
 
 
+class TestScreenDetection:
+    """Rendered-screen detection should fail soft and keep monitoring alive."""
+
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_render_error_falls_back_to_raw_buffer_detection(self, mock_pm):
+        class BrokenScreen:
+            @property
+            def display(self):
+                raise RuntimeError("torn pyte frame")
+
+        provider = MagicMock()
+        provider.get_status.return_value = TerminalStatus.IDLE
+        mock_pm.get_provider.side_effect = AssertionError("provider should not be refetched")
+
+        sm = StatusMonitor()
+        sm._screens["t1"] = (BrokenScreen(), MagicMock())
+        sm._buffers["t1"] = "raw buffer with idle footer"
+
+        assert sm._detect_screen("t1", provider) == TerminalStatus.IDLE
+        provider.get_status.assert_called_once_with("raw buffer with idle footer")
+        mock_pm.get_provider.assert_not_called()
+
+
 class _SequencedMonitor:
     """Drive _process_chunk with a scripted sequence of detected statuses.
 

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -289,6 +289,28 @@ class TestSessionConstants:
         assert SESSION_PREFIX == "cao-"
 
 
+class TestEventBusConstants:
+    """Tests for event bus configuration constants."""
+
+    def _reload_constants(self, env_overrides):
+        import importlib
+        import os
+
+        env_copy = os.environ.copy()
+        env_copy.pop("CAO_EVENT_BUS_MAX_QUEUE_SIZE", None)
+        env_copy.update(env_overrides)
+        with patch.dict("os.environ", env_copy, clear=True):
+            import cli_agent_orchestrator.constants as constants_module
+
+            importlib.reload(constants_module)
+            return constants_module
+
+    def test_event_bus_queue_size_falls_back_when_env_is_non_numeric(self):
+        mod = self._reload_constants({"CAO_EVENT_BUS_MAX_QUEUE_SIZE": "not-a-number"})
+
+        assert mod.EVENT_BUS_MAX_QUEUE_SIZE == 16384
+
+
 class TestOpenCodeConstants:
     """Tests for OpenCode provider path constants."""
 

--- a/test/utils/test_skills.py
+++ b/test/utils/test_skills.py
@@ -421,9 +421,9 @@ class TestBuildSkillCatalog:
         assert build_skill_catalog() == (
             "## Available Skills\n\n"
             "The following skills are available exclusively in this CAO orchestration context. "
-            "To load a skill's full content, use the `load_skill` MCP tool provided by the "
-            "CAO MCP server. These skills are not accessible through provider-native skill "
-            "commands or directories.\n\n"
+            "To load a skill's full content, use the `mcp__cao-mcp-server__load_skill` "
+            "tool (NOT the Skill command). These skills are not accessible through "
+            "provider-native skill commands or directories.\n\n"
             "- **cao-worker-protocols**: Worker communication\n"
             "- **python-testing**: Pytest conventions"
         )


### PR DESCRIPTION
## Problem

Provider startup/status detection can be brittle under bursty TUI output and rendered-screen edge cases:

1. Claude Code MCP startup can be slow when several MCP servers are configured.
2. Claude Code should receive `--strict-mcp-config` when CAO passes an explicit MCP config, so startup fails loudly if the injected config is invalid or ignored.
3. OpenCode status detection currently depends on the rolling raw buffer, which can lose visible status markers during TUI redraw bursts.
4. pyte-rendered screen detection should fail soft when a transient render error occurs, instead of tearing down status monitoring.
5. CAO-injected skill catalog text tells workers to use the generic `load_skill` tool name, but provider-native Skill commands are not the CAO MCP skill loader.

## Root cause

The status pipeline still had a few assumptions that are fragile for modern CLI TUIs:

- the event bus subscriber queue was bounded at 1024 events, which can be too small for Claude startup bursts made of many small chunks;
- OpenCode had raw-buffer status detection but no provider-specific `get_status_from_screen()` implementation for the pyte path;
- `_detect_screen()` assumed `screen.display` can always be materialized, while pyte can transiently fail during complex redraws;
- the first screen-detector implementation treated any visible `esc interrupt` as PROCESSING, without the raw detector’s stale-footer guard for older processing rows above newer idle/completed rows;
- tests parsed Claude launch commands with string splitting, so they did not model shell argument boundaries once extra flags followed `--mcp-config`;
- the skill catalog named the wrong tool for this orchestration context.

## Fix

- Make `EVENT_BUS_MAX_QUEUE_SIZE` configurable via `CAO_EVENT_BUS_MAX_QUEUE_SIZE`, defaulting to 16384.
- Add `--strict-mcp-config` to Claude Code launches that pass a generated MCP config.
- Keep compatibility with the file-based Claude MCP config delivery that landed in #318.
- Add OpenCode pyte-screen status detection for permission, processing, completed, idle, and unknown states.
- Mirror OpenCode raw detection’s stale `esc interrupt` guard in the screen path.
- Fall back to the already-resolved provider’s raw-buffer detection if pyte screen rendering raises.
- Clarify injected skill catalog instructions to use `mcp__cao-mcp-server__load_skill` rather than a provider-native Skill command.
- Update and extend unit coverage for Claude MCP command parsing, OpenCode screen detection, StatusMonitor fallback behavior, and skill catalog rendering.

## Testing

- `uv run pytest test/providers/test_opencode_cli_unit.py test/providers/test_claude_code_unit.py test/services/test_status_monitor.py test/utils/test_skills.py` — 234 passed
- `uv run black --check src/cli_agent_orchestrator/providers/opencode_cli.py src/cli_agent_orchestrator/services/status_monitor.py test/providers/test_opencode_cli_unit.py test/services/test_status_monitor.py test/providers/test_claude_code_unit.py test/utils/test_skills.py`
- `uv run isort --check-only src/cli_agent_orchestrator/providers/opencode_cli.py src/cli_agent_orchestrator/services/status_monitor.py test/providers/test_opencode_cli_unit.py test/services/test_status_monitor.py test/providers/test_claude_code_unit.py test/utils/test_skills.py`
- `uv run pytest -k "not test_installed_agent_visible_in_opencode_list"` — 2872 passed, 22 skipped, 93 deselected

## Notes

A full local `uv run pytest` has one environment-specific failure in `test_installed_agent_visible_in_opencode_list`: the installed `opencode 1.17.9` binary reads the user-level OpenCode agent list instead of the temporary test config. The same suite passes locally when that live smoke test is excluded.

Related nearby PRs: #319 fixes a different Claude startup prompt false-match path; #325 fixes Kiro 2.8.x TUI idle detection; #318 added file-based Claude Code prompt/MCP config delivery and this branch has been rebased onto it.