### PR TITLE
feat(cli): consolidate server operations under one `cao` CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+CLI Agent Orchestrator (CAO) is a local multi-agent orchestrator for AI coding CLIs (Claude Code, Kiro CLI, Codex, Gemini, Hermes, Kimi, Copilot, OpenCode, Cursor, Q CLI). Each agent runs as a *real CLI process inside its own tmux session*; CAO coordinates them with a supervisor–worker pattern. The orchestrator does not wrap provider APIs — it drives the actual terminal, so every CLI's native features and auth are preserved.
+
+## Commands
+
+Dev uses `uv`. Always prefix Python tooling with `uv run`.
+
+```bash
+uv sync                                                      # install deps (incl. dev group)
+uv run cao --help                                            # the CLI entrypoint
+
+# Tests — default addopts already excludes e2e and adds coverage
+uv run pytest test/ --ignore=test/e2e -m "not integration" -v   # fast unit run (what CI gates on)
+uv run pytest test/providers/test_claude_code_unit.py -v         # single file
+uv run pytest test/providers/test_codex_provider_unit.py::TestCodexBuildCommand -v   # single class/test
+uv run pytest -n auto                                            # parallel
+uv run pytest -m integration -v                                 # integration (needs provider CLI installed+authed)
+uv run pytest -m e2e test/e2e/ -v                              # e2e (needs running cao-server + tmux + authed CLIs)
+
+# Quality (run all three before committing — CI enforces them)
+uv run black src/ test/
+uv run isort src/ test/
+uv run mypy src/
+
+# Regenerate captured provider-output fixtures when a CLI changes its TUI
+uv run python test/providers/fixtures/generate_fixtures.py
+```
+
+Running the system locally: `cao-server` (starts FastAPI on `localhost:9889` + Web UI), then `cao launch --agents code_supervisor` in another terminal. `cao shutdown --all` to clean up. Sessions live in tmux — `tmux attach -t <session>` to watch/steer an agent live.
+
+## Operating the server
+
+CAO is one background daemon (`cao-server`) with the CLI/MCP/WebUI as thin REST clients. The daemon is managed *without leaving `cao`*:
+
+- **Lifecycle:** `cao server start` (detached; no-op if already healthy — single-instance guard via `/health` + a pidfile at `~/.aws/cli-agent-orchestrator/server.pid`), `cao server stop`, `cao server restart`, `cao server status` (PID/port/health components/version). `cao server start --foreground` runs it blocking with live logs.
+- **Auto-start:** `cao launch` starts the daemon automatically if it isn't running, so the common path never needs a separate `cao-server` terminal. Opt out with `cao launch --no-auto-start` (errors instead of spawning).
+- **Health check:** `cao doctor` is *tiered*. Static (`cao doctor`) spawns nothing and costs no tokens: server reachability, per-provider binary install status over `PREFERRED_PROVIDERS`, discoverable profiles, and effective `settings.json` timeouts. Live (`cao doctor --live [--provider X]`) spawns a throwaway agent per installed provider and asserts it reaches IDLE within `provider_init_timeout` (real agents — costs tokens). It's the manual twin of the opt-in e2e smoke test (`test/e2e/test_provider_smoke.py`).
+- **Logs:** `cao logs [--server] [--terminal <id>] [-f] [-n N]` tails the latest `cao_*.log` (server) or a terminal's per-terminal log — read the truth without `grep`/`tail`. Launch/send failures now name the relevant log and point at `cao logs --server` + `cao doctor --live`.
+
+**Provider priority is `opencode_cli` (default) → `claude_code` → `codex`** (`PREFERRED_PROVIDERS` in `constants.py`). When no provider is explicitly chosen (no `--provider`, no profile `provider:`) and the default's CLI binary is missing, CAO downgrades to the first *installed* preferred provider and logs a warning — an explicit `--provider` (or a profile-declared `provider:`) is a deliberate choice and never downgrades (it errors loudly if absent).
+
+**Timeout knobs** (`settings.json` → `server`, defaults bumped): `mcp_request_timeout` (120s), `provider_init_timeout` (90s). Raise these if a slow provider keeps masquerading as a launch failure (`cao doctor --live` reports its real time-to-IDLE).
+
+**Driving agents:** prefer headless/async — `cao launch --headless --async` or `cao session send --async` — and attach via `tmux attach -t <session>` only to *observe/steer*, never as the control path (attaching mid-init can drop keystrokes; see issue #220). Pin providers explicitly (`--provider` or a profile `provider:`) for reproducible heterogeneous panels rather than relying on the install-aware default.
+
+## Web UI
+
+React + Vite + Tailwind in `web/`. The built bundle is a *build artifact* not committed to git — it lands in `src/cli_agent_orchestrator/web_ui/`. If `cao-server` returns `404 Not Found`, the bundle is missing: `cd web && npm install && npm run build`, then `uv tool install --reinstall .`. Dev mode: `npm run dev` (port 5173, proxies API to `:9889`). Node is only needed for frontend work — pure-Python usage installs from the wheel.
+
+## Architecture
+
+The system is **event-driven** around a central pub/sub `event_bus` with wildcard topic matching. The canonical pipeline:
+
+```
+tmux pane → FIFO (named pipe) → fifo_reader → publishes terminal.{id}.output
+                                                  ├─ status_monitor → terminal.{id}.status (parses TUI to derive IDLE/PROCESSING/COMPLETED/ERROR)
+                                                  ├─ log_writer → debug logs
+                                                  └─ inbox_service (consumes .status) → delivers queued messages when terminal goes IDLE/COMPLETED
+```
+
+Request flow is layered: **entry points** (CLI / MCP servers) → **FastAPI HTTP API** (`api/main.py`, port 9889) → **services** (business logic) → **clients** (`tmux`, `database`/SQLite) and **providers** (per-CLI integration). The CLI commands and MCP tools are thin packagings of the REST API — there is one source of truth (the API), three control planes on top.
+
+Key directories under `src/cli_agent_orchestrator/`:
+- `api/` — FastAPI endpoints, the single backend surface. Localhost-only; validates `Host` header (DNS-rebinding guard).
+- `services/` — all business logic. event_bus, fifo_reader, status_monitor, inbox_service, terminal_service, session_service, flow_service (cron scheduling), memory_service (cross-session agent memory), install_service, plugin_dispatch.
+- `providers/` — one module per CLI (`claude_code.py`, `kiro_cli.py`, `codex.py`, …). Each subclasses `base.py` and teaches CAO that CLI's prompt detection, ready/trust-prompt handling, command construction, and tool-restriction translation. **This is where most provider-specific bugs live** — TUI output parsing is fragile and version-sensitive.
+- `backends/` — abstraction over the session runtime: `tmux_backend.py` (default) vs `herdr_backend.py` (experimental, agent-aware, event-based instead of output polling). Selected via `factory.py`/`registry.py`.
+- `clients/` — `tmux.py` (sets `CAO_TERMINAL_ID`, send_keys / bracketed-paste) and `database.py` (SQLite: terminals + inbox_messages).
+- `mcp_server/` — `cao-mcp-server`: tools for agents *inside* a session (`handoff`, `assign`, `send_message`).
+- `ops_mcp_server/` — `cao-ops-mcp-server`: tools for a primary agent *outside* CAO to manage sessions (install/launch/monitor).
+- `cli/commands/` — `cao` subcommands (launch, session, shutdown, flow, install, skills, memory, terminal, env, info).
+- `plugins/` — observer-only extensions reacting to server events (outbound: Discord/Slack/webhooks, memory injection). Registered via `cao.plugins` entry points in pyproject.
+- `agent_store/` + `skills/` — bundled agent profiles (`.md` with frontmatter) and SKILL.md guides seeded into sessions.
+
+### Orchestration primitives (how agents coordinate)
+- **handoff** — synchronous: spawn a worker terminal, send task, block until COMPLETED, return output, then exit/delete the worker (scrollback snapshotted to `~/.aws/cli-agent-orchestrator/logs/` for `cao terminal restore`).
+- **assign** — async fire-and-forget: spawn worker, inject the caller's terminal id, return immediately; worker calls `send_message` back when done.
+- **send_message** — deliver to a terminal's inbox; held PENDING until the receiver is idle, then DELIVERED.
+
+Every terminal has a unique `CAO_TERMINAL_ID` env var — the server routes all messages and tracks status by this id.
+
+### State and home dir
+Runtime state lives under `~/.aws/cli-agent-orchestrator/` (`CAO_HOME_DIR`): `db/` (SQLite), `logs/`, `fifos/` (named pipes), `agent-store/`, `skills/`, `memory/`. Port and paths are in `constants.py`; port overridable via `CAO_API_PORT`.
+
+## Conventions & gotchas
+
+- **black line-length 100, isort profile=black.** mypy config is in `mypy.ini` (note: `pyproject.toml` also has a `[tool.mypy]` block — `mypy.ini` is the effective per-module config with targeted error-code suppressions for SQLAlchemy/CLI/MCP modules).
+- Adding a provider: implement a `providers/<name>.py` subclass of `base.py`, register it, add a `valid` provider value, and add `test_<name>_unit.py` (fixture-driven) + optionally `_integration.py`. Provider unit tests run in dedicated path-triggered CI workflows.
+- **Q CLI is slated for deprecation** — don't build new workflows on it; default to Kiro CLI, Claude Code, or Codex.
+- Behavior is heavily configurable via `CAO_*` env vars (e.g. `CAO_ENABLE_WORKING_DIRECTORY`, `CAO_ENABLE_SENDER_ID_INJECTION`); see `docs/settings.md`.
+- Deep-dive docs live in `docs/` (one per provider, plus `event-driven-architecture.md`, `control-planes.md`, `terminal-lifecycle.md`, `tool-restrictions.md`, `memory.md`, `flows.md`). `CODEBASE.md` has the original architecture diagrams (slightly behind current dir layout). `DEVELOPMENT.md` is the full dev/test reference.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -275,7 +275,7 @@ class CreateFlowRequest(BaseModel):
     name: str
     schedule: str
     agent_profile: str
-    provider: str = "kiro_cli"
+    provider: str = DEFAULT_PROVIDER
     prompt_template: str
 
     @field_validator("name")
@@ -518,25 +518,20 @@ async def install_agent_profile_endpoint(request: InstallAgentProfileRequest) ->
 @app.get("/agents/providers")
 async def list_providers_endpoint() -> List[Dict]:
     """List available providers with installation status."""
-    import shutil
+    from cli_agent_orchestrator.utils.providers import (
+        PROVIDER_BINARIES,
+        provider_binary_installed,
+    )
 
-    provider_binaries = {
-        "kiro_cli": "kiro-cli",
-        "claude_code": "claude",
-        "q_cli": "q",
-        "codex": "codex",
-        "gemini_cli": "gemini",
-        "hermes": "hermes",
-        "kimi_cli": "kimi",
-        "copilot_cli": "copilot",
-        "opencode_cli": "opencode",
-        "cursor_cli": "agent",
-        "antigravity_cli": "agy",
-    }
     result = []
-    for provider, binary in provider_binaries.items():
-        installed = shutil.which(binary) is not None
-        result.append({"name": provider, "binary": binary, "installed": installed})
+    for provider, binary in PROVIDER_BINARIES.items():
+        result.append(
+            {
+                "name": provider,
+                "binary": binary,
+                "installed": provider_binary_installed(provider),
+            }
+        )
     return result
 
 
@@ -800,7 +795,9 @@ async def create_terminal_in_session(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     try:
         if provider is None:
-            resolved_provider = resolve_provider(agent_profile, fallback_provider="kiro_cli")
+            resolved_provider = resolve_provider(
+                agent_profile, fallback_provider=DEFAULT_PROVIDER, install_aware=True
+            )
         else:
             resolved_provider = provider
 

--- a/src/cli_agent_orchestrator/cli/commands/doctor.py
+++ b/src/cli_agent_orchestrator/cli/commands/doctor.py
@@ -1,0 +1,200 @@
+"""``cao doctor`` — tiered health check for a CAO install.
+
+Static tier (``cao doctor``): no agents spawned, no token cost. Reports whether
+the server is reachable, which preferred providers have their CLI binary
+installed, which agent profiles are discoverable, and the effective server
+timeouts.
+
+Live tier (``cao doctor --live``): for each installed preferred provider, spawn
+a throwaway session via the API, assert it reaches IDLE within
+``provider_init_timeout``, report time-to-IDLE, then exit + delete it. This
+spawns REAL agents and therefore costs tokens — it is the manual twin of the
+opt-in e2e provider smoke test.
+"""
+
+import time
+
+import click
+import requests
+
+from cli_agent_orchestrator.constants import (
+    API_BASE_URL,
+    PREFERRED_PROVIDERS,
+    SERVER_HOST,
+    SERVER_PORT,
+)
+from cli_agent_orchestrator.services.settings_service import get_server_settings
+from cli_agent_orchestrator.utils.providers import provider_binary, provider_binary_installed
+from cli_agent_orchestrator.utils.server_process import health, read_pidfile
+
+_OK = click.style("✓", fg="green")
+_BAD = click.style("✗", fg="red")
+
+
+def _mark(ok: bool) -> str:
+    return _OK if ok else _BAD
+
+
+@click.command()
+@click.option(
+    "--live",
+    is_flag=True,
+    help="Spawn a throwaway agent per installed provider to confirm it reaches IDLE. "
+    "Costs tokens (real agents).",
+)
+@click.option(
+    "--provider",
+    "only_provider",
+    default=None,
+    help="Limit --live checks to a single provider.",
+)
+def doctor(live, only_provider):
+    """Diagnose a CAO install (static checks; --live spawns real agents)."""
+    _static_report()
+    if live:
+        _live_report(only_provider)
+
+
+def _static_report() -> None:
+    click.echo(click.style("CAO doctor — static checks", bold=True))
+    click.echo("")
+
+    # 1. Server reachability
+    info = health()
+    pid = read_pidfile()
+    if info is not None:
+        pid_str = f" (pid {pid})" if pid else ""
+        click.echo(f"{_mark(True)} server: running on {SERVER_HOST}:{SERVER_PORT}{pid_str}")
+        components = info.get("components") or {}
+        for name, state in components.items():
+            click.echo(f"    {_mark(state == 'ok')} {name}: {state}")
+    else:
+        click.echo(f"{_mark(False)} server: not reachable on {SERVER_HOST}:{SERVER_PORT}")
+        click.echo("    Start it with: cao server start")
+
+    # 2. Preferred providers — binary install status
+    click.echo("")
+    click.echo("Providers (preferred order):")
+    for name in PREFERRED_PROVIDERS:
+        installed = provider_binary_installed(name)
+        binary = provider_binary(name) or "?"
+        click.echo(f"    {_mark(installed)} {name} ({binary})")
+
+    # 3. Discoverable agent profiles
+    click.echo("")
+    profiles = _list_profiles(info is not None)
+    if profiles is None:
+        click.echo(f"{_mark(False)} profiles: could not query (server unreachable)")
+    else:
+        click.echo(f"{_mark(bool(profiles))} profiles: {len(profiles)} discoverable")
+        for p in profiles[:10]:
+            click.echo(f"      - {p.get('name')} [{p.get('source', '?')}]")
+        if len(profiles) > 10:
+            click.echo(f"      ... and {len(profiles) - 10} more")
+
+    # 4. Effective server timeouts
+    click.echo("")
+    settings = get_server_settings()
+    click.echo("Effective server settings:")
+    click.echo(f"      mcp_request_timeout:    {settings['mcp_request_timeout']}s")
+    click.echo(f"      provider_init_timeout:  {settings['provider_init_timeout']}s")
+    click.echo(
+        f"      startup_prompt_handler_timeout: {settings['startup_prompt_handler_timeout']}s"
+    )
+
+
+def _list_profiles(server_up: bool):
+    """Return discoverable profiles via the API, or None on failure."""
+    if not server_up:
+        return None
+    try:
+        resp = requests.get(f"{API_BASE_URL}/agents/profiles", timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.RequestException:
+        return None
+
+
+def _live_report(only_provider) -> None:
+    click.echo("")
+    click.echo(
+        click.style("CAO doctor — live checks (spawns real agents, costs tokens)", bold=True)
+    )
+
+    if not health():
+        raise click.ClickException(
+            "Server not reachable — cannot run --live checks. Start it with: cao server start"
+        )
+
+    targets = [only_provider] if only_provider else list(PREFERRED_PROVIDERS)
+    init_timeout = get_server_settings()["provider_init_timeout"]
+
+    for provider in targets:
+        if not provider_binary_installed(provider):
+            click.echo(f"{_mark(False)} {provider}: binary not installed — skipping")
+            continue
+        click.echo(f"  {provider}: spawning throwaway session...")
+        ok, elapsed, detail = _probe_provider(provider, init_timeout)
+        if ok:
+            click.echo(f"{_mark(True)} {provider}: reached IDLE in {elapsed:.1f}s")
+        else:
+            click.echo(f"{_mark(False)} {provider}: {detail}")
+
+
+def _probe_provider(provider: str, init_timeout: float):
+    """Create a throwaway session, wait for IDLE, then clean up.
+
+    Returns (ok, elapsed_seconds, detail).
+    """
+    session_name = f"doctor-{provider}-{int(time.time())}"
+    terminal_id = None
+    actual_session = session_name
+    start = time.time()
+    try:
+        resp = requests.post(
+            f"{API_BASE_URL}/sessions",
+            params={
+                "provider": provider,
+                "agent_profile": "code_supervisor",
+                "session_name": session_name,
+            },
+            timeout=init_timeout + 30,
+        )
+        if resp.status_code not in (200, 201):
+            return False, 0.0, f"session creation failed: {resp.status_code} {resp.text[:200]}"
+        data = resp.json()
+        terminal_id = data["id"]
+        actual_session = data["session_name"]
+
+        deadline = time.time() + init_timeout
+        while time.time() < deadline:
+            status = _terminal_status(terminal_id)
+            if status == "idle":
+                return True, time.time() - start, ""
+            if status == "error":
+                return False, time.time() - start, "terminal reported ERROR"
+            time.sleep(2)
+        return False, time.time() - start, f"did not reach IDLE within {init_timeout:.0f}s"
+    except requests.exceptions.RequestException as e:
+        return False, time.time() - start, f"request failed: {e}"
+    finally:
+        if terminal_id is not None:
+            try:
+                requests.post(f"{API_BASE_URL}/terminals/{terminal_id}/exit", timeout=10)
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(1)
+        try:
+            requests.delete(f"{API_BASE_URL}/sessions/{actual_session}", timeout=10)
+        except requests.exceptions.RequestException:
+            pass
+
+
+def _terminal_status(terminal_id: str) -> str:
+    try:
+        resp = requests.get(f"{API_BASE_URL}/terminals/{terminal_id}", timeout=10)
+        if resp.status_code != 200:
+            return "unknown"
+        return str(resp.json().get("status", "unknown"))
+    except requests.exceptions.RequestException:
+        return "unknown"

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -144,6 +144,11 @@ def _parse_env_pairs(pairs):
     "the URL. Blocked prefixes (CLAUDE/CODEX_/__MISE_) and >=2048-byte values "
     "are rejected. See issue #248.",
 )
+@click.option(
+    "--no-auto-start",
+    is_flag=True,
+    help="Do not auto-start cao-server if it is not running (fail instead).",
+)
 def launch(
     message,
     agents,
@@ -157,6 +162,7 @@ def launch(
     working_directory,
     memory,
     env_pairs,
+    no_auto_start,
 ):
     """Launch cao session with specified agent profile."""
     try:
@@ -205,7 +211,7 @@ def launch(
         if provider is None:
             from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
 
-            provider = resolve_provider(agents, DEFAULT_PROVIDER)
+            provider = resolve_provider(agents, DEFAULT_PROVIDER, install_aware=True)
 
         # Validate provider
         if provider not in PROVIDERS:
@@ -267,6 +273,26 @@ def launch(
                 )
                 if not auto_approve and not click.confirm("Proceed?", default=True):
                     raise click.ClickException("Launch cancelled by user")
+
+        # Auto-start the daemon so the common path never requires a separate
+        # ``cao-server`` terminal. Opt out with --no-auto-start. See rec #1.
+        from cli_agent_orchestrator.utils.server_process import (
+            is_server_running,
+            start_server_detached,
+        )
+
+        if not is_server_running():
+            if no_auto_start:
+                raise click.ClickException(
+                    "cao-server is not running and --no-auto-start was given. "
+                    "Start it with: cao server start"
+                )
+            click.echo("cao-server not running — starting it...")
+            try:
+                start_server_detached()
+            except RuntimeError as e:
+                raise click.ClickException(f"Failed to auto-start cao-server: {e}")
+            click.echo("cao-server started.")
 
         # Call API to create session — pass working_directory only if explicitly
         # provided. When omitted, the server defaults to its own CWD.
@@ -360,8 +386,15 @@ def launch(
                 click.echo(output)
 
     except requests.exceptions.RequestException as e:
-        raise click.ClickException(f"Failed to connect to cao-server: {str(e)}")
+        raise click.ClickException(_enrich_server_error(e))
     except click.ClickException:
         raise
     except Exception as e:
         raise click.ClickException(str(e))
+
+
+def _enrich_server_error(exc: Exception) -> str:
+    """Build a launch-failure message that points at the server log."""
+    from cli_agent_orchestrator.utils.server_process import server_error_hint
+
+    return f"Failed to connect to cao-server: {exc}\n{server_error_hint()}"

--- a/src/cli_agent_orchestrator/cli/commands/logs.py
+++ b/src/cli_agent_orchestrator/cli/commands/logs.py
@@ -1,0 +1,79 @@
+"""``cao logs`` — read CAO logs without leaving the tool.
+
+Replaces hand-rolled ``grep``/``tail`` over ``~/.aws/cli-agent-orchestrator/logs``.
+``--server`` (default) tails the latest ``cao_*.log``; ``--terminal <id>`` tails
+that terminal's per-terminal log.
+"""
+
+import time
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from cli_agent_orchestrator.constants import TERMINAL_LOG_DIR
+from cli_agent_orchestrator.utils.logging import latest_server_log_path
+
+# Number of trailing lines printed by default (without --follow).
+_TAIL_LINES = 200
+
+
+def _print_tail(path: Path, lines: int) -> None:
+    """Print the last ``lines`` lines of ``path``."""
+    try:
+        content = path.read_text(errors="replace").splitlines()
+    except OSError as e:
+        raise click.ClickException(f"Could not read {path}: {e}")
+    for line in content[-lines:]:
+        click.echo(line)
+
+
+def _follow(path: Path) -> None:
+    """Stream new lines appended to ``path`` (tail -f), until Ctrl-C."""
+    try:
+        with path.open("r", errors="replace") as fh:
+            fh.seek(0, 2)  # end of file
+            while True:
+                line = fh.readline()
+                if line:
+                    click.echo(line.rstrip("\n"))
+                else:
+                    time.sleep(0.5)
+    except KeyboardInterrupt:
+        pass
+    except OSError as e:
+        raise click.ClickException(f"Could not follow {path}: {e}")
+
+
+@click.command()
+@click.option("--server", "server", is_flag=True, help="Tail the latest server log (default).")
+@click.option("--terminal", "terminal_id", default=None, help="Tail a specific terminal's log.")
+@click.option("--follow", "-f", is_flag=True, help="Follow the log (tail -f).")
+@click.option(
+    "--lines",
+    "-n",
+    default=_TAIL_LINES,
+    show_default=True,
+    help="Number of trailing lines to print (ignored with --follow start).",
+)
+def logs(server, terminal_id, follow, lines):
+    """Print or follow CAO logs (server log by default)."""
+    path: Optional[Path]
+    if terminal_id:
+        path = TERMINAL_LOG_DIR / f"{terminal_id}.log"
+        if not path.exists():
+            raise click.ClickException(
+                f"No log for terminal {terminal_id} at {path}. " "Has it produced output yet?"
+            )
+    else:
+        # --server is the default even when the flag is omitted.
+        path = latest_server_log_path()
+        if path is None:
+            raise click.ClickException(
+                "No server logs found. Start the server with: cao server start"
+            )
+
+    click.echo(click.style(f"# {path}", dim=True))
+    _print_tail(path, lines)
+    if follow:
+        _follow(path)

--- a/src/cli_agent_orchestrator/cli/commands/server.py
+++ b/src/cli_agent_orchestrator/cli/commands/server.py
@@ -1,0 +1,128 @@
+"""``cao server`` — manage the background cao-server daemon without leaving cao.
+
+The daemon is a single FastAPI process (``cao-server``); the CLI, MCP servers,
+and Web UI are all thin REST clients of it. These subcommands fold the manual
+start/stop/restart/status steps (previously done with ``cao-server`` by hand,
+``ss -ltnp`` to find the PID, and ``kill`` to restart) back under ``cao``.
+"""
+
+import click
+
+from cli_agent_orchestrator.constants import (
+    SERVER_HOST,
+    SERVER_PIDFILE,
+    SERVER_PORT,
+    SERVER_VERSION,
+)
+from cli_agent_orchestrator.utils.server_process import (
+    clear_pidfile,
+    health,
+    is_server_running,
+    read_pidfile,
+    start_server_detached,
+    stop_server,
+)
+
+
+@click.group()
+def server():
+    """Manage the cao-server background daemon."""
+
+
+@server.command("start")
+@click.option("--host", default=None, help=f"Server host (default: {SERVER_HOST})")
+@click.option("--port", default=None, type=int, help=f"Server port (default: {SERVER_PORT})")
+@click.option(
+    "--foreground",
+    is_flag=True,
+    help="Run cao-server in the foreground (blocking) instead of detaching.",
+)
+def start(host, port, foreground):
+    """Start the cao-server daemon (no-op if already running)."""
+    # Single-instance guard: if /health already answers, report and exit 0.
+    if is_server_running():
+        pid = read_pidfile()
+        pid_str = f" (pid {pid})" if pid else ""
+        click.echo(f"cao-server already running on {SERVER_HOST}:{SERVER_PORT}{pid_str}")
+        return
+
+    if foreground:
+        # Defer to the real entry point in-process so the user gets live logs.
+        import sys
+
+        from cli_agent_orchestrator.api.main import main as server_main
+
+        argv = ["cao-server"]
+        if host:
+            argv += ["--host", host]
+        if port:
+            argv += ["--port", str(port)]
+        sys.argv = argv
+        server_main()
+        return
+
+    try:
+        pid = start_server_detached(host=host, port=port)
+    except RuntimeError as e:
+        raise click.ClickException(str(e))
+
+    click.echo(f"cao-server started on {host or SERVER_HOST}:{port or SERVER_PORT} (pid {pid})")
+
+
+@server.command("stop")
+def stop():
+    """Stop the running cao-server daemon."""
+    if not is_server_running() and read_pidfile() is None:
+        click.echo("cao-server is not running.")
+        clear_pidfile()
+        return
+
+    if stop_server():
+        click.echo("cao-server stopped.")
+    else:
+        raise click.ClickException(
+            "Failed to stop cao-server — it may still be running. "
+            f"Check the pidfile at {SERVER_PIDFILE}."
+        )
+
+
+@server.command("restart")
+@click.option("--host", default=None, help=f"Server host (default: {SERVER_HOST})")
+@click.option("--port", default=None, type=int, help=f"Server port (default: {SERVER_PORT})")
+def restart(host, port):
+    """Restart the cao-server daemon (stop, then start)."""
+    if is_server_running() or read_pidfile() is not None:
+        if not stop_server():
+            raise click.ClickException("Failed to stop the running cao-server before restart.")
+        click.echo("cao-server stopped.")
+    try:
+        pid = start_server_detached(host=host, port=port)
+    except RuntimeError as e:
+        raise click.ClickException(str(e))
+    click.echo(f"cao-server restarted on {host or SERVER_HOST}:{port or SERVER_PORT} (pid {pid})")
+
+
+@server.command("status")
+def status():
+    """Show whether the cao-server daemon is running and its health."""
+    info = health()
+    pid = read_pidfile()
+    if info is None:
+        click.echo("cao-server: not running")
+        if pid is not None:
+            click.echo(f"  (stale pidfile {SERVER_PIDFILE} → pid {pid})")
+        return
+
+    click.echo(f"cao-server: running on {SERVER_HOST}:{SERVER_PORT}")
+    if pid is not None:
+        click.echo(f"  pid:     {pid}")
+    click.echo(f"  version: {SERVER_VERSION}")
+    backend = info.get("terminal_backend")
+    if backend:
+        click.echo(f"  backend: {backend}")
+    components = info.get("components") or {}
+    if components:
+        click.echo("  components:")
+        for name, state in components.items():
+            mark = "✓" if state == "ok" else "✗"
+            click.echo(f"    {mark} {name}: {state}")

--- a/src/cli_agent_orchestrator/cli/commands/session.py
+++ b/src/cli_agent_orchestrator/cli/commands/session.py
@@ -230,7 +230,9 @@ def send(session_name, message, terminal_id, is_async, timeout):
         )
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        raise click.ClickException(f"Failed to connect to cao-server: {e}")
+        from cli_agent_orchestrator.utils.server_process import server_error_hint
+
+        raise click.ClickException(f"Failed to connect to cao-server: {e}\n{server_error_hint()}")
 
     if is_async:
         click.echo(f"Message sent to terminal {target_id}")

--- a/src/cli_agent_orchestrator/cli/main.py
+++ b/src/cli_agent_orchestrator/cli/main.py
@@ -2,14 +2,17 @@
 
 import click
 
+from cli_agent_orchestrator.cli.commands.doctor import doctor
 from cli_agent_orchestrator.cli.commands.env import env
 from cli_agent_orchestrator.cli.commands.flow import flow
 from cli_agent_orchestrator.cli.commands.info import info
 from cli_agent_orchestrator.cli.commands.init import init
 from cli_agent_orchestrator.cli.commands.install import install
 from cli_agent_orchestrator.cli.commands.launch import launch
+from cli_agent_orchestrator.cli.commands.logs import logs
 from cli_agent_orchestrator.cli.commands.mcp_server import mcp_server
 from cli_agent_orchestrator.cli.commands.memory import memory
+from cli_agent_orchestrator.cli.commands.server import server
 from cli_agent_orchestrator.cli.commands.session import session
 from cli_agent_orchestrator.cli.commands.shutdown import shutdown
 from cli_agent_orchestrator.cli.commands.skills import skills
@@ -36,6 +39,9 @@ cli.add_command(skills)
 cli.add_command(session)
 cli.add_command(terminal)
 cli.add_command(workflow)
+cli.add_command(server)
+cli.add_command(doctor)
+cli.add_command(logs)
 
 
 if __name__ == "__main__":

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -35,8 +35,15 @@ SESSION_PREFIX = "cao-"
 PROVIDERS = [p.value for p in ProviderType]
 
 # Default provider used when --provider flag is not specified
-# Kiro CLI is the recommended provider for new projects
-DEFAULT_PROVIDER = ProviderType.KIRO_CLI.value
+DEFAULT_PROVIDER = ProviderType.OPENCODE_CLI.value
+
+# Preferred provider order for CAO. Used by ``cao doctor`` as the target set to
+# health-check and by the install-aware default fallback: when no provider is
+# explicitly chosen and the resolved default's binary is missing, CAO downgrades
+# to the first *installed* provider in this list. Order is deliberate —
+# opencode_cli is the default, with claude_code and codex as the next-best
+# backstops.
+PREFERRED_PROVIDERS = ["opencode_cli", "claude_code", "codex"]
 
 # =============================================================================
 # Tmux Configuration
@@ -56,6 +63,10 @@ CAO_ENV_FILE = CAO_HOME_DIR / ".env"
 
 # SQLite database directory
 DB_DIR = CAO_HOME_DIR / "db"
+
+# Pidfile written by ``cao server start`` so ``cao server stop/status`` can find
+# the detached ``cao-server`` daemon without scanning the process table.
+SERVER_PIDFILE = CAO_HOME_DIR / "server.pid"
 
 # Log file directory structure
 LOG_DIR = CAO_HOME_DIR / "logs"
@@ -194,7 +205,10 @@ SERVER_VERSION = "0.1.0"
 API_BASE_URL = f"http://{SERVER_HOST}:{SERVER_PORT}"
 
 # Default timeout (seconds) for HTTP calls to the CAO API server.
-MCP_REQUEST_TIMEOUT = 30
+# NOTE: the live, operator-tunable value lives in settings_service._SERVER_DEFAULTS
+# ("mcp_request_timeout") and is read via get_server_settings(). This constant is
+# a static fallback kept in sync with that default.
+MCP_REQUEST_TIMEOUT = 120
 
 
 # Operators can extend network allowlists via the env vars handled below.

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -99,8 +99,17 @@ GET_STATUS_COMPLETION_PATTERN = r"[✶✢✽✻✳][^\n…]*\bfor\b"
 # lines are tolerated (not arbitrary content), so a "❯ my task" echo or a
 # "⏺ response"/compaction line between separators still cannot match, and the
 # {0,2} bound keeps the match local so it cannot span two distinct separators.
+#
+# Claude Code 2.1+ renders dynamic GHOST PLACEHOLDER text on the empty input
+# line, e.g. ``❯ Try "how does projects.ts work?"``. It is shown only before any
+# input is typed/pasted, so it is present exactly when we probe for the initial
+# ready prompt. The optional ``(?:Try [^\n]*)?`` tolerates that placeholder while
+# still rejecting a real echoed task (a pasted brief does not begin with "Try "),
+# so the box stays "essentially empty". Without this the ready prompt is never
+# detected on 2.1, initialize() times out, and the first task is never delivered
+# (ISS-012).
 NEW_TUI_BOX_PATTERN = re.compile(
-    r"─{8,}[^\n]*\n(?:[ \t\xa0]*\n){0,2}[ \t]*[>❯][ \t\xa0]*\n(?:[ \t\xa0]*\n){0,2}[ \t]*─{8,}",
+    r"─{8,}[^\n]*\n(?:[ \t\xa0]*\n){0,2}[ \t]*[>❯][ \t\xa0]*(?:Try [^\n]*)?\n(?:[ \t\xa0]*\n){0,2}[ \t]*─{8,}",
     re.MULTILINE,
 )
 # Live spinner in the new TUI: spinner glyph + a gerund ("…ing") + the … ellipsis,

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -74,6 +74,17 @@ class OpenCodeCliProvider(BaseProvider):
         _model: Optional model override (e.g. ``anthropic/claude-sonnet-4-6``)
     """
 
+    # Opt in to pyte-rendered status detection (gated by CAO_PYTE_STATUS).
+    # OpenCode's TUI draws its footer with absolute cursor moves, so the idle
+    # anchor renders as separate tokens in the raw byte stream ("ctrl+p" and
+    # "commands" are never contiguous there) and IDLE_FOOTER_PATTERN never
+    # matches — the agent looks like it never reaches IDLE and initialize()
+    # times out. A composited pyte viewport resolves the cursor moves so the
+    # footer reads "ctrl+p commands" on one line. The existing get_status logic
+    # already operates on a newline-joined string, so the base-class default
+    # get_status_from_screen (join rows -> get_status) is the correct detector.
+    supports_screen_detection = True
+
     def __init__(
         self,
         terminal_id: str,

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -24,7 +24,7 @@ from typing import Dict, List
 
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import list_terminals_by_session
-from cli_agent_orchestrator.constants import SESSION_PREFIX
+from cli_agent_orchestrator.constants import DEFAULT_PROVIDER, SESSION_PREFIX
 from cli_agent_orchestrator.models.terminal import Terminal
 from cli_agent_orchestrator.plugins import (
     PluginRegistry,
@@ -55,7 +55,9 @@ async def create_session(
     in the same session inherits them. See issue #248.
     """
     if provider is None:
-        resolved_provider = resolve_provider(agent_profile, fallback_provider="kiro_cli")
+        resolved_provider = resolve_provider(
+            agent_profile, fallback_provider=DEFAULT_PROVIDER, install_aware=True
+        )
     else:
         resolved_provider = provider
 

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -69,9 +69,9 @@ def set_agent_dirs(dirs: Dict[str, str]) -> Dict[str, str]:
 
 # Default server tuning values
 _SERVER_DEFAULTS = {
-    "mcp_request_timeout": 30,
+    "mcp_request_timeout": 120,
     "event_bus_max_queue_size": 1024,
-    "provider_init_timeout": 60,
+    "provider_init_timeout": 90,
     "startup_prompt_handler_timeout": 20,
 }
 
@@ -84,9 +84,9 @@ def get_server_settings() -> Dict[str, Any]:
     """Get server tuning settings (cached; re-reads only when file changes).
 
     Returns a dict with the following keys (defaults shown):
-      - mcp_request_timeout (30): Seconds to wait for MCP HTTP calls
+      - mcp_request_timeout (120): Seconds to wait for MCP HTTP calls
       - event_bus_max_queue_size (1024): Max events buffered per subscriber
-      - provider_init_timeout (60): Seconds to wait for a CLI agent to reach IDLE
+      - provider_init_timeout (90): Seconds to wait for a CLI agent to reach IDLE
       - startup_prompt_handler_timeout (20): Seconds to handle startup prompts
         (e.g., workspace trust dialogs) before giving up
 
@@ -95,9 +95,9 @@ def get_server_settings() -> Dict[str, Any]:
 
         {
           "server": {
-            "mcp_request_timeout": 120,
+            "mcp_request_timeout": 180,
             "event_bus_max_queue_size": 8192,
-            "provider_init_timeout": 90,
+            "provider_init_timeout": 120,
             "startup_prompt_handler_timeout": 5
           }
         }

--- a/src/cli_agent_orchestrator/utils/agent_profiles.py
+++ b/src/cli_agent_orchestrator/utils/agent_profiles.py
@@ -229,7 +229,53 @@ def load_agent_profile(agent_name: str) -> AgentProfile:
         raise RuntimeError(f"Failed to load agent profile '{agent_name}': {e}")
 
 
-def resolve_provider(agent_profile_name: str, fallback_provider: str) -> str:
+def _install_aware_fallback(fallback_provider: str) -> str:
+    """Downgrade an uninstalled default provider to the first installed one.
+
+    This applies ONLY on the implicit-default path (no ``--provider``, no
+    profile ``provider:``). When the resolved default's CLI binary is missing,
+    a launch would fail with an opaque init error; instead we pick the first
+    *installed* provider from ``PREFERRED_PROVIDERS`` and log a clear warning.
+
+    An explicit ``--provider`` must never reach here — that path is expected to
+    error loudly if its binary is absent, so substitution stays surprising-free.
+    """
+    from cli_agent_orchestrator.constants import PREFERRED_PROVIDERS
+    from cli_agent_orchestrator.utils.providers import (
+        installed_providers,
+        provider_binary_installed,
+    )
+
+    if provider_binary_installed(fallback_provider):
+        return fallback_provider
+
+    for candidate in PREFERRED_PROVIDERS:
+        if candidate != fallback_provider and provider_binary_installed(candidate):
+            logger.warning(
+                "Default provider '%s' is not installed (binary missing); "
+                "downgrading to '%s'. Install '%s' or pass --provider to override.",
+                fallback_provider,
+                candidate,
+                fallback_provider,
+            )
+            return candidate
+
+    # Nothing installed — keep the original default; provider.initialize() will
+    # surface a clear error naming the missing binary.
+    installed = installed_providers()
+    logger.warning(
+        "Default provider '%s' is not installed and no preferred provider is "
+        "available (installed: %s). Proceeding with '%s'; the launch will likely fail.",
+        fallback_provider,
+        installed or "none",
+        fallback_provider,
+    )
+    return fallback_provider
+
+
+def resolve_provider(
+    agent_profile_name: str, fallback_provider: str, install_aware: bool = False
+) -> str:
     """Resolve the provider to use for an agent profile.
 
     Loads the agent profile from the CAO agent store and checks for a
@@ -241,19 +287,33 @@ def resolve_provider(agent_profile_name: str, fallback_provider: str) -> str:
         agent_profile_name: Name of the agent profile to look up.
         fallback_provider: Provider to use when the profile does not specify
             one or specifies an invalid value.
+        install_aware: When True, the *fallback* branch (no profile provider)
+            applies an install-aware downgrade: if the fallback's CLI binary is
+            missing, swap to the first installed provider in
+            ``PREFERRED_PROVIDERS``. Enabled only on the implicit-default path
+            (``DEFAULT_PROVIDER``); the handoff/assign inheritance path leaves
+            it False so a worker keeps the supervisor's (running, installed)
+            provider verbatim. A profile-declared provider is a deliberate
+            choice and is never downgraded.
 
     Returns:
         Resolved provider type string.
     """
+
+    def _fallback() -> str:
+        return _install_aware_fallback(fallback_provider) if install_aware else fallback_provider
+
     try:
         profile = load_agent_profile(agent_profile_name)
     except (FileNotFoundError, RuntimeError):
         # Profile not found or failed to load — provider.initialize()
         # will surface a clear error later.  Fall back for now.
-        return fallback_provider
+        return _fallback()
 
     if profile.provider:
         if profile.provider in PROVIDERS:
+            # A profile-declared provider is a deliberate choice — honour it
+            # without install-aware downgrade (like an explicit --provider).
             return profile.provider
         else:
             logger.warning(
@@ -265,4 +325,4 @@ def resolve_provider(agent_profile_name: str, fallback_provider: str) -> str:
                 fallback_provider,
             )
 
-    return fallback_provider
+    return _fallback()

--- a/src/cli_agent_orchestrator/utils/logging.py
+++ b/src/cli_agent_orchestrator/utils/logging.py
@@ -1,6 +1,8 @@
 import logging
 import os
 from datetime import datetime
+from pathlib import Path
+from typing import Optional
 
 from cli_agent_orchestrator.constants import LOG_DIR
 
@@ -23,3 +25,19 @@ def setup_logging() -> None:
     print(f"Server logs: {log_file}")
     print("For debug logs: export CAO_LOG_LEVEL=DEBUG && cao-server")
     logging.info(f"Logging to: {log_file}")
+
+
+def latest_server_log_path() -> Optional[Path]:
+    """Return the most recently modified ``cao_*.log`` in LOG_DIR, or None.
+
+    Used to point error messages at the server log that explains a failure
+    (e.g. a launch that 500s on provider init) so users can read the truth
+    without leaving ``cao``.
+    """
+    try:
+        logs = list(LOG_DIR.glob("cao_*.log"))
+    except OSError:
+        return None
+    if not logs:
+        return None
+    return max(logs, key=lambda p: p.stat().st_mtime)

--- a/src/cli_agent_orchestrator/utils/providers.py
+++ b/src/cli_agent_orchestrator/utils/providers.py
@@ -1,0 +1,48 @@
+"""Shared provider-installation helpers.
+
+Single source of truth for the provider → CLI-binary mapping and the
+``shutil.which`` installation check. Both the ``/agents/providers`` API
+endpoint and the install-aware default fallback (``resolve_provider``) consume
+this so the binary map never drifts between them.
+"""
+
+import shutil
+from typing import Dict, List
+
+# Provider name → the executable looked up on PATH to decide "installed".
+# Keep in sync with the ProviderType enum; a provider absent here is treated as
+# "binary unknown" (reported uninstalled).
+PROVIDER_BINARIES: Dict[str, str] = {
+    "kiro_cli": "kiro-cli",
+    "claude_code": "claude",
+    "q_cli": "q",
+    "codex": "codex",
+    "gemini_cli": "gemini",
+    "hermes": "hermes",
+    "kimi_cli": "kimi",
+    "copilot_cli": "copilot",
+    "opencode_cli": "opencode",
+    "cursor_cli": "agent",
+    "antigravity_cli": "agy",
+}
+
+
+def provider_binary(name: str) -> str | None:
+    """Return the CLI binary name for a provider, or None if unknown."""
+    return PROVIDER_BINARIES.get(name)
+
+
+def provider_binary_installed(name: str) -> bool:
+    """Return True when the provider's CLI binary is present on PATH.
+
+    Unknown providers (no entry in ``PROVIDER_BINARIES``) return False.
+    """
+    binary = PROVIDER_BINARIES.get(name)
+    if binary is None:
+        return False
+    return shutil.which(binary) is not None
+
+
+def installed_providers() -> List[str]:
+    """Return the list of known providers whose CLI binary is on PATH."""
+    return [name for name in PROVIDER_BINARIES if provider_binary_installed(name)]

--- a/src/cli_agent_orchestrator/utils/server_process.py
+++ b/src/cli_agent_orchestrator/utils/server_process.py
@@ -1,0 +1,222 @@
+"""Process-lifecycle helpers for the detached ``cao-server`` daemon.
+
+These back the ``cao server`` subcommands and the ``cao launch`` auto-start
+path. The goal is to manage the background daemon without leaving ``cao``:
+probe ``/health`` to know if it is up, spawn the existing ``cao-server`` entry
+point detached, track its PID in a pidfile, and tear it down with SIGTERM.
+
+The ``cao-server`` binary itself is left untouched (it is referenced by MCP
+configs and the devcontainer); these helpers only wrap it.
+"""
+
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from cli_agent_orchestrator.constants import (
+    API_BASE_URL,
+    LOG_DIR,
+    SERVER_HOST,
+    SERVER_PIDFILE,
+    SERVER_PORT,
+)
+
+logger = logging.getLogger(__name__)
+
+# How long to wait for /health after spawning the daemon before giving up.
+_START_TIMEOUT_S = 30.0
+# How long to wait for /health to stop responding after SIGTERM.
+_STOP_TIMEOUT_S = 15.0
+
+
+def server_error_hint() -> str:
+    """Return a multi-line troubleshooting hint pointing at the server log.
+
+    A 500/timeout from the API rarely explains itself at the CLI; the
+    explanation is in the server log. Shared by ``cao launch`` and
+    ``cao session`` so a failed call names the latest ``cao_*.log`` plus the
+    commands that surface it. See rec #5.
+    """
+    from cli_agent_orchestrator.utils.logging import latest_server_log_path
+
+    hints = ["", "Troubleshooting:", "  - View the server log: cao logs --server"]
+    log_path = latest_server_log_path()
+    if log_path is not None:
+        hints.append(f"    (latest: {log_path})")
+    hints.append(
+        "  - If a provider is slow to initialize: cao doctor --live "
+        "and raise provider_init_timeout in settings.json"
+    )
+    return "\n".join(hints)
+
+
+def health(timeout: float = 2.0) -> Optional[dict]:
+    """Return the parsed ``/health`` JSON if the server answers, else None."""
+    try:
+        resp = requests.get(f"{API_BASE_URL}/health", timeout=timeout)
+    except requests.exceptions.RequestException:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def is_server_running(timeout: float = 2.0) -> bool:
+    """Return True when the server answers ``/health`` with 200."""
+    return health(timeout=timeout) is not None
+
+
+def read_pidfile() -> Optional[int]:
+    """Return the PID recorded in the pidfile, or None if absent/unreadable."""
+    try:
+        text = SERVER_PIDFILE.read_text().strip()
+    except (OSError, ValueError):
+        return None
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def write_pidfile(pid: int) -> None:
+    """Record ``pid`` in the pidfile (creating CAO_HOME_DIR if needed)."""
+    SERVER_PIDFILE.parent.mkdir(parents=True, exist_ok=True)
+    SERVER_PIDFILE.write_text(str(pid))
+
+
+def clear_pidfile() -> None:
+    """Remove the pidfile if present (best-effort)."""
+    try:
+        SERVER_PIDFILE.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.warning(f"Failed to remove pidfile {SERVER_PIDFILE}: {e}")
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if a process with ``pid`` exists (signal 0 probe)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _server_command(host: Optional[str], port: Optional[int]) -> list[str]:
+    """Build the argv that launches the ``cao-server`` entry point.
+
+    Prefers the installed ``cao-server`` console script; falls back to
+    ``python -m`` invocation of the same entry point so it works from a source
+    checkout where the script may not be on PATH.
+    """
+    cao_server = shutil.which("cao-server")
+    if cao_server:
+        cmd = [cao_server]
+    else:
+        cmd = [sys.executable, "-m", "cli_agent_orchestrator.api.main"]
+    if host:
+        cmd += ["--host", host]
+    if port:
+        cmd += ["--port", str(port)]
+    return cmd
+
+
+def _startup_log_path() -> Path:
+    """Path the detached daemon's stdout/stderr is redirected to."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    return LOG_DIR / "server-startup.log"
+
+
+def start_server_detached(
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    timeout: float = _START_TIMEOUT_S,
+) -> int:
+    """Spawn ``cao-server`` detached and wait for ``/health``.
+
+    Returns the child PID. Raises ``RuntimeError`` if the server does not
+    become healthy within ``timeout`` seconds. If a server is already running,
+    returns its recorded PID (or 0 if unknown) without spawning a second one.
+    """
+    if is_server_running():
+        return read_pidfile() or 0
+
+    cmd = _server_command(host, port)
+    startup_log = _startup_log_path()
+    # Open in append mode so successive starts keep history; the daemon
+    # detaches via start_new_session so it survives the parent CLI exiting.
+    log_fh = open(startup_log, "ab")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    finally:
+        log_fh.close()
+
+    write_pidfile(proc.pid)
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if is_server_running():
+            return proc.pid
+        # Bail early if the child died before becoming healthy.
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"cao-server exited during startup (code {proc.returncode}); " f"see {startup_log}"
+            )
+        time.sleep(0.5)
+
+    raise RuntimeError(
+        f"cao-server did not become healthy within {timeout:.0f}s; see {startup_log}"
+    )
+
+
+def stop_server(timeout: float = _STOP_TIMEOUT_S) -> bool:
+    """Stop the running server via SIGTERM to the pidfile PID.
+
+    Returns True if the server stopped (``/health`` no longer responds),
+    False if no PID was known or it could not be confirmed stopped.
+    """
+    pid = read_pidfile()
+    if pid is None:
+        # No pidfile — nothing we can target. Report based on health.
+        return not is_server_running()
+
+    if _pid_alive(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except PermissionError as e:
+            logger.warning(f"Not permitted to signal pid {pid}: {e}")
+            return False
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not is_server_running() and not _pid_alive(pid):
+            clear_pidfile()
+            return True
+        time.sleep(0.5)
+
+    return not is_server_running()

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cli_agent_orchestrator.api.main import app
+from cli_agent_orchestrator.constants import DEFAULT_PROVIDER
 from cli_agent_orchestrator.models.terminal import Terminal
 
 
@@ -648,7 +649,9 @@ class TestCrossProviderResolution:
 
             assert response.status_code == 201
             # Verify resolve_provider was called with the default fallback
-            mock_resolve.assert_called_once_with("developer", fallback_provider="kiro_cli")
+            mock_resolve.assert_called_once_with(
+                "developer", fallback_provider=DEFAULT_PROVIDER, install_aware=True
+            )
             # Verify terminal_service got the resolved provider
             call_kwargs = mock_svc.create_terminal.call_args.kwargs
             assert call_kwargs["provider"] == "claude_code"

--- a/test/cli/commands/test_doctor.py
+++ b/test/cli/commands/test_doctor.py
@@ -1,0 +1,133 @@
+"""Tests for the ``cao doctor`` command."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli_agent_orchestrator.cli.commands.doctor import doctor
+
+_DP = "cli_agent_orchestrator.cli.commands.doctor"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestDoctorStatic:
+    @patch(f"{_DP}.read_pidfile", return_value=4321)
+    @patch(
+        f"{_DP}.health",
+        return_value={"components": {"cao": "ok", "herdr": "unavailable"}},
+    )
+    @patch(f"{_DP}.provider_binary_installed", return_value=True)
+    @patch(f"{_DP}.provider_binary", return_value="opencode")
+    @patch(f"{_DP}.requests.get")
+    def test_static_table_assembly(self, mock_get, _binary, _installed, _health, _pid, runner):
+        """Static table shows server, providers, profiles, and timeouts."""
+        profiles_resp = MagicMock(status_code=200)
+        profiles_resp.json.return_value = [
+            {"name": "code_supervisor", "source": "built-in"},
+        ]
+        profiles_resp.raise_for_status.return_value = None
+        mock_get.return_value = profiles_resp
+
+        result = runner.invoke(doctor, [])
+
+        assert result.exit_code == 0
+        assert "static checks" in result.output
+        assert "server: running" in result.output
+        # Preferred providers listed
+        assert "opencode_cli" in result.output
+        assert "claude_code" in result.output
+        assert "codex" in result.output
+        # Profiles
+        assert "code_supervisor" in result.output
+        # Effective settings (new defaults)
+        assert "provider_init_timeout" in result.output
+
+    @patch(f"{_DP}.read_pidfile", return_value=None)
+    @patch(f"{_DP}.health", return_value=None)
+    @patch(f"{_DP}.provider_binary_installed", return_value=False)
+    @patch(f"{_DP}.provider_binary", return_value="opencode")
+    def test_static_server_down(self, _binary, _installed, _health, _pid, runner):
+        result = runner.invoke(doctor, [])
+
+        assert result.exit_code == 0
+        assert "not reachable" in result.output
+        assert "cao server start" in result.output
+
+
+class TestDoctorLive:
+    @patch(f"{_DP}.read_pidfile", return_value=None)
+    @patch(f"{_DP}.health", return_value=None)
+    @patch(f"{_DP}.provider_binary_installed", return_value=False)
+    @patch(f"{_DP}.provider_binary", return_value="opencode")
+    def test_live_requires_server(self, _binary, _installed, _health, _pid, runner):
+        result = runner.invoke(doctor, ["--live"])
+
+        assert result.exit_code != 0
+        assert "Server not reachable" in result.output
+
+    @patch(f"{_DP}.read_pidfile", return_value=4321)
+    @patch(f"{_DP}.health", return_value={"components": {}})
+    @patch(f"{_DP}.provider_binary", return_value="opencode")
+    @patch(f"{_DP}.provider_binary_installed")
+    @patch(f"{_DP}._probe_provider", return_value=(True, 4.2, ""))
+    def test_live_probes_installed_provider(
+        self, mock_probe, mock_installed, _binary, _health, _pid, runner
+    ):
+        """--live with a single installed provider reports time-to-IDLE."""
+        mock_installed.side_effect = lambda name: name == "opencode_cli"
+
+        result = runner.invoke(doctor, ["--live", "--provider", "opencode_cli"])
+
+        assert result.exit_code == 0
+        assert "reached IDLE in 4.2s" in result.output
+        mock_probe.assert_called_once()
+
+    @patch(f"{_DP}.read_pidfile", return_value=4321)
+    @patch(f"{_DP}.health", return_value={"components": {}})
+    @patch(f"{_DP}.provider_binary", return_value="opencode")
+    @patch(f"{_DP}.provider_binary_installed", return_value=False)
+    @patch(f"{_DP}._probe_provider")
+    def test_live_skips_uninstalled_provider(
+        self, mock_probe, _installed, _binary, _health, _pid, runner
+    ):
+        result = runner.invoke(doctor, ["--live", "--provider", "opencode_cli"])
+
+        assert result.exit_code == 0
+        assert "not installed" in result.output
+        mock_probe.assert_not_called()
+
+
+class TestProbeProvider:
+    @patch(f"{_DP}._terminal_status", return_value="idle")
+    @patch(f"{_DP}.requests")
+    def test_probe_success(self, mock_requests, _status):
+        from cli_agent_orchestrator.cli.commands.doctor import _probe_provider
+
+        # requests.exceptions must remain a real exception namespace for except.
+        mock_requests.exceptions = __import__("requests").exceptions
+        create_resp = MagicMock(status_code=201)
+        create_resp.json.return_value = {"id": "t1", "session_name": "doctor-x"}
+        mock_requests.post.return_value = create_resp
+
+        ok, elapsed, detail = _probe_provider("opencode_cli", init_timeout=10)
+
+        assert ok is True
+        assert detail == ""
+
+    @patch(f"{_DP}.requests")
+    def test_probe_create_failure(self, mock_requests):
+        from cli_agent_orchestrator.cli.commands.doctor import _probe_provider
+
+        mock_requests.exceptions = __import__("requests").exceptions
+        create_resp = MagicMock(status_code=500, text="boom")
+        mock_requests.post.return_value = create_resp
+
+        ok, _elapsed, detail = _probe_provider("opencode_cli", init_timeout=10)
+
+        assert ok is False
+        assert "session creation failed" in detail

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -7,6 +7,28 @@ import pytest
 from click.testing import CliRunner
 
 from cli_agent_orchestrator.cli.commands.launch import _parse_env_pairs, launch
+from cli_agent_orchestrator.constants import DEFAULT_PROVIDER
+
+
+@pytest.fixture(autouse=True)
+def _server_already_running():
+    """Treat cao-server as already up for all launch tests.
+
+    ``cao launch`` auto-starts the daemon when ``is_server_running()`` is False.
+    Stubbing it True keeps tests hermetic — they neither probe localhost nor
+    spawn a real ``cao-server`` — and leaves the mocked ``requests.get`` side
+    effects for the assertions that actually exercise them. Tests covering the
+    auto-start path itself override this locally.
+    """
+    with (
+        patch(
+            "cli_agent_orchestrator.utils.server_process.is_server_running",
+            return_value=True,
+        ),
+        patch("cli_agent_orchestrator.utils.server_process.start_server_detached"),
+    ):
+        yield
+
 
 # ── Backend auto-detection (issue #308) ──────────────────────────────
 
@@ -408,7 +430,7 @@ def test_launch_workspace_confirmation_skipped_with_yolo_flag():
 
 
 def test_launch_workspace_confirmation_for_default_provider():
-    """Test that default provider (kiro_cli) also triggers workspace confirmation."""
+    """Test that the default provider also triggers workspace confirmation."""
     runner = CliRunner()
 
     with (
@@ -421,11 +443,11 @@ def test_launch_workspace_confirmation_for_default_provider():
         }
         mock_post.return_value.raise_for_status.return_value = None
 
-        # Default provider is kiro_cli, which requires workspace confirmation
+        # Default provider requires workspace confirmation
         result = runner.invoke(launch, ["--agents", "test-agent", "--headless"], input="y\n")
 
         assert result.exit_code == 0
-        assert "launching on kiro_cli" in result.output
+        assert f"launching on {DEFAULT_PROVIDER}" in result.output
         assert "Proceed?" in result.output
 
 
@@ -694,7 +716,7 @@ def test_launch_yolo_still_resolves_profile_provider():
 
         assert result.exit_code == 0
         # Provider resolution must run even on the --yolo branch.
-        mock_resolve.assert_called_once_with("codex_panelist", "kiro_cli")
+        mock_resolve.assert_called_once_with("codex_panelist", DEFAULT_PROVIDER, install_aware=True)
         # The kiro_cli-specific yolo warning text must NOT appear, because
         # the profile's provider ("claude_code") was honoured.
         assert "kiro_cli will launch in --legacy-ui mode" not in result.output
@@ -731,7 +753,9 @@ def test_launch_allowed_tools_still_resolves_profile_provider():
         )
 
         assert result.exit_code == 0
-        mock_resolve.assert_called_once_with("gemini_panelist", "kiro_cli")
+        mock_resolve.assert_called_once_with(
+            "gemini_panelist", DEFAULT_PROVIDER, install_aware=True
+        )
         # Local prompts must reflect the resolved provider, not the default.
         assert "launching on gemini_cli" in result.output
 
@@ -799,6 +823,62 @@ def test_launch_yolo_falls_back_to_default_when_profile_lacks_provider():
         # The kiro_cli-specific yolo warning IS expected here because the
         # profile didn't override and the fallback is kiro_cli.
         assert "kiro_cli will launch in --legacy-ui mode" in result.output
+
+
+# ── Auto-start cao-server (rec #1) ───────────────────────────────────
+
+
+def test_launch_auto_starts_server_when_down():
+    """When the server is down, launch starts it before creating the session."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch(
+            "cli_agent_orchestrator.utils.server_process.is_server_running",
+            return_value=False,
+        ),
+        patch(
+            "cli_agent_orchestrator.utils.server_process.start_server_detached",
+            return_value=4321,
+        ) as mock_start,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
+
+        assert result.exit_code == 0
+        mock_start.assert_called_once()
+        assert "starting it" in result.output
+
+
+def test_launch_no_auto_start_fails_when_down():
+    """--no-auto-start surfaces a clear error instead of spawning the server."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post"),
+        patch(
+            "cli_agent_orchestrator.utils.server_process.is_server_running",
+            return_value=False,
+        ),
+        patch(
+            "cli_agent_orchestrator.utils.server_process.start_server_detached",
+        ) as mock_start,
+    ):
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo", "--no-auto-start"])
+
+        assert result.exit_code != 0
+        assert "cao server start" in result.output
+        mock_start.assert_not_called()
 
 
 # ── --env forwarded env vars (issue #248) ────────────────────────────

--- a/test/cli/commands/test_logs.py
+++ b/test/cli/commands/test_logs.py
@@ -1,0 +1,68 @@
+"""Tests for the ``cao logs`` command."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli_agent_orchestrator.cli.commands.logs import logs
+
+_LP = "cli_agent_orchestrator.cli.commands.logs"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestServerLogs:
+    @patch(f"{_LP}.latest_server_log_path")
+    def test_tails_latest_server_log(self, mock_latest, runner, tmp_path):
+        log = tmp_path / "cao_2026.log"
+        log.write_text("line1\nline2\nline3\n")
+        mock_latest.return_value = log
+
+        result = runner.invoke(logs, ["--server"])
+
+        assert result.exit_code == 0
+        assert "line3" in result.output
+        assert str(log) in result.output
+
+    @patch(f"{_LP}.latest_server_log_path")
+    def test_respects_lines_limit(self, mock_latest, runner, tmp_path):
+        log = tmp_path / "cao_2026.log"
+        log.write_text("\n".join(f"line{i}" for i in range(100)) + "\n")
+        mock_latest.return_value = log
+
+        result = runner.invoke(logs, ["-n", "5"])
+
+        assert result.exit_code == 0
+        assert "line99" in result.output
+        assert "line94" not in result.output  # outside last 5
+
+    @patch(f"{_LP}.latest_server_log_path", return_value=None)
+    def test_no_server_logs(self, _latest, runner):
+        result = runner.invoke(logs, [])
+
+        assert result.exit_code != 0
+        assert "No server logs found" in result.output
+
+
+class TestTerminalLogs:
+    def test_tails_terminal_log(self, runner, tmp_path):
+        term_log = tmp_path / "abc123.log"
+        term_log.write_text("terminal output here\n")
+
+        with patch(f"{_LP}.TERMINAL_LOG_DIR", Path(tmp_path)):
+            result = runner.invoke(logs, ["--terminal", "abc123"])
+
+        assert result.exit_code == 0
+        assert "terminal output here" in result.output
+
+    def test_missing_terminal_log(self, runner, tmp_path):
+        with patch(f"{_LP}.TERMINAL_LOG_DIR", Path(tmp_path)):
+            result = runner.invoke(logs, ["--terminal", "nope"])
+
+        assert result.exit_code != 0
+        assert "No log for terminal" in result.output

--- a/test/cli/commands/test_server.py
+++ b/test/cli/commands/test_server.py
@@ -1,0 +1,121 @@
+"""Tests for the ``cao server`` command group."""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli_agent_orchestrator.cli.commands.server import server
+
+_SP = "cli_agent_orchestrator.cli.commands.server"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestServerStart:
+    @patch(f"{_SP}.read_pidfile", return_value=4321)
+    @patch(f"{_SP}.is_server_running", return_value=True)
+    @patch(f"{_SP}.start_server_detached")
+    def test_start_noop_when_already_running(self, mock_start, _running, _pid, runner):
+        """Single-instance guard: start is a no-op when /health answers."""
+        result = runner.invoke(server, ["start"])
+
+        assert result.exit_code == 0
+        assert "already running" in result.output
+        assert "4321" in result.output
+        mock_start.assert_not_called()
+
+    @patch(f"{_SP}.read_pidfile", return_value=None)
+    @patch(f"{_SP}.is_server_running", return_value=False)
+    @patch(f"{_SP}.start_server_detached", return_value=999)
+    def test_start_spawns_when_down(self, mock_start, _running, _pid, runner):
+        result = runner.invoke(server, ["start"])
+
+        assert result.exit_code == 0
+        assert "started" in result.output
+        assert "999" in result.output
+        mock_start.assert_called_once()
+
+    @patch(f"{_SP}.read_pidfile", return_value=None)
+    @patch(f"{_SP}.is_server_running", return_value=False)
+    @patch(f"{_SP}.start_server_detached", side_effect=RuntimeError("did not become healthy"))
+    def test_start_reports_failure(self, _start, _running, _pid, runner):
+        result = runner.invoke(server, ["start"])
+
+        assert result.exit_code != 0
+        assert "did not become healthy" in result.output
+
+
+class TestServerStop:
+    @patch(f"{_SP}.clear_pidfile")
+    @patch(f"{_SP}.read_pidfile", return_value=None)
+    @patch(f"{_SP}.is_server_running", return_value=False)
+    def test_stop_when_not_running(self, _running, _pid, _clear, runner):
+        result = runner.invoke(server, ["stop"])
+
+        assert result.exit_code == 0
+        assert "not running" in result.output
+
+    @patch(f"{_SP}.stop_server", return_value=True)
+    @patch(f"{_SP}.read_pidfile", return_value=4321)
+    @patch(f"{_SP}.is_server_running", return_value=True)
+    def test_stop_success(self, _running, _pid, mock_stop, runner):
+        result = runner.invoke(server, ["stop"])
+
+        assert result.exit_code == 0
+        assert "stopped" in result.output
+        mock_stop.assert_called_once()
+
+    @patch(f"{_SP}.stop_server", return_value=False)
+    @patch(f"{_SP}.read_pidfile", return_value=4321)
+    @patch(f"{_SP}.is_server_running", return_value=True)
+    def test_stop_failure(self, _running, _pid, _stop, runner):
+        result = runner.invoke(server, ["stop"])
+
+        assert result.exit_code != 0
+        assert "Failed to stop" in result.output
+
+
+class TestServerStatus:
+    @patch(f"{_SP}.read_pidfile", return_value=None)
+    @patch(f"{_SP}.health", return_value=None)
+    def test_status_not_running(self, _health, _pid, runner):
+        result = runner.invoke(server, ["status"])
+
+        assert result.exit_code == 0
+        assert "not running" in result.output
+
+    @patch(f"{_SP}.read_pidfile", return_value=4321)
+    @patch(
+        f"{_SP}.health",
+        return_value={
+            "terminal_backend": "tmux",
+            "components": {"cao": "ok", "herdr": "unavailable"},
+        },
+    )
+    def test_status_running_shows_components(self, _health, _pid, runner):
+        result = runner.invoke(server, ["status"])
+
+        assert result.exit_code == 0
+        assert "running" in result.output
+        assert "4321" in result.output
+        assert "tmux" in result.output
+        assert "cao" in result.output
+        assert "herdr" in result.output
+
+
+class TestServerRestart:
+    @patch(f"{_SP}.start_server_detached", return_value=999)
+    @patch(f"{_SP}.stop_server", return_value=True)
+    @patch(f"{_SP}.read_pidfile", return_value=4321)
+    @patch(f"{_SP}.is_server_running", return_value=True)
+    def test_restart_stops_then_starts(self, _running, _pid, mock_stop, mock_start, runner):
+        result = runner.invoke(server, ["restart"])
+
+        assert result.exit_code == 0
+        assert "restarted" in result.output
+        mock_stop.assert_called_once()
+        mock_start.assert_called_once()

--- a/test/e2e/test_provider_smoke.py
+++ b/test/e2e/test_provider_smoke.py
@@ -1,0 +1,42 @@
+"""Opt-in e2e smoke test: each preferred provider reaches IDLE on init.
+
+This is the automated twin of ``cao doctor --live``. For each provider in
+``PREFERRED_PROVIDERS`` it spawns a throwaway session and asserts the agent
+reaches IDLE within ``provider_init_timeout``, then tears it down.
+
+Requires a running cao-server, tmux, and the provider CLI installed + authed.
+Excluded from default runs by ``addopts = -m 'not e2e'``; run with:
+
+    uv run cao-server
+    uv run pytest -m e2e test/e2e/test_provider_smoke.py -v
+"""
+
+import shutil
+from test.e2e.conftest import cleanup_terminal, create_terminal, wait_for_status
+
+import pytest
+
+from cli_agent_orchestrator.constants import PREFERRED_PROVIDERS
+from cli_agent_orchestrator.utils.providers import provider_binary
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.parametrize("provider", PREFERRED_PROVIDERS)
+def test_provider_reaches_idle(provider):
+    """A throwaway session for ``provider`` should reach IDLE on init."""
+    binary = provider_binary(provider)
+    if not binary or shutil.which(binary) is None:
+        pytest.skip(f"{provider} CLI ({binary}) not installed")
+
+    session_name = f"smoke-{provider}"
+    terminal_id, actual_session = create_terminal(
+        provider=provider,
+        agent_profile="code_supervisor",
+        session_name=session_name,
+    )
+    try:
+        reached = wait_for_status(terminal_id, "idle", timeout=90)
+        assert reached, f"{provider} did not reach IDLE within 90s"
+    finally:
+        cleanup_terminal(terminal_id, actual_session)

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -44,6 +44,51 @@ def make_provider(
 
 
 # ---------------------------------------------------------------------------
+# Screen-detection opt-in: OpenCode's footer is drawn with absolute cursor
+# moves, so the idle anchor is non-contiguous in the raw byte stream and only
+# resolves to "ctrl+p commands" once a pyte viewport composites the frame.
+# The provider must route through the screen path so initialize() sees IDLE.
+# ---------------------------------------------------------------------------
+
+
+class TestScreenDetection:
+    def test_provider_opts_into_screen_detection(self):
+        # Required so the StatusMonitor renders a pyte viewport before detecting.
+        assert OpenCodeCliProvider.supports_screen_detection is True
+
+    def test_absolute_cursor_footer_fails_raw_but_passes_via_screen(self):
+        """Regression for the init-timeout bug.
+
+        Build a footer the way OpenCode does — writing "ctrl+p" and "commands"
+        at separate columns via absolute cursor-position escapes (CSI row;col H).
+        In the raw stream the two tokens are non-contiguous, so get_status()
+        cannot match IDLE_FOOTER_PATTERN. After a pyte viewport composites the
+        cursor moves, the footer reads "ctrl+p commands" on one row and the
+        screen path returns IDLE.
+        """
+        pyte = pytest.importorskip("pyte")
+        provider = make_provider()
+
+        # Splash body + a footer split across absolute cursor jumps.
+        raw = (
+            "\x1b[2J\x1b[H"  # clear + home
+            "\x1b[3;10HAsk anything...\r\n"
+            "\x1b[10;1Htab agents"
+            "\x1b[10;30Hctrl+p"  # jump right, write first token
+            "\x1b[10;40Hcommands"  # jump further right, write second token
+        )
+
+        # Raw path cannot see a contiguous idle footer.
+        assert provider.get_status(raw) != TerminalStatus.IDLE
+
+        # Composited viewport (same dimensions CAO uses) resolves the moves.
+        screen = pyte.Screen(220, 50)
+        stream = pyte.Stream(screen)
+        stream.feed(raw)
+        assert provider.get_status_from_screen(screen.display) == TerminalStatus.IDLE
+
+
+# ---------------------------------------------------------------------------
 # (g) Regex patterns individually match expected substrings
 # ---------------------------------------------------------------------------
 

--- a/test/services/test_session_service.py
+++ b/test/services/test_session_service.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from cli_agent_orchestrator.constants import DEFAULT_PROVIDER
 from cli_agent_orchestrator.services.session_service import (
     create_session,
     delete_session,
@@ -30,7 +31,9 @@ class TestCreateSession:
 
         await create_session(provider=None, agent_profile="my_agent")
 
-        mock_resolve.assert_called_once_with("my_agent", fallback_provider="kiro_cli")
+        mock_resolve.assert_called_once_with(
+            "my_agent", fallback_provider=DEFAULT_PROVIDER, install_aware=True
+        )
         assert mock_create_terminal.call_args.kwargs["provider"] == "claude_code"
 
     @pytest.mark.asyncio

--- a/test/services/test_settings_service.py
+++ b/test/services/test_settings_service.py
@@ -286,9 +286,9 @@ class TestGetServerSettings:
 
         result = get_server_settings()
         assert result == {
-            "mcp_request_timeout": 30,
+            "mcp_request_timeout": 120,
             "event_bus_max_queue_size": 1024,
-            "provider_init_timeout": 60,
+            "provider_init_timeout": 90,
             "startup_prompt_handler_timeout": 20,
         }
 
@@ -319,7 +319,7 @@ class TestGetServerSettings:
 
         _save({"server": {"mcp_request_timeout": "not_a_number"}})
         result = get_server_settings()
-        assert result["mcp_request_timeout"] == 30
+        assert result["mcp_request_timeout"] == 120
 
     def test_negative_value_falls_back_to_default(self, settings_file):
         """Negative values fall back to defaults."""
@@ -327,4 +327,4 @@ class TestGetServerSettings:
 
         _save({"server": {"provider_init_timeout": -5}})
         result = get_server_settings()
-        assert result["provider_init_timeout"] == 60
+        assert result["provider_init_timeout"] == 90

--- a/test/utils/test_agent_profiles.py
+++ b/test/utils/test_agent_profiles.py
@@ -185,6 +185,79 @@ class TestResolveProvider:
         assert result == "kiro_cli"
 
 
+class TestInstallAwareFallback:
+    """Tests for the install-aware default fallback in resolve_provider."""
+
+    _BIN = "cli_agent_orchestrator.utils.providers.provider_binary_installed"
+
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_no_downgrade_when_install_aware_false(self, mock_load):
+        """Without install_aware, the fallback is returned verbatim (inheritance)."""
+        mock_load.return_value = AgentProfile(name="reviewer", description="r")
+
+        # Even if opencode is "not installed", inheritance must not downgrade.
+        with patch(self._BIN, return_value=False):
+            result = resolve_provider("reviewer", fallback_provider="claude_code")
+
+        assert result == "claude_code"
+
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_no_downgrade_when_default_installed(self, mock_load):
+        """install_aware keeps the default when its binary is present."""
+        mock_load.return_value = AgentProfile(name="reviewer", description="r")
+
+        with patch(self._BIN, return_value=True):
+            result = resolve_provider(
+                "reviewer", fallback_provider="opencode_cli", install_aware=True
+            )
+
+        assert result == "opencode_cli"
+
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_downgrades_to_first_installed_preferred(self, mock_load, caplog):
+        """install_aware downgrades a missing default to the first installed preferred."""
+        mock_load.return_value = AgentProfile(name="reviewer", description="r")
+
+        # opencode missing, claude installed, codex installed.
+        def _installed(name):
+            return name in ("claude_code", "codex")
+
+        with patch(self._BIN, side_effect=_installed):
+            with caplog.at_level(logging.WARNING):
+                result = resolve_provider(
+                    "reviewer", fallback_provider="opencode_cli", install_aware=True
+                )
+
+        assert result == "claude_code"
+        assert "downgrading" in caplog.text.lower()
+
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_keeps_default_when_nothing_installed(self, mock_load, caplog):
+        """When no preferred provider is installed, the default is kept (launch will error)."""
+        mock_load.return_value = AgentProfile(name="reviewer", description="r")
+
+        with patch(self._BIN, return_value=False):
+            with patch(
+                "cli_agent_orchestrator.utils.providers.installed_providers", return_value=[]
+            ):
+                with caplog.at_level(logging.WARNING):
+                    result = resolve_provider(
+                        "reviewer", fallback_provider="opencode_cli", install_aware=True
+                    )
+
+        assert result == "opencode_cli"
+
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_profile_provider_never_downgrades(self, mock_load):
+        """A profile-declared provider is honoured even if uninstalled (deliberate choice)."""
+        mock_load.return_value = AgentProfile(name="dev", description="d", provider="opencode_cli")
+
+        with patch(self._BIN, return_value=False):
+            result = resolve_provider("dev", fallback_provider="claude_code", install_aware=True)
+
+        assert result == "opencode_cli"
+
+
 class TestListAgentProfiles:
     """Tests for list_agent_profiles function."""
 

--- a/test/utils/test_logging.py
+++ b/test/utils/test_logging.py
@@ -7,7 +7,31 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cli_agent_orchestrator.utils.logging import setup_logging
+from cli_agent_orchestrator.utils.logging import latest_server_log_path, setup_logging
+
+
+class TestLatestServerLogPath:
+    """Tests for latest_server_log_path."""
+
+    @patch("cli_agent_orchestrator.utils.logging.LOG_DIR")
+    def test_returns_most_recent_cao_log(self, mock_log_dir, tmp_path):
+        old = tmp_path / "cao_2026-01-01.log"
+        new = tmp_path / "cao_2026-06-01.log"
+        old.write_text("old")
+        new.write_text("new")
+        # Make `new` newer than `old`.
+        import os
+
+        os.utime(old, (1, 1))
+        os.utime(new, (10_000, 10_000))
+        mock_log_dir.glob = lambda pat: list(tmp_path.glob(pat))
+
+        assert latest_server_log_path() == new
+
+    @patch("cli_agent_orchestrator.utils.logging.LOG_DIR")
+    def test_returns_none_when_no_logs(self, mock_log_dir, tmp_path):
+        mock_log_dir.glob = lambda pat: list(tmp_path.glob(pat))
+        assert latest_server_log_path() is None
 
 
 class TestSetupLogging:

--- a/test/utils/test_providers.py
+++ b/test/utils/test_providers.py
@@ -1,0 +1,31 @@
+"""Tests for the shared provider-installation helpers."""
+
+from unittest.mock import patch
+
+from cli_agent_orchestrator.utils import providers
+
+_P = "cli_agent_orchestrator.utils.providers"
+
+
+def test_provider_binary_known_and_unknown():
+    assert providers.provider_binary("opencode_cli") == "opencode"
+    assert providers.provider_binary("does_not_exist") is None
+
+
+@patch(f"{_P}.shutil.which")
+def test_provider_binary_installed(mock_which):
+    mock_which.side_effect = lambda b: "/usr/bin/opencode" if b == "opencode" else None
+    assert providers.provider_binary_installed("opencode_cli") is True
+    assert providers.provider_binary_installed("codex") is False
+    # Unknown provider → False without consulting PATH.
+    assert providers.provider_binary_installed("ghost") is False
+
+
+@patch(f"{_P}.shutil.which")
+def test_installed_providers(mock_which):
+    installed = {"claude", "codex"}
+    mock_which.side_effect = lambda b: f"/usr/bin/{b}" if b in installed else None
+    result = providers.installed_providers()
+    assert "claude_code" in result
+    assert "codex" in result
+    assert "opencode_cli" not in result

--- a/test/utils/test_server_process.py
+++ b/test/utils/test_server_process.py
@@ -1,0 +1,119 @@
+"""Tests for server-process lifecycle helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from cli_agent_orchestrator.utils import server_process as sp
+
+_SP = "cli_agent_orchestrator.utils.server_process"
+
+
+class TestHealth:
+    @patch(f"{_SP}.requests.get")
+    def test_health_returns_json_when_ok(self, mock_get):
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"status": "ok"}
+        mock_get.return_value = resp
+
+        assert sp.health() == {"status": "ok"}
+        assert sp.is_server_running() is True
+
+    @patch(f"{_SP}.requests.get", side_effect=requests.exceptions.ConnectionError())
+    def test_health_none_on_connection_error(self, _get):
+        assert sp.health() is None
+        assert sp.is_server_running() is False
+
+    @patch(f"{_SP}.requests.get")
+    def test_health_none_on_non_200(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=503)
+        assert sp.health() is None
+
+
+class TestPidfile:
+    def test_write_read_clear_roundtrip(self, tmp_path):
+        pidfile = tmp_path / "server.pid"
+        with patch(f"{_SP}.SERVER_PIDFILE", pidfile):
+            sp.write_pidfile(1234)
+            assert sp.read_pidfile() == 1234
+            sp.clear_pidfile()
+            assert sp.read_pidfile() is None
+
+    def test_read_pidfile_missing(self, tmp_path):
+        with patch(f"{_SP}.SERVER_PIDFILE", tmp_path / "nope.pid"):
+            assert sp.read_pidfile() is None
+
+    def test_read_pidfile_garbage(self, tmp_path):
+        pidfile = tmp_path / "server.pid"
+        pidfile.write_text("not-a-pid")
+        with patch(f"{_SP}.SERVER_PIDFILE", pidfile):
+            assert sp.read_pidfile() is None
+
+
+class TestStartServerDetached:
+    @patch(f"{_SP}.read_pidfile", return_value=7777)
+    @patch(f"{_SP}.is_server_running", return_value=True)
+    def test_noop_when_already_running(self, _running, _pid):
+        assert sp.start_server_detached() == 7777
+
+    @patch(f"{_SP}.write_pidfile")
+    @patch(f"{_SP}.subprocess.Popen")
+    @patch(f"{_SP}.is_server_running")
+    def test_spawns_and_waits_for_health(self, mock_running, mock_popen, mock_write, tmp_path):
+        # Not running at first check, healthy after spawn.
+        mock_running.side_effect = [False, True]
+        proc = MagicMock(pid=4242)
+        proc.poll.return_value = None
+        mock_popen.return_value = proc
+
+        with patch(f"{_SP}.LOG_DIR", tmp_path):
+            pid = sp.start_server_detached(timeout=5)
+
+        assert pid == 4242
+        mock_write.assert_called_once_with(4242)
+        # Detached process group requested.
+        assert mock_popen.call_args.kwargs["start_new_session"] is True
+
+    @patch(f"{_SP}.write_pidfile")
+    @patch(f"{_SP}.subprocess.Popen")
+    @patch(f"{_SP}.is_server_running")
+    def test_raises_when_child_dies(self, mock_running, mock_popen, _write, tmp_path):
+        mock_running.return_value = False
+        proc = MagicMock(pid=4242, returncode=1)
+        proc.poll.return_value = 1  # exited
+        mock_popen.return_value = proc
+
+        with patch(f"{_SP}.LOG_DIR", tmp_path):
+            try:
+                sp.start_server_detached(timeout=5)
+                assert False, "expected RuntimeError"
+            except RuntimeError as e:
+                assert "exited during startup" in str(e)
+
+
+class TestStopServer:
+    @patch(f"{_SP}.clear_pidfile")
+    @patch(f"{_SP}._pid_alive")
+    @patch(f"{_SP}.is_server_running", return_value=False)
+    @patch(f"{_SP}.os.kill")
+    @patch(f"{_SP}.read_pidfile", return_value=4321)
+    def test_stop_success(self, _pid, mock_kill, _running, mock_alive, _clear):
+        # Alive when SIGTERM is sent, dead on the confirmation loop.
+        mock_alive.side_effect = [True, False]
+        assert sp.stop_server(timeout=5) is True
+        mock_kill.assert_called_once()
+
+    @patch(f"{_SP}.read_pidfile", return_value=None)
+    @patch(f"{_SP}.is_server_running", return_value=False)
+    def test_stop_no_pidfile_reports_health(self, _running, _pid):
+        # No PID known but health already down → treat as stopped.
+        assert sp.stop_server(timeout=5) is True
+
+
+class TestServerErrorHint:
+    def test_hint_mentions_logs_command(self):
+        with patch(
+            "cli_agent_orchestrator.utils.logging.latest_server_log_path", return_value=None
+        ):
+            hint = sp.server_error_hint()
+        assert "cao logs --server" in hint


### PR DESCRIPTION
## What & why

CAO is architecturally consolidated (one `cao-server` daemon; CLI/MCP/WebUI are thin REST clients) but **operationally scattered**: running it reliably meant stepping outside `cao` — starting `cao-server` by hand, hunting its PID, killing/restarting on every change, hand-editing `settings.json` for timeouts, `grep`ping logs, and eyeballing tmux to confirm a provider reached IDLE. Two real failure modes also surfaced: opencode timing out on init, and launches failing because the default provider's binary wasn't installed — with errors that never pointed at the logs explaining why.

This folds those manual steps back under the single `cao` command, stops slow providers from masquerading as failures, and locks the behavior in with tests. Provider priority is **opencode_cli (default) → claude_code → codex**.

## New CLI surface

- **`cao server {start,stop,restart,status}`** — manage the detached daemon. `start` has a single-instance guard (`/health` probe + pidfile), spawns `cao-server` detached, and polls until healthy. Backed by `utils/server_process.py`.
- **`cao doctor [--live]`** — tiered. Static (`cao doctor`) spawns nothing and costs no tokens: server health, per-provider binary status over `PREFERRED_PROVIDERS`, discoverable profiles, effective timeouts. Live (`cao doctor --live [--provider X]`) spawns a throwaway agent per installed provider and reports time-to-IDLE — the manual twin of the e2e smoke test.
- **`cao logs [--server|--terminal <id>] [-f] [-n N]`** — tail server/terminal logs without leaving `cao`.

## Reliability

- **Auto-start**: `cao launch` starts the daemon when down (`--no-auto-start` opts out).
- **Install-aware default fallback**: when no provider is explicitly chosen and the default's binary is missing, downgrade to the first installed provider in `PREFERRED_PROVIDERS` with a warning. Explicit `--provider` and profile-declared `provider:` are deliberate and never downgrade. Gated so handoff/assign inheritance is untouched.
- **Bumped timeouts**: `mcp_request_timeout` 30→120, `provider_init_timeout` 60→90 (+ aligned the `MCP_REQUEST_TIMEOUT` constant and docstrings).
- **Log-pointing errors**: launch/`session send` failures now name the latest server log and suggest `cao logs --server` / `cao doctor --live`.
- Shared `utils/providers.py` is the single provider→binary map, also consumed by the `/agents/providers` endpoint.

## Tests

Unit coverage for the new commands and helpers (`test_server.py`, `test_doctor.py`, `test_logs.py`, `test_server_process.py`, `test_providers.py`), install-aware fallback, `latest_server_log_path`, updated settings defaults, and an opt-in e2e provider smoke test (`test/e2e/test_provider_smoke.py`, parametrized over `PREFERRED_PROVIDERS`, skip-if-missing). Existing launch/session/API tests updated for the new signatures.

**Verification:** full unit suite green (2896 passed, 6 skipped); `black`/`isort` clean; new/modified files pass `mypy`.

## Docs

Added an "Operating the server" section to `CLAUDE.md` covering lifecycle, auto-start, tiered doctor, logs, timeout knobs, the opencode→claude→codex priority, and headless/async-drive guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)