### PR TITLE
fix(fifo): non-blocking reader loop + event-loop-safe session teardown (fixes #382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `cao flow` — use `cao schedule` instead; the alias will be removed in a future release (#378)
 
+### Fixed
+
+- fifo: non-blocking FIFO reader loop and event-loop-safe session teardown — reader threads can no longer be stranded in a blocking FIFO `open()` by a stop/reopen race, and `DELETE /sessions` runs teardown in a worker thread, so repeated create/delete cycles can no longer wedge cao-server (#382)
+
 ## [2.2.0] - 2026-06-04
 
 ### Highlights

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -937,7 +937,14 @@ async def delete_session(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     try:
-        result = session_service.delete_session(session_name, registry=get_plugin_registry(request))
+        # Off the event loop: teardown is fully synchronous (tmux kills, FIFO
+        # cleanup, DB writes) and has wedged the whole server — /health
+        # included — when a FIFO operation stalled in the kernel (issue #382).
+        # A worker thread bounds the blast radius of any future stall to this
+        # one request.
+        result = await asyncio.to_thread(
+            session_service.delete_session, session_name, registry=get_plugin_registry(request)
+        )
         return {"success": True, **result}
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -5,8 +5,8 @@ Publisher: terminal.{id}.output
 
 import logging
 import os
+import select
 import threading
-import time
 from typing import Dict
 
 from cli_agent_orchestrator.constants import FIFO_DIR
@@ -15,6 +15,10 @@ from cli_agent_orchestrator.services.event_bus import bus
 logger = logging.getLogger(__name__)
 
 CHUNK_SIZE = 4096
+
+# How often a parked reader re-checks its stop flag. Bounds both shutdown
+# latency and the cost of an idle terminal (one select wakeup per interval).
+_POLL_INTERVAL = 0.5
 
 
 class FifoManager:
@@ -66,17 +70,23 @@ class FifoManager:
         fifo_path = FIFO_DIR / f"{terminal_id}.fifo"
 
         if stop_flag and thread:
+            # The reader never blocks in open()/read() (non-blocking fd +
+            # select with a timeout), so setting the flag is sufficient — it is
+            # observed within one poll interval. No write-side "wakeup" open is
+            # needed; the old wakeup raced with the reader's reopen cycle and
+            # could strand the thread forever in a blocking FIFO open on an
+            # unlinked inode (issue #382).
             stop_flag.set()
-
-            # Unblock thread if stuck on open() by briefly opening write side
-            try:
-                fd = os.open(fifo_path, os.O_WRONLY | os.O_NONBLOCK)
-                os.close(fd)
-            except OSError:
-                pass
-
             thread.join(timeout=2.0)
-            logger.info(f"Stopped FIFO reader for terminal {terminal_id}")
+            if thread.is_alive():
+                # Never silent: a leaked reader thread was how #382's wedge
+                # built up. With the non-blocking loop this should not happen.
+                logger.warning(
+                    f"FIFO reader thread for terminal {terminal_id} did not exit "
+                    "within 2s; leaking a daemon thread"
+                )
+            else:
+                logger.info(f"Stopped FIFO reader for terminal {terminal_id}")
 
         # Best-effort unlink regardless of whether a reader was tracked — when
         # none is tracked there is no active reader holding the FIFO, so removing
@@ -88,24 +98,58 @@ class FifoManager:
 
     @staticmethod
     def _reader_loop(terminal_id: str, fifo_path, stop_flag: threading.Event) -> None:
-        """Read chunks from FIFO and publish to event bus. Reopens on EOF."""
-        while not stop_flag.is_set():
-            fd = -1
-            try:
-                fd = os.open(str(fifo_path), os.O_RDONLY)
-                while not stop_flag.is_set():
-                    raw = os.read(fd, CHUNK_SIZE)
-                    if not raw:
-                        break
+        """Read chunks from FIFO and publish to the event bus.
+
+        Never blocks in a FIFO ``open()`` (issue #382): the previous design
+        opened the pipe with a plain blocking ``O_RDONLY`` and reopened on
+        every EOF, which parked the thread in the kernel's ``wait_for_partner``
+        whenever no writer was attached. ``stop_reader``'s write-side wakeup
+        only worked if the thread happened to be inside ``open()`` at that
+        instant — miss the window (post-EOF reopen, error sleep) and the
+        thread was stranded forever on an inode whose name had been unlinked.
+        Accumulated leaks eventually wedged the whole server.
+
+        Instead:
+        - the read end is opened ``O_RDONLY | O_NONBLOCK``, which succeeds
+          immediately for a FIFO even with no writer;
+        - a keepalive write end is held by this process, so the pipe never
+          reaches writer-count zero — ``select`` therefore only reports the fd
+          readable when actual data arrives (avoiding the busy EOF spin a
+          writer-less non-blocking FIFO would otherwise produce), and tmux
+          detaching its ``pipe-pane`` writer produces no EOF churn at all;
+        - ``select`` uses a timeout so the stop flag is observed within
+          ``_POLL_INTERVAL`` seconds regardless of traffic.
+        """
+        read_fd = -1
+        keepalive_fd = -1
+        try:
+            # Non-blocking read open of a FIFO succeeds immediately (POSIX),
+            # writer attached or not.
+            read_fd = os.open(str(fifo_path), os.O_RDONLY | os.O_NONBLOCK)
+            # With our read end open, a non-blocking write open cannot ENXIO.
+            keepalive_fd = os.open(str(fifo_path), os.O_WRONLY | os.O_NONBLOCK)
+
+            while not stop_flag.is_set():
+                readable, _, _ = select.select([read_fd], [], [], _POLL_INTERVAL)
+                if not readable:
+                    continue
+                try:
+                    raw = os.read(read_fd, CHUNK_SIZE)
+                except BlockingIOError:
+                    continue
+                if raw:
                     chunk = raw.decode("utf-8", errors="replace")
                     bus.publish(f"terminal.{terminal_id}.output", {"data": chunk})
-            except Exception as e:
-                if not stop_flag.is_set():
-                    logger.error(f"FIFO read error for terminal {terminal_id}: {e}")
-                    time.sleep(1.0)
-            finally:
+        except Exception as e:
+            if not stop_flag.is_set():
+                logger.error(f"FIFO reader for terminal {terminal_id} exiting on error: {e}")
+        finally:
+            for fd in (read_fd, keepalive_fd):
                 if fd >= 0:
-                    os.close(fd)
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
 
 
 # Module-level singleton

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -42,3 +42,107 @@ class TestStopReader:
 
         # Must not raise even though there is nothing to stop or unlink.
         manager.stop_reader("term-missing")
+
+
+class TestReaderThreadLifecycle:
+    """Issue #382 regressions: reader threads must never leak, no matter when
+    stop_reader is called relative to writer activity. The old blocking-open
+    loop stranded threads in the kernel's ``wait_for_partner`` whenever the
+    stop-time wakeup missed the reader's reopen window; leaked threads
+    accumulated across create/delete cycles until the server wedged."""
+
+    def _manager(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path)
+        return FifoManager()
+
+    def _thread(self, manager, terminal_id):
+        with manager._lock:
+            return manager._threads.get(terminal_id)
+
+    def test_stop_with_no_writer_ever_attached_does_not_leak(self, tmp_path, monkeypatch):
+        """The #382 leak case: reader parked with no writer, then stopped.
+
+        The old loop blocked inside ``open(O_RDONLY)`` here; if the wakeup
+        raced, join timed out and the unlink stranded the thread forever."""
+        manager = self._manager(tmp_path, monkeypatch)
+        manager.create_reader("term-nolock")
+        thread = self._thread(manager, "term-nolock")
+        assert thread is not None and thread.is_alive()
+
+        manager.stop_reader("term-nolock")
+
+        thread.join(timeout=3.0)
+        assert not thread.is_alive()
+        assert not (tmp_path / "term-nolock.fifo").exists()
+
+    def test_stop_right_after_writer_eof_does_not_leak(self, tmp_path, monkeypatch):
+        """The race window of the old design: a writer connects and disconnects
+        (EOF pulse — what stop_pipe_pane produces) immediately before
+        stop_reader. The old loop was mid-reopen at that point and the wakeup
+        open failed with ENXIO, leaking the thread."""
+        manager = self._manager(tmp_path, monkeypatch)
+        manager.create_reader("term-race")
+        fifo_path = tmp_path / "term-race.fifo"
+
+        # Writer attaches and detaches, like tmux tearing down pipe-pane.
+        wfd = os.open(fifo_path, os.O_WRONLY | os.O_NONBLOCK)
+        os.close(wfd)
+
+        thread = self._thread(manager, "term-race")
+        manager.stop_reader("term-race")
+
+        thread.join(timeout=3.0)
+        assert not thread.is_alive()
+        assert not fifo_path.exists()
+
+    def test_data_received_across_writer_reconnects(self, tmp_path, monkeypatch):
+        """Chunks written by successive writers (tmux re-attaching pipe-pane)
+        are all published; writer disconnects must not kill the reader."""
+        import time
+
+        from cli_agent_orchestrator.services import fifo_reader as fr
+
+        received = []
+        monkeypatch.setattr(
+            fr.bus, "publish", lambda topic, data: received.append((topic, data["data"]))
+        )
+        manager = self._manager(tmp_path, monkeypatch)
+        manager.create_reader("term-data")
+        fifo_path = tmp_path / "term-data.fifo"
+
+        for payload in (b"first", b"second"):
+            wfd = os.open(fifo_path, os.O_WRONLY | os.O_NONBLOCK)
+            os.write(wfd, payload)
+            os.close(wfd)
+            # Wait for the reader's select loop to pick the chunk up.
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline and not any(
+                payload.decode() in d for _, d in received
+            ):
+                time.sleep(0.02)
+
+        manager.stop_reader("term-data")
+
+        data = "".join(d for _, d in received)
+        assert "first" in data
+        assert "second" in data
+        assert all(t == "terminal.term-data.output" for t, _ in received)
+
+    def test_repeated_create_stop_cycles_leave_no_threads(self, tmp_path, monkeypatch):
+        """Accumulation guard: the #382 report showed 26+ leaked reader threads
+        after repeated session create/delete cycles."""
+        import threading as _threading
+
+        manager = self._manager(tmp_path, monkeypatch)
+        threads = []
+        for i in range(5):
+            tid = f"term-cycle{i}"
+            manager.create_reader(tid)
+            threads.append(self._thread(manager, tid))
+            manager.stop_reader(tid)
+
+        for t in threads:
+            t.join(timeout=3.0)
+        assert all(not t.is_alive() for t in threads)
+        leftover = [t.name for t in _threading.enumerate() if t.name.startswith("fifo-term-cycle")]
+        assert leftover == []


### PR DESCRIPTION
Fixes #382.

## Root cause

Two compounding defects (full analysis on the issue thread):

**1. Reader threads leak into permanent FIFO-open blocks.** `FifoManager._reader_loop` opened the pipe with a plain blocking `os.open(O_RDONLY)` and reopened on every EOF. `stop_reader`'s write-side "wakeup" open (`fifo_reader.py:71-76`) only unblocked the thread if it happened to be parked inside `open()` at that exact instant — if it was between close and reopen (e.g. right after the EOF that `stop_pipe_pane` just caused) or in its 1s error sleep, the wakeup failed with a **silently swallowed ENXIO**, `thread.join(timeout=2.0)` timed out with the result never checked, and the FIFO was unlinked anyway — stranding the thread forever in the kernel's `wait_for_partner` on an inode no writer can ever reach. Accumulated over create/delete cycles → the reporter's 26+ leaked threads.

**2. Teardown ran on the event loop.** `DELETE /sessions` is `async def` but called the fully synchronous `session_service.delete_session()` inline — tmux kills, DB writes, and FIFO operations (including an `os.open` on a named pipe) all executed on the uvicorn event-loop thread. Once a FIFO operation stalled in the kernel (`fifo_open` takes the per-pipe mutex in an uninterruptible wait), the entire server froze — `/health` included — matching the reported unkillable D-state.

## Fix

- **`_reader_loop` never blocks in `open()`/`read()` anymore:** the read end is opened `O_RDONLY | O_NONBLOCK` (succeeds immediately for a FIFO, writer attached or not), and the process holds its own **keepalive write end**, so the pipe never reaches writer-count zero — `select()` only reports readable on real data (no EOF churn, and no busy-spin, which a writer-less non-blocking FIFO would otherwise produce), and its timeout bounds stop-flag latency to 0.5s.
- **`stop_reader` simplified:** the racy wakeup hack is gone (nothing to wake). `stop_flag.set()` + `join(2.0)`, and a failed join now logs a **loud warning** naming the leaked thread instead of failing silently — the silence is how #382's wedge built up unnoticed.
- **`DELETE /sessions` teardown runs in a worker thread** (`asyncio.to_thread`), so even a pathological kernel stall costs one request, not the server. (The `POST /sessions` failure-cleanup path also calls `stop_reader`; with the reader now non-blocking that call is bounded at ~0.5s, so it no longer needs offloading.)

## Testing

- **4 new regression tests** (`test/services/test_fifo_reader.py`) with real FIFOs and real threads:
  - stop with **no writer ever attached** — the primary leak case (old code parked in blocking `open()` here);
  - stop **immediately after a writer EOF pulse** — the exact race window (old wakeup died with ENXIO here);
  - **data delivery across writer reconnects** (tmux re-attaching `pipe-pane`);
  - **repeated create/stop cycles leave zero threads** — the accumulation the issue reported.
- Full Python suite: **3328 passed** (the one failure is the pre-existing, order-dependent `TestGetServerSettings` flake that also fails on clean `main`).
- Live smoke on a running `cao-server`: `/health` stayed **200 throughout** rapid create/teardown churn, zero leak warnings, zero stale `*.fifo` files, stable process thread count. (The full agent-terminal path is exercised by the unit tests; the smoke pins the event-loop-responsiveness claim.)

@klabulan — this should eliminate both the thread accumulation and the whole-server freeze you traced. If you can re-run your create/delete reproduction against this branch, that would be a great confirmation; the loud join-timeout warning will also make any residual leak visible immediately instead of silent.
