### PR TITLE
fix: reliability fixes for handoff crash detection, output capture, and status detection

### DIFF
--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -681,6 +681,38 @@ async def _handoff_impl(
         # when provider == codex; otherwise returns the message unchanged).
         shaped_message = _shape_handoff_message(provider, message)
 
+        # Inherit the conductor's working directory when the caller didn't pin
+        # one, so a handed-off worker runs in the SAME project directory as the
+        # supervisor — not the cao-server process CWD. assign()/_create_terminal
+        # already resolve this; handoff omitted it, so handed-off workers
+        # launched in the daemon's directory and operated on the wrong tree.
+        if working_directory is None:
+            current_terminal_id = os.environ.get("CAO_TERMINAL_ID")
+            if current_terminal_id:
+                try:
+                    wd_resp = requests.get(
+                        f"{API_BASE_URL}/terminals/{current_terminal_id}/working-directory",
+                        timeout=_mcp_timeout(),
+                    )
+                    if wd_resp.status_code == 200:
+                        working_directory = wd_resp.json().get("working_directory")
+                        logger.info(
+                            "Handoff inherited working directory from conductor: %s",
+                            working_directory,
+                        )
+                    else:
+                        logger.warning(
+                            "Handoff could not fetch conductor working directory "
+                            "(status %s); using server default",
+                            wd_resp.status_code,
+                        )
+                except Exception as e:
+                    logger.warning(
+                        "Handoff error fetching conductor working directory: %s; "
+                        "using server default",
+                        e,
+                    )
+
         # Single combined call: create -> ready-wait -> input -> complete-wait ->
         # extract -> teardown, all server-side via run_agent_step. session_name
         # places the worker in the supervisor's session; caller_id/allowed_tools

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -42,6 +42,16 @@ class BaseProvider(ABC):
         _allowed_tools: CAO-vocabulary tool names this agent is allowed to use
     """
 
+    # Environment variables exported into the launch pane for every terminal
+    # of this provider. Declarative replacement for hand-rolled inline command
+    # prefixes (e.g. ``FOO=bar claude ...``): the service layer merges this into
+    # the tmux pane environment at terminal creation, so the launched CLI
+    # inherits it. Provider-scoped (only this provider's panes get it) and
+    # restart-safe by construction — re-derived from the class on every spawn,
+    # unlike operator ``--env`` vars which live in a process-local store.
+    # Subclasses override with provider-specific defaults.
+    DEFAULT_LAUNCH_ENV: Dict[str, str] = {}
+
     def __init__(
         self,
         terminal_id: str,

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -39,7 +39,17 @@ RESPONSE_PATTERN = r"⏺(?:\x1b\[[0-9;]*m)*\s+"  # Handle any ANSI codes between
 # RESPONSE_PATTERN so get_status's legacy ⏺-COMPLETED check is unaffected (adding
 # "●" there could fire COMPLETED mid-stream while a response is still rendering).
 EXTRACTION_RESPONSE_PATTERN = re.compile(
-    r"^[ \t]*(?:\x1b\[[0-9;]*m)*[⏺●](?:\x1b\[[0-9;]*m)*\s+",
+    # Response marker at the start of a line. The trailing negative lookahead
+    # rejects the TUI effort footer "● high · /effort" (also medium/low/xhigh/…):
+    # the line-start anchor alone only excludes the footer when it renders inline
+    # ("… esc to interrupt ● high · /effort"), but the effort indicator also
+    # renders on its OWN line, where the leading "●" would otherwise read as a
+    # response marker — flipping get_status to a false COMPLETED on the idle
+    # launch screen (the ❯ box + this footer satisfy the completion heuristic)
+    # and making extraction return "high · /effort" as the message. The footer
+    # is identified by its line ending in "/effort"; real responses don't.
+    r"^[ \t]*(?:\x1b\[[0-9;]*m)*[⏺●](?:\x1b\[[0-9;]*m)*\s+"
+    r"(?![^\n]*/effort(?:\x1b\[[0-9;]*m)*[ \t]*$)",
     re.MULTILINE,
 )
 # Match Claude Code processing spinners:

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -805,16 +805,29 @@ class ClaudeCodeProvider(BaseProvider):
         lines = remaining_text.split("\n")
         response_lines = []
 
-        for line in lines:
+        for i, line in enumerate(lines):
             clean_line = re.sub(ANSI_CODE_PATTERN, "", line).strip()
             if self._SOL_IDLE_RE.match(line):
                 break
-            # Match full-width Claude UI separator (20+ U+2500 dashes spanning the line).
-            # Table borders also contain ──── runs but always pair with other box-drawing
-            # chars (corners, intersections U+2501-U+257F). Claude's separator uses only
-            # U+2500 dashes plus optional text — no other box-drawing chars present.
+            # A full-width run of 20+ U+2500 dashes with no other box-drawing
+            # chars (corners/intersections U+2501-U+257F) is ambiguous: it is
+            # BOTH the TUI turn-separator that frames the ❯ input box AND how
+            # Claude's renderer draws a markdown thematic break (``---``) or a
+            # plain table rule inside the agent's own report. Only the former
+            # ends the message. Treat the run as a terminator only when it frames
+            # the input box — the next non-blank line is the ❯/> prompt, or the
+            # capture ends here. A rule followed by more report text is content,
+            # so drop the rule line and keep extracting. Without this, reports
+            # were clipped at the first ``---`` heading divider or results table —
+            # exactly the section a handoff consumer needs.
             if re.search(r"─{20,}", clean_line) and not re.search("[━-╿]", clean_line):
-                break
+                next_nonblank = next(
+                    (raw for raw in lines[i + 1 :] if re.sub(ANSI_CODE_PATTERN, "", raw).strip()),
+                    None,
+                )
+                if next_nonblank is None or self._SOL_IDLE_RE.match(next_nonblank):
+                    break
+                continue
             if re.search(COMPLETION_SUMMARY_PATTERN, clean_line):
                 break
 

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -657,6 +657,32 @@ class ClaudeCodeProvider(BaseProvider):
         last_sol_response = None
         for m in re.finditer(EXTRACTION_RESPONSE_PATTERN, output):
             last_sol_response = m
+
+        # In-progress tool use looks like a finished turn here. The newest TUI
+        # renders an active tool call as a response-marker line ending in the "…"
+        # ellipsis ("⏺ Reading 1 file…", "● Running command…"): the agent emitted
+        # the marker but is still working. During a quiet think the live spinner
+        # scrolls out of the rolling buffer, so the PROCESSING checks above miss
+        # it and this falls through to COMPLETED — false-completing a handoff in
+        # ~10s and returning the preamble instead of the report. Treat a freshest
+        # response-marker line that ends in "…" as still PROCESSING. Gated on
+        # last_completion is None: a genuinely finished turn shows the
+        # "✻ Worked for Ns" summary (a separate, trustworthy signal), so this
+        # never blocks real completion. Only the single-char "…" (U+2026) the TUI
+        # emits is matched, so prose ending in ASCII "..." cannot false-trigger.
+        if last_completion is None:
+            response_marker = max(
+                (m for m in (last_sol_response, last_response) if m is not None),
+                key=lambda m: m.start(),
+                default=None,
+            )
+            if last_idle is not None and response_marker is not None:
+                line_start = output.rfind("\n", 0, response_marker.start()) + 1
+                line_end = output.find("\n", response_marker.start())
+                marker_line = output[line_start : line_end if line_end != -1 else len(output)]
+                if re.sub(ANSI_CODE_PATTERN, "", marker_line).rstrip().endswith("…"):
+                    return TerminalStatus.PROCESSING
+
         if last_idle is not None and (
             last_completion is not None
             or last_sol_response is not None

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -120,6 +120,17 @@ NEW_TUI_BOX_SPINNER_PATTERN = re.compile(r"^[ \t]*[✶✢✽✻✳·*][ \t]+\w*i
 class ClaudeCodeProvider(BaseProvider):
     """Provider for Claude Code CLI tool integration."""
 
+    # Claude Code ships as a Bun-compiled binary. The JavaScriptCore DFG JIT
+    # tier in some bundled Bun versions can segfault on its background compile
+    # thread (speculationFromCell) when a hot function is optimized mid-task —
+    # e.g. during a long `npm test` run — taking down the whole worker and
+    # leaving the supervisor with a truncated/half-finished handoff. Disabling
+    # only the DFG tier sidesteps the crash; the baseline JIT stays on, so the
+    # runtime cost is small. Exported into every claude_code launch pane via the
+    # shared DEFAULT_LAUNCH_ENV mechanism. Remove once the bundled Bun ships a
+    # DFG fix.
+    DEFAULT_LAUNCH_ENV = {"BUN_JSC_useDFGJIT": "0"}
+
     def __init__(
         self,
         terminal_id: str,

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # pane environment must be assembled at tmux session/window creation, which
 # happens before the provider is instantiated and initialized. Kept exhaustive
 # over ProviderType by test_default_launch_env_covers_all_provider_types.
-_PROVIDER_CLASS_BY_TYPE: Dict[str, type] = {
+_PROVIDER_CLASS_BY_TYPE: Dict[str, type[BaseProvider]] = {
     ProviderType.Q_CLI.value: QCliProvider,
     ProviderType.KIRO_CLI.value: KiroCliProvider,
     ProviderType.CLAUDE_CODE.value: ClaudeCodeProvider,
@@ -53,7 +53,7 @@ def default_launch_env(provider_type: str) -> Dict[str, str]:
     return dict(getattr(cls, "DEFAULT_LAUNCH_ENV", {})) if cls is not None else {}
 
 
-def provider_class_for(provider_type: str) -> Optional[type]:
+def provider_class_for(provider_type: str) -> Optional[type[BaseProvider]]:
     """Provider class for ``provider_type``, or None if unknown.
 
     Lets callers reach a provider's stateless helpers (e.g.

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -53,6 +53,17 @@ def default_launch_env(provider_type: str) -> Dict[str, str]:
     return dict(getattr(cls, "DEFAULT_LAUNCH_ENV", {})) if cls is not None else {}
 
 
+def provider_class_for(provider_type: str) -> Optional[type]:
+    """Provider class for ``provider_type``, or None if unknown.
+
+    Lets callers reach a provider's stateless helpers (e.g.
+    ``extract_last_message_from_script``) without a live, registered instance —
+    used to re-extract a torn-down worker's final message from its persisted
+    scrollback snapshot.
+    """
+    return _PROVIDER_CLASS_BY_TYPE.get(provider_type)
+
+
 class ProviderManager:
     """Simplified provider manager with direct mapping."""
 

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -21,6 +21,38 @@ from cli_agent_orchestrator.providers.q_cli import QCliProvider
 logger = logging.getLogger(__name__)
 
 
+# Provider type string -> provider class. Used to resolve class-level data
+# (e.g. DEFAULT_LAUNCH_ENV) BEFORE a provider instance exists — the launch
+# pane environment must be assembled at tmux session/window creation, which
+# happens before the provider is instantiated and initialized. Kept exhaustive
+# over ProviderType by test_default_launch_env_covers_all_provider_types.
+_PROVIDER_CLASS_BY_TYPE: Dict[str, type] = {
+    ProviderType.Q_CLI.value: QCliProvider,
+    ProviderType.KIRO_CLI.value: KiroCliProvider,
+    ProviderType.CLAUDE_CODE.value: ClaudeCodeProvider,
+    ProviderType.CODEX.value: CodexProvider,
+    ProviderType.KIMI_CLI.value: KimiCliProvider,
+    ProviderType.GEMINI_CLI.value: GeminiCliProvider,
+    ProviderType.COPILOT_CLI.value: CopilotCliProvider,
+    ProviderType.OPENCODE_CLI.value: OpenCodeCliProvider,
+    ProviderType.HERMES.value: HermesProvider,
+    ProviderType.CURSOR_CLI.value: CursorCliProvider,
+    ProviderType.ANTIGRAVITY_CLI.value: AntigravityCliProvider,
+}
+
+
+def default_launch_env(provider_type: str) -> Dict[str, str]:
+    """Class-level launch-env defaults for ``provider_type`` (a fresh copy).
+
+    Returns the provider's ``DEFAULT_LAUNCH_ENV`` so the service layer can merge
+    it into the tmux pane environment at terminal creation. Unknown provider
+    types yield ``{}`` (no defaults) rather than raising — provider validation
+    happens at instantiation.
+    """
+    cls = _PROVIDER_CLASS_BY_TYPE.get(provider_type)
+    return dict(getattr(cls, "DEFAULT_LAUNCH_ENV", {})) if cls is not None else {}
+
+
 class ProviderManager:
     """Simplified provider manager with direct mapping."""
 

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -199,6 +199,16 @@ async def run_agent_step(
                 kind="error",
                 terminal_id=terminal_id,
             )
+        # A crashed CLI pins status at PROCESSING/UNKNOWN (a dead pane emits no
+        # output to advance it), so the wait times out. Probe pane liveness to
+        # report the crash as kind="error" rather than mislabeling a 5s crash as
+        # a full-timeout run.
+        if terminal_service.worker_returned_to_shell(terminal_id):
+            raise StepExecutionError(
+                f"terminal {terminal_id} worker process exited before completing",
+                kind="error",
+                terminal_id=terminal_id,
+            )
         raise StepExecutionError(
             f"step on terminal {terminal_id} did not complete within {timeout}s",
             kind="timeout",
@@ -211,6 +221,19 @@ async def run_agent_step(
     if final_status == TerminalStatus.ERROR:
         raise StepExecutionError(
             f"terminal {terminal_id} reached ERROR status",
+            kind="error",
+            terminal_id=terminal_id,
+        )
+
+    # Crash-vs-completion guard: a segfaulted CLI freezes the pane, and a frozen
+    # screen with a leftover response marker can satisfy the COMPLETED heuristic
+    # trivially — death is permanent stability, so the confirm-stable window
+    # passes BECAUSE the process is dead. Before claiming success and extracting
+    # a (necessarily truncated) message, verify the CLI is still running; if it
+    # has dropped back to the shell, report a crash instead of a false success.
+    if terminal_service.worker_returned_to_shell(terminal_id):
+        raise StepExecutionError(
+            f"terminal {terminal_id} worker process exited before completing",
             kind="error",
             terminal_id=terminal_id,
         )

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -112,7 +112,26 @@ class StatusMonitor:
           resumed) and at quiescence (output stopped) — see
           _schedule_screen_detection.
         """
-        provider = provider_manager.get_provider(terminal_id)
+        try:
+            provider = provider_manager.get_provider(terminal_id)
+        except ValueError:
+            # Terminal's DB row is gone but stray output chunks are still
+            # arriving — e.g. a crashed worker whose pane keeps emitting the
+            # shell prompt / "Resume this session" banner and tmux redraws
+            # after its record was deleted, or chunks draining out of the
+            # event bus after delete_terminal stopped the FIFO reader. Release
+            # any residual buffer/latch state once and drop the chunk. Without
+            # this, get_provider raised ValueError for every such chunk and
+            # run()'s handler logged a full traceback per chunk, spamming the
+            # log until the pane went quiet. Mirrors the defensive
+            # get_provider() handling already in get_status().
+            if terminal_id in self._buffers or terminal_id in self._last_status:
+                self.clear_terminal(terminal_id)
+            logger.debug("Dropping output for unknown/deleted terminal %s", terminal_id)
+            return
+        except Exception:
+            logger.exception("Error resolving provider for %s; dropping chunk", terminal_id)
+            return
         use_screen = (
             CAO_PYTE_STATUS
             and provider is not None

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -42,7 +42,7 @@ from cli_agent_orchestrator.plugins import (
     PostKillTerminalEvent,
     PostSendMessageEvent,
 )
-from cli_agent_orchestrator.providers.manager import provider_manager
+from cli_agent_orchestrator.providers.manager import default_launch_env, provider_manager
 from cli_agent_orchestrator.services.fifo_reader import fifo_manager
 from cli_agent_orchestrator.services.herdr_inbox_registry import get_herdr_inbox_service
 from cli_agent_orchestrator.services.memory_service import MemoryService
@@ -184,6 +184,15 @@ async def create_terminal(
 
         window_name = generate_window_name(agent_profile)
 
+        # Provider-scoped launch-env defaults (e.g. claude_code's BUN_JSC guard),
+        # resolved from the provider class before instantiation. Merged UNDER any
+        # operator-forwarded --env so an operator can still override, and applied
+        # to both the supervisor (new session) and every worker (new window).
+        # Not persisted via set_session_env: it is re-derived from the provider
+        # on every spawn, so it survives a cao-server restart that would wipe the
+        # process-local --env store.
+        provider_launch_env = default_launch_env(provider)
+
         # Step 2: Create tmux session or window
         if new_session:
             # Ensure session name has the CAO prefix for identification
@@ -204,7 +213,7 @@ async def create_terminal(
                 window_name,
                 terminal_id,
                 working_directory,
-                extra_env=env_vars,
+                extra_env={**provider_launch_env, **(env_vars or {})},
             )
             session_created = True  # only set after successful creation
 
@@ -222,7 +231,7 @@ async def create_terminal(
                 window_name,
                 terminal_id,
                 working_directory,
-                extra_env=get_session_env(session_name),
+                extra_env={**provider_launch_env, **get_session_env(session_name)},
             )
 
         # Step 3: Load the profile once for allowed tool resolution before

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -604,6 +604,56 @@ def exit_terminal_cli(terminal_id: str) -> None:
         send_input(terminal_id, exit_command)
 
 
+def _persisted_output(terminal_id: str, mode: OutputMode) -> Optional[str]:
+    """Recover a torn-down terminal's output from its on-disk snapshot.
+
+    ``handoff`` always tears the worker down once it finishes (DB row deleted),
+    so a supervisor that re-reads the worker via ``get_terminal_output`` would
+    otherwise get a 404 — the in-band handoff result is the only copy. But
+    ``delete_terminal`` persists the full plain-text scrollback to
+    ``{id}.scrollback`` plus a ``{id}.snapshot.json`` recording the provider.
+    Serve that instead of failing: FULL returns the raw scrollback; LAST
+    re-extracts the final message with the recorded provider's (stateless)
+    extractor, falling back to the raw scrollback if extraction can't run.
+
+    Returns None when no snapshot exists (genuinely-unknown terminal).
+    """
+    scrollback_path = TERMINAL_LOG_DIR / f"{terminal_id}.scrollback"
+    if not scrollback_path.exists():
+        return None
+    try:
+        raw = scrollback_path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("Failed to read persisted scrollback for %s: %s", terminal_id, e)
+        return None
+
+    if mode != OutputMode.LAST:
+        return raw
+
+    # LAST: try to re-extract the final message using the recorded provider.
+    try:
+        import json as _json
+
+        from cli_agent_orchestrator.providers.manager import provider_class_for
+
+        snapshot_path = TERMINAL_LOG_DIR / f"{terminal_id}.snapshot.json"
+        provider_type = _json.loads(snapshot_path.read_text(encoding="utf-8"))["provider"]
+        provider_cls = provider_class_for(provider_type)
+        if provider_cls is not None:
+            # extract_last_message_from_script reads only class-level regexes,
+            # not live terminal state, so a throwaway instance is sufficient.
+            extractor = provider_cls(terminal_id, "", "")
+            return extractor.extract_last_message_from_script(raw)
+    except Exception as e:
+        logger.debug(
+            "Could not re-extract last message for torn-down %s (%s); "
+            "returning raw scrollback",
+            terminal_id,
+            e,
+        )
+    return raw
+
+
 def get_output(terminal_id: str, mode: OutputMode = OutputMode.FULL) -> str:
     """Get terminal output.
 
@@ -637,6 +687,12 @@ def get_output(terminal_id: str, mode: OutputMode = OutputMode.FULL) -> str:
     try:
         metadata = get_terminal_metadata(terminal_id)
         if not metadata:
+            # Terminal is gone (e.g. a handoff worker torn down after finishing).
+            # Recover its output from the delete-time scrollback snapshot rather
+            # than 404-ing the supervisor's re-read.
+            persisted = _persisted_output(terminal_id, mode)
+            if persisted is not None:
+                return persisted
             raise ValueError(f"Terminal '{terminal_id}' not found")
 
         # Get output from StatusMonitor buffer (instant, no tmux call)

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -316,6 +316,22 @@ async def create_terminal(
             skill_prompt=skill_prompt,
             model=profile.model if profile else None,
         )
+
+        # Capture the shell's foreground command BEFORE the CLI launches, for
+        # every provider (historically kiro-only). This baseline lets us later
+        # detect a worker that crashed back to the shell — its pane foreground
+        # reverts to this value — instead of mistaking the frozen, permanently
+        # "stable" screen for a completed turn. Best-effort: providers that
+        # capture their own baseline during initialize() (kiro, after its
+        # shell-ready wait) simply re-set the same value below.
+        if not provider_instance.shell_baseline:
+            try:
+                provider_instance.shell_baseline = get_backend().get_pane_current_command(
+                    session_name, window_name
+                )
+            except Exception as e:  # noqa: BLE001 — baseline is a best-effort liveness aid
+                logger.debug("Could not capture shell baseline for %s: %s", terminal_id, e)
+
         await provider_instance.initialize()
 
         # Persist shell_command baseline if the provider captured one
@@ -602,6 +618,38 @@ def exit_terminal_cli(terminal_id: str) -> None:
         send_special_key(terminal_id, exit_command)
     else:
         send_input(terminal_id, exit_command)
+
+
+def worker_returned_to_shell(terminal_id: str) -> bool:
+    """True if the terminal's CLI exited and the pane is back at the shell.
+
+    A live agent keeps its CLI as the pane's foreground process (e.g. ``claude``
+    / ``node``); only a crashed or exited one reverts to the shell captured as
+    ``shell_baseline`` at launch. Used to tell a genuine "completed" turn apart
+    from a frozen, permanently-silent crashed screen — death is otherwise
+    indistinguishable from completion because a dead process can never emit
+    output to break the completion heuristic's stability window.
+
+    Fail-safe: returns False on ANY uncertainty (no live provider, no captured
+    baseline, backend error), so a healthy or indeterminate worker is never
+    misreported as crashed and a legitimate long-running step is never aborted.
+    """
+    try:
+        provider = provider_manager.get_provider(terminal_id)
+    except Exception:
+        return False
+    if provider is None:
+        return False
+    baseline = provider.shell_baseline
+    if not baseline:
+        return False
+    try:
+        current = get_backend().get_pane_current_command(
+            provider.session_name, provider.window_name
+        )
+    except Exception:
+        return False
+    return bool(current) and current == baseline
 
 
 def _persisted_output(terminal_id: str, mode: OutputMode) -> Optional[str]:

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -694,8 +694,7 @@ def _persisted_output(terminal_id: str, mode: OutputMode) -> Optional[str]:
             return extractor.extract_last_message_from_script(raw)
     except Exception as e:
         logger.debug(
-            "Could not re-extract last message for torn-down %s (%s); "
-            "returning raw scrollback",
+            "Could not re-extract last message for torn-down %s (%s); " "returning raw scrollback",
             terminal_id,
             e,
         )

--- a/test/mcp_server/test_handoff_equivalence.py
+++ b/test/mcp_server/test_handoff_equivalence.py
@@ -203,3 +203,56 @@ class TestEngineHandoffEquivalence:
         # worker is identical across paths. Identical kinds alone could not catch
         # a divergent prompt/timeout — this does.
         assert engine.send_prompts() == handoff.send_prompts() == ["do the task"]
+
+
+class TestHandoffInheritsConductorWorkingDirectory:
+    """handoff() must place the worker in the supervisor's working directory,
+    not the cao-server process CWD. assign()/_create_terminal already inherit
+    the conductor's directory; handoff omitted it, so handed-off workers ran in
+    the wrong tree (e.g. ~/dev/personal/cao instead of the project repo)."""
+
+    def test_handoff_payload_carries_conductor_working_directory(self):
+        import asyncio
+        import os
+        from unittest.mock import MagicMock, patch
+
+        from cli_agent_orchestrator.mcp_server.server import HandoffContext, _handoff_impl
+
+        captured = {}
+
+        def fake_get(url, timeout=None):
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {"working_directory": "/Users/cdisalle/dev/personal/riskprep"}
+            return r
+
+        def fake_post(url, json=None, timeout=None):
+            captured["payload"] = json
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {
+                "last_message": "done",
+                "status": "completed",
+                "terminal_id": "deadbeef",
+            }
+            return r
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervis1"}):
+            with patch(
+                "cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider",
+                return_value=HandoffContext("claude_code", "cao-sess", "supervis1", None),
+            ):
+                with patch("cli_agent_orchestrator.mcp_server.server.requests") as mock_requests:
+                    mock_requests.get.side_effect = fake_get
+                    mock_requests.post.side_effect = fake_post
+                    mock_requests.Timeout = Exception
+                    result = asyncio.run(_handoff_impl("developer", "do the recon"))
+
+        assert result.success is True
+        # The worker is created in the supervisor's project directory.
+        assert captured["payload"]["working_directory"] == "/Users/cdisalle/dev/personal/riskprep"
+        # And it queried the conductor's working-directory endpoint to get it.
+        assert any(
+            "/terminals/supervis1/working-directory" in str(c.args[0])
+            for c in mock_requests.get.call_args_list
+        )

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1711,3 +1711,49 @@ class TestClaudeCodeScreenDetection:
 
     def test_empty_screen_is_unknown(self):
         assert self._p().get_status_from_screen(["", "", ""]) == TerminalStatus.UNKNOWN
+
+
+class TestEffortFooterNotAResponse:
+    """The TUI effort footer "● high · /effort" can render at the START of a line
+    (not only inline as "… esc to interrupt ● high · /effort"). The line-start
+    "●" must NOT be read as a response marker, or the idle launch screen (❯ box +
+    this footer) flips get_status to a false COMPLETED and a handoff completes in
+    ~10s extracting "high · /effort" as the report. Regression for that.
+    """
+
+    def _idle_footer_screen(self):
+        return (
+            "● high · /effort\n" + "─" * 100 + "\n"
+            '❯ Try "create a util logging.py that..."\n' + "─" * 100 + "\n"
+            "  ⏵⏵ bypass permissions · esc to interrupt\n"
+        )
+
+    def test_idle_footer_screen_is_not_completed(self):
+        provider = ClaudeCodeProvider("t", "s", "w")
+        assert provider.get_status(self._idle_footer_screen()) != TerminalStatus.COMPLETED
+
+    def test_idle_footer_screen_yields_no_extractable_response(self):
+        provider = ClaudeCodeProvider("t", "s", "w")
+        with pytest.raises(ValueError, match="No Claude Code response found"):
+            provider.extract_last_message_from_script(self._idle_footer_screen())
+
+    def test_sol_effort_footer_levels_all_excluded(self):
+        provider = ClaudeCodeProvider("t", "s", "w")
+        for level in ("high", "medium", "low", "xhigh", "max", "none"):
+            screen = f"● {level} · /effort\n" + "─" * 80 + "\n❯ \n"
+            with pytest.raises(ValueError, match="No Claude Code response found"):
+                provider.extract_last_message_from_script(screen)
+
+    def test_real_response_above_footer_still_extracts(self):
+        provider = ClaudeCodeProvider("t", "s", "w")
+        screen = "● Final answer here\nmore detail\n" + "─" * 60 + "\n❯ \n" "● high · /effort\n"
+        result = provider.extract_last_message_from_script(screen)
+        assert "Final answer here" in result
+        assert "more detail" in result
+        assert "/effort" not in result
+
+    def test_response_completion_still_detected(self):
+        """The fix must not suppress genuine completion."""
+        provider = ClaudeCodeProvider("t", "s", "w")
+        real = "❯ do recon\n● Here is the report\nLine two\n✻ Worked for 3s\n" + "─" * 60 + "\n❯ \n"
+        assert provider.get_status(real) == TerminalStatus.COMPLETED

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1002,14 +1002,59 @@ Map<String, List<Integer>> nested = getMap();
         assert "Map<String, List<Integer>>" in result
 
     def test_extract_message_with_separator(self):
-        """Test extraction stops at Claude's full-width UI separator (20+ dashes, no box chars)."""
-        # Claude's turn separator spans the full terminal width — always 20+ dashes
-        output = "⏺ Response content\n" + "─" * 80 + "\nMore content\n> "
+        """Extraction stops at the full-width turn separator that frames the ❯
+        input box, and excludes the footer chrome below it."""
+        # Realistic layout: response, the turn separator, then the ❯ box + footer.
+        output = (
+            "⏺ Response content\n"
+            + "─" * 80
+            + "\n❯ \n"
+            + "─" * 80
+            + "\n  footer chrome here\n"
+        )
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         result = provider.extract_last_message_from_script(output)
 
         assert "Response content" in result
-        assert "More content" not in result
+        assert "footer chrome here" not in result
+
+    def test_extract_message_markdown_rule_in_report_not_truncated(self):
+        """A markdown thematic break (``---``) renders as a full-width U+2500 rule
+        identical to the turn separator. When it appears INSIDE the report
+        (followed by more content, not the ❯ prompt) extraction must keep going,
+        not clip the rest of the message."""
+        output = (
+            "● Recon complete. Here is my report.\n"
+            + "─" * 60 + "\n"  # rendered markdown '---'
+            "Architecture: Next.js 16 + Postgres RLS\n"
+            "Unit tests: 427 files / 7830 passed\n"
+            + "─" * 60 + "\n"  # the real turn separator
+            "❯ \n"
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.extract_last_message_from_script(output)
+
+        assert "Recon complete" in result
+        assert "Next.js 16 + Postgres RLS" in result
+        assert "427 files / 7830 passed" in result  # the previously-clipped section
+
+    def test_extract_message_pure_dash_table_rule_in_report_not_truncated(self):
+        """A simple table whose divider is a pure U+2500 run (no corner glyphs)
+        must not terminate extraction mid-report."""
+        output = (
+            "● Results:\n"
+            "Suite        Passed\n"
+            + "─" * 30 + "\n"  # pure-dash table rule, no box chars
+            "auth         120\n"
+            "billing      88\n"
+            "End of report\n"
+            "❯ \n"
+        )
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        result = provider.extract_last_message_from_script(output)
+
+        assert "auth         120" in result
+        assert "End of report" in result
 
     def test_extract_message_new_tui_circle_glyph(self):
         """Newest TUI uses '●' (U+25CF) as the response marker instead of '⏺'.

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1757,3 +1757,41 @@ class TestEffortFooterNotAResponse:
         provider = ClaudeCodeProvider("t", "s", "w")
         real = "❯ do recon\n● Here is the report\nLine two\n✻ Worked for 3s\n" + "─" * 60 + "\n❯ \n"
         assert provider.get_status(real) == TerminalStatus.COMPLETED
+
+
+class TestInProgressToolUseNotCompleted:
+    """An in-progress tool-use marker line ("⏺ Reading 1 file…") ending in the
+    "…" ellipsis must read as PROCESSING, not COMPLETED. Otherwise, when the
+    worker emits a preamble then thinks quietly (>10s, live spinner scrolled out
+    of the rolling buffer), get_status latches a false COMPLETED, the handoff's
+    confirm window passes, and it false-completes in ~10s returning the preamble.
+    """
+
+    BOX = "─" * 100
+
+    def test_preamble_tool_use_is_processing(self):
+        p = ClaudeCodeProvider("t", "s", "w")
+        buf = (
+            "⏺ I'll start by reading the task description.\n"
+            "⏺ Reading 1 file…\n" + self.BOX + "\n❯ \n" + self.BOX + "\n  ⏵⏵ esc to interrupt\n"
+        )
+        assert p.get_status(buf) == TerminalStatus.PROCESSING
+
+    def test_real_response_without_ellipsis_still_completes(self):
+        p = ClaudeCodeProvider("t", "s", "w")
+        buf = "❯ do the task\n⏺ Here is the completed response\n" + self.BOX + "\n❯ "
+        assert p.get_status(buf) == TerminalStatus.COMPLETED
+
+    def test_completion_summary_overrides_ellipsis_marker(self):
+        """A finished turn shows '✻ Worked for Ns'; that trustworthy signal must
+        still complete even if an earlier tool line ends in '…'."""
+        p = ClaudeCodeProvider("t", "s", "w")
+        buf = "⏺ Reading 1 file…\n✻ Worked for 3s\n" + self.BOX + "\n❯ \n"
+        assert p.get_status(buf) == TerminalStatus.COMPLETED
+
+    def test_ascii_triple_dot_does_not_false_trigger(self):
+        """Only the single-char '…' (U+2026) the TUI emits should match; a real
+        answer ending in ASCII '...' must still complete."""
+        p = ClaudeCodeProvider("t", "s", "w")
+        buf = "⏺ That's all for now...\n" + self.BOX + "\n❯ "
+        assert p.get_status(buf) == TerminalStatus.COMPLETED

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1006,11 +1006,7 @@ Map<String, List<Integer>> nested = getMap();
         input box, and excludes the footer chrome below it."""
         # Realistic layout: response, the turn separator, then the ❯ box + footer.
         output = (
-            "⏺ Response content\n"
-            + "─" * 80
-            + "\n❯ \n"
-            + "─" * 80
-            + "\n  footer chrome here\n"
+            "⏺ Response content\n" + "─" * 80 + "\n❯ \n" + "─" * 80 + "\n  footer chrome here\n"
         )
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         result = provider.extract_last_message_from_script(output)
@@ -1024,11 +1020,9 @@ Map<String, List<Integer>> nested = getMap();
         (followed by more content, not the ❯ prompt) extraction must keep going,
         not clip the rest of the message."""
         output = (
-            "● Recon complete. Here is my report.\n"
-            + "─" * 60 + "\n"  # rendered markdown '---'
+            "● Recon complete. Here is my report.\n" + "─" * 60 + "\n"  # rendered markdown '---'
             "Architecture: Next.js 16 + Postgres RLS\n"
-            "Unit tests: 427 files / 7830 passed\n"
-            + "─" * 60 + "\n"  # the real turn separator
+            "Unit tests: 427 files / 7830 passed\n" + "─" * 60 + "\n"  # the real turn separator
             "❯ \n"
         )
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
@@ -1043,8 +1037,7 @@ Map<String, List<Integer>> nested = getMap();
         must not terminate extraction mid-report."""
         output = (
             "● Results:\n"
-            "Suite        Passed\n"
-            + "─" * 30 + "\n"  # pure-dash table rule, no box chars
+            "Suite        Passed\n" + "─" * 30 + "\n"  # pure-dash table rule, no box chars
             "auth         120\n"
             "billing      88\n"
             "End of report\n"

--- a/test/providers/test_provider_manager_unit.py
+++ b/test/providers/test_provider_manager_unit.py
@@ -279,3 +279,38 @@ def test_get_provider_no_shell_baseline_when_metadata_missing_shell_command():
         provider = manager.get_provider("t1")
 
     assert provider.shell_baseline is None
+
+
+class TestDefaultLaunchEnv:
+    """default_launch_env() resolves class-level launch-env defaults by provider type."""
+
+    def test_claude_code_carries_bun_jit_guard(self):
+        from cli_agent_orchestrator.providers.manager import default_launch_env
+
+        assert default_launch_env(ProviderType.CLAUDE_CODE.value) == {"BUN_JSC_useDFGJIT": "0"}
+
+    def test_provider_without_defaults_returns_empty(self):
+        from cli_agent_orchestrator.providers.manager import default_launch_env
+
+        assert default_launch_env(ProviderType.CODEX.value) == {}
+
+    def test_unknown_provider_returns_empty_not_raises(self):
+        from cli_agent_orchestrator.providers.manager import default_launch_env
+
+        assert default_launch_env("does-not-exist") == {}
+
+    def test_returns_a_fresh_copy_each_call(self):
+        """Mutating the result must not corrupt the class-level default."""
+        from cli_agent_orchestrator.providers.manager import default_launch_env
+
+        first = default_launch_env(ProviderType.CLAUDE_CODE.value)
+        first["BUN_JSC_useDFGJIT"] = "tampered"
+        assert default_launch_env(ProviderType.CLAUDE_CODE.value) == {"BUN_JSC_useDFGJIT": "0"}
+
+    def test_default_launch_env_covers_all_provider_types(self):
+        """Every ProviderType must be resolvable so launch-env injection can't
+        silently skip a provider as new ones are added."""
+        from cli_agent_orchestrator.providers.manager import _PROVIDER_CLASS_BY_TYPE
+
+        uncovered = [p.value for p in ProviderType if p.value not in _PROVIDER_CLASS_BY_TYPE]
+        assert uncovered == []

--- a/test/services/test_agent_step.py
+++ b/test/services/test_agent_step.py
@@ -256,3 +256,63 @@ class TestTeardownIsBestEffort:
         assert result.status == TerminalStatus.COMPLETED
         # Exit failed but delete still ran.
         m_delete.assert_called_once_with("abc12345", registry=None)
+
+
+class TestWorkerCrashDetection:
+    """A crashed CLI freezes the pane; the frozen screen can satisfy the
+    COMPLETED heuristic (death == permanent stability) or pin status so the wait
+    times out. A pane-liveness probe must convert both into kind="error" so the
+    handoff reports success=False instead of a false success / mislabeled
+    timeout. The probe is fail-safe: a healthy worker (probe False) is unaffected.
+    """
+
+    def test_completed_but_worker_exited_raises_error_not_success(self):
+        """False-success: wait sees COMPLETED but the CLI has dropped to the
+        shell — must raise kind="error", never return a (truncated) result."""
+        create, send, delete, get_output, exit_cli, wait, status = _patch_terminal_layer(
+            wait_results=(True, True),  # ready, then "completed"
+            final_status=TerminalStatus.COMPLETED,
+        )
+        crashed = patch(
+            f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=True
+        )
+        with create, send, delete, get_output as m_out, exit_cli, wait, status, crashed:
+            with pytest.raises(StepExecutionError) as ei:
+                asyncio.run(run_agent_step("claude_code", "developer", "do the task"))
+
+        assert ei.value.kind == "error"
+        assert "exited before completing" in str(ei.value)
+        m_out.assert_not_called()  # never extract a truncated message from a dead pane
+
+    def test_timeout_with_exited_worker_is_error_not_timeout(self):
+        """False-timeout: completion wait times out and the CLI is back at the
+        shell — report kind="error" (crash), not kind="timeout" (ran long)."""
+        create, send, delete, get_output, exit_cli, wait, status = _patch_terminal_layer(
+            wait_results=(True, False),  # ready, then completion times out
+            final_status=TerminalStatus.PROCESSING,  # stuck (UNKNOWN suppressed)
+        )
+        crashed = patch(
+            f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=True
+        )
+        with create, send, delete, get_output, exit_cli, wait, status, crashed:
+            with pytest.raises(StepExecutionError) as ei:
+                asyncio.run(run_agent_step("claude_code", "developer", "do the task"))
+
+        assert ei.value.kind == "error"
+        assert "exited before completing" in str(ei.value)
+
+    def test_healthy_completed_worker_still_succeeds(self):
+        """Probe False (CLI still running) — the happy path is unchanged."""
+        create, send, delete, get_output, exit_cli, wait, status = _patch_terminal_layer(
+            wait_results=(True, True),
+            final_status=TerminalStatus.COMPLETED,
+            output="the full report",
+        )
+        alive = patch(
+            f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=False
+        )
+        with create, send, delete, get_output, exit_cli, wait, status, alive:
+            result = asyncio.run(run_agent_step("claude_code", "developer", "do the task"))
+
+        assert result.last_message == "the full report"
+        assert result.status == TerminalStatus.COMPLETED

--- a/test/services/test_agent_step.py
+++ b/test/services/test_agent_step.py
@@ -273,9 +273,7 @@ class TestWorkerCrashDetection:
             wait_results=(True, True),  # ready, then "completed"
             final_status=TerminalStatus.COMPLETED,
         )
-        crashed = patch(
-            f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=True
-        )
+        crashed = patch(f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=True)
         with create, send, delete, get_output as m_out, exit_cli, wait, status, crashed:
             with pytest.raises(StepExecutionError) as ei:
                 asyncio.run(run_agent_step("claude_code", "developer", "do the task"))
@@ -291,9 +289,7 @@ class TestWorkerCrashDetection:
             wait_results=(True, False),  # ready, then completion times out
             final_status=TerminalStatus.PROCESSING,  # stuck (UNKNOWN suppressed)
         )
-        crashed = patch(
-            f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=True
-        )
+        crashed = patch(f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=True)
         with create, send, delete, get_output, exit_cli, wait, status, crashed:
             with pytest.raises(StepExecutionError) as ei:
                 asyncio.run(run_agent_step("claude_code", "developer", "do the task"))
@@ -308,9 +304,7 @@ class TestWorkerCrashDetection:
             final_status=TerminalStatus.COMPLETED,
             output="the full report",
         )
-        alive = patch(
-            f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=False
-        )
+        alive = patch(f"{_MODULE}.terminal_service.worker_returned_to_shell", return_value=False)
         with create, send, delete, get_output, exit_cli, wait, status, alive:
             result = asyncio.run(run_agent_step("claude_code", "developer", "do the task"))
 

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -377,3 +377,37 @@ class TestRawDebounceArmedDetection:
         sm._process_chunk("t1", "● Working on task...")
 
         assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+
+
+class TestProcessChunkDeletedTerminal:
+    """_process_chunk must tolerate stray output for a vanished terminal.
+
+    Regression: when a worker crashes, its DB row is deleted but the pane keeps
+    emitting (shell prompt, "Resume this session" banner, tmux redraws). Each
+    stray chunk made provider_manager.get_provider raise ValueError, which
+    run()'s handler logged as a full traceback — thousands of lines until the
+    pane went quiet. _process_chunk must instead drop the chunk and release any
+    residual buffer/latch state, mirroring get_status()'s defensive handling.
+    """
+
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_value_error_does_not_propagate_and_clears_state(self, mock_pm):
+        mock_pm.get_provider.side_effect = ValueError("Terminal t1 not found in database")
+        sm = StatusMonitor()
+        # Residual state as if the terminal had produced output before dying.
+        sm._buffers["t1"] = "prior output"
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+
+        # Must not raise, and must release the residual state.
+        sm._process_chunk("t1", "stray chunk after death\n")
+
+        assert "t1" not in sm._buffers
+        assert "t1" not in sm._last_status
+
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_repeated_stray_chunks_never_raise(self, mock_pm):
+        mock_pm.get_provider.side_effect = ValueError("Terminal t1 not found in database")
+        sm = StatusMonitor()
+        # No prior state at all (clear_terminal already ran) — still must not raise.
+        for i in range(5):
+            sm._process_chunk("t1", f"stray {i}\n")  # would have raised pre-fix

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1096,9 +1096,17 @@ class TestCreateTerminalLaunchEnv:
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
     @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
     async def test_supervisor_new_session_gets_provider_launch_env(
-        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
-        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
-        mock_fifo_manager, mock_status_monitor,
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
     ):
         mock_gen_id.return_value = "test1234"
         mock_gen_session.return_value = "cao-session"
@@ -1127,9 +1135,17 @@ class TestCreateTerminalLaunchEnv:
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
     @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
     async def test_operator_env_overrides_provider_default(
-        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
-        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
-        mock_fifo_manager, mock_status_monitor,
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
     ):
         mock_gen_id.return_value = "test1234"
         mock_gen_session.return_value = "cao-session"
@@ -1142,7 +1158,9 @@ class TestCreateTerminalLaunchEnv:
         mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
 
         await create_terminal(
-            "claude_code", "developer", new_session=True,
+            "claude_code",
+            "developer",
+            new_session=True,
             env_vars={"BUN_JSC_useDFGJIT": "1"},
         )
 
@@ -1161,9 +1179,17 @@ class TestCreateTerminalLaunchEnv:
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
     @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
     async def test_worker_window_gets_provider_launch_env(
-        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
-        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
-        mock_fifo_manager, mock_status_monitor,
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
     ):
         mock_gen_id.return_value = "test1234"
         mock_gen_session.return_value = "cao-session"
@@ -1193,9 +1219,17 @@ class TestCreateTerminalLaunchEnv:
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
     @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
     async def test_provider_without_defaults_injects_nothing(
-        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
-        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
-        mock_fifo_manager, mock_status_monitor,
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
     ):
         mock_gen_id.return_value = "test1234"
         mock_gen_session.return_value = "cao-session"

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1211,3 +1211,48 @@ class TestCreateTerminalLaunchEnv:
 
         extra_env = mock_tmux.create_session.call_args.kwargs["extra_env"]
         assert "BUN_JSC_useDFGJIT" not in extra_env
+
+
+class TestGetOutputPersistedFallback:
+    """get_output recovers a torn-down terminal's output from its scrollback snapshot.
+
+    handoff tears the worker down when it finishes (DB row deleted), so a
+    supervisor re-reading it via get_terminal_output used to get a 404 — the
+    in-band handoff result was the only copy. delete_terminal persists
+    {id}.scrollback + {id}.snapshot.json; get_output now serves those.
+    """
+
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
+    def test_full_mode_serves_raw_scrollback(self, mock_log_dir, mock_meta, tmp_path):
+        mock_meta.return_value = None  # terminal gone
+        mock_log_dir.__truediv__ = lambda self_, name: tmp_path / name
+        (tmp_path / "deadterm.scrollback").write_text("full session history here", encoding="utf-8")
+
+        assert get_output("deadterm", OutputMode.FULL) == "full session history here"
+
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
+    def test_last_mode_reextracts_with_recorded_provider(self, mock_log_dir, mock_meta, tmp_path):
+        mock_meta.return_value = None
+        mock_log_dir.__truediv__ = lambda self_, name: tmp_path / name
+        # A claude_code report in the raw scrollback, framed by the ● marker + prompt.
+        (tmp_path / "deadterm.scrollback").write_text(
+            "● Final report line one\nFinal report line two\n❯ ", encoding="utf-8"
+        )
+        (tmp_path / "deadterm.snapshot.json").write_text(
+            '{"terminal_id": "deadterm", "provider": "claude_code"}', encoding="utf-8"
+        )
+
+        result = get_output("deadterm", OutputMode.LAST)
+        assert "Final report line one" in result
+        assert "Final report line two" in result
+
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
+    def test_no_snapshot_still_raises_not_found(self, mock_log_dir, mock_meta, tmp_path):
+        mock_meta.return_value = None
+        mock_log_dir.__truediv__ = lambda self_, name: tmp_path / name  # empty dir
+
+        with pytest.raises(ValueError, match="not found"):
+            get_output("ghost", OutputMode.FULL)

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1256,3 +1256,56 @@ class TestGetOutputPersistedFallback:
 
         with pytest.raises(ValueError, match="not found"):
             get_output("ghost", OutputMode.FULL)
+
+
+class TestWorkerReturnedToShell:
+    """Liveness probe behind crash detection. Fail-safe: any uncertainty -> False
+    so a healthy/indeterminate worker is never misreported as crashed."""
+
+    def _provider(self, *, baseline):
+        p = MagicMock()
+        p.shell_baseline = baseline
+        p.session_name = "cao-s"
+        p.window_name = "w"
+        return p
+
+    @patch("cli_agent_orchestrator.services.terminal_service.get_backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    def test_true_when_foreground_reverts_to_shell(self, mock_pm, mock_backend):
+        from cli_agent_orchestrator.services.terminal_service import worker_returned_to_shell
+
+        mock_pm.get_provider.return_value = self._provider(baseline="zsh")
+        mock_backend.return_value.get_pane_current_command.return_value = "zsh"
+        assert worker_returned_to_shell("t1") is True
+
+    @patch("cli_agent_orchestrator.services.terminal_service.get_backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    def test_false_when_cli_still_foreground(self, mock_pm, mock_backend):
+        from cli_agent_orchestrator.services.terminal_service import worker_returned_to_shell
+
+        mock_pm.get_provider.return_value = self._provider(baseline="zsh")
+        mock_backend.return_value.get_pane_current_command.return_value = "claude"
+        assert worker_returned_to_shell("t1") is False
+
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    def test_false_when_no_baseline_captured(self, mock_pm):
+        from cli_agent_orchestrator.services.terminal_service import worker_returned_to_shell
+
+        mock_pm.get_provider.return_value = self._provider(baseline=None)
+        assert worker_returned_to_shell("t1") is False
+
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    def test_false_when_provider_lookup_raises(self, mock_pm):
+        from cli_agent_orchestrator.services.terminal_service import worker_returned_to_shell
+
+        mock_pm.get_provider.side_effect = ValueError("not in db")
+        assert worker_returned_to_shell("t1") is False
+
+    @patch("cli_agent_orchestrator.services.terminal_service.get_backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    def test_false_when_backend_errors(self, mock_pm, mock_backend):
+        from cli_agent_orchestrator.services.terminal_service import worker_returned_to_shell
+
+        mock_pm.get_provider.return_value = self._provider(baseline="zsh")
+        mock_backend.return_value.get_pane_current_command.side_effect = RuntimeError("tmux gone")
+        assert worker_returned_to_shell("t1") is False

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1072,3 +1072,142 @@ class TestDeleteTerminal:
         result = delete_terminal("test1234")
 
         assert result is True
+
+
+class TestCreateTerminalLaunchEnv:
+    """Provider DEFAULT_LAUNCH_ENV is merged into the tmux pane environment.
+
+    Regression: the claude_code BUN_JSC DFG-JIT guard used to be a hand-rolled
+    inline command prefix in the provider. It is now declarative class data
+    injected at pane creation, so it reaches both the supervisor (new session)
+    and every worker (new window), is provider-scoped, and survives a
+    cao-server restart (re-derived per spawn, unlike the --env store).
+    """
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_supervisor_new_session_gets_provider_launch_env(
+        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
+        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
+        mock_fifo_manager, mock_status_monitor,
+    ):
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        await create_terminal("claude_code", "developer", new_session=True)
+
+        extra_env = mock_tmux.create_session.call_args.kwargs["extra_env"]
+        assert extra_env["BUN_JSC_useDFGJIT"] == "0"
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_operator_env_overrides_provider_default(
+        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
+        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
+        mock_fifo_manager, mock_status_monitor,
+    ):
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        await create_terminal(
+            "claude_code", "developer", new_session=True,
+            env_vars={"BUN_JSC_useDFGJIT": "1"},
+        )
+
+        extra_env = mock_tmux.create_session.call_args.kwargs["extra_env"]
+        assert extra_env["BUN_JSC_useDFGJIT"] == "1"  # operator --env wins
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_worker_window_gets_provider_launch_env(
+        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
+        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
+        mock_fifo_manager, mock_status_monitor,
+    ):
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = True
+        mock_tmux.create_window.return_value = "developer-abcd"
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        await create_terminal("claude_code", "developer", session_name="cao-existing")
+
+        extra_env = mock_tmux.create_window.call_args.kwargs["extra_env"]
+        assert extra_env["BUN_JSC_useDFGJIT"] == "0"
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_provider_without_defaults_injects_nothing(
+        self, mock_load_profile, mock_gen_id, mock_gen_session, mock_gen_window,
+        mock_tmux, mock_db_create, mock_provider_manager, mock_fifo_dir,
+        mock_fifo_manager, mock_status_monitor,
+    ):
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        await create_terminal("kiro_cli", "developer", new_session=True)
+
+        extra_env = mock_tmux.create_session.call_args.kwargs["extra_env"]
+        assert "BUN_JSC_useDFGJIT" not in extra_env


### PR DESCRIPTION
## Summary

A `claude_code` worker segfaulted mid-handoff during a read-only recon run. Debugging that one incident surfaced a chain of independent reliability bugs in the handoff/teardown/status path — each of which can turn a worker problem into a *silent* bad result (a crash reported as success, a report truncated, a 10s "completion" that did no work). This PR fixes all of them.

Each fix is its own commit with a self-contained message, so the PR can be reviewed commit-by-commit. All changes are unit-tested.

## The fixes

1. **`status_monitor`: drop stray output for deleted terminals instead of raising.**
   When a worker dies, its DB row is deleted but the pane keeps emitting (shell prompt, the "Resume this session" banner, tmux redraws). `_process_chunk` called `provider_manager.get_provider()` unguarded, which raises `ValueError` for an unknown terminal, and `run()` logged a full traceback *per stray chunk* — flooding the log until the pane went quiet. Guarded like `get_status()` already is.

2. **`agent_step`: detect a crashed worker instead of reporting false success.**
   A segfaulted CLI freezes its pane. A frozen screen with a leftover response marker satisfies the `COMPLETED` heuristic *trivially* — death is permanent stability, so the confirm-stable window passes *because* the process is dead — and the handoff returns `success` with a truncated message. (A frozen screen matching no marker instead pins `PROCESSING` and the wait burns the full timeout, mislabeling a 5s crash as a 600s timeout.) Adds a fail-safe pane-liveness probe (`worker_returned_to_shell`): a live agent keeps its CLI as the pane foreground; only a crashed/exited one reverts to the shell baseline captured at launch. Probed at both decision points so a crash becomes `kind="error"` → 502 → handoff `success=False`. Generalizes the shell-baseline capture (previously kiro-only) to every provider. The probe returns `False` on any uncertainty, so healthy/indeterminate workers are never aborted.

3. **`claude_code`: stop clipping reports at in-report markdown rules / tables.**
   `extract_last_message_from_script` stopped at the first full-width `─` run, assuming it was the TUI turn-separator. But the renderer draws a markdown thematic break (`---`) and plain table dividers with the same pure-dash run, so any report containing one was clipped mid-message. Now a dash run terminates extraction only when it frames the `❯` input box (next non-blank line is the prompt, or the capture ends); a rule followed by more report text is content.

4. **`terminal_service`: serve persisted scrollback when re-reading a torn-down terminal.**
   `handoff` tears the worker down when it finishes (DB row deleted), so re-reading it via `get_terminal_output` returned 404 — the in-band handoff result was the only copy. `delete_terminal` already persists `{id}.scrollback` + `{id}.snapshot.json`; `get_output` now falls back to them (FULL → raw scrollback; LAST → re-extract with the recorded provider). A genuinely-unknown terminal still 404s.

5. **`providers`: declarative `DEFAULT_LAUNCH_ENV` for per-provider launch env.**
   Generalizes per-provider launch-environment injection instead of hand-rolling inline shell prefixes. Providers declare a class-level `DEFAULT_LAUNCH_ENV`; the service layer resolves it by provider type (before the instance exists, since the pane env is assembled at session/window creation) and merges it into `extra_env` for both supervisor and workers, *under* any operator `--env`. Unlike the process-local `--env` store, it is re-derived from the provider class on every spawn, so it survives a `cao-server` restart. First user: `claude_code` sets `BUN_JSC_useDFGJIT=0` to disable the Bun DFG-JIT tier whose background compile thread can segfault mid-task.

6. **`claude_code`: don't read the start-of-line effort footer as a response.**
   The effort indicator renders as `● high · /effort` (also medium/low/xhigh/…). `EXTRACTION_RESPONSE_PATTERN`'s line-start anchor only excluded it when rendered inline (`… esc to interrupt ● high · /effort`), but it also renders on its **own line**, where the leading `●` was read as a response marker — flipping `get_status` to a false `COMPLETED` on the idle launch screen (the `❯` box + this footer satisfy the completion heuristic), so a handoff "completed" in ~10s before the worker did any work and extraction returned `high · /effort` as the message. Adds a negative lookahead rejecting a start-of-line marker whose line ends in `/effort`.

7. **`claude_code`: treat an in-progress tool-use marker as PROCESSING, not done.**
   A response-marker line ending in the `…` ellipsis (`⏺ Reading 1 file…`, `● Running command…`) is an active tool call, not a finished answer. When the worker emits a preamble and then thinks quietly for >10s, the live spinner scrolls out of the rolling buffer, the PROCESSING checks miss it, and `get_status` falls through to `COMPLETED` on the marker + idle prompt — false-completing a handoff in ~10s and returning the preamble instead of the report. Now the freshest response-marker line ending in `…` reads as `PROCESSING`. Gated on `last_completion is None`, so a genuinely finished turn (which shows the `✻ Worked for Ns` summary) still completes; only the single-char `…` (U+2026) the TUI emits is matched, so prose ending in ASCII `...` cannot false-trigger.

8. **`handoff`: inherit the conductor's working directory.**
   `handoff()` placed the worker in the cao-server process CWD instead of the supervisor's project directory. `assign()`/`_create_terminal` resolve the conductor's working directory when none is pinned, but `_handoff_impl` never did — so a supervisor launched in `~/dev/personal/myrepo` handed off to a developer that ran in whatever directory the daemon was started from, operating on the wrong tree (recon only worked because it used absolute paths). `_handoff_impl` now resolves the conductor's working directory when the caller didn't pin one, mirroring `_create_terminal`.

## Testing

- Full non-integration suite green: `uv run pytest test/ --ignore=test/e2e -m "not integration"` → **3226 passed**.
- New regression tests for each fix (status_monitor deleted-terminal, crash detection + liveness probe, extraction of in-report rules, persisted-output fallback, `DEFAULT_LAUNCH_ENV` resolution + injection, effort-footer exclusion, in-progress tool-use detection, handoff working-directory inheritance).
- `black`, `isort`, `mypy src/` clean (no new findings; pre-existing pyte typing notes in `status_monitor` unchanged).
- Verified live end-to-end against a real recon: pane-env delivery confirmed; a previously-crashing/false-completing handoff now runs a real ~40s handoff (worker actually executes `npm run typecheck` + `test:unit`) and returns an un-truncated report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
