### PR TITLE
fix(status): per-provider pyte override so claude_code and opencode_cli coexist

### DIFF
--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -142,6 +142,15 @@ class BaseProvider(ABC):
     # depends on raw \r) whose detectors are tuned for the raw stream.
     supports_screen_detection: bool = False
 
+    # Per-provider override of the global ``CAO_PYTE_STATUS`` flag. When None
+    # (default), this provider follows the global setting. When True/False, it
+    # forces pyte on/off for THIS provider regardless of the global — so a
+    # provider whose raw detector is reliable but whose pyte path regresses on a
+    # given CLI version (e.g. claude_code on Claude 2.1.x) can pin itself to raw
+    # while pyte-dependent providers (opencode_cli) still use the screen path in
+    # the same deployment. Resolved in StatusMonitor._process_chunk.
+    screen_detection_default: Optional[bool] = None
+
     def get_status_from_screen(self, screen_lines: List[str]) -> TerminalStatus:
         """Detect status from a pyte-rendered screen (composited viewport).
 

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -649,9 +649,15 @@ class ClaudeCodeProvider(BaseProvider):
 
         return TerminalStatus.UNKNOWN
 
-    # Opt in to pyte rendered-screen detection (gated by CAO_PYTE_STATUS). The
-    # detector below is tuned for a COMPOSITED viewport, not the raw stream.
+    # The pyte screen path is implemented (get_status_from_screen below) but is
+    # pinned OFF by default: on Claude Code 2.1.x the rendered-screen path
+    # quiescence-gaps and init times out, whereas the RAW detector
+    # (NEW_TUI_BOX_PATTERN, verified against 2.1.197's stream) is reliable. Pin
+    # to raw here rather than globally so pyte-dependent providers (opencode_cli)
+    # still get the screen path in the same deployment. Flip to True (or clear
+    # screen_detection_default) if a future Claude release fixes the pyte path.
     supports_screen_detection = True
+    screen_detection_default = False
 
     def get_status_from_screen(self, screen_lines: List[str]) -> TerminalStatus:
         """Detect status from a pyte-composited viewport (escape-free rows).

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -113,8 +113,18 @@ class StatusMonitor:
           _schedule_screen_detection.
         """
         provider = provider_manager.get_provider(terminal_id)
+        # Resolve pyte per-provider: a provider may pin itself on/off via
+        # ``screen_detection_default`` (None = follow the global CAO_PYTE_STATUS).
+        # This lets claude_code use the raw path (its pyte detector regresses on
+        # Claude 2.1.x) while opencode_cli uses the screen path (its footer only
+        # composites under pyte) in the SAME deployment — previously impossible
+        # with a single global flag.
+        prov_default = (
+            getattr(provider, "screen_detection_default", None) if provider is not None else None
+        )
+        pyte_on = CAO_PYTE_STATUS if prov_default is None else prov_default
         use_screen = (
-            CAO_PYTE_STATUS
+            pyte_on
             and provider is not None
             and getattr(provider, "supports_screen_detection", False)
         )

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -141,6 +141,47 @@ class _SequencedMonitor:
         return self.sm._last_status.get("t1")
 
 
+class TestPerProviderPyteRouting:
+    """A provider's ``screen_detection_default`` overrides the global
+    CAO_PYTE_STATUS so claude_code (raw) and opencode_cli (pyte) can coexist."""
+
+    def _route(self, *, global_pyte, supports, prov_default):
+        sm = StatusMonitor()
+        provider = MagicMock()
+        provider.supports_screen_detection = supports
+        provider.screen_detection_default = prov_default
+        calls = []
+        with (
+            patch("cli_agent_orchestrator.services.status_monitor.provider_manager") as mock_pm,
+            patch("cli_agent_orchestrator.services.status_monitor.CAO_PYTE_STATUS", global_pyte),
+            patch.object(
+                sm, "_schedule_screen_detection", side_effect=lambda *a, **k: calls.append("screen")
+            ),
+            patch.object(
+                sm, "_schedule_raw_detection", side_effect=lambda *a, **k: calls.append("raw")
+            ),
+            patch.object(sm, "_feed_screen_locked"),
+        ):
+            mock_pm.get_provider.return_value = provider
+            sm._process_chunk("t1", "x")
+        return calls[0] if calls else None
+
+    def test_pinned_off_uses_raw_despite_global_on(self):  # claude_code case
+        assert self._route(global_pyte=True, supports=True, prov_default=False) == "raw"
+
+    def test_pinned_on_uses_screen_despite_global_off(self):
+        assert self._route(global_pyte=False, supports=True, prov_default=True) == "screen"
+
+    def test_none_follows_global_on(self):  # opencode_cli case (default)
+        assert self._route(global_pyte=True, supports=True, prov_default=None) == "screen"
+
+    def test_none_follows_global_off(self):
+        assert self._route(global_pyte=False, supports=True, prov_default=None) == "raw"
+
+    def test_no_screen_support_always_raw(self):
+        assert self._route(global_pyte=True, supports=False, prov_default=None) == "raw"
+
+
 class TestStickyLatching:
     """Pin the sticky ready-status latch + notify_input_sent state machine."""
 


### PR DESCRIPTION
## Problem
`CAO_PYTE_STATUS` is a single **global** flag, but two providers that both opt into `supports_screen_detection` need it set to **opposite** values:

- **claude_code** needs the **raw** path — its pyte screen detector quiescence-gaps on Claude Code 2.1.x and init times out; the raw `NEW_TUI_BOX_PATTERN` is reliable (verified against 2.1.197's stream).
- **opencode_cli** needs the **pyte** path — its idle footer uses absolute cursor moves and only composites correctly under pyte; the raw stream never matches.

With one global flag there is **no configuration where both reach IDLE** (`pyte-on` → opencode works, claude times out; `pyte-off` → claude works, opencode never matches).

## Fix
Make the pyte decision **per-provider**, with the global as the default:

- `base.py`: add `screen_detection_default: Optional[bool]` (None = follow the global `CAO_PYTE_STATUS`).
- `status_monitor._process_chunk`: resolve pyte per-provider (the class default overrides the global) then AND with `supports_screen_detection`.
- `claude_code`: pin `screen_detection_default = False`; `opencode_cli` keeps `None` so it follows the pyte-on default. Clear/flip claude's pin if a future Claude release fixes the pyte path.

## Verification
Live, under the shipped default (pyte-on), probing each provider in isolation:
- `claude_code` reaches IDLE in ~5s (raw), `opencode_cli` in ~7s (pyte) — **previously mutually exclusive**.
- `codex`/`hermes` unaffected (they don't use pyte).

Adds 5 routing tests to `test_status_monitor.py`; full status_monitor suite (32) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
