### PR TITLE
fix(antigravity): dismiss startup feedback survey so init doesn't block

### DIFF
--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -105,6 +105,13 @@ SEPARATOR_PATTERN = r"^\s*─{20,}\s*$"
 # in initialize() by sending Enter (accepts the pre-selected "Yes").
 TRUST_PROMPT_PATTERN = r"Yes, I trust this folder|requires permission to read, edit"
 
+# Feedback-survey dialog agy occasionally shows right after startup ("How's
+# the CLI experience so far? [1] Good [2] Fine [3] Bad [0] Skip"). Like the
+# trust picker it blocks IDLE until answered — dismissed by sending "0"
+# (Skip) + Enter. Note the ready footer ("? for shortcuts") stays visible
+# UNDER this dialog, so it must be checked before any idle-footer early-exit.
+SURVEY_PROMPT_PATTERN = r"How'?s the CLI experience so far"
+
 # Interactive prompts that block on user input (approval dialogs, pickers).
 # With --dangerously-skip-permissions these are rare, but we still classify
 # them as WAITING_USER_ANSWER so orchestrated input is not mistaken for the
@@ -368,29 +375,44 @@ class AntigravityCliProvider(BaseProvider):
             self._mcp_server_names = []
 
     def _handle_startup_dialog(self, timeout: Optional[float] = None) -> None:
-        """Accept agy's workspace-trust dialog if it appears at startup.
+        """Dismiss agy's blocking startup dialogs (workspace-trust, survey).
 
         Mirrors ClaudeCodeProvider._handle_startup_prompts / KimiCliProvider.
-        Polls the pane for the trust picker and sends Enter (the "Yes, I trust
-        this folder" option is pre-selected). Exits early once agy is at its
-        ready footer, so an already-trusted cwd isn't delayed.
+        Polls the pane and answers, in whatever order they appear:
+        - workspace-trust picker → Enter (accepts the pre-selected "Yes")
+        - feedback survey → "0" + Enter (Skip)
+        Both can appear in ONE startup (trust first, survey after), so a
+        dismissal continues the loop rather than returning. Exits once agy is
+        at its ready footer with no dialog on screen — the survey renders ON
+        TOP of the footer, so the survey check must run before the idle exit.
         """
         if timeout is None:
             timeout = get_server_settings()["startup_prompt_handler_timeout"]
+        from cli_agent_orchestrator.services.status_monitor import status_monitor
+
         start_time = time.time()
+        trust_done = survey_done = False
         while time.time() - start_time < timeout:
             output = get_backend().get_history(self.session_name, self.window_name)
             if output:
                 clean = strip_terminal_escapes(output)
-                if re.search(TRUST_PROMPT_PATTERN, clean):
-                    from cli_agent_orchestrator.services.status_monitor import status_monitor
-
+                if not trust_done and re.search(TRUST_PROMPT_PATTERN, clean):
                     logger.info("Antigravity workspace-trust dialog detected, accepting")
                     status_monitor.notify_input_sent(self.terminal_id)
                     get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                    trust_done = True
                     time.sleep(1.0)
-                    return
-                # Already at the ready footer → no dialog to handle, stop early.
+                    continue
+                if not survey_done and re.search(SURVEY_PROMPT_PATTERN, clean):
+                    logger.info("Antigravity feedback survey detected, skipping")
+                    status_monitor.notify_input_sent(self.terminal_id)
+                    get_backend().send_keys(self.session_name, self.window_name, "0", enter_count=0)
+                    time.sleep(0.5)
+                    get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                    survey_done = True
+                    time.sleep(1.0)
+                    continue
+                # At the ready footer with no dialog pending → done.
                 if re.search(IDLE_FOOTER_PATTERN, clean):
                     return
             time.sleep(1.0)


### PR DESCRIPTION
## Problem

`agy` occasionally shows a feedback survey right after startup:

```
How's the CLI experience so far? Help us improve:
[1] Good  [2] Fine  [3] Bad  [0] Skip
```

Like the workspace-trust picker (#364), it blocks until answered — the terminal never reads IDLE and `initialize()` burns the whole init timeout. Observed live: a launch took 111s (of a 139s task) stuck on this dialog until it was skipped manually. The survey was already known to the response-extraction chrome filter (`_SURVEY_PATTERN`), but nothing answered it at init.

A subtlety: the ready footer (`? for shortcuts`) stays visible **under** the survey, so any idle-footer early-exit sees "ready" while the dialog still blocks input.

## Fix

`_handle_startup_dialog` now dismisses **both** startup dialogs in one polling loop, in whatever order they appear:

- workspace-trust picker → `Enter` (accepts the pre-selected *Yes*)
- feedback survey → `0` + `Enter` (*Skip*)

Each dismissal `continue`s the loop (both can appear in one startup: trust first, survey after) instead of returning, and the loop only exits on the ready footer once no dialog is pending — the survey check runs **before** the idle-footer exit for the reason above. Per-dialog `trust_done`/`survey_done` guards prevent re-answering a dialog that is already dismissed but still present in scrollback (`get_history` includes it).

## Testing

- `test/providers/test_antigravity_cli_unit.py` — 52 passed
- Live: with the fix, `agy` sessions reach IDLE and complete orchestrated tasks; before it, a session sat on the survey until manual dismissal
- `black` / `isort` / `mypy` clean

Follow-up to #364 (workspace-trust) — same failure class, same handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)