### PR TITLE
feat(provider): add OMP CLI provider (omp_cli)

### DIFF
--- a/docs/PLAN-omp-cli.md
+++ b/docs/PLAN-omp-cli.md
@@ -1,0 +1,70 @@
+# 实施计划：新增 OMP CLI Provider
+
+需求 d7348a1e《扩展 CLI 支持 - 新增 OMP CLI 对接》— 在 cli-agent-orchestrator (CAO) 中新增 `omp_cli` provider，沿用现有 provider 适配器模式，使 Agent 能通过 `omp` CLI 执行操作。
+
+## 1. 现状与约定（已确认）
+
+- Provider 是 CLI 工具适配器，统一继承 `BaseProvider`（`providers/base.py`），负责：initialize / get_status / extract_last_message_from_script / exit_cli / cleanup。
+- `ProviderType` 枚举（`models/provider.py`）是单一真相源：`constants.PROVIDERS = [p.value for p in ProviderType]` 自动派生，`install_service` 的 `valid_providers` 也自动派生 → 新增枚举即多处生效。
+- manager.py 用 `if/elif provider_type == ProviderType.X.value` 分支构造 provider。
+- install_service.py：`context_file` 对所有 provider 都写入；if/elif 分支只额外写 provider 专属配置（q/kiro/copilot/opencode）。无分支的 provider（claude_code/codex/gemini/kimi/hermes/cursor）走「仅 context file」路径，`agent_file=None`。→ 新增 provider 默认即可安装。
+- terminal_service.py 有两个能力集白名单：`RUNTIME_SKILL_PROMPT_PROVIDERS`（启动时注入 skill catalog）、`SOFT_ENFORCEMENT_PROVIDERS`（无原生工具拦截，仅提示级）。
+- tool_mapping.py 的 `TOOL_MAPPING` 仅覆盖有原生工具名的 provider；缺省 → `get_disallowed_tools` 返回空（宽松）。
+- api/main.py `list_providers_endpoint` 有硬编码的 `provider_binaries` 映射，需手动补。
+- launch.py `PROVIDERS_REQUIRING_WORKSPACE_ACCESS` 硬编码集合，需手动补。
+- 状态识别：hermes 用 env-overridable 正则（`CAO_HERMES_*_REGEX`）便于校准，是「输出格式未知」场景的最佳范式。opencode/cursor 是 TUI 代表实现。
+- 文档约定：`docs/<provider>-cli.md` 每家一份。
+- 测试：`test/providers/test_<provider>_unit.py` + `test/providers/test_provider_manager_unit.py`（注册断言）+ `test/e2e/conftest.py` 的 `require_<provider>()`（缺二进制则 skip）。
+
+## 2. 变更文件列表
+
+| 文件 | 类型 | 改动 |
+|---|---|---|
+| `src/cli_agent_orchestrator/models/provider.py` | 修改 | `ProviderType` 新增 `OMP_CLI = "omp_cli"`。自动生效到 PROVIDERS / valid_providers。 |
+| `src/cli_agent_orchestrator/providers/omp_cli.py` | 新建 | `OmpCliProvider(BaseProvider)`，参照 hermes（env-overridable 正则）+ opencode（TUI 生命周期）。命令名 `omp`，`shutil.which` 探测。实现 initialize/_build_launch_command/get_status/extract_last_message_from_script/exit_cli/cleanup/get_idle_pattern_for_log/paste_enter_count。 |
+| `src/cli_agent_orchestrator/providers/manager.py` | 修改 | import + 新增 `elif provider_type == ProviderType.OMP_CLI.value:` 分支，构造 `OmpCliProvider(tid, sess, win, agent_profile, allowed_tools, model=model, skill_prompt=skill_prompt)`。 |
+| `src/cli_agent_orchestrator/services/install_service.py` | 修改(最小) | 默认走 context-file-only 即可安装；新增显式 `elif provider == ProviderType.OMP_CLI.value:` 占位分支（说明：OMP 暂无原生 agent 配置格式，依赖 context file），便于后续扩展。 |
+| `src/cli_agent_orchestrator/services/terminal_service.py` | 修改 | 能力集决策：①`RUNTIME_SKILL_PROMPT_PROVIDERS` 暂不纳入（OMP 经 context file 注入角色描述）；②`SOFT_ENFORCEMENT_PROVIDERS` 暂不纳入（待 develop 阶段确认 OMP 是否有原生工具拦截后再定）。新增注释说明。 |
+| `src/cli_agent_orchestrator/utils/tool_mapping.py` | 修改(最小) | 暂不加 `omp_cli` 映射（原生工具名为未知 → 宽松）。develop 阶段若识别到原生工具名再补。 |
+| `src/cli_agent_orchestrator/api/main.py` | 修改 | `provider_binaries` 映射补 `"omp_cli": "omp"`。 |
+| `src/cli_agent_orchestrator/cli/commands/launch.py` | 修改 | `PROVIDERS_REQUIRING_WORKSPACE_ACCESS` 补 `"omp_cli"`；按需补 per-provider 提示分支（若 OMP 需特殊权限跳过）。 |
+| `test/providers/test_omp_cli_unit.py` | 新建 | 单测：get_status 各态、extract、launch 命令、exit_cli、paste_enter_count。参照 test_opencode_cli_unit.py / test_cursor_cli_unit.py，用 fixture + env-overridable 正则便于校准。 |
+| `test/providers/test_provider_manager_unit.py` | 修改 | 新增 `test_create_provider_omp_cli_stores_mapping`，断言 manager 能构造并存储 omp_cli。 |
+| `test/e2e/conftest.py` | 修改 | 新增 `require_omp()`（`_cli_available("omp")`，缺则 skip）。 |
+| `docs/omp-cli.md` | 新建 | per-provider 文档，说明安装/启动/状态识别/已知限制。 |
+
+## 3. 实施步骤（顺序）
+
+1. 枚举 + provider 类骨架（models/provider.py + providers/omp_cli.py）→ 让导入链先通。
+2. manager.py 注册分支 → provider 可被 create。
+3. api/main.py + launch.py 接入 → 列表/启动链路通。
+4. install_service / terminal_service / tool_mapping 的能力集与占位分支。
+5. 单测（unit + manager 注册），先以 hermes-style 默认正则跑通，标 TODO 等真实输出校准。
+6. e2e conftest `require_omp` + 文档。
+7. develop 阶段用真实 `omp` 输出校准正则与提取逻辑（env-overridable 设计使校准无需改代码常量即可在测试中调）。
+
+## 4. 关键设计决策
+
+- **状态识别用 env-overridable 正则**（`CAO_OMP_IDLE_PROMPT_REGEX` 等）：OMP TUI 输出格式未知，遵循 hermes 范式，develop/test 阶段用真实输出校准而不必反复改源码常量。
+- **命令名 `omp` + which 探测**：避免手抖；参照 cursor 的 binary 解析思路。
+- **install/工具拦截走默认宽松**：context-file-only + 无 tool_mapping → 与 claude_code 早期待遇一致，风险最低；真实能力在 develop 阶段补强。
+- **不改动任何现有 provider 行为**：纯新增。
+
+## 5. 风险评估
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| OMP TUI 真实输出格式未知 → get_status / extract 误判 | 中 | env-overridable 正则 + develop 阶段真实输出校准；单测先以占位 fixture 跑通。 |
+| `omp` 命令名与他工具冲突 | 低 | `shutil.which` + 可选 `--version` 探测（参照 cursor）。 |
+| 原生工具词汇未知 → 工具限制不生效（仅提示级） | 低 | 默认宽松；SOFT_ENFORCEMENT 待确认；文档明示限制。 |
+| OMP 是否需原生 agent 配置未知 | 低 | install 默认 context-file-only；占位分支预留扩展。 |
+| 影响现有 provider | 低 | 纯新增，无现有逻辑改动。 |
+
+## 6. 验收 / 测试策略
+
+- 单测：`test/providers/test_omp_cli_unit.py` 覆盖 status 四态 + extract + 命令构造。
+- 注册：`test_provider_manager_unit.py` 断言 omp_cli 可被 manager 构造。
+- e2e：`require_omp()` 守护，无 omp 二进制环境自动 skip；有则跑一条 send→完成 提取链路。
+- plan→develop handoff：develop 阶段必须用真实 `omp` 输出回填正则与 fixture。
+
+复杂度评估：simple（纯新增适配器，沿用成熟模式，无架构改动）。

--- a/docs/omp-cli.md
+++ b/docs/omp-cli.md
@@ -1,0 +1,89 @@
+# OMP CLI Provider
+
+CAO can launch the OMP CLI (`omp`) as a built-in provider. OMP is integrated as
+a generic TUI agent: its role context reaches the agent through the install-time
+context file, and status detection uses environment-overridable regexes so the
+patterns can be recalibrated against real `omp` output without a code change.
+
+## Prerequisites
+
+- The OMP CLI is installed and authenticated.
+- The `omp` binary is on `PATH`. CAO resolves it with `shutil.which("omp")` and
+  raises a provider error at launch time if it is missing.
+
+```bash
+which omp
+```
+
+## CAO Profile
+
+Create a CAO agent profile that selects the OMP provider:
+
+```yaml
+---
+name: omp_default
+description: Developer backed by OMP CLI
+provider: omp_cli
+role: developer
+---
+
+You are a helpful developer agent.
+```
+
+An optional `model` is read from the agent profile (or set explicitly) and
+forwarded as `--model` at launch.
+
+## Installation behaviour
+
+OMP has no native agent-config format yet, so installation is
+**context-file-only**: CAO writes the profile's role body to the standard
+context file, which `omp` reads at startup. No per-provider agent file is
+written. This is the same lowest-friction path the early-stage
+`claude_code` / `hermes` providers took.
+
+## Capability set (intentionally minimal)
+
+For now OMP is deliberately excluded from both `terminal_service` capability
+sets:
+
+- **Runtime skill prompts** — skills reach OMP via the context file, not a
+  launch-time system prompt, so there is no `skill_prompt` to consume.
+- **Soft tool enforcement** — OMP's native tool vocabulary is not yet
+  characterised, so there is no reliable advisory prompt to emit. Tool
+  restrictions are still recorded but only reach the agent via the context file.
+
+Both decisions should be revisited once OMP's native tool / approval model is
+confirmed.
+
+## Status detection
+
+Status detection classifies the terminal buffer into IDLE, PROCESSING,
+COMPLETED, WAITING_USER_ANSWER, ERROR, and UNKNOWN. The agent distinguishes a
+fresh spawn (IDLE) from a delivered turn (COMPLETED) via an internal turn
+counter incremented on every `send_input`; the buffer alone cannot tell them
+apart.
+
+All detection patterns are overridable via environment variables:
+
+| Env var | Purpose |
+|---|---|
+| `CAO_OMP_IDLE_PROMPT_REGEX` | Idle prompt line (wait for next message). |
+| `CAO_OMP_IDLE_LOG_REGEX` | Idle prompt substring used for log monitoring. |
+| `CAO_OMP_PROCESSING_REGEX` | Spinner / in-flight indicator while generating. |
+| `CAO_OMP_WAITING_REGEX` | Approval / selection dialog that blocks the agent. |
+| `CAO_OMP_USER_PREFIX_REGEX` | User message marker (response extraction). |
+| `CAO_OMP_ASSISTANT_HEADER_REGEX` | Assistant message marker (response extraction). |
+
+The defaults are placeholders calibrated against representative TUI agents.
+Capture real `omp` output and set the env vars to refine detection — no source
+change required.
+
+## Known limitations
+
+- **Unknown real output format.** The default regexes are generic placeholders;
+  they must be calibrated against real `omp` output before OMP is used in
+  production orchestration.
+- **Advisory tool restrictions.** No native tool-blocking flag; restrictions are
+  prompt-level only.
+- **`omp` is a short name.** `shutil.which` resolves the first `omp` on `PATH`;
+  ensure the intended OMP binary is the one found.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -503,6 +503,7 @@ async def list_providers_endpoint() -> List[Dict]:
         "copilot_cli": "copilot",
         "opencode_cli": "opencode",
         "cursor_cli": "agent",
+        "omp_cli": "omp",
     }
     result = []
     for provider, binary in provider_binaries.items():

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -33,6 +33,7 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     "kimi_cli",
     "kiro_cli",
     "opencode_cli",
+    "omp_cli",
 }
 
 # Validation constraints for ``--env`` forwarded vars (mirrored server-side

--- a/src/cli_agent_orchestrator/models/provider.py
+++ b/src/cli_agent_orchestrator/models/provider.py
@@ -14,3 +14,4 @@ class ProviderType(str, Enum):
     OPENCODE_CLI = "opencode_cli"
     HERMES = "hermes"
     CURSOR_CLI = "cursor_cli"
+    OMP_CLI = "omp_cli"

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -14,6 +14,7 @@ from cli_agent_orchestrator.providers.gemini_cli import GeminiCliProvider
 from cli_agent_orchestrator.providers.hermes import HermesProvider
 from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
+from cli_agent_orchestrator.providers.omp_cli import OmpCliProvider
 from cli_agent_orchestrator.providers.opencode_cli import OpenCodeCliProvider
 from cli_agent_orchestrator.providers.q_cli import QCliProvider
 
@@ -125,6 +126,16 @@ class ProviderManager:
                 )
             elif provider_type == ProviderType.CURSOR_CLI.value:
                 provider = CursorCliProvider(
+                    terminal_id,
+                    tmux_session,
+                    tmux_window,
+                    agent_profile,
+                    allowed_tools,
+                    model=model,
+                    skill_prompt=skill_prompt,
+                )
+            elif provider_type == ProviderType.OMP_CLI.value:
+                provider = OmpCliProvider(
                     terminal_id,
                     tmux_session,
                     tmux_window,

--- a/src/cli_agent_orchestrator/providers/omp_cli.py
+++ b/src/cli_agent_orchestrator/providers/omp_cli.py
@@ -1,0 +1,381 @@
+"""OMP CLI provider implementation.
+
+This module provides the :class:`OmpCliProvider` for integrating with the OMP
+CLI — a terminal-native AI agent invoked via the ``omp`` binary. OMP is treated
+as a generic TUI agent: like Hermes, its concrete output format is not
+hard-known at integration time, so the status-detection and extraction regexes
+are **environment-overridable** (``CAO_OMP_*_REGEX``). The defaults below are
+reasonable placeholders calibrated against representative TUI agents; the
+develop / test stages refine them against real ``omp`` output by setting the
+env vars rather than editing source constants.
+
+Provider responsibilities (see :class:`BaseProvider`):
+
+- ``initialize`` — probe for the ``omp`` binary on ``$PATH``, launch the TUI
+  inside the tmux window, wait for IDLE / COMPLETED.
+- ``get_status`` — classify the terminal buffer into IDLE / PROCESSING /
+  COMPLETED / WAITING_USER_ANSWER / ERROR / UNKNOWN.
+- ``extract_last_message_from_script`` — pull the agent's last response out of
+  the scrollback.
+- ``exit_cli`` / ``cleanup`` — tear the session down.
+
+The provider intentionally takes the lowest-friction integration path: OMP has
+no native agent-config format yet, so installation is context-file-only (see
+``install_service``), tool restrictions are advisory (no tool_mapping entry),
+and the CAO skill catalog is delivered via the context file rather than a
+native launch flag. This mirrors the early-stage stance that ``claude_code``
+and ``hermes`` took and keeps the change purely additive — no existing
+provider's behaviour is touched.
+"""
+
+import logging
+import os
+import re
+import shlex
+import shutil
+from typing import Optional
+
+from cli_agent_orchestrator.backends.registry import get_backend
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
+from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
+from cli_agent_orchestrator.utils.text import strip_terminal_escapes
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderError(Exception):
+    """Exception raised for OMP CLI provider-specific errors."""
+
+    pass
+
+
+# =============================================================================
+# Regex patterns — env-overridable so calibration against real `omp` output
+# never requires editing these source constants (see docs/omp-cli.md).
+# =============================================================================
+
+# CSI / OSC escape sequences. Broader than the SGR-only pattern some providers
+# use because OMP's real escape behaviour is unknown; strips cursor moves and
+# OSC title updates so the structural checks below fire on rendered text.
+ANSI_CODE_PATTERN = r"\x1b\[[0-9;]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"
+
+# The idle prompt OMP renders when waiting for the next user message. Defaults
+# to a generic ``omp>`` / ``OMP>`` prompt line; override with
+# ``CAO_OMP_IDLE_PROMPT_REGEX`` once the real prompt glyph is observed.
+IDLE_PROMPT_PATTERN = os.environ.get(
+    "CAO_OMP_IDLE_PROMPT_REGEX", r"^\s*(?:omp|OMP)>\s*$"
+)
+IDLE_PROMPT_PATTERN_LOG = os.environ.get("CAO_OMP_IDLE_LOG_REGEX", r"(?:omp|OMP)>")
+
+# Spinner / in-flight indicator shown while OMP is generating. Defaults cover
+# the braille-spinner + ellipsis vocabulary shared by most TUI agents.
+PROCESSING_PATTERN = os.environ.get(
+    "CAO_OMP_PROCESSING_REGEX",
+    r"(?:Thinking|Working|musing\.\.\.|interrupt|cancel|"
+    r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✶✢✽✻✳][^\n]*…)",
+)
+
+# Approval / selection dialogs that block the agent pending operator input.
+WAITING_PROMPT_PATTERN = os.environ.get(
+    "CAO_OMP_WAITING_REGEX",
+    r"(?:Approve|Allow|Proceed|Confirm|permission)[^\n]*(?:y/n|yes/no|\[y/N\])"
+    r"|↑/↓\s*(?:to )?(?:select|navigate)",
+)
+
+ERROR_PATTERN = r"^(?:Error:|ERROR:|Traceback \(most recent call last\):|omp .*failed:)"
+
+# User / assistant message markers used for response extraction. Defaults are
+# generic; override once OMP's concrete markers are known.
+USER_PREFIX_PATTERN = os.environ.get("CAO_OMP_USER_PREFIX_REGEX", r"^\s*(?:You|User|●)[:,]?\s")
+ASSISTANT_HEADER_PATTERN = os.environ.get(
+    "CAO_OMP_ASSISTANT_HEADER_REGEX", r"^\s*(?:Assistant|OMP|omp)[:,]\s"
+)
+
+# Lines that are TUI chrome (status bar, separators, prompt) and should be
+# stripped from an extracted response region.
+SEPARATOR_PATTERN = r"^[\s─━═-]{10,}$"
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(ANSI_CODE_PATTERN, "", text)
+
+
+def _is_idle_line(line: str) -> bool:
+    return re.search(IDLE_PROMPT_PATTERN, line) is not None
+
+
+def _is_chrome_line(line: str) -> bool:
+    stripped = line.strip()
+    return (
+        not stripped
+        or _is_idle_line(stripped)
+        or re.match(SEPARATOR_PATTERN, stripped) is not None
+        or re.search(PROCESSING_PATTERN, stripped, re.IGNORECASE) is not None
+        or re.search(ASSISTANT_HEADER_PATTERN, stripped) is not None
+        or re.search(USER_PREFIX_PATTERN, stripped) is not None
+    )
+
+
+class OmpCliProvider(BaseProvider):
+    """Provider for the OMP CLI (``omp``) — a generic TUI agent adapter.
+
+    Manages the lifecycle of an OMP TUI session inside a tmux window:
+    initialization, status detection, response extraction, and cleanup. Status
+    detection uses env-overridable regexes so the patterns can be recalibrated
+    against real ``omp`` output without a code change.
+
+    Attributes:
+        terminal_id: Unique identifier for this terminal instance.
+        session_name: Name of the tmux session containing this terminal.
+        window_name: Name of the tmux window for this terminal.
+        _agent_profile: Optional CAO agent profile name (role context is
+            delivered via the install-time context file; the profile is only
+            consulted for optional model / binary overrides).
+        _model: Optional model override forwarded as ``--model`` at launch.
+    """
+
+    def __init__(
+        self,
+        terminal_id: str,
+        session_name: str,
+        window_name: str,
+        agent_profile: Optional[str] = None,
+        allowed_tools: Optional[list] = None,
+        model: Optional[str] = None,
+        skill_prompt: Optional[str] = None,
+    ):
+        """Initialize the OMP CLI provider.
+
+        Args:
+            terminal_id: Unique identifier for this terminal.
+            session_name: Name of the tmux session.
+            window_name: Name of the tmux window.
+            agent_profile: Optional CAO agent profile name. The profile's role
+                body reaches OMP via the context file; the profile is consulted
+                here only for an optional model override.
+            allowed_tools: Optional list of CAO tool names the agent is allowed
+                to use. OMP has no native ``--disallowedTools`` flag, so
+                restrictions are advisory (no tool_mapping entry).
+            model: Optional model override (e.g. ``"gpt-5"``).
+            skill_prompt: Optional skill catalog text. OMP does not inject a
+                CAO runtime skill catalog at launch (skills reach the agent via
+                the context file); the value is accepted for API symmetry and
+                ignored with a log line.
+        """
+        super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
+        self._initialized = False
+        self._agent_profile = agent_profile
+        self._model = model
+        # Turn counter: 0 (fresh spawn) → IDLE; ≥1 once input has been
+        # delivered → COMPLETED when the agent returns to a non-processing
+        # state. OMP's TUI cannot otherwise distinguish "just spawned" from
+        # "turn delivered" from the buffer alone, mirroring cursor_cli.
+        self._turns: int = 0
+
+    @property
+    def paste_enter_count(self) -> int:
+        """OMP submits on a single Enter after bracketed paste."""
+        return 1
+
+    def mark_input_received(self) -> None:
+        """Record that a turn has been delivered to the agent (see _turns)."""
+        self._turns += 1
+
+    def _build_launch_command(self) -> str:
+        """Build the ``omp`` launch command.
+
+        Resolves the ``omp`` binary on ``$PATH`` (raises :class:`ProviderError`
+        if missing), then forwards an optional ``--model`` override. The CAO
+        agent profile's role body is **not** passed on the command line — it is
+        already materialised into the context file at install time, which OMP
+        reads at startup.
+
+        Returns:
+            A properly shell-escaped launch command string.
+        """
+        binary = shutil.which("omp")
+        if not binary:
+            raise ProviderError(
+                "OMP CLI not found: 'omp' is not on $PATH. Install OMP CLI before launching."
+            )
+
+        model = self._model
+        if model is None and self._agent_profile is not None:
+            try:
+                profile = load_agent_profile(self._agent_profile)
+                if profile and profile.model:
+                    model = profile.model
+            except Exception as exc:  # noqa: BLE001 — profile load is best-effort here
+                logger.warning("Could not load agent profile %r for model override: %s", self._agent_profile, exc)
+
+        command_parts = [binary]
+        if model:
+            command_parts.extend(["--model", model])
+
+        if self._skill_prompt:
+            logger.info(
+                "OMP provider does not inject a CAO runtime skill catalog at launch; "
+                "skills reach the agent via the install-time context file."
+            )
+
+        if self._allowed_tools and "*" not in self._allowed_tools:
+            logger.info(
+                "OMP provider has no CAO-native tool restriction flag; "
+                "restrictions are advisory (delivered via the context file)."
+            )
+
+        return shlex.join(command_parts)
+
+    async def initialize(self) -> bool:
+        """Start the OMP TUI and wait for the idle / completed splash.
+
+        Returns:
+            True if initialization completed successfully.
+
+        Raises:
+            TimeoutError: If the shell or OMP TUI does not reach IDLE /
+                COMPLETED in time.
+            ProviderError: If the ``omp`` binary is not on ``$PATH``.
+        """
+        if not await wait_for_shell(self.terminal_id, timeout=10.0):
+            raise TimeoutError("Shell initialization timed out after 10 seconds")
+
+        command = self._build_launch_command()
+        get_backend().send_keys(self.session_name, self.window_name, command)
+
+        if not await wait_until_status(
+            self.terminal_id,
+            {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+            timeout=120.0,
+        ):
+            raise TimeoutError("OMP CLI initialization timed out after 120 seconds")
+
+        self._initialized = True
+        return True
+
+    def get_status(self, output: str) -> TerminalStatus:
+        """Classify the terminal buffer into a terminal status.
+
+        Priority order:
+
+        1. Empty buffer → UNKNOWN.
+        2. WAITING_USER_ANSWER — an approval / selection dialog is active and
+           no idle prompt follows it (the user already dismissed it).
+        3. ERROR — an error pattern in the recent tail.
+        4. PROCESSING — a processing indicator in the tail with no following
+           idle prompt.
+        5. COMPLETED — idle prompt present and at least one turn delivered.
+        6. IDLE — idle prompt present, fresh spawn.
+        7. UNKNOWN — fallback.
+
+        Args:
+            output: Raw terminal output (rolling buffer, up to ~8KB).
+
+        Returns:
+            Current :class:`TerminalStatus`.
+        """
+        if not output:
+            return TerminalStatus.UNKNOWN
+
+        clean = _strip_ansi(strip_terminal_escapes(output))
+        lines = clean.splitlines()
+        tail_lines = lines[-30:]
+        tail_output = "\n".join(tail_lines)
+        bottom_lines = [line for line in tail_lines if line.strip()][-8:]
+        bottom_output = "\n".join(bottom_lines)
+
+        has_idle_prompt = any(_is_idle_line(line.strip()) for line in bottom_lines)
+
+        # ── 2. WAITING_USER_ANSWER ───────────────────────────────────────────
+        waiting_matches = list(re.finditer(WAITING_PROMPT_PATTERN, clean, re.IGNORECASE))
+        if waiting_matches:
+            last_waiting_end = waiting_matches[-1].end()
+            if not re.search(IDLE_PROMPT_PATTERN, clean[last_waiting_end:], re.MULTILINE):
+                return TerminalStatus.WAITING_USER_ANSWER
+
+        # ── 3. ERROR ─────────────────────────────────────────────────────────
+        if re.search(ERROR_PATTERN, tail_output, re.IGNORECASE | re.MULTILINE):
+            return TerminalStatus.ERROR
+
+        # ── 4. PROCESSING ────────────────────────────────────────────────────
+        # Position guard: a processing indicator is only authoritative when no
+        # idle prompt appears after it (otherwise it is stale scrollback from a
+        # completed turn). ``re.MULTILINE`` is required so the line-anchored
+        # idle pattern can match a prompt mid-buffer, not just at the very end.
+        proc_matches = list(re.finditer(PROCESSING_PATTERN, clean, re.IGNORECASE))
+        if proc_matches:
+            last_proc_end = proc_matches[-1].end()
+            if not re.search(IDLE_PROMPT_PATTERN, clean[last_proc_end:], re.MULTILINE):
+                return TerminalStatus.PROCESSING
+
+        # ── 5/6. IDLE / COMPLETED ────────────────────────────────────────────
+        if has_idle_prompt:
+            return TerminalStatus.COMPLETED if self._turns > 0 else TerminalStatus.IDLE
+
+        # ── 7. UNKNOWN ───────────────────────────────────────────────────────
+        return TerminalStatus.UNKNOWN
+
+    def get_idle_pattern_for_log(self) -> str:
+        """Return the idle prompt pattern used for log file monitoring."""
+        return IDLE_PROMPT_PATTERN_LOG
+
+    def _extract_response(self, clean_output: str) -> str:
+        """Extract the last OMP response from the cleaned buffer.
+
+        Anchors on the last user message (or, failing that, the last assistant
+        header) and returns the text up to the trailing idle prompt, with TUI
+        chrome stripped. A leading assistant-header marker (``OMP:`` /
+        ``Assistant:``) on a response line is stripped off, but any content on
+        the same line is preserved — OMP may emit the marker and the response
+        body on one line.
+        """
+        user_matches = list(re.finditer(USER_PREFIX_PATTERN, clean_output, re.MULTILINE))
+        if user_matches:
+            last_user = user_matches[-1]
+            line_end = clean_output.find("\n", last_user.end())
+            search_region = (
+                clean_output[line_end + 1 :] if line_end != -1 else clean_output[last_user.end() :]
+            )
+        else:
+            header_matches = list(re.finditer(ASSISTANT_HEADER_PATTERN, clean_output, re.MULTILINE))
+            if not header_matches:
+                raise ValueError("No OMP response found - no assistant header or user message detected")
+            search_region = clean_output[header_matches[-1].end() :]
+
+        end_match = re.search(IDLE_PROMPT_PATTERN, search_region, re.MULTILINE)
+        candidate_text = search_region[: end_match.start()] if end_match else search_region
+
+        response_lines: list[str] = []
+        for raw_line in candidate_text.splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            if _is_idle_line(stripped) or re.match(SEPARATOR_PATTERN, stripped):
+                continue
+            if re.search(PROCESSING_PATTERN, stripped, re.IGNORECASE):
+                continue
+            # Strip a leading assistant-header marker but keep any same-line
+            # content that follows it.
+            stripped = re.sub(r"^\s*(?:Assistant|OMP|omp)[:,]\s*", "", raw_line).rstrip()
+            if stripped:
+                response_lines.append(stripped)
+
+        response = "\n".join(response_lines).strip()
+        if not response:
+            raise ValueError("Empty OMP response - no content found")
+        return response
+
+    def extract_last_message_from_script(self, script_output: str) -> str:
+        """Extract the last OMP assistant response from terminal output."""
+        clean_output = _strip_ansi(strip_terminal_escapes(script_output))
+        return self._extract_response(clean_output)
+
+    def exit_cli(self) -> str:
+        """Return the command to exit the OMP TUI."""
+        return "/exit"
+
+    def cleanup(self) -> None:
+        """Clean up OMP provider state."""
+        self._initialized = False

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -359,6 +359,15 @@ def install_agent(
             else:
                 remove_agent_tools(agent_id)
 
+        elif provider == ProviderType.OMP_CLI.value:
+            # OMP CLI has no native agent-config format yet: the CAO role
+            # context is delivered via the install-time context file (written
+            # for every provider above) and read by `omp` at startup. agent_file
+            # stays None. This branch is intentionally explicit so a future
+            # native OMP agent format can slot in here without touching the
+            # fall-through default path.
+            pass
+
         return InstallResult(
             success=True,
             message=f"Agent '{profile.name}' installed successfully",

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -127,6 +127,16 @@ SOFT_ENFORCEMENT_PROVIDERS = {
     ProviderType.CODEX.value,
 }
 
+# OMP CLI is deliberately excluded from BOTH capability sets above:
+# - RUNTIME_SKILL_PROMPT_PROVIDERS: OMP receives its role (and any skill
+#   catalog) via the install-time context file rather than a launch-time
+#   system prompt, so it has no skill_prompt kwarg to consume.
+# - SOFT_ENFORCEMENT_PROVIDERS: OMP's native tool vocabulary is not yet
+#   characterised, so there is no reliable advisory prompt to emit. Restrictions
+#   still reach the agent via the context file but are not surfaced as a
+#   separate soft-enforcement prompt. Revisit both once OMP's native tool /
+#   approval model is confirmed.
+
 
 async def create_terminal(
     provider: str,

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -122,7 +122,7 @@ class TestAgentProviders:
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 10
+        assert len(data) == 11
         names = [p["name"] for p in data]
         assert "kiro_cli" in names
         assert "claude_code" in names
@@ -134,6 +134,7 @@ class TestAgentProviders:
         assert "copilot_cli" in names
         assert "opencode_cli" in names
         assert "cursor_cli" in names
+        assert "omp_cli" in names
         for p in data:
             assert p["installed"] is True
 

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -142,6 +142,13 @@ def require_cursor():
     pytest.skip("Cursor CLI (agent / cursor-agent) not installed")
 
 
+@pytest.fixture()
+def require_omp():
+    """Skip test if the OMP CLI (`omp` binary) is not available."""
+    if not _cli_available("omp"):
+        pytest.skip("OMP CLI (omp) not installed")
+
+
 def create_terminal(
     provider: str,
     agent_profile: str,

--- a/test/providers/test_omp_cli_unit.py
+++ b/test/providers/test_omp_cli_unit.py
@@ -1,0 +1,165 @@
+"""Unit tests for the OMP CLI provider.
+
+The provider's status / extraction regexes are environment-overridable
+(``CAO_OMP_*_REGEX``). The fixtures below exercise the *default* placeholder
+patterns; the develop / test stages refine the env vars against real ``omp``
+output without editing these tests' expectations.
+
+These tests use synthetic buffers that match the documented default patterns so
+they pass in any environment regardless of whether ``omp`` is installed.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.omp_cli import OmpCliProvider, ProviderError
+
+
+def make_provider(agent_profile=None, model=None) -> OmpCliProvider:
+    return OmpCliProvider(
+        terminal_id="test-tid",
+        session_name="test-session",
+        window_name="window-0",
+        agent_profile=agent_profile,
+        allowed_tools=None,
+        model=model,
+    )
+
+
+OMP_IDLE_OUTPUT = """OMP CLI v1.0.0
+Ready.
+
+omp>
+"""
+
+OMP_PROCESSING_OUTPUT = """● Summarize this
+
+ omp Thinking…
+"""
+
+# After a turn has been delivered and the agent returned to the idle prompt.
+OMP_COMPLETED_OUTPUT = """● Summarize this
+
+ OMP: Here is a short summary.
+
+omp>
+"""
+
+OMP_WAITING_OUTPUT = """● Run a command
+
+ Approve this action? [y/N]
+"""
+
+OMP_ERROR_OUTPUT = """● do thing
+Error: omp connection failed:
+"""
+
+
+class TestOmpCliStatus:
+    def test_empty_buffer_is_unknown(self):
+        p = make_provider()
+        assert p.get_status("") is TerminalStatus.UNKNOWN
+
+    def test_idle_detected(self):
+        p = make_provider()
+        assert p.get_status(OMP_IDLE_OUTPUT) is TerminalStatus.IDLE
+
+    def test_processing_detected(self):
+        p = make_provider()
+        assert p.get_status(OMP_PROCESSING_OUTPUT) is TerminalStatus.PROCESSING
+
+    def test_completed_requires_a_delivered_turn(self):
+        # Fresh spawn with a completed-looking buffer is still IDLE (no turn
+        # delivered yet).
+        p = make_provider()
+        assert p.get_status(OMP_COMPLETED_OUTPUT) is TerminalStatus.IDLE
+
+        p.mark_input_received()
+        assert p.get_status(OMP_COMPLETED_OUTPUT) is TerminalStatus.COMPLETED
+
+    def test_processing_with_following_idle_is_not_processing(self):
+        # A stale processing indicator followed by an idle prompt must not flip
+        # to PROCESSING (position guard).
+        p = make_provider()
+        buffer = "omp Thinking…\n\nomp>\n"
+        assert p.get_status(buffer) in {TerminalStatus.IDLE, TerminalStatus.COMPLETED}
+
+    def test_waiting_user_answer(self):
+        p = make_provider()
+        assert p.get_status(OMP_WAITING_OUTPUT) is TerminalStatus.WAITING_USER_ANSWER
+
+    def test_error_detected(self):
+        p = make_provider()
+        assert p.get_status(OMP_ERROR_OUTPUT) is TerminalStatus.ERROR
+
+    def test_idle_pattern_for_log(self):
+        p = make_provider()
+        assert p.get_idle_pattern_for_log()  # non-empty pattern
+
+
+class TestOmpCliExtraction:
+    def test_extract_last_message_with_assistant_header(self):
+        p = make_provider()
+        output = """● Summarize this
+
+ OMP: Here is the answer.
+
+omp>
+"""
+        result = p.extract_last_message_from_script(output)
+        assert "Here is the answer." in result
+
+    def test_extract_ansi_stripped(self):
+        p = make_provider()
+        output = "● q\n OMP: \x1b[32mGreen answer\x1b[0m\nomp>\n"
+        result = p.extract_last_message_from_script(output)
+        assert "Green answer" in result
+        assert "\x1b[" not in result
+
+    def test_extract_raises_when_no_response(self):
+        p = make_provider()
+        with pytest.raises(ValueError):
+            p.extract_last_message_from_script("omp>\n")
+
+
+class TestOmpCliLifecycle:
+    def test_paste_enter_count_is_one(self):
+        assert make_provider().paste_enter_count == 1
+
+    def test_exit_cli(self):
+        assert make_provider().exit_cli() == "/exit"
+
+    def test_mark_input_received_increments_turns(self):
+        p = make_provider()
+        assert p._turns == 0
+        p.mark_input_received()
+        assert p._turns == 1
+
+    def test_cleanup_resets_initialized(self):
+        p = make_provider()
+        p._initialized = True
+        p.cleanup()
+        assert p._initialized is False
+
+    def test_build_launch_command_requires_binary(self):
+        p = make_provider()
+        with patch("cli_agent_orchestrator.providers.omp_cli.shutil.which", return_value=None):
+            with pytest.raises(ProviderError):
+                p._build_launch_command()
+
+    def test_build_launch_command_with_model(self):
+        p = make_provider(model="gpt-5")
+        with patch("cli_agent_orchestrator.providers.omp_cli.shutil.which", return_value="/usr/local/bin/omp"):
+            cmd = p._build_launch_command()
+        assert "omp" in cmd
+        assert "--model" in cmd
+        assert "gpt-5" in cmd
+
+    def test_build_launch_command_without_model(self):
+        p = make_provider()
+        with patch("cli_agent_orchestrator.providers.omp_cli.shutil.which", return_value="/usr/local/bin/omp"):
+            cmd = p._build_launch_command()
+        assert "omp" in cmd
+        assert "--model" not in cmd

--- a/test/providers/test_provider_manager_unit.py
+++ b/test/providers/test_provider_manager_unit.py
@@ -9,6 +9,7 @@ from cli_agent_orchestrator.providers.codex import CodexProvider
 from cli_agent_orchestrator.providers.copilot_cli import CopilotCliProvider
 from cli_agent_orchestrator.providers.hermes import HermesProvider
 from cli_agent_orchestrator.providers.manager import ProviderManager
+from cli_agent_orchestrator.providers.omp_cli import OmpCliProvider
 
 
 def test_create_provider_codex_stores_mapping():
@@ -63,6 +64,20 @@ def test_create_provider_unknown_type_raises():
             tmux_window="w1",
             agent_profile=None,
         )
+
+
+def test_create_provider_omp_cli_stores_mapping():
+    manager = ProviderManager()
+    provider = manager.create_provider(
+        ProviderType.OMP_CLI.value,
+        terminal_id="t1",
+        tmux_session="s1",
+        tmux_window="w1",
+        agent_profile=None,
+    )
+
+    assert isinstance(provider, OmpCliProvider)
+    assert manager.get_provider("t1") is provider
 
 
 def test_get_provider_creates_on_demand_from_metadata():


### PR DESCRIPTION
# feat(provider): add OMP CLI provider (omp_cli)

Adds a new provider adapter for the OMP CLI (`omp` binary), following the
existing adapter pattern. OMP is integrated as a generic TUI agent. Work item
d7348a1e-f6d6-4a24-96a9-edab9b74d8ff.

## Changes (purely additive — no existing provider behaviour touched)

- `providers/omp_cli.py` — `OmpCliProvider` implementing `BaseProvider`:
  - env-overridable regexes (`CAO_OMP_*_REGEX`) so status detection / response
    extraction can be recalibrated against real `omp` output **without a code
    change** (same pattern Hermes uses).
  - binary resolved via `shutil.which("omp")`; optional `--model` override
    (constructor or agent profile).
  - fresh-spawn vs delivered-turn (IDLE vs COMPLETED) distinguished via an
    internal turn counter (`mark_input_received`), since the buffer alone can't
    tell them apart (mirrors cursor_cli).
  - status priority: empty→UNKNOWN, WAITING_USER_ANSWER, ERROR, PROCESSING
    (with a position guard against stale scrollback), COMPLETED/IDLE, UNKNOWN.
- `providers/manager.py` — register the `OMP_CLI` construction branch.
- `services/install_service.py` — explicit context-file-only placeholder
  branch (OMP has no native agent-config format yet; `agent_file` stays None).
- `services/terminal_service.py` — documents OMP's deliberate exclusion from
  both capability sets (skills via context file; native tool vocabulary not yet
  characterised).
- `api/main.py` — `provider_binaries` gains `omp_cli -> omp`.
- `cli/commands/launch.py` — add `omp_cli` to `PROVIDERS_REQUIRING_WORKSPACE_ACCESS`.
- `models/provider.py` — `ProviderType.OMP_CLI` enum (`PROVIDERS` /
  `valid_providers` auto-derived).
- `test/providers/test_omp_cli_unit.py` — status four-states + extraction +
  lifecycle (36 tests incl. manager).
- `test/providers/test_provider_manager_unit.py` — `omp_cli` registration
  assertion.
- `test/e2e/conftest.py` — `require_omp` fixture.
- `docs/omp-cli.md` — per-provider documentation.

## Validation

- `pytest test/providers/test_omp_cli_unit.py test/providers/test_provider_manager_unit.py` → 36 passed.
- `python -c` import + manager build smoke test passes; `PROVIDERS` and
  `PROVIDERS_REQUIRING_WORKSPACE_ACCESS` both contain `omp_cli`.

## Known follow-ups

Default status/extraction regexes are placeholders calibrated against
representative TUI agents. Calibration against real `omp` output is owed and is
designed to be done via env vars (no source edit) during test_e2e/test_unit.

## Note on fork

The upstream `awslabs/cli-agent-orchestrator` is read-only for the contributor,
so this PR targets `awslabs:main` from the fork `bigyee66:harness/d7348a1e`.
