### PR TITLE
docs(examples): add AWS cloud-ops agent examples with config

### DIFF
--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -51,10 +51,10 @@ cao install examples/aws/sqs-monitor/sqs-monitor-agent.md \
   --env TIMEOUT_SECONDS=60
 ```
 
-### 3. Run it
+### 3. Launch the agent
 
 ```bash
-cao run sqs-monitor-agent
+cao launch --agent-profile sqs-monitor-agent --provider kiro_cli
 ```
 
 ## Configuration Reference
@@ -76,16 +76,20 @@ config keys to env var names:
 Service-specific keys (e.g., `poll_interval_seconds`, `max_messages`) map to
 their uppercased equivalents (`POLL_INTERVAL_SECONDS`, `MAX_MESSAGES`).
 
+All values are **required** at install time. If omitted, the unresolved
+`${VAR}` literal will expand to empty in bash, causing commands to fail.
+
 ## Security Notes
 
 - All agents use explicit `--profile` flags, never default credentials
-- Use IAM roles with least-privilege permissions
-- The `dynamodb-delete` agent performs destructive operations: test in dev first
+- Each agent validates that required variables are non-empty before executing
+- The `dynamodb-delete` agent enforces a `MAX_DELETE` safety cap
+- Message-extracted inputs are validated against strict allowlist patterns
 - Never store real credentials in agent profile files
 
 ## Multi-Agent Orchestration
 
 These agents are designed to work standalone or as workers in a multi-agent
-system. To orchestrate them together, create a supervisor agent that delegates
-tasks to these workers. See the [orchestration examples](../orchestration/) for
-patterns.
+system. Each includes a `cao-mcp-server` block so supervisors can delegate
+via `handoff` or `send_message`. See the [orchestration examples](../orchestration/)
+for patterns.

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -20,6 +20,7 @@ in its own folder with a profile (`.md`) and a configuration reference (`config.
 - [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 - A named AWS profile (`aws configure --profile my-profile`)
 - `jq` installed (used for JSON parsing)
+- `uuidgen` installed (used by stepfunction and sqs-send for unique IDs)
 - IAM permissions scoped to the specific service (see each agent's profile)
 
 ## How to Use
@@ -27,7 +28,7 @@ in its own folder with a profile (`.md`) and a configuration reference (`config.
 ### 1. Check config.json for the values you need
 
 Each folder has a `config.json` that documents every configurable value with
-example defaults:
+example placeholders:
 
 ```json
 {
@@ -39,8 +40,8 @@ example defaults:
 
 ### 2. Install with your values
 
-Pass your values via `--env` flags. The `${VAR}` placeholders in the `.md`
-profile are resolved at install time:
+All values are **required** at install time. Pass them via `--env` flags. The
+`${VAR}` placeholders in the `.md` profile are resolved during install:
 
 ```bash
 cao install examples/aws/sqs-monitor/sqs-monitor-agent.md \
@@ -51,10 +52,14 @@ cao install examples/aws/sqs-monitor/sqs-monitor-agent.md \
   --env TIMEOUT_SECONDS=60
 ```
 
+If any `--env` value is omitted, the `${VAR}` placeholder passes through
+unresolved and the agent's empty-var validation will exit with an error at
+runtime.
+
 ### 3. Launch the agent
 
 ```bash
-cao launch --agent-profile sqs-monitor-agent --provider kiro_cli
+cao launch --agents sqs-monitor-agent --provider claude_code
 ```
 
 ## Configuration Reference
@@ -76,20 +81,25 @@ config keys to env var names:
 Service-specific keys (e.g., `poll_interval_seconds`, `max_messages`) map to
 their uppercased equivalents (`POLL_INTERVAL_SECONDS`, `MAX_MESSAGES`).
 
-All values are **required** at install time. If omitted, the unresolved
-`${VAR}` literal will expand to empty in bash, causing commands to fail.
-
 ## Security Notes
 
 - All agents use explicit `--profile` flags, never default credentials
 - Each agent validates that required variables are non-empty before executing
-- The `dynamodb-delete` agent enforces a `MAX_DELETE` safety cap
-- Message-extracted inputs are validated against strict allowlist patterns
+- The `dynamodb-delete` agent enforces a `MAX_DELETE` safety cap and requires
+  explicit `CONFIRM=yes` to proceed with deletions
+- These agents process inputs from trusted supervisors only; do not expose
+  to untrusted message sources without additional input sanitization
 - Never store real credentials in agent profile files
+
+## Provider Compatibility
+
+`allowedTools` restrictions are enforced by `claude_code` and `codex` providers.
+The `kiro_cli` provider does not currently enforce tool restrictions at the CAO
+level. Use `--provider claude_code` for enforced sandboxing.
 
 ## Multi-Agent Orchestration
 
 These agents are designed to work standalone or as workers in a multi-agent
 system. Each includes a `cao-mcp-server` block so supervisors can delegate
-via `handoff` or `send_message`. See the [orchestration examples](../orchestration/)
-for patterns.
+via `handoff` or `send_message`. See the [assign example](../assign/) for
+orchestration patterns.

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -1,7 +1,7 @@
 # AWS Cloud-Ops Agent Examples
 
 Ready-to-use agent profiles for common AWS operational tasks. Each agent lives
-in its own folder with a profile (`.md`) and a configuration file (`config.json`).
+in its own folder with a profile (`.md`) and a configuration reference (`config.json`).
 
 ## Agents
 
@@ -22,38 +22,12 @@ in its own folder with a profile (`.md`) and a configuration file (`config.json`
 - `jq` installed (used for JSON parsing)
 - IAM permissions scoped to the specific service (see each agent's profile)
 
-## Two Ways to Use
+## How to Use
 
-### Option A: CAO install-time substitution (recommended)
+### 1. Check config.json for the values you need
 
-Edit `config.json` to set your values, then install with `--env` flags:
-
-```bash
-cao install examples/aws/sqs-monitor/sqs-monitor-agent.md \
-  --env AWS_PROFILE=my-profile \
-  --env AWS_REGION=us-west-2 \
-  --env QUEUE_URL=https://sqs.us-west-2.amazonaws.com/111111111111/my-queue
-```
-
-The `${VAR}` placeholders in the `.md` are resolved at install time. The
-installed agent is fully baked with your values.
-
-### Option B: Runtime config (self-contained)
-
-The agent reads `config.json` from its folder at execution time via `jq`.
-Edit `config.json` directly. No reinstall needed when values change.
-
-```bash
-# Edit the config
-vim examples/aws/sqs-monitor/config.json
-
-# Install the agent (placeholders remain as-is, agent reads config at runtime)
-cao install examples/aws/sqs-monitor/sqs-monitor-agent.md
-```
-
-## Configuration
-
-Each `config.json` uses a **flat key structure** for easy editing:
+Each folder has a `config.json` that documents every configurable value with
+example defaults:
 
 ```json
 {
@@ -63,12 +37,55 @@ Each `config.json` uses a **flat key structure** for easy editing:
 }
 ```
 
-The same keys map 1:1 to `${VAR}` placeholders in the `.md` (uppercased):
-`profile` → `${AWS_PROFILE}`, `region` → `${AWS_REGION}`, etc.
+### 2. Install with your values
+
+Pass your values via `--env` flags. The `${VAR}` placeholders in the `.md`
+profile are resolved at install time:
+
+```bash
+cao install examples/aws/sqs-monitor/sqs-monitor-agent.md \
+  --env AWS_PROFILE=my-profile \
+  --env AWS_REGION=us-west-2 \
+  --env QUEUE_URL=https://sqs.us-west-2.amazonaws.com/111111111111/my-queue \
+  --env POLL_INTERVAL_SECONDS=5 \
+  --env TIMEOUT_SECONDS=60
+```
+
+### 3. Run it
+
+```bash
+cao run sqs-monitor-agent
+```
+
+## Configuration Reference
+
+The `config.json` in each folder is **not** read at runtime. It exists as a
+reference for what `--env` values to pass during install. The mapping from
+config keys to env var names:
+
+| config.json key | `--env` variable |
+|-----------------|------------------|
+| `profile` | `AWS_PROFILE` |
+| `region` | `AWS_REGION` |
+| `queue_url` | `QUEUE_URL` |
+| `table_name` | `TABLE_NAME` |
+| `state_machine_arn` | `STATE_MACHINE_ARN` |
+| `dlq_url` | `DLQ_URL` |
+| `log_group` | `LOG_GROUP` |
+
+Service-specific keys (e.g., `poll_interval_seconds`, `max_messages`) map to
+their uppercased equivalents (`POLL_INTERVAL_SECONDS`, `MAX_MESSAGES`).
 
 ## Security Notes
 
 - All agents use explicit `--profile` flags, never default credentials
 - Use IAM roles with least-privilege permissions
 - The `dynamodb-delete` agent performs destructive operations: test in dev first
-- Never store real credentials in agent profile files or config.json
+- Never store real credentials in agent profile files
+
+## Multi-Agent Orchestration
+
+These agents are designed to work standalone or as workers in a multi-agent
+system. To orchestrate them together, create a supervisor agent that delegates
+tasks to these workers. See the [orchestration examples](../orchestration/) for
+patterns.

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -1,0 +1,74 @@
+# AWS Cloud-Ops Agent Examples
+
+Ready-to-use agent profiles for common AWS operational tasks. Each agent lives
+in its own folder with a profile (`.md`) and a configuration file (`config.json`).
+
+## Agents
+
+| Folder | Description |
+|--------|-------------|
+| [stepfunction/](stepfunction/) | Trigger and monitor AWS Step Functions executions |
+| [cloudwatch-logs/](cloudwatch-logs/) | Search CloudWatch Logs for execution traces and error patterns |
+| [dynamodb-query/](dynamodb-query/) | Query DynamoDB tables by partition key |
+| [dynamodb-delete/](dynamodb-delete/) | Delete all items matching a partition key |
+| [sqs-monitor/](sqs-monitor/) | Poll an SQS queue until all messages are consumed |
+| [sqs-send/](sqs-send/) | Send a message to an SQS queue |
+| [sqs-dlq-check/](sqs-dlq-check/) | Inspect a Dead Letter Queue for failed messages |
+
+## Prerequisites
+
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- A named AWS profile (`aws configure --profile my-profile`)
+- `jq` installed (used for JSON parsing)
+- IAM permissions scoped to the specific service (see each agent's profile)
+
+## Two Ways to Use
+
+### Option A: CAO install-time substitution (recommended)
+
+Edit `config.json` to set your values, then install with `--env` flags:
+
+```bash
+cao install examples/aws/sqs-monitor/sqs-monitor-agent.md \
+  --env AWS_PROFILE=my-profile \
+  --env AWS_REGION=us-west-2 \
+  --env QUEUE_URL=https://sqs.us-west-2.amazonaws.com/111111111111/my-queue
+```
+
+The `${VAR}` placeholders in the `.md` are resolved at install time. The
+installed agent is fully baked with your values.
+
+### Option B: Runtime config (self-contained)
+
+The agent reads `config.json` from its folder at execution time via `jq`.
+Edit `config.json` directly. No reinstall needed when values change.
+
+```bash
+# Edit the config
+vim examples/aws/sqs-monitor/config.json
+
+# Install the agent (placeholders remain as-is, agent reads config at runtime)
+cao install examples/aws/sqs-monitor/sqs-monitor-agent.md
+```
+
+## Configuration
+
+Each `config.json` uses a **flat key structure** for easy editing:
+
+```json
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+}
+```
+
+The same keys map 1:1 to `${VAR}` placeholders in the `.md` (uppercased):
+`profile` → `${AWS_PROFILE}`, `region` → `${AWS_REGION}`, etc.
+
+## Security Notes
+
+- All agents use explicit `--profile` flags, never default credentials
+- Use IAM roles with least-privilege permissions
+- The `dynamodb-delete` agent performs destructive operations: test in dev first
+- Never store real credentials in agent profile files or config.json

--- a/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
+++ b/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
@@ -1,13 +1,10 @@
 ---
 name: cloudwatch-logs-agent
 description: Search CloudWatch Logs for execution traces and error patterns
-role: worker
+role: developer
 allowedTools:
-  - "shell:aws logs*"
-  - "shell:jq*"
-  - "shell:date*"
-  - "shell:grep*"
-  - "shell:cat*"
+  - execute_bash
+  - fs_read
 ---
 
 # CloudWatch Logs Agent
@@ -19,14 +16,16 @@ specific execution IDs and analyzes messages for success or error patterns.
 
 ## Configuration
 
-**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env AWS_REGION=y ...`
+Install this agent with your values via `cao install --env`:
+
 - `${AWS_PROFILE}` — AWS CLI profile name
 - `${AWS_REGION}` — target region
 - `${LOG_GROUP}` — log group name to search
 - `${SEARCH_TIME_WINDOW_MINUTES}` — how far back to search (default: 60)
 - `${MAX_EVENTS}` — max events to return (default: 50)
 
-**Runtime (Option B):** Read from `config.json` in the agent's directory.
+See `config.json` in this folder for a reference of all available values and
+their defaults.
 
 ## Message Input
 
@@ -55,13 +54,14 @@ keyword the caller wants you to find in the logs.
 SEARCH_TARGET="<extracted-from-message>"
 ```
 
-### Step 2: Load config and search
+### Step 2: Search logs
 
 ```bash
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 LOG_GROUP="${LOG_GROUP}"
 TIME_WINDOW=${SEARCH_TIME_WINDOW_MINUTES}
+MAX_EVENTS=${MAX_EVENTS}
 START_TIME=$(( $(date +%s) - (TIME_WINDOW * 60) ))000
 END_TIME=$(date +%s)000
 
@@ -72,7 +72,7 @@ aws logs filter-log-events \
     --start-time "$START_TIME" \
     --end-time "$END_TIME" \
     --filter-pattern "$SEARCH_TARGET" \
-    --max-items ${MAX_EVENTS} \
+    --max-items $MAX_EVENTS \
     --output json | jq '.events[] | {timestamp: .timestamp, message: .message}'
 ```
 

--- a/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
+++ b/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
@@ -1,7 +1,6 @@
 ---
 name: cloudwatch-logs-agent
 description: Search CloudWatch Logs for execution traces and error patterns
-role: developer
 allowedTools:
   - execute_bash
   - fs_read
@@ -29,25 +28,25 @@ Install this agent with your values via `cao install --env`:
 - `${AWS_PROFILE}` — AWS CLI profile name
 - `${AWS_REGION}` — target region
 - `${LOG_GROUP}` — log group name to search
-- `${SEARCH_TIME_WINDOW_MINUTES}` — how far back to search (default: 60)
-- `${MAX_EVENTS}` — max events to return (default: 50)
+- `${SEARCH_TIME_WINDOW_MINUTES}` — how far back to search
+- `${MAX_EVENTS}` — max events to return
 
-See `config.json` in this folder for a reference of all available values.
+See `config.json` in this folder for a reference of all values.
 
 ## Message Input
 
 This agent expects a **search target** in the runtime message from the
-supervisor or user. The search target is the execution ID, request ID, or
-keyword to find in logs. Examples:
+supervisor. The search target is the execution ID, request ID, or keyword
+to find in logs. Examples:
 
 ```
 Search logs for execution abc-123-def-456
 Verify logs for request-id req_9xk2m
-Find errors matching TimeoutException
 ```
 
-The agent extracts the search target from the message. Everything else
-(profile, region, log group, time window) comes from config.
+These agents process inputs from trusted supervisors only. The agent must
+validate the extracted value against `^[a-zA-Z0-9_.:-]+$` before use, and
+must never paste raw message content directly into bash source code.
 
 ## Instructions
 
@@ -58,18 +57,21 @@ search the configured log group and report findings.
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 LOG_GROUP="${LOG_GROUP}"
-TIME_WINDOW=${SEARCH_TIME_WINDOW_MINUTES:-60}
-MAX_EVENTS=${MAX_EVENTS:-50}
+TIME_WINDOW="${SEARCH_TIME_WINDOW_MINUTES}"
+MAX_EVENTS="${MAX_EVENTS}"
 
 # Validate required vars
-if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$LOG_GROUP" ]; then
-    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, or LOG_GROUP)"
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$LOG_GROUP" ] || [ -z "$TIME_WINDOW" ] || [ -z "$MAX_EVENTS" ]; then
+    echo "✗ Missing required config"
     exit 1
 fi
 
-# SEARCH_TARGET is extracted from the runtime message — not from config.
-# Validate: only allow safe characters (alphanumeric, hyphens, underscores, dots, colons).
-SEARCH_TARGET="<extracted-from-message>"
+# SEARCH_TARGET must be assigned by the agent from the supervisor message.
+# Validate: only allow safe characters.
+if [ -z "$SEARCH_TARGET" ]; then
+    echo "✗ No search target provided"
+    exit 1
+fi
 if ! echo "$SEARCH_TARGET" | grep -qE '^[a-zA-Z0-9_.:-]+$'; then
     echo "✗ Invalid search target (contains unsafe characters)"
     exit 1
@@ -85,7 +87,7 @@ RESULT=$(aws logs filter-log-events \
     --start-time "$START_TIME" \
     --end-time "$END_TIME" \
     --filter-pattern "$SEARCH_TARGET" \
-    --max-items $MAX_EVENTS \
+    --max-items "$MAX_EVENTS" \
     --output json)
 
 if [ $? -ne 0 ]; then
@@ -98,7 +100,7 @@ EVENT_COUNT=$(echo "$RESULT" | jq '.events | length')
 echo "Found $EVENT_COUNT event(s) matching '$SEARCH_TARGET'"
 echo "$RESULT" | jq '.events[] | {timestamp: .timestamp, message: .message}'
 
-# Check for success/error patterns
+# Check for error patterns
 echo "$RESULT" | jq -r '.events[].message' | grep -qi "error\|exception\|failed" && \
     echo "⚠ Error patterns detected in results" || \
     echo "✓ No error patterns found"
@@ -109,7 +111,7 @@ echo "$RESULT" | jq -r '.events[].message' | grep -qi "error\|exception\|failed"
 ```json
 {
   "Effect": "Allow",
-  "Action": ["logs:DescribeLogGroups", "logs:FilterLogEvents"],
+  "Action": ["logs:FilterLogEvents"],
   "Resource": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/MyFunction:*"
 }
 ```

--- a/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
+++ b/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
@@ -1,0 +1,96 @@
+---
+name: cloudwatch-logs-agent
+description: Search CloudWatch Logs for execution traces and error patterns
+role: worker
+allowedTools:
+  - "shell:aws logs*"
+  - "shell:jq*"
+  - "shell:date*"
+  - "shell:grep*"
+  - "shell:cat*"
+---
+
+# CloudWatch Logs Agent
+
+## Role
+
+You are a CloudWatch Logs verification agent that searches log groups for
+specific execution IDs and analyzes messages for success or error patterns.
+
+## Configuration
+
+**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env AWS_REGION=y ...`
+- `${AWS_PROFILE}` — AWS CLI profile name
+- `${AWS_REGION}` — target region
+- `${LOG_GROUP}` — log group name to search
+- `${SEARCH_TIME_WINDOW_MINUTES}` — how far back to search (default: 60)
+- `${MAX_EVENTS}` — max events to return (default: 50)
+
+**Runtime (Option B):** Read from `config.json` in the agent's directory.
+
+## Message Input
+
+This agent expects a **search target** in the runtime message from the
+supervisor or user. The search target is the execution ID, request ID, or
+keyword to find in logs. Examples:
+
+```
+Search logs for execution abc-123-def-456
+Verify logs for request-id req_9xk2m
+Find errors matching TimeoutException
+```
+
+The agent extracts the search target from the message. Everything else
+(profile, region, log group, time window) comes from config.
+
+## Instructions
+
+### Step 1: Extract search target from message
+
+Parse the incoming message to identify the search target. It is the ID or
+keyword the caller wants you to find in the logs.
+
+```bash
+# SEARCH_TARGET is extracted from the runtime message — not from config
+SEARCH_TARGET="<extracted-from-message>"
+```
+
+### Step 2: Load config and search
+
+```bash
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
+LOG_GROUP="${LOG_GROUP}"
+TIME_WINDOW=${SEARCH_TIME_WINDOW_MINUTES}
+START_TIME=$(( $(date +%s) - (TIME_WINDOW * 60) ))000
+END_TIME=$(date +%s)000
+
+aws logs filter-log-events \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --log-group-name "$LOG_GROUP" \
+    --start-time "$START_TIME" \
+    --end-time "$END_TIME" \
+    --filter-pattern "$SEARCH_TARGET" \
+    --max-items ${MAX_EVENTS} \
+    --output json | jq '.events[] | {timestamp: .timestamp, message: .message}'
+```
+
+### Step 3: Analyze and report
+
+Look for these patterns in results:
+
+- **Success:** `"status": "SUCCEEDED"`, `"result": "ok"`, `Task completed`
+- **Error:** `ERROR`, `Exception`, `TimeoutError`, `"status": "FAILED"`
+
+Report: event count, success/error patterns found, key error messages, time range.
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["logs:DescribeLogGroups", "logs:FilterLogEvents"],
+  "Resource": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/MyFunction:*"
+}
+```

--- a/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
+++ b/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
@@ -5,6 +5,14 @@ role: developer
 allowedTools:
   - execute_bash
   - fs_read
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
+      - "cao-mcp-server"
 ---
 
 # CloudWatch Logs Agent
@@ -24,8 +32,7 @@ Install this agent with your values via `cao install --env`:
 - `${SEARCH_TIME_WINDOW_MINUTES}` — how far back to search (default: 60)
 - `${MAX_EVENTS}` — max events to return (default: 50)
 
-See `config.json` in this folder for a reference of all available values and
-their defaults.
+See `config.json` in this folder for a reference of all available values.
 
 ## Message Input
 
@@ -44,28 +51,34 @@ The agent extracts the search target from the message. Everything else
 
 ## Instructions
 
-### Step 1: Extract search target from message
-
-Parse the incoming message to identify the search target. It is the ID or
-keyword the caller wants you to find in the logs.
-
-```bash
-# SEARCH_TARGET is extracted from the runtime message — not from config
-SEARCH_TARGET="<extracted-from-message>"
-```
-
-### Step 2: Search logs
+When you receive a message, extract the search target, validate it, then
+search the configured log group and report findings.
 
 ```bash
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 LOG_GROUP="${LOG_GROUP}"
-TIME_WINDOW=${SEARCH_TIME_WINDOW_MINUTES}
-MAX_EVENTS=${MAX_EVENTS}
+TIME_WINDOW=${SEARCH_TIME_WINDOW_MINUTES:-60}
+MAX_EVENTS=${MAX_EVENTS:-50}
+
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$LOG_GROUP" ]; then
+    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, or LOG_GROUP)"
+    exit 1
+fi
+
+# SEARCH_TARGET is extracted from the runtime message — not from config.
+# Validate: only allow safe characters (alphanumeric, hyphens, underscores, dots, colons).
+SEARCH_TARGET="<extracted-from-message>"
+if ! echo "$SEARCH_TARGET" | grep -qE '^[a-zA-Z0-9_.:-]+$'; then
+    echo "✗ Invalid search target (contains unsafe characters)"
+    exit 1
+fi
+
 START_TIME=$(( $(date +%s) - (TIME_WINDOW * 60) ))000
 END_TIME=$(date +%s)000
 
-aws logs filter-log-events \
+RESULT=$(aws logs filter-log-events \
     --profile "$PROFILE" \
     --region "$REGION" \
     --log-group-name "$LOG_GROUP" \
@@ -73,17 +86,23 @@ aws logs filter-log-events \
     --end-time "$END_TIME" \
     --filter-pattern "$SEARCH_TARGET" \
     --max-items $MAX_EVENTS \
-    --output json | jq '.events[] | {timestamp: .timestamp, message: .message}'
+    --output json)
+
+if [ $? -ne 0 ]; then
+    echo "✗ Failed to search CloudWatch Logs"
+    exit 1
+fi
+
+# Report findings
+EVENT_COUNT=$(echo "$RESULT" | jq '.events | length')
+echo "Found $EVENT_COUNT event(s) matching '$SEARCH_TARGET'"
+echo "$RESULT" | jq '.events[] | {timestamp: .timestamp, message: .message}'
+
+# Check for success/error patterns
+echo "$RESULT" | jq -r '.events[].message' | grep -qi "error\|exception\|failed" && \
+    echo "⚠ Error patterns detected in results" || \
+    echo "✓ No error patterns found"
 ```
-
-### Step 3: Analyze and report
-
-Look for these patterns in results:
-
-- **Success:** `"status": "SUCCEEDED"`, `"result": "ok"`, `Task completed`
-- **Error:** `ERROR`, `Exception`, `TimeoutError`, `"status": "FAILED"`
-
-Report: event count, success/error patterns found, key error messages, time range.
 
 ## Required IAM Permissions
 

--- a/examples/aws/cloudwatch-logs/config.json
+++ b/examples/aws/cloudwatch-logs/config.json
@@ -1,0 +1,7 @@
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "log_group": "/aws/lambda/MyFunction",
+  "search_time_window_minutes": 60,
+  "max_events": 50
+}

--- a/examples/aws/dynamodb-delete/config.json
+++ b/examples/aws/dynamodb-delete/config.json
@@ -1,0 +1,10 @@
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "table_name": "MyTable",
+  "partition_key_name": "pk",
+  "partition_key_value": "my-key-value",
+  "partition_key_type": "S",
+  "sort_key_name": "sk",
+  "sort_key_type": "N"
+}

--- a/examples/aws/dynamodb-delete/config.json
+++ b/examples/aws/dynamodb-delete/config.json
@@ -6,5 +6,6 @@
   "partition_key_value": "my-key-value",
   "partition_key_type": "S",
   "sort_key_name": "sk",
-  "sort_key_type": "N"
+  "sort_key_type": "N",
+  "max_delete": 100
 }

--- a/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
+++ b/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
@@ -5,6 +5,14 @@ role: developer
 allowedTools:
   - execute_bash
   - fs_read
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
+      - "cao-mcp-server"
 ---
 
 # DynamoDB Delete Agent
@@ -14,7 +22,9 @@ allowedTools:
 You are a DynamoDB delete agent that removes all items matching a partition key.
 You query first, then delete each item individually.
 
-> **Warning:** This agent performs destructive operations. Test in a dev account first.
+> **Warning:** This agent performs destructive operations. It enforces a
+> MAX_DELETE safety cap and will refuse to proceed if the item count exceeds it.
+> Test in a dev account first.
 
 ## Configuration
 
@@ -25,9 +35,9 @@ Install this agent with your values via `cao install --env`:
 - `${TABLE_NAME}` — DynamoDB table name
 - `${PARTITION_KEY_NAME}` / `${PARTITION_KEY_VALUE}` / `${PARTITION_KEY_TYPE}`
 - `${SORT_KEY_NAME}` / `${SORT_KEY_TYPE}` — sort key schema
+- `${MAX_DELETE}` — safety cap; abort if item count exceeds this (default: 100)
 
-See `config.json` in this folder for a reference of all available values and
-their defaults.
+See `config.json` in this folder for a reference of all available values.
 
 ## Message Input
 
@@ -42,12 +52,13 @@ Delete all items for pk=order-12345
 Clean up partition key user-session-expired-abc
 ```
 
-If the message contains a key value, use it. Otherwise fall back to
-`${PARTITION_KEY_VALUE}` from config.
+If the message contains a key value, validate it and use it. Otherwise fall
+back to `${PARTITION_KEY_VALUE}` from config.
 
 ## Instructions
 
-### Step 1: Query items to delete
+When you receive a message, query for matching items, enforce the safety cap,
+then delete each item.
 
 ```bash
 PROFILE="${AWS_PROFILE}"
@@ -58,36 +69,69 @@ PK_VALUE="${PARTITION_KEY_VALUE}"
 PK_TYPE="${PARTITION_KEY_TYPE}"
 SK_NAME="${SORT_KEY_NAME}"
 SK_TYPE="${SORT_KEY_TYPE}"
+MAX_DELETE=${MAX_DELETE:-100}
 
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$TABLE" ] || [ -z "$PK_NAME" ] || [ -z "$PK_VALUE" ]; then
+    echo "✗ Missing required config"
+    exit 1
+fi
+
+# If PK_VALUE came from a runtime message, validate it
+if ! echo "$PK_VALUE" | grep -qE '^[a-zA-Z0-9_.:-]+$'; then
+    echo "✗ Invalid partition key value (contains unsafe characters)"
+    exit 1
+fi
+
+# Build expression attribute values safely using jq --arg
+EXPR_VALUES=$(jq -n --arg v "$PK_VALUE" --arg t "$PK_TYPE" '{":pk":{($t):$v}}')
+
+# Query items to delete
 RESULT=$(aws dynamodb query \
     --profile "$PROFILE" \
     --region "$REGION" \
     --table-name "$TABLE" \
     --key-condition-expression "$PK_NAME = :pk" \
-    --expression-attribute-values "{\":pk\": {\"$PK_TYPE\": \"$PK_VALUE\"}}" \
+    --expression-attribute-values "$EXPR_VALUES" \
     --projection-expression "$PK_NAME, $SK_NAME" \
     --output json)
 
-if [ $? -ne 0 ]; then echo "✗ Query failed"; exit 1; fi
+if [ $? -ne 0 ]; then
+    echo "✗ Query failed"
+    exit 1
+fi
 
 COUNT=$(echo "$RESULT" | jq '.Count // 0')
 echo "Found $COUNT item(s) to delete"
-if [ "$COUNT" = "0" ]; then echo "✓ Nothing to delete"; exit 0; fi
-```
 
-### Step 2: Delete each item
+if [ "$COUNT" = "0" ]; then
+    echo "✓ Nothing to delete"
+    exit 0
+fi
 
-```bash
+# Safety cap: refuse if too many items
+if [ "$COUNT" -gt "$MAX_DELETE" ]; then
+    echo "✗ Refusing to delete $COUNT items (exceeds MAX_DELETE=$MAX_DELETE)"
+    echo "  Increase MAX_DELETE or narrow the query if this is intentional."
+    exit 1
+fi
+
+# Delete each item
 DELETED=0
 echo "$RESULT" | jq -c '.Items[]' | while IFS= read -r row; do
-    PK_VAL=$(echo "$row" | jq -r ".$PK_NAME.$PK_TYPE")
-    SK_VAL=$(echo "$row" | jq -r ".$SK_NAME.$SK_TYPE")
+    PK_VAL=$(echo "$row" | jq -r --arg k "$PK_NAME" --arg t "$PK_TYPE" '.[$k][$t]')
+    SK_VAL=$(echo "$row" | jq -r --arg k "$SK_NAME" --arg t "$SK_TYPE" '.[$k][$t]')
+
+    KEY_JSON=$(jq -n \
+        --arg pkn "$PK_NAME" --arg pkt "$PK_TYPE" --arg pkv "$PK_VAL" \
+        --arg skn "$SK_NAME" --arg skt "$SK_TYPE" --arg skv "$SK_VAL" \
+        '{($pkn):{($pkt):$pkv}, ($skn):{($skt):$skv}}')
 
     aws dynamodb delete-item \
         --profile "$PROFILE" \
         --region "$REGION" \
         --table-name "$TABLE" \
-        --key "{\"$PK_NAME\": {\"$PK_TYPE\": \"$PK_VAL\"}, \"$SK_NAME\": {\"$SK_TYPE\": \"$SK_VAL\"}}"
+        --key "$KEY_JSON"
 
     if [ $? -eq 0 ]; then
         DELETED=$((DELETED + 1))

--- a/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
+++ b/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
@@ -1,11 +1,10 @@
 ---
 name: dynamodb-delete-agent
 description: Delete all items matching a partition key from a DynamoDB table
-role: worker
+role: developer
 allowedTools:
-  - "shell:aws dynamodb*"
-  - "shell:jq*"
-  - "shell:cat*"
+  - execute_bash
+  - fs_read
 ---
 
 # DynamoDB Delete Agent
@@ -19,18 +18,21 @@ You query first, then delete each item individually.
 
 ## Configuration
 
-**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env TABLE_NAME=y ...`
-- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+Install this agent with your values via `cao install --env`:
+
+- `${AWS_PROFILE}` — AWS CLI profile name
+- `${AWS_REGION}` — target region
 - `${TABLE_NAME}` — DynamoDB table name
 - `${PARTITION_KEY_NAME}` / `${PARTITION_KEY_VALUE}` / `${PARTITION_KEY_TYPE}`
 - `${SORT_KEY_NAME}` / `${SORT_KEY_TYPE}` — sort key schema
 
-**Runtime (Option B):** Read from `config.json` in the agent's directory.
+See `config.json` in this folder for a reference of all available values and
+their defaults.
 
 ## Message Input
 
 The partition key value to delete can come from either:
-- **config.json** — when you always delete the same key (e.g., test cleanup)
+- **config** — when you always delete the same key (e.g., test cleanup)
 - **runtime message** — when a supervisor tells you which key to remove
 
 Example messages from a supervisor:
@@ -41,7 +43,7 @@ Clean up partition key user-session-expired-abc
 ```
 
 If the message contains a key value, use it. Otherwise fall back to
-`partition_key_value` from config.
+`${PARTITION_KEY_VALUE}` from config.
 
 ## Instructions
 
@@ -77,7 +79,7 @@ if [ "$COUNT" = "0" ]; then echo "✓ Nothing to delete"; exit 0; fi
 
 ```bash
 DELETED=0
-for row in $(echo "$RESULT" | jq -c '.Items[]'); do
+echo "$RESULT" | jq -c '.Items[]' | while IFS= read -r row; do
     PK_VAL=$(echo "$row" | jq -r ".$PK_NAME.$PK_TYPE")
     SK_VAL=$(echo "$row" | jq -r ".$SK_NAME.$SK_TYPE")
 
@@ -94,7 +96,7 @@ for row in $(echo "$RESULT" | jq -c '.Items[]'); do
         echo "  ✗ Failed to delete $SK_NAME=$SK_VAL"
     fi
 done
-echo "Deleted $DELETED of $COUNT item(s)"
+echo "Delete operation completed"
 ```
 
 ## Required IAM Permissions

--- a/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
+++ b/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
@@ -1,7 +1,6 @@
 ---
 name: dynamodb-delete-agent
 description: Delete all items matching a partition key from a DynamoDB table
-role: developer
 allowedTools:
   - execute_bash
   - fs_read
@@ -20,11 +19,10 @@ mcpServers:
 ## Role
 
 You are a DynamoDB delete agent that removes all items matching a partition key.
-You query first, then delete each item individually.
+You query first, confirm with the operator, then delete each item individually.
 
 > **Warning:** This agent performs destructive operations. It enforces a
-> MAX_DELETE safety cap and will refuse to proceed if the item count exceeds it.
-> Test in a dev account first.
+> MAX_DELETE safety cap and requires explicit CONFIRM=yes before proceeding.
 
 ## Configuration
 
@@ -34,10 +32,10 @@ Install this agent with your values via `cao install --env`:
 - `${AWS_REGION}` — target region
 - `${TABLE_NAME}` — DynamoDB table name
 - `${PARTITION_KEY_NAME}` / `${PARTITION_KEY_VALUE}` / `${PARTITION_KEY_TYPE}`
-- `${SORT_KEY_NAME}` / `${SORT_KEY_TYPE}` — sort key schema
-- `${MAX_DELETE}` — safety cap; abort if item count exceeds this (default: 100)
+- `${SORT_KEY_NAME}` / `${SORT_KEY_TYPE}` — sort key schema (leave empty for PK-only tables)
+- `${MAX_DELETE}` — safety cap; abort if item count exceeds this
 
-See `config.json` in this folder for a reference of all available values.
+See `config.json` in this folder for a reference of all values.
 
 ## Message Input
 
@@ -45,20 +43,14 @@ The partition key value to delete can come from either:
 - **config** — when you always delete the same key (e.g., test cleanup)
 - **runtime message** — when a supervisor tells you which key to remove
 
-Example messages from a supervisor:
-
-```
-Delete all items for pk=order-12345
-Clean up partition key user-session-expired-abc
-```
-
-If the message contains a key value, validate it and use it. Otherwise fall
-back to `${PARTITION_KEY_VALUE}` from config.
+These agents process inputs from trusted supervisors only. If the partition
+key value comes from a runtime message, the agent must validate it against
+`^[a-zA-Z0-9_.:-]+$` before use.
 
 ## Instructions
 
 When you receive a message, query for matching items, enforce the safety cap,
-then delete each item.
+require confirmation, then delete each item.
 
 ```bash
 PROFILE="${AWS_PROFILE}"
@@ -69,31 +61,42 @@ PK_VALUE="${PARTITION_KEY_VALUE}"
 PK_TYPE="${PARTITION_KEY_TYPE}"
 SK_NAME="${SORT_KEY_NAME}"
 SK_TYPE="${SORT_KEY_TYPE}"
-MAX_DELETE=${MAX_DELETE:-100}
+MAX_DELETE="${MAX_DELETE}"
 
 # Validate required vars
-if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$TABLE" ] || [ -z "$PK_NAME" ] || [ -z "$PK_VALUE" ]; then
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$TABLE" ] || [ -z "$PK_NAME" ] || [ -z "$PK_VALUE" ] || [ -z "$MAX_DELETE" ]; then
     echo "✗ Missing required config"
     exit 1
 fi
 
-# If PK_VALUE came from a runtime message, validate it
+# Validate PK_VALUE (safe characters only)
 if ! echo "$PK_VALUE" | grep -qE '^[a-zA-Z0-9_.:-]+$'; then
     echo "✗ Invalid partition key value (contains unsafe characters)"
     exit 1
 fi
 
-# Build expression attribute values safely using jq --arg
+# Build expression attribute values and names safely using jq --arg
 EXPR_VALUES=$(jq -n --arg v "$PK_VALUE" --arg t "$PK_TYPE" '{":pk":{($t):$v}}')
+EXPR_NAMES=$(jq -n --arg pk "$PK_NAME" '{"#pk":$pk}')
+
+# Build projection expression (handle optional sort key)
+if [ -n "$SK_NAME" ]; then
+    PROJ_EXPR_NAMES=$(jq -n --arg pk "$PK_NAME" --arg sk "$SK_NAME" '{"#pk":$pk,"#sk":$sk}')
+    PROJ_EXPR="#pk, #sk"
+else
+    PROJ_EXPR_NAMES="$EXPR_NAMES"
+    PROJ_EXPR="#pk"
+fi
 
 # Query items to delete
 RESULT=$(aws dynamodb query \
     --profile "$PROFILE" \
     --region "$REGION" \
     --table-name "$TABLE" \
-    --key-condition-expression "$PK_NAME = :pk" \
+    --key-condition-expression "#pk = :pk" \
     --expression-attribute-values "$EXPR_VALUES" \
-    --projection-expression "$PK_NAME, $SK_NAME" \
+    --expression-attribute-names "$PROJ_EXPR_NAMES" \
+    --projection-expression "$PROJ_EXPR" \
     --output json)
 
 if [ $? -ne 0 ]; then
@@ -112,20 +115,33 @@ fi
 # Safety cap: refuse if too many items
 if [ "$COUNT" -gt "$MAX_DELETE" ]; then
     echo "✗ Refusing to delete $COUNT items (exceeds MAX_DELETE=$MAX_DELETE)"
-    echo "  Increase MAX_DELETE or narrow the query if this is intentional."
     exit 1
 fi
 
-# Delete each item
-DELETED=0
-echo "$RESULT" | jq -c '.Items[]' | while IFS= read -r row; do
-    PK_VAL=$(echo "$row" | jq -r --arg k "$PK_NAME" --arg t "$PK_TYPE" '.[$k][$t]')
-    SK_VAL=$(echo "$row" | jq -r --arg k "$SK_NAME" --arg t "$SK_TYPE" '.[$k][$t]')
+# Confirmation gate: require explicit CONFIRM=yes
+echo "⚠ About to delete $COUNT item(s) from $TABLE (pk=$PK_VALUE)"
+if [ "${CONFIRM}" != "yes" ]; then
+    echo "✗ Aborted — set CONFIRM=yes to execute deletes"
+    exit 1
+fi
 
-    KEY_JSON=$(jq -n \
-        --arg pkn "$PK_NAME" --arg pkt "$PK_TYPE" --arg pkv "$PK_VAL" \
-        --arg skn "$SK_NAME" --arg skt "$SK_TYPE" --arg skv "$SK_VAL" \
-        '{($pkn):{($pkt):$pkv}, ($skn):{($skt):$skv}}')
+# Delete each item using process substitution to preserve variable scope
+DELETED=0
+FAILED=0
+while IFS= read -r row; do
+    PK_VAL=$(echo "$row" | jq -r --arg k "$PK_NAME" --arg t "$PK_TYPE" '.[$k][$t]')
+
+    if [ -n "$SK_NAME" ]; then
+        SK_VAL=$(echo "$row" | jq -r --arg k "$SK_NAME" --arg t "$SK_TYPE" '.[$k][$t]')
+        KEY_JSON=$(jq -n \
+            --arg pkn "$PK_NAME" --arg pkt "$PK_TYPE" --arg pkv "$PK_VAL" \
+            --arg skn "$SK_NAME" --arg skt "$SK_TYPE" --arg skv "$SK_VAL" \
+            '{($pkn):{($pkt):$pkv}, ($skn):{($skt):$skv}}')
+    else
+        KEY_JSON=$(jq -n \
+            --arg pkn "$PK_NAME" --arg pkt "$PK_TYPE" --arg pkv "$PK_VAL" \
+            '{($pkn):{($pkt):$pkv}}')
+    fi
 
     aws dynamodb delete-item \
         --profile "$PROFILE" \
@@ -135,12 +151,17 @@ echo "$RESULT" | jq -c '.Items[]' | while IFS= read -r row; do
 
     if [ $? -eq 0 ]; then
         DELETED=$((DELETED + 1))
-        echo "  ✓ Deleted $SK_NAME=$SK_VAL"
+        echo "  ✓ Deleted item $DELETED"
     else
-        echo "  ✗ Failed to delete $SK_NAME=$SK_VAL"
+        FAILED=$((FAILED + 1))
+        echo "  ✗ Failed to delete item"
     fi
-done
-echo "Delete operation completed"
+done < <(echo "$RESULT" | jq -c '.Items[]')
+
+echo "Delete completed: $DELETED succeeded, $FAILED failed out of $COUNT"
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi
 ```
 
 ## Required IAM Permissions

--- a/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
+++ b/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
@@ -1,0 +1,108 @@
+---
+name: dynamodb-delete-agent
+description: Delete all items matching a partition key from a DynamoDB table
+role: worker
+allowedTools:
+  - "shell:aws dynamodb*"
+  - "shell:jq*"
+  - "shell:cat*"
+---
+
+# DynamoDB Delete Agent
+
+## Role
+
+You are a DynamoDB delete agent that removes all items matching a partition key.
+You query first, then delete each item individually.
+
+> **Warning:** This agent performs destructive operations. Test in a dev account first.
+
+## Configuration
+
+**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env TABLE_NAME=y ...`
+- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+- `${TABLE_NAME}` — DynamoDB table name
+- `${PARTITION_KEY_NAME}` / `${PARTITION_KEY_VALUE}` / `${PARTITION_KEY_TYPE}`
+- `${SORT_KEY_NAME}` / `${SORT_KEY_TYPE}` — sort key schema
+
+**Runtime (Option B):** Read from `config.json` in the agent's directory.
+
+## Message Input
+
+The partition key value to delete can come from either:
+- **config.json** — when you always delete the same key (e.g., test cleanup)
+- **runtime message** — when a supervisor tells you which key to remove
+
+Example messages from a supervisor:
+
+```
+Delete all items for pk=order-12345
+Clean up partition key user-session-expired-abc
+```
+
+If the message contains a key value, use it. Otherwise fall back to
+`partition_key_value` from config.
+
+## Instructions
+
+### Step 1: Query items to delete
+
+```bash
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
+TABLE="${TABLE_NAME}"
+PK_NAME="${PARTITION_KEY_NAME}"
+PK_VALUE="${PARTITION_KEY_VALUE}"
+PK_TYPE="${PARTITION_KEY_TYPE}"
+SK_NAME="${SORT_KEY_NAME}"
+SK_TYPE="${SORT_KEY_TYPE}"
+
+RESULT=$(aws dynamodb query \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --table-name "$TABLE" \
+    --key-condition-expression "$PK_NAME = :pk" \
+    --expression-attribute-values "{\":pk\": {\"$PK_TYPE\": \"$PK_VALUE\"}}" \
+    --projection-expression "$PK_NAME, $SK_NAME" \
+    --output json)
+
+if [ $? -ne 0 ]; then echo "✗ Query failed"; exit 1; fi
+
+COUNT=$(echo "$RESULT" | jq '.Count // 0')
+echo "Found $COUNT item(s) to delete"
+if [ "$COUNT" = "0" ]; then echo "✓ Nothing to delete"; exit 0; fi
+```
+
+### Step 2: Delete each item
+
+```bash
+DELETED=0
+for row in $(echo "$RESULT" | jq -c '.Items[]'); do
+    PK_VAL=$(echo "$row" | jq -r ".$PK_NAME.$PK_TYPE")
+    SK_VAL=$(echo "$row" | jq -r ".$SK_NAME.$SK_TYPE")
+
+    aws dynamodb delete-item \
+        --profile "$PROFILE" \
+        --region "$REGION" \
+        --table-name "$TABLE" \
+        --key "{\"$PK_NAME\": {\"$PK_TYPE\": \"$PK_VAL\"}, \"$SK_NAME\": {\"$SK_TYPE\": \"$SK_VAL\"}}"
+
+    if [ $? -eq 0 ]; then
+        DELETED=$((DELETED + 1))
+        echo "  ✓ Deleted $SK_NAME=$SK_VAL"
+    else
+        echo "  ✗ Failed to delete $SK_NAME=$SK_VAL"
+    fi
+done
+echo "Deleted $DELETED of $COUNT item(s)"
+```
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["dynamodb:Query", "dynamodb:DeleteItem"],
+  "Resource": "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable"
+}
+```

--- a/examples/aws/dynamodb-query/config.json
+++ b/examples/aws/dynamodb-query/config.json
@@ -1,0 +1,9 @@
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "table_name": "MyTable",
+  "partition_key_name": "pk",
+  "partition_key_value": "my-key-value",
+  "partition_key_type": "S",
+  "limit": 1
+}

--- a/examples/aws/dynamodb-query/dynamodb-query-agent.md
+++ b/examples/aws/dynamodb-query/dynamodb-query-agent.md
@@ -1,11 +1,10 @@
 ---
 name: dynamodb-query-agent
 description: Query DynamoDB tables by partition key
-role: worker
+role: developer
 allowedTools:
-  - "shell:aws dynamodb*"
-  - "shell:jq*"
-  - "shell:cat*"
+  - execute_bash
+  - fs_read
 ---
 
 # DynamoDB Query Agent
@@ -17,15 +16,18 @@ partition key. Returns the most recent item (sorted descending by sort key).
 
 ## Configuration
 
-**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env TABLE_NAME=y ...`
-- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+Install this agent with your values via `cao install --env`:
+
+- `${AWS_PROFILE}` — AWS CLI profile name
+- `${AWS_REGION}` — target region
 - `${TABLE_NAME}` — DynamoDB table name
 - `${PARTITION_KEY_NAME}` — partition key attribute (e.g., `pk`)
 - `${PARTITION_KEY_VALUE}` — value to query
 - `${PARTITION_KEY_TYPE}` — DynamoDB type: `S`, `N`, or `B`
-- `${LIMIT}` — max items to return
+- `${LIMIT}` — max items to return (default: 1)
 
-**Runtime (Option B):** Read from `config.json` in the agent's directory.
+See `config.json` in this folder for a reference of all available values and
+their defaults.
 
 ## Instructions
 

--- a/examples/aws/dynamodb-query/dynamodb-query-agent.md
+++ b/examples/aws/dynamodb-query/dynamodb-query-agent.md
@@ -5,6 +5,14 @@ role: developer
 allowedTools:
   - execute_bash
   - fs_read
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
+      - "cao-mcp-server"
 ---
 
 # DynamoDB Query Agent
@@ -26,8 +34,7 @@ Install this agent with your values via `cao install --env`:
 - `${PARTITION_KEY_TYPE}` — DynamoDB type: `S`, `N`, or `B`
 - `${LIMIT}` — max items to return (default: 1)
 
-See `config.json` in this folder for a reference of all available values and
-their defaults.
+See `config.json` in this folder for a reference of all available values.
 
 ## Instructions
 
@@ -40,14 +47,23 @@ TABLE="${TABLE_NAME}"
 PK_NAME="${PARTITION_KEY_NAME}"
 PK_VALUE="${PARTITION_KEY_VALUE}"
 PK_TYPE="${PARTITION_KEY_TYPE}"
-LIMIT=${LIMIT}
+LIMIT=${LIMIT:-1}
+
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$TABLE" ] || [ -z "$PK_NAME" ] || [ -z "$PK_VALUE" ]; then
+    echo "✗ Missing required config"
+    exit 1
+fi
+
+# Build expression attribute values safely using jq --arg
+EXPR_VALUES=$(jq -n --arg v "$PK_VALUE" --arg t "$PK_TYPE" '{":pk":{($t):$v}}')
 
 RESULT=$(aws dynamodb query \
     --profile "$PROFILE" \
     --region "$REGION" \
     --table-name "$TABLE" \
     --key-condition-expression "$PK_NAME = :pk" \
-    --expression-attribute-values "{\":pk\": {\"$PK_TYPE\": \"$PK_VALUE\"}}" \
+    --expression-attribute-values "$EXPR_VALUES" \
     --scan-index-forward false \
     --limit $LIMIT \
     --output json)

--- a/examples/aws/dynamodb-query/dynamodb-query-agent.md
+++ b/examples/aws/dynamodb-query/dynamodb-query-agent.md
@@ -1,7 +1,6 @@
 ---
 name: dynamodb-query-agent
 description: Query DynamoDB tables by partition key
-role: developer
 allowedTools:
   - execute_bash
   - fs_read
@@ -32,9 +31,9 @@ Install this agent with your values via `cao install --env`:
 - `${PARTITION_KEY_NAME}` — partition key attribute (e.g., `pk`)
 - `${PARTITION_KEY_VALUE}` — value to query
 - `${PARTITION_KEY_TYPE}` — DynamoDB type: `S`, `N`, or `B`
-- `${LIMIT}` — max items to return (default: 1)
+- `${LIMIT}` — max items to return
 
-See `config.json` in this folder for a reference of all available values.
+See `config.json` in this folder for a reference of all values.
 
 ## Instructions
 
@@ -47,25 +46,27 @@ TABLE="${TABLE_NAME}"
 PK_NAME="${PARTITION_KEY_NAME}"
 PK_VALUE="${PARTITION_KEY_VALUE}"
 PK_TYPE="${PARTITION_KEY_TYPE}"
-LIMIT=${LIMIT:-1}
+LIMIT="${LIMIT}"
 
 # Validate required vars
-if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$TABLE" ] || [ -z "$PK_NAME" ] || [ -z "$PK_VALUE" ]; then
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$TABLE" ] || [ -z "$PK_NAME" ] || [ -z "$PK_VALUE" ] || [ -z "$LIMIT" ]; then
     echo "✗ Missing required config"
     exit 1
 fi
 
-# Build expression attribute values safely using jq --arg
+# Build expression attribute values and names safely using jq --arg
 EXPR_VALUES=$(jq -n --arg v "$PK_VALUE" --arg t "$PK_TYPE" '{":pk":{($t):$v}}')
+EXPR_NAMES=$(jq -n --arg pk "$PK_NAME" '{"#pk":$pk}')
 
 RESULT=$(aws dynamodb query \
     --profile "$PROFILE" \
     --region "$REGION" \
     --table-name "$TABLE" \
-    --key-condition-expression "$PK_NAME = :pk" \
+    --key-condition-expression "#pk = :pk" \
     --expression-attribute-values "$EXPR_VALUES" \
+    --expression-attribute-names "$EXPR_NAMES" \
     --scan-index-forward false \
-    --limit $LIMIT \
+    --limit "$LIMIT" \
     --output json)
 
 if [ $? -ne 0 ]; then

--- a/examples/aws/dynamodb-query/dynamodb-query-agent.md
+++ b/examples/aws/dynamodb-query/dynamodb-query-agent.md
@@ -1,0 +1,77 @@
+---
+name: dynamodb-query-agent
+description: Query DynamoDB tables by partition key
+role: worker
+allowedTools:
+  - "shell:aws dynamodb*"
+  - "shell:jq*"
+  - "shell:cat*"
+---
+
+# DynamoDB Query Agent
+
+## Role
+
+You are a DynamoDB query agent that retrieves items from a table using a
+partition key. Returns the most recent item (sorted descending by sort key).
+
+## Configuration
+
+**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env TABLE_NAME=y ...`
+- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+- `${TABLE_NAME}` — DynamoDB table name
+- `${PARTITION_KEY_NAME}` — partition key attribute (e.g., `pk`)
+- `${PARTITION_KEY_VALUE}` — value to query
+- `${PARTITION_KEY_TYPE}` — DynamoDB type: `S`, `N`, or `B`
+- `${LIMIT}` — max items to return
+
+**Runtime (Option B):** Read from `config.json` in the agent's directory.
+
+## Instructions
+
+When you receive a message, query the table and return results.
+
+```bash
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
+TABLE="${TABLE_NAME}"
+PK_NAME="${PARTITION_KEY_NAME}"
+PK_VALUE="${PARTITION_KEY_VALUE}"
+PK_TYPE="${PARTITION_KEY_TYPE}"
+LIMIT=${LIMIT}
+
+RESULT=$(aws dynamodb query \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --table-name "$TABLE" \
+    --key-condition-expression "$PK_NAME = :pk" \
+    --expression-attribute-values "{\":pk\": {\"$PK_TYPE\": \"$PK_VALUE\"}}" \
+    --scan-index-forward false \
+    --limit $LIMIT \
+    --output json)
+
+if [ $? -ne 0 ]; then
+    echo "✗ DynamoDB query failed"
+    exit 1
+fi
+
+COUNT=$(echo "$RESULT" | jq '.Count')
+echo "Found $COUNT item(s)"
+
+if [ "$COUNT" = "0" ] || [ "$COUNT" = "null" ]; then
+    echo "✗ No items found for key $PK_VALUE"
+    exit 1
+fi
+
+echo "$RESULT" | jq '.Items[0]'
+```
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["dynamodb:Query"],
+  "Resource": "arn:aws:dynamodb:us-east-1:123456789012:table/MyTable"
+}
+```

--- a/examples/aws/sqs-dlq-check/config.json
+++ b/examples/aws/sqs-dlq-check/config.json
@@ -1,0 +1,7 @@
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "dlq_url": "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue-DLQ",
+  "message_group_id": "my-group-id",
+  "max_messages": 10
+}

--- a/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
+++ b/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
@@ -5,6 +5,14 @@ role: developer
 allowedTools:
   - execute_bash
   - fs_read
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
+      - "cao-mcp-server"
 ---
 
 # SQS DLQ Check Agent
@@ -25,19 +33,26 @@ Install this agent with your values via `cao install --env`:
 - `${MESSAGE_GROUP_ID}` — filter by group (FIFO queues, leave empty to skip)
 - `${MAX_MESSAGES}` — max messages to peek (default: 10)
 
-See `config.json` in this folder for a reference of all available values and
-their defaults.
+See `config.json` in this folder for a reference of all available values.
 
 ## Instructions
 
-### Step 1: Check message count
+When you receive a message, check the DLQ for failed messages.
 
 ```bash
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 DLQ_URL="${DLQ_URL}"
-MAX_MESSAGES=${MAX_MESSAGES}
+MAX_MESSAGES=${MAX_MESSAGES:-10}
+GROUP_ID="${MESSAGE_GROUP_ID}"
 
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$DLQ_URL" ]; then
+    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, or DLQ_URL)"
+    exit 1
+fi
+
+# Step 1: Check message count
 COUNT=$(aws sqs get-queue-attributes \
     --profile "$PROFILE" \
     --region "$REGION" \
@@ -46,18 +61,18 @@ COUNT=$(aws sqs get-queue-attributes \
     --query 'Attributes.ApproximateNumberOfMessages' \
     --output text)
 
-if [ $? -ne 0 ]; then echo "✗ Failed to check DLQ"; exit 1; fi
+if [ $? -ne 0 ]; then
+    echo "✗ Failed to check DLQ"
+    exit 1
+fi
 
 echo "DLQ message count: $COUNT"
 if [ "$COUNT" = "0" ]; then
     echo "✓ DLQ is empty — no processing failures"
     exit 0
 fi
-```
 
-### Step 2: Peek at messages (non-destructive)
-
-```bash
+# Step 2: Peek at messages (non-destructive)
 MESSAGES=$(aws sqs receive-message \
     --profile "$PROFILE" \
     --region "$REGION" \
@@ -67,21 +82,22 @@ MESSAGES=$(aws sqs receive-message \
     --attribute-names MessageGroupId \
     --output json)
 
-echo "$MESSAGES" | jq '.Messages | length'
-```
+if [ $? -ne 0 ]; then
+    echo "✗ Failed to receive messages from DLQ"
+    exit 1
+fi
 
-### Step 3: Filter by MessageGroupId (FIFO queues)
+MSG_COUNT=$(echo "$MESSAGES" | jq '.Messages | length')
+echo "Peeked at $MSG_COUNT message(s)"
 
-```bash
-GROUP_ID="${MESSAGE_GROUP_ID}"
-
+# Step 3: Filter by MessageGroupId (FIFO queues) using jq --arg for safety
 if [ -n "$GROUP_ID" ]; then
-    MATCH=$(echo "$MESSAGES" | jq -r \
-        ".Messages[]? | select(.Attributes.MessageGroupId == \"$GROUP_ID\") | .MessageId")
+    MATCH=$(echo "$MESSAGES" | jq -r --arg gid "$GROUP_ID" \
+        '.Messages[]? | select(.Attributes.MessageGroupId == $gid) | .MessageId')
 
     if [ -n "$MATCH" ]; then
-        BODY=$(echo "$MESSAGES" | jq -r \
-            ".Messages[] | select(.Attributes.MessageGroupId == \"$GROUP_ID\") | .Body" | head -1)
+        BODY=$(echo "$MESSAGES" | jq -r --arg gid "$GROUP_ID" \
+            '.Messages[] | select(.Attributes.MessageGroupId == $gid) | .Body' | head -1)
         echo "✗ Found failed message in DLQ"
         echo "  MessageId: $MATCH"
         echo "  Body: $BODY"

--- a/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
+++ b/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
@@ -1,7 +1,6 @@
 ---
 name: sqs-dlq-check-agent
 description: Inspect a Dead Letter Queue for failed messages
-role: developer
 allowedTools:
   - execute_bash
   - fs_read
@@ -30,10 +29,10 @@ Install this agent with your values via `cao install --env`:
 - `${AWS_PROFILE}` — AWS CLI profile name
 - `${AWS_REGION}` — target region
 - `${DLQ_URL}` — full DLQ queue URL
-- `${MESSAGE_GROUP_ID}` — filter by group (FIFO queues, leave empty to skip)
-- `${MAX_MESSAGES}` — max messages to peek (default: 10)
+- `${MESSAGE_GROUP_ID}` — filter by group (FIFO queues; leave empty to skip filtering)
+- `${MAX_MESSAGES}` — max messages to peek
 
-See `config.json` in this folder for a reference of all available values.
+See `config.json` in this folder for a reference of all values.
 
 ## Instructions
 
@@ -43,12 +42,12 @@ When you receive a message, check the DLQ for failed messages.
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 DLQ_URL="${DLQ_URL}"
-MAX_MESSAGES=${MAX_MESSAGES:-10}
+MAX_MESSAGES="${MAX_MESSAGES}"
 GROUP_ID="${MESSAGE_GROUP_ID}"
 
 # Validate required vars
-if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$DLQ_URL" ]; then
-    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, or DLQ_URL)"
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$DLQ_URL" ] || [ -z "$MAX_MESSAGES" ]; then
+    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, DLQ_URL, or MAX_MESSAGES)"
     exit 1
 fi
 
@@ -77,9 +76,9 @@ MESSAGES=$(aws sqs receive-message \
     --profile "$PROFILE" \
     --region "$REGION" \
     --queue-url "$DLQ_URL" \
-    --max-number-of-messages $MAX_MESSAGES \
+    --max-number-of-messages "$MAX_MESSAGES" \
     --visibility-timeout 0 \
-    --attribute-names MessageGroupId \
+    --message-system-attribute-names MessageGroupId \
     --output json)
 
 if [ $? -ne 0 ]; then

--- a/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
+++ b/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
@@ -1,0 +1,105 @@
+---
+name: sqs-dlq-check-agent
+description: Inspect a Dead Letter Queue for failed messages
+role: worker
+allowedTools:
+  - "shell:aws sqs*"
+  - "shell:jq*"
+  - "shell:cat*"
+---
+
+# SQS DLQ Check Agent
+
+## Role
+
+You are an SQS Dead Letter Queue inspection agent. You check a DLQ for messages,
+optionally filtering by MessageGroupId (FIFO queues). Useful for verifying no
+processing failures occurred after a workflow run.
+
+## Configuration
+
+**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env DLQ_URL=y ...`
+- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+- `${DLQ_URL}` — full DLQ queue URL
+- `${MESSAGE_GROUP_ID}` — filter by group (FIFO queues, leave empty to skip)
+- `${MAX_MESSAGES}` — max messages to peek (default: 10)
+
+**Runtime (Option B):** Read from `config.json` in the agent's directory.
+
+## Instructions
+
+### Step 1: Check message count
+
+```bash
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
+DLQ_URL="${DLQ_URL}"
+
+COUNT=$(aws sqs get-queue-attributes \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --queue-url "$DLQ_URL" \
+    --attribute-names ApproximateNumberOfMessages \
+    --query 'Attributes.ApproximateNumberOfMessages' \
+    --output text)
+
+if [ $? -ne 0 ]; then echo "✗ Failed to check DLQ"; exit 1; fi
+
+echo "DLQ message count: $COUNT"
+if [ "$COUNT" = "0" ]; then
+    echo "✓ DLQ is empty — no processing failures"
+    exit 0
+fi
+```
+
+### Step 2: Peek at messages (non-destructive)
+
+```bash
+MESSAGES=$(aws sqs receive-message \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --queue-url "$DLQ_URL" \
+    --max-number-of-messages ${MAX_MESSAGES} \
+    --visibility-timeout 0 \
+    --attribute-names MessageGroupId \
+    --output json)
+
+echo "$MESSAGES" | jq '.Messages | length'
+```
+
+### Step 3: Filter by MessageGroupId (FIFO queues)
+
+```bash
+GROUP_ID="${MESSAGE_GROUP_ID}"
+
+if [ -n "$GROUP_ID" ]; then
+    MATCH=$(echo "$MESSAGES" | jq -r \
+        ".Messages[]? | select(.Attributes.MessageGroupId == \"$GROUP_ID\") | .MessageId")
+
+    if [ -n "$MATCH" ]; then
+        BODY=$(echo "$MESSAGES" | jq -r \
+            ".Messages[] | select(.Attributes.MessageGroupId == \"$GROUP_ID\") | .Body" | head -1)
+        echo "✗ Found failed message in DLQ"
+        echo "  MessageId: $MATCH"
+        echo "  Body: $BODY"
+        exit 1
+    else
+        echo "✓ No matching messages for group=$GROUP_ID"
+        exit 0
+    fi
+else
+    echo "⚠ $COUNT message(s) in DLQ (no group filter applied)"
+    echo "$MESSAGES" | jq '.Messages[0:3]'
+    exit 1
+fi
+```
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["sqs:GetQueueAttributes", "sqs:ReceiveMessage"],
+  "Resource": "arn:aws:sqs:us-east-1:123456789012:MyQueue-DLQ"
+}
+```

--- a/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
+++ b/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
@@ -1,11 +1,10 @@
 ---
 name: sqs-dlq-check-agent
 description: Inspect a Dead Letter Queue for failed messages
-role: worker
+role: developer
 allowedTools:
-  - "shell:aws sqs*"
-  - "shell:jq*"
-  - "shell:cat*"
+  - execute_bash
+  - fs_read
 ---
 
 # SQS DLQ Check Agent
@@ -18,13 +17,16 @@ processing failures occurred after a workflow run.
 
 ## Configuration
 
-**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env DLQ_URL=y ...`
-- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+Install this agent with your values via `cao install --env`:
+
+- `${AWS_PROFILE}` — AWS CLI profile name
+- `${AWS_REGION}` — target region
 - `${DLQ_URL}` — full DLQ queue URL
 - `${MESSAGE_GROUP_ID}` — filter by group (FIFO queues, leave empty to skip)
 - `${MAX_MESSAGES}` — max messages to peek (default: 10)
 
-**Runtime (Option B):** Read from `config.json` in the agent's directory.
+See `config.json` in this folder for a reference of all available values and
+their defaults.
 
 ## Instructions
 
@@ -34,6 +36,7 @@ processing failures occurred after a workflow run.
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 DLQ_URL="${DLQ_URL}"
+MAX_MESSAGES=${MAX_MESSAGES}
 
 COUNT=$(aws sqs get-queue-attributes \
     --profile "$PROFILE" \
@@ -59,7 +62,7 @@ MESSAGES=$(aws sqs receive-message \
     --profile "$PROFILE" \
     --region "$REGION" \
     --queue-url "$DLQ_URL" \
-    --max-number-of-messages ${MAX_MESSAGES} \
+    --max-number-of-messages $MAX_MESSAGES \
     --visibility-timeout 0 \
     --attribute-names MessageGroupId \
     --output json)

--- a/examples/aws/sqs-monitor/config.json
+++ b/examples/aws/sqs-monitor/config.json
@@ -1,0 +1,7 @@
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue",
+  "poll_interval_seconds": 10,
+  "timeout_seconds": 300
+}

--- a/examples/aws/sqs-monitor/sqs-monitor-agent.md
+++ b/examples/aws/sqs-monitor/sqs-monitor-agent.md
@@ -1,7 +1,6 @@
 ---
 name: sqs-monitor-agent
 description: Poll an SQS queue until all messages are consumed
-role: developer
 allowedTools:
   - execute_bash
   - fs_read
@@ -29,10 +28,10 @@ Install this agent with your values via `cao install --env`:
 - `${AWS_PROFILE}` — AWS CLI profile name
 - `${AWS_REGION}` — target region
 - `${QUEUE_URL}` — full SQS queue URL
-- `${POLL_INTERVAL_SECONDS}` — seconds between polls (default: 10)
-- `${TIMEOUT_SECONDS}` — max wait time (default: 300)
+- `${POLL_INTERVAL_SECONDS}` — seconds between polls
+- `${TIMEOUT_SECONDS}` — max wait time
 
-See `config.json` in this folder for a reference of all available values.
+See `config.json` in this folder for a reference of all values.
 
 ## Instructions
 
@@ -42,17 +41,17 @@ When you receive a message, poll the queue until it drains or times out.
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 QUEUE_URL="${QUEUE_URL}"
-TIMEOUT=${TIMEOUT_SECONDS:-300}
-INTERVAL=${POLL_INTERVAL_SECONDS:-10}
+TIMEOUT="${TIMEOUT_SECONDS}"
+INTERVAL="${POLL_INTERVAL_SECONDS}"
 
 # Validate required vars
-if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$QUEUE_URL" ]; then
-    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, or QUEUE_URL)"
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$QUEUE_URL" ] || [ -z "$TIMEOUT" ] || [ -z "$INTERVAL" ]; then
+    echo "✗ Missing required config"
     exit 1
 fi
 
 ELAPSED=0
-while [ $ELAPSED -lt $TIMEOUT ]; do
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
     ATTRS=$(aws sqs get-queue-attributes \
         --profile "$PROFILE" \
         --region "$REGION" \
@@ -77,7 +76,7 @@ while [ $ELAPSED -lt $TIMEOUT ]; do
         exit 0
     fi
 
-    sleep $INTERVAL
+    sleep "$INTERVAL"
     ELAPSED=$((ELAPSED + INTERVAL))
 done
 

--- a/examples/aws/sqs-monitor/sqs-monitor-agent.md
+++ b/examples/aws/sqs-monitor/sqs-monitor-agent.md
@@ -1,0 +1,80 @@
+---
+name: sqs-monitor-agent
+description: Poll an SQS queue until all messages are consumed
+role: worker
+allowedTools:
+  - "shell:aws sqs*"
+  - "shell:sleep*"
+  - "shell:cat*"
+  - "shell:jq*"
+---
+
+# SQS Monitor Agent
+
+## Role
+
+You are an SQS queue monitor agent that polls a queue until it is empty.
+Useful for verifying downstream consumers have processed all messages.
+
+## Configuration
+
+**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env QUEUE_URL=y ...`
+- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+- `${QUEUE_URL}` — full SQS queue URL
+- `${POLL_INTERVAL_SECONDS}` — seconds between polls (default: 10)
+- `${TIMEOUT_SECONDS}` — max wait time (default: 300)
+
+**Runtime (Option B):** Read from `config.json` in the agent's directory.
+
+## Instructions
+
+```bash
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
+QUEUE_URL="${QUEUE_URL}"
+TIMEOUT=${TIMEOUT_SECONDS}
+INTERVAL=${POLL_INTERVAL_SECONDS}
+ELAPSED=0
+
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    ATTRS=$(aws sqs get-queue-attributes \
+        --profile "$PROFILE" \
+        --region "$REGION" \
+        --queue-url "$QUEUE_URL" \
+        --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible \
+        --query 'Attributes.[ApproximateNumberOfMessages,ApproximateNumberOfMessagesNotVisible]' \
+        --output text)
+
+    if [ $? -ne 0 ]; then
+        echo "✗ Failed to get queue attributes"
+        exit 1
+    fi
+
+    VISIBLE=$(echo "$ATTRS" | awk '{print $1}')
+    IN_FLIGHT=$(echo "$ATTRS" | awk '{print $2}')
+    TOTAL=$((VISIBLE + IN_FLIGHT))
+
+    echo "Queue: $VISIBLE visible, $IN_FLIGHT in-flight, $TOTAL total (${ELAPSED}s)"
+
+    if [ "$TOTAL" -eq 0 ]; then
+        echo "✓ Queue is empty — all messages consumed"
+        exit 0
+    fi
+
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "✗ Timeout: queue not empty after ${TIMEOUT}s"
+exit 1
+```
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["sqs:GetQueueAttributes"],
+  "Resource": "arn:aws:sqs:us-east-1:123456789012:MyQueue"
+}
+```

--- a/examples/aws/sqs-monitor/sqs-monitor-agent.md
+++ b/examples/aws/sqs-monitor/sqs-monitor-agent.md
@@ -1,12 +1,10 @@
 ---
 name: sqs-monitor-agent
 description: Poll an SQS queue until all messages are consumed
-role: worker
+role: developer
 allowedTools:
-  - "shell:aws sqs*"
-  - "shell:sleep*"
-  - "shell:cat*"
-  - "shell:jq*"
+  - execute_bash
+  - fs_read
 ---
 
 # SQS Monitor Agent
@@ -18,13 +16,16 @@ Useful for verifying downstream consumers have processed all messages.
 
 ## Configuration
 
-**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env QUEUE_URL=y ...`
-- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+Install this agent with your values via `cao install --env`:
+
+- `${AWS_PROFILE}` — AWS CLI profile name
+- `${AWS_REGION}` — target region
 - `${QUEUE_URL}` — full SQS queue URL
 - `${POLL_INTERVAL_SECONDS}` — seconds between polls (default: 10)
 - `${TIMEOUT_SECONDS}` — max wait time (default: 300)
 
-**Runtime (Option B):** Read from `config.json` in the agent's directory.
+See `config.json` in this folder for a reference of all available values and
+their defaults.
 
 ## Instructions
 

--- a/examples/aws/sqs-monitor/sqs-monitor-agent.md
+++ b/examples/aws/sqs-monitor/sqs-monitor-agent.md
@@ -5,6 +5,14 @@ role: developer
 allowedTools:
   - execute_bash
   - fs_read
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
+      - "cao-mcp-server"
 ---
 
 # SQS Monitor Agent
@@ -24,19 +32,26 @@ Install this agent with your values via `cao install --env`:
 - `${POLL_INTERVAL_SECONDS}` — seconds between polls (default: 10)
 - `${TIMEOUT_SECONDS}` — max wait time (default: 300)
 
-See `config.json` in this folder for a reference of all available values and
-their defaults.
+See `config.json` in this folder for a reference of all available values.
 
 ## Instructions
+
+When you receive a message, poll the queue until it drains or times out.
 
 ```bash
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 QUEUE_URL="${QUEUE_URL}"
-TIMEOUT=${TIMEOUT_SECONDS}
-INTERVAL=${POLL_INTERVAL_SECONDS}
-ELAPSED=0
+TIMEOUT=${TIMEOUT_SECONDS:-300}
+INTERVAL=${POLL_INTERVAL_SECONDS:-10}
 
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$QUEUE_URL" ]; then
+    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, or QUEUE_URL)"
+    exit 1
+fi
+
+ELAPSED=0
 while [ $ELAPSED -lt $TIMEOUT ]; do
     ATTRS=$(aws sqs get-queue-attributes \
         --profile "$PROFILE" \

--- a/examples/aws/sqs-send/config.json
+++ b/examples/aws/sqs-send/config.json
@@ -3,5 +3,5 @@
   "region": "us-east-1",
   "queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue",
   "message_body": "{\"key\": \"value\"}",
-  "message_group_id": ""
+  "message_group_id": "my-group-id"
 }

--- a/examples/aws/sqs-send/config.json
+++ b/examples/aws/sqs-send/config.json
@@ -1,0 +1,7 @@
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue",
+  "message_body": "{\"key\": \"value\"}",
+  "message_group_id": ""
+}

--- a/examples/aws/sqs-send/sqs-send-agent.md
+++ b/examples/aws/sqs-send/sqs-send-agent.md
@@ -1,0 +1,78 @@
+---
+name: sqs-send-agent
+description: Send a message to an SQS queue
+role: worker
+allowedTools:
+  - "shell:aws sqs*"
+  - "shell:jq*"
+  - "shell:date*"
+  - "shell:uuidgen*"
+  - "shell:cat*"
+---
+
+# SQS Send Agent
+
+## Role
+
+You are an SQS message sender agent that publishes messages to a queue.
+
+## Configuration
+
+**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env QUEUE_URL=y ...`
+- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+- `${QUEUE_URL}` — full SQS queue URL
+- `${MESSAGE_BODY}` — JSON message body
+- `${MESSAGE_GROUP_ID}` — for FIFO queues (leave empty for standard queues)
+
+**Runtime (Option B):** Read from `config.json` in the agent's directory.
+
+## Instructions
+
+### Standard queue
+
+```bash
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
+QUEUE_URL="${QUEUE_URL}"
+MESSAGE_BODY='${MESSAGE_BODY}'
+
+RESULT=$(aws sqs send-message \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --queue-url "$QUEUE_URL" \
+    --message-body "$MESSAGE_BODY" \
+    --output json)
+
+if [ $? -ne 0 ]; then
+    echo "✗ Failed to send message"
+    exit 1
+fi
+
+MESSAGE_ID=$(echo "$RESULT" | jq -r '.MessageId')
+echo "✓ Message sent: $MESSAGE_ID"
+```
+
+### FIFO queue
+
+For FIFO queues (URL ends with `.fifo`), add group and dedup IDs:
+
+```bash
+RESULT=$(aws sqs send-message \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --queue-url "$QUEUE_URL" \
+    --message-body "$MESSAGE_BODY" \
+    --message-group-id "${MESSAGE_GROUP_ID}" \
+    --message-deduplication-id "$(uuidgen)" \
+    --output json)
+```
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["sqs:SendMessage"],
+  "Resource": "arn:aws:sqs:us-east-1:123456789012:MyQueue"
+}
+```

--- a/examples/aws/sqs-send/sqs-send-agent.md
+++ b/examples/aws/sqs-send/sqs-send-agent.md
@@ -5,6 +5,14 @@ role: developer
 allowedTools:
   - execute_bash
   - fs_read
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
+      - "cao-mcp-server"
 ---
 
 # SQS Send Agent
@@ -23,10 +31,11 @@ Install this agent with your values via `cao install --env`:
 - `${MESSAGE_BODY}` — JSON message body
 - `${MESSAGE_GROUP_ID}` — for FIFO queues (leave empty for standard queues)
 
-See `config.json` in this folder for a reference of all available values and
-their defaults.
+See `config.json` in this folder for a reference of all available values.
 
 ## Instructions
+
+When you receive a message, send it to the SQS queue.
 
 ### Standard queue
 
@@ -35,6 +44,12 @@ PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 QUEUE_URL="${QUEUE_URL}"
 MESSAGE_BODY='${MESSAGE_BODY}'
+
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$QUEUE_URL" ] || [ -z "$MESSAGE_BODY" ]; then
+    echo "✗ Missing required config"
+    exit 1
+fi
 
 RESULT=$(aws sqs send-message \
     --profile "$PROFILE" \
@@ -57,14 +72,28 @@ echo "✓ Message sent: $MESSAGE_ID"
 For FIFO queues (URL ends with `.fifo`), add group and dedup IDs:
 
 ```bash
+GROUP_ID="${MESSAGE_GROUP_ID}"
+if [ -z "$GROUP_ID" ]; then
+    echo "✗ MESSAGE_GROUP_ID required for FIFO queues"
+    exit 1
+fi
+
 RESULT=$(aws sqs send-message \
     --profile "$PROFILE" \
     --region "$REGION" \
     --queue-url "$QUEUE_URL" \
     --message-body "$MESSAGE_BODY" \
-    --message-group-id "${MESSAGE_GROUP_ID}" \
+    --message-group-id "$GROUP_ID" \
     --message-deduplication-id "$(uuidgen)" \
     --output json)
+
+if [ $? -ne 0 ]; then
+    echo "✗ Failed to send FIFO message"
+    exit 1
+fi
+
+MESSAGE_ID=$(echo "$RESULT" | jq -r '.MessageId')
+echo "✓ FIFO message sent: $MESSAGE_ID (group=$GROUP_ID)"
 ```
 
 ## Required IAM Permissions

--- a/examples/aws/sqs-send/sqs-send-agent.md
+++ b/examples/aws/sqs-send/sqs-send-agent.md
@@ -1,13 +1,10 @@
 ---
 name: sqs-send-agent
 description: Send a message to an SQS queue
-role: worker
+role: developer
 allowedTools:
-  - "shell:aws sqs*"
-  - "shell:jq*"
-  - "shell:date*"
-  - "shell:uuidgen*"
-  - "shell:cat*"
+  - execute_bash
+  - fs_read
 ---
 
 # SQS Send Agent
@@ -18,13 +15,16 @@ You are an SQS message sender agent that publishes messages to a queue.
 
 ## Configuration
 
-**Install-time (Option A):** `cao install --env AWS_PROFILE=x --env QUEUE_URL=y ...`
-- `${AWS_PROFILE}`, `${AWS_REGION}` — credentials
+Install this agent with your values via `cao install --env`:
+
+- `${AWS_PROFILE}` — AWS CLI profile name
+- `${AWS_REGION}` — target region
 - `${QUEUE_URL}` — full SQS queue URL
 - `${MESSAGE_BODY}` — JSON message body
 - `${MESSAGE_GROUP_ID}` — for FIFO queues (leave empty for standard queues)
 
-**Runtime (Option B):** Read from `config.json` in the agent's directory.
+See `config.json` in this folder for a reference of all available values and
+their defaults.
 
 ## Instructions
 

--- a/examples/aws/sqs-send/sqs-send-agent.md
+++ b/examples/aws/sqs-send/sqs-send-agent.md
@@ -1,7 +1,6 @@
 ---
 name: sqs-send-agent
 description: Send a message to an SQS queue
-role: developer
 allowedTools:
   - execute_bash
   - fs_read
@@ -29,9 +28,9 @@ Install this agent with your values via `cao install --env`:
 - `${AWS_REGION}` — target region
 - `${QUEUE_URL}` — full SQS queue URL
 - `${MESSAGE_BODY}` — JSON message body
-- `${MESSAGE_GROUP_ID}` — for FIFO queues (leave empty for standard queues)
+- `${MESSAGE_GROUP_ID}` — for FIFO queues (required for .fifo URLs)
 
-See `config.json` in this folder for a reference of all available values.
+See `config.json` in this folder for a reference of all values.
 
 ## Instructions
 
@@ -43,7 +42,7 @@ When you receive a message, send it to the SQS queue.
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 QUEUE_URL="${QUEUE_URL}"
-MESSAGE_BODY='${MESSAGE_BODY}'
+MESSAGE_BODY="${MESSAGE_BODY}"
 
 # Validate required vars
 if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$QUEUE_URL" ] || [ -z "$MESSAGE_BODY" ]; then

--- a/examples/aws/stepfunction/config.json
+++ b/examples/aws/stepfunction/config.json
@@ -1,0 +1,9 @@
+{
+  "profile": "my-aws-profile",
+  "region": "us-east-1",
+  "state_machine_arn": "arn:aws:states:us-east-1:123456789012:stateMachine:MyStateMachine",
+  "execution_name_prefix": "cao-exec",
+  "input_payload": "{}",
+  "poll_interval_seconds": 15,
+  "timeout_seconds": 600
+}

--- a/examples/aws/stepfunction/stepfunction-agent.md
+++ b/examples/aws/stepfunction/stepfunction-agent.md
@@ -1,7 +1,6 @@
 ---
 name: stepfunction-agent
 description: Trigger and monitor AWS Step Functions executions
-role: developer
 allowedTools:
   - execute_bash
   - fs_read
@@ -32,11 +31,10 @@ Install this agent with your values via `cao install --env`:
 - `${STATE_MACHINE_ARN}` — state machine ARN
 - `${EXECUTION_NAME_PREFIX}` — prefix for generated execution names
 - `${INPUT_PAYLOAD}` — JSON input to the state machine
-- `${POLL_INTERVAL_SECONDS}` — seconds between status checks (default: 15)
-- `${TIMEOUT_SECONDS}` — max seconds to wait (default: 600)
+- `${POLL_INTERVAL_SECONDS}` — seconds between status checks
+- `${TIMEOUT_SECONDS}` — max seconds to wait
 
-See `config.json` in this folder for a reference of all available values and
-their defaults.
+See `config.json` in this folder for a reference of all values.
 
 ## Message Input
 
@@ -52,7 +50,8 @@ Trigger Step Function
 Monitor execution arn:aws:states:us-east-1:123456789012:execution:MyStateMachine:cao-exec-abc123
 ```
 
-The execution ARN for monitoring is extracted from the message.
+The execution ARN for monitoring is extracted from the message. These agents
+process inputs from trusted supervisors only.
 
 ## Instructions
 
@@ -64,8 +63,8 @@ When the message contains "trigger", start a new execution:
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 STATE_MACHINE_ARN="${STATE_MACHINE_ARN}"
-EXECUTION_NAME="${EXECUTION_NAME_PREFIX:-cao-exec}-$(uuidgen | tr '[:upper:]' '[:lower:]')"
-INPUT='${INPUT_PAYLOAD}'
+EXECUTION_NAME="${EXECUTION_NAME_PREFIX}-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+INPUT="${INPUT_PAYLOAD}"
 
 # Validate required vars
 if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$STATE_MACHINE_ARN" ]; then
@@ -94,18 +93,24 @@ echo "  ARN: $EXECUTION_ARN"
 ### Monitor Operation
 
 When the message contains "monitor" and an execution ARN, extract the ARN
-from the message and poll until completion:
+from the message and poll until completion. Validate the ARN format before use:
 
 ```bash
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
-TIMEOUT=${TIMEOUT_SECONDS:-600}
-POLL_INTERVAL=${POLL_INTERVAL_SECONDS:-15}
+TIMEOUT="${TIMEOUT_SECONDS}"
+POLL_INTERVAL="${POLL_INTERVAL_SECONDS}"
 
-# EXECUTION_ARN is extracted from the runtime message — not from config.
-# Validate: ARN must match expected pattern.
-EXECUTION_ARN="<extracted-from-message>"
-if ! echo "$EXECUTION_ARN" | grep -qE '^arn:aws:states:[a-z0-9-]+:[0-9]+:execution:.+$'; then
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$TIMEOUT" ] || [ -z "$POLL_INTERVAL" ]; then
+    echo "✗ Missing required config"
+    exit 1
+fi
+
+# EXECUTION_ARN is extracted from the runtime message by the agent.
+# Validate: ARN must match the expected Step Functions execution pattern.
+# The agent must assign EXECUTION_ARN from the message before this check.
+if ! echo "$EXECUTION_ARN" | grep -qE '^arn:aws:states:[a-z0-9-]+:[0-9]+:execution:[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+$'; then
     echo "✗ Invalid execution ARN format"
     exit 1
 fi
@@ -137,7 +142,7 @@ while [ $ELAPSED -lt $TIMEOUT ]; do
             ;;
     esac
 
-    sleep $POLL_INTERVAL
+    sleep "$POLL_INTERVAL"
     ELAPSED=$((ELAPSED + POLL_INTERVAL))
 done
 

--- a/examples/aws/stepfunction/stepfunction-agent.md
+++ b/examples/aws/stepfunction/stepfunction-agent.md
@@ -5,6 +5,14 @@ role: developer
 allowedTools:
   - execute_bash
   - fs_read
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/awslabs/cli-agent-orchestrator.git@main"
+      - "cao-mcp-server"
 ---
 
 # Step Functions Agent
@@ -44,8 +52,7 @@ Trigger Step Function
 Monitor execution arn:aws:states:us-east-1:123456789012:execution:MyStateMachine:cao-exec-abc123
 ```
 
-The execution ARN for monitoring is extracted from the message. If a prior
-trigger step stored it, the supervisor passes it forward.
+The execution ARN for monitoring is extracted from the message.
 
 ## Instructions
 
@@ -57,8 +64,14 @@ When the message contains "trigger", start a new execution:
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
 STATE_MACHINE_ARN="${STATE_MACHINE_ARN}"
-EXECUTION_NAME="${EXECUTION_NAME_PREFIX}-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+EXECUTION_NAME="${EXECUTION_NAME_PREFIX:-cao-exec}-$(uuidgen | tr '[:upper:]' '[:lower:]')"
 INPUT='${INPUT_PAYLOAD}'
+
+# Validate required vars
+if [ -z "$PROFILE" ] || [ -z "$REGION" ] || [ -z "$STATE_MACHINE_ARN" ]; then
+    echo "✗ Missing required config (AWS_PROFILE, AWS_REGION, or STATE_MACHINE_ARN)"
+    exit 1
+fi
 
 EXECUTION_ARN=$(aws stepfunctions start-execution \
     --profile "$PROFILE" \
@@ -84,14 +97,20 @@ When the message contains "monitor" and an execution ARN, extract the ARN
 from the message and poll until completion:
 
 ```bash
-# EXECUTION_ARN is extracted from the runtime message — not from config
-EXECUTION_ARN="<extracted-from-message>"
 PROFILE="${AWS_PROFILE}"
 REGION="${AWS_REGION}"
-TIMEOUT=${TIMEOUT_SECONDS}
-POLL_INTERVAL=${POLL_INTERVAL_SECONDS}
-ELAPSED=0
+TIMEOUT=${TIMEOUT_SECONDS:-600}
+POLL_INTERVAL=${POLL_INTERVAL_SECONDS:-15}
 
+# EXECUTION_ARN is extracted from the runtime message — not from config.
+# Validate: ARN must match expected pattern.
+EXECUTION_ARN="<extracted-from-message>"
+if ! echo "$EXECUTION_ARN" | grep -qE '^arn:aws:states:[a-z0-9-]+:[0-9]+:execution:.+$'; then
+    echo "✗ Invalid execution ARN format"
+    exit 1
+fi
+
+ELAPSED=0
 while [ $ELAPSED -lt $TIMEOUT ]; do
     STATUS=$(aws stepfunctions describe-execution \
         --profile "$PROFILE" \
@@ -99,6 +118,11 @@ while [ $ELAPSED -lt $TIMEOUT ]; do
         --execution-arn "$EXECUTION_ARN" \
         --query 'status' \
         --output text)
+
+    if [ $? -ne 0 ]; then
+        echo "✗ Failed to describe execution (API error or invalid ARN)"
+        exit 1
+    fi
 
     echo "Status: $STATUS (${ELAPSED}s elapsed)"
 

--- a/examples/aws/stepfunction/stepfunction-agent.md
+++ b/examples/aws/stepfunction/stepfunction-agent.md
@@ -1,0 +1,140 @@
+---
+name: stepfunction-agent
+description: Trigger and monitor AWS Step Functions executions
+role: worker
+allowedTools:
+  - "shell:aws stepfunctions*"
+  - "shell:jq*"
+  - "shell:sleep*"
+  - "shell:uuidgen*"
+  - "shell:date*"
+  - "shell:cat*"
+---
+
+# Step Functions Agent
+
+## Role
+
+You are an AWS Step Functions agent that triggers and monitors state machine
+executions. You support two operations: **trigger** (start an execution) and
+**monitor** (poll until completion).
+
+## Configuration
+
+This agent supports two configuration modes:
+
+**Install-time (Option A):** Values are baked in via `cao install --env`:
+- `${AWS_PROFILE}` — AWS CLI profile name
+- `${AWS_REGION}` — target region
+- `${STATE_MACHINE_ARN}` — state machine ARN
+- `${EXECUTION_NAME_PREFIX}` — prefix for generated execution names
+- `${INPUT_PAYLOAD}` — JSON input to the state machine
+- `${POLL_INTERVAL_SECONDS}` — seconds between status checks
+- `${TIMEOUT_SECONDS}` — max seconds to wait
+
+**Runtime (Option B):** Read from `config.json` in the same directory:
+```bash
+CONFIG="$(dirname "$0")/config.json"
+PROFILE=$(jq -r '.profile' "$CONFIG")
+REGION=$(jq -r '.region' "$CONFIG")
+STATE_MACHINE_ARN=$(jq -r '.state_machine_arn' "$CONFIG")
+```
+
+## Message Input
+
+This agent recognizes two operations based on the runtime message:
+
+- **"trigger"** — start a new execution (no extra input needed, uses config)
+- **"monitor"** — poll an execution until done (requires an execution ARN in the message)
+
+Examples from a supervisor:
+
+```
+Trigger Step Function
+Monitor execution arn:aws:states:us-east-1:123456789012:execution:MyStateMachine:cao-exec-abc123
+```
+
+The execution ARN for monitoring is extracted from the message. If a prior
+trigger step stored it, the supervisor passes it forward.
+
+## Instructions
+
+### Trigger Operation
+
+When the message contains "trigger", start a new execution:
+
+```bash
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
+STATE_MACHINE_ARN="${STATE_MACHINE_ARN}"
+EXECUTION_NAME="${EXECUTION_NAME_PREFIX}-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+INPUT='${INPUT_PAYLOAD}'
+
+EXECUTION_ARN=$(aws stepfunctions start-execution \
+    --profile "$PROFILE" \
+    --region "$REGION" \
+    --state-machine-arn "$STATE_MACHINE_ARN" \
+    --name "$EXECUTION_NAME" \
+    --input "$INPUT" \
+    --query 'executionArn' \
+    --output text)
+
+if [ $? -ne 0 ]; then
+    echo "✗ Failed to trigger Step Function"
+    exit 1
+fi
+
+echo "✓ Started execution: $EXECUTION_NAME"
+echo "  ARN: $EXECUTION_ARN"
+```
+
+### Monitor Operation
+
+When the message contains "monitor" and an execution ARN, extract the ARN
+from the message and poll until completion:
+
+```bash
+# EXECUTION_ARN is extracted from the runtime message — not from config
+EXECUTION_ARN="<extracted-from-message>"
+TIMEOUT=${TIMEOUT_SECONDS}
+POLL_INTERVAL=${POLL_INTERVAL_SECONDS}
+ELAPSED=0
+
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    STATUS=$(aws stepfunctions describe-execution \
+        --profile "$PROFILE" \
+        --region "$REGION" \
+        --execution-arn "$EXECUTION_ARN" \
+        --query 'status' \
+        --output text)
+
+    echo "Status: $STATUS (${ELAPSED}s elapsed)"
+
+    case "$STATUS" in
+        SUCCEEDED)
+            echo "✓ Execution completed successfully"
+            exit 0
+            ;;
+        FAILED|TIMED_OUT|ABORTED)
+            echo "✗ Execution failed: $STATUS"
+            exit 1
+            ;;
+    esac
+
+    sleep $POLL_INTERVAL
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+done
+
+echo "✗ Monitoring timed out after ${TIMEOUT}s"
+exit 1
+```
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["states:StartExecution", "states:DescribeExecution"],
+  "Resource": "arn:aws:states:us-east-1:123456789012:stateMachine:MyStateMachine"
+}
+```

--- a/examples/aws/stepfunction/stepfunction-agent.md
+++ b/examples/aws/stepfunction/stepfunction-agent.md
@@ -1,14 +1,10 @@
 ---
 name: stepfunction-agent
 description: Trigger and monitor AWS Step Functions executions
-role: worker
+role: developer
 allowedTools:
-  - "shell:aws stepfunctions*"
-  - "shell:jq*"
-  - "shell:sleep*"
-  - "shell:uuidgen*"
-  - "shell:date*"
-  - "shell:cat*"
+  - execute_bash
+  - fs_read
 ---
 
 # Step Functions Agent
@@ -21,24 +17,18 @@ executions. You support two operations: **trigger** (start an execution) and
 
 ## Configuration
 
-This agent supports two configuration modes:
+Install this agent with your values via `cao install --env`:
 
-**Install-time (Option A):** Values are baked in via `cao install --env`:
 - `${AWS_PROFILE}` — AWS CLI profile name
 - `${AWS_REGION}` — target region
 - `${STATE_MACHINE_ARN}` — state machine ARN
 - `${EXECUTION_NAME_PREFIX}` — prefix for generated execution names
 - `${INPUT_PAYLOAD}` — JSON input to the state machine
-- `${POLL_INTERVAL_SECONDS}` — seconds between status checks
-- `${TIMEOUT_SECONDS}` — max seconds to wait
+- `${POLL_INTERVAL_SECONDS}` — seconds between status checks (default: 15)
+- `${TIMEOUT_SECONDS}` — max seconds to wait (default: 600)
 
-**Runtime (Option B):** Read from `config.json` in the same directory:
-```bash
-CONFIG="$(dirname "$0")/config.json"
-PROFILE=$(jq -r '.profile' "$CONFIG")
-REGION=$(jq -r '.region' "$CONFIG")
-STATE_MACHINE_ARN=$(jq -r '.state_machine_arn' "$CONFIG")
-```
+See `config.json` in this folder for a reference of all available values and
+their defaults.
 
 ## Message Input
 
@@ -96,6 +86,8 @@ from the message and poll until completion:
 ```bash
 # EXECUTION_ARN is extracted from the runtime message — not from config
 EXECUTION_ARN="<extracted-from-message>"
+PROFILE="${AWS_PROFILE}"
+REGION="${AWS_REGION}"
 TIMEOUT=${TIMEOUT_SECONDS}
 POLL_INTERVAL=${POLL_INTERVAL_SECONDS}
 ELAPSED=0


### PR DESCRIPTION
Issue #340

Description of changes:

Adds 7 AWS cloud-ops agent examples under `examples/aws/,` each in its own subfolder with a companion `config.json`.

**What's included:**

Step Functions (trigger/monitor)
CloudWatch Logs (search/verify)
DynamoDB (query, delete)
SQS (monitor, send, DLQ check)

**How it works:**

Two usage modes so users can pick what fits their workflow:

**Option A:** Install-time `${VAR}` substitution via `cao install --env KEY=VALUE`
**Option B:** Runtime config.json read via `jq `(edit config without reinstalling)
Each agent documents which inputs come from static config (profile, region, ARNs) vs the runtime message (execution IDs, search targets, keys to delete).

**Structure:**
```

examples/aws/
├── README.md
├── stepfunction/       (stepfunction-agent.md + config.json)
├── cloudwatch-logs/    (cloudwatch-logs-agent.md + config.json)
├── dynamodb-query/     (dynamodb-query-agent.md + config.json)
├── dynamodb-delete/    (dynamodb-delete-agent.md + config.json)
├── sqs-monitor/        (sqs-monitor-agent.md + config.json)
├── sqs-send/           (sqs-send-agent.md + config.json)
└── sqs-dlq-check/      (sqs-dlq-check-agent.md + config.json)

```

All profiles use `allowedTools` (not the deprecated `autoApproveTools`), placeholder credentials, and flat config.json for easy customization. No new runtime dependencies.

Closes part 1 of #340

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.