### PR TITLE
fix(claude_code): background task ("✻ Waiting for N workflows") no longer reads as COMPLETED (fixes #392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- claude_code: a backgrounded task (“✻ Waiting for N dynamic workflow(s) to finish”) no longer reads as COMPLETED — the wait line has no spinner ellipsis (invisible to every PROCESSING check) while the printed response + idle ❯ box look like a finished turn, and it even matched the lenient completion pattern; both the raw-buffer and pyte screen paths now report PROCESSING until a newer response/completion summary appears, so dashboards and wait_until_terminal_status no longer see a mid-run terminal as done (#392)
+
 - fifo: non-blocking FIFO reader loop and event-loop-safe session teardown — reader threads can no longer be stranded in a blocking FIFO `open()` by a stop/reopen race, and `DELETE /sessions` runs teardown in a worker thread, so repeated create/delete cycles can no longer wedge cao-server (#382)
 
 ## [2.2.0] - 2026-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- claude_code: a backgrounded task (“✻ Waiting for N dynamic workflow(s) to finish”) no longer reads as COMPLETED — the wait line has no spinner ellipsis (invisible to every PROCESSING check) while the printed response + idle ❯ box look like a finished turn, and it even matched the lenient completion pattern; both the raw-buffer and pyte screen paths now report PROCESSING until a newer response/completion summary appears, so dashboards and wait_until_terminal_status no longer see a mid-run terminal as done (#392)
+- claude_code: a backgrounded task ("✻ Waiting for N dynamic workflow(s) to finish") no longer reads as COMPLETED — the wait line has no spinner ellipsis (invisible to every PROCESSING check) while the printed response + idle ❯ box look like a finished turn, and it even matched the lenient completion pattern; both the raw-buffer and pyte screen paths now report PROCESSING until a newer response/completion summary appears, so dashboards and wait_until_terminal_status no longer see a mid-run terminal as done (#392)
 
 - fifo: non-blocking FIFO reader loop and event-loop-safe session teardown — reader threads can no longer be stranded in a blocking FIFO `open()` by a stop/reopen race, and `DELETE /sessions` runs teardown in a worker thread, so repeated create/delete cycles can no longer wedge cao-server (#382)
 

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -93,7 +93,23 @@ GET_STATUS_COMPLETION_PATTERN = r"[✶✢✽✻✳][^\n…]*\bfor\b"
 # lenient glyph+"for" match ("✻ Waiting *for* 1 …"), so without special
 # handling the whole frame reads COMPLETED while work continues (GH #392:
 # the Runs board showed "Done" with the TUI footer at "2/3 agents done").
-BACKGROUND_WAIT_PATTERN = r"[✶✢✽✻✳·*][ \t]+Waiting for\b"
+#
+# Match shape (review-hardened, PR #393):
+# - Start-of-line anchor + a REQUIRED tail keyword (workflow/task/background/
+#   "to finish"), so a markdown bullet in a settled response body
+#   ("* Waiting for review") can never match — an over-match here pins the
+#   terminal at PROCESSING via the ready-latch (denial-of-progress).
+# - The glyph class DELIBERATELY keeps "·" and "*", unlike
+#   GET_STATUS_COMPLETION_PATTERN: the TUI cycles the glyph through
+#   "· ✢ * ✶ ✻ ✽", and a single missed frame here would false-COMPLETE and
+#   latch (the exact #392 bug) — the tail keywords carry the disambiguation
+#   the completion pattern gets from excluding those glyphs.
+# - "\xa0" is allowed as the gap, matching IDLE_PROMPT_PATTERN's handling of
+#   the TUI's non-breaking-space rendering.
+BACKGROUND_WAIT_PATTERN = re.compile(
+    r"(?m)^[ \t\xa0]*[✶✢✽✻✳·*][ \t\xa0]+Waiting for\b"
+    r"(?=[^\n]*\b(?:workflows?|tasks?|to finish|background)\b)"
+)
 # The newest Claude Code TUI renders the ❯ input prompt BOXED between two
 # horizontal separator lines (the older TUI used a single separator ABOVE ❯).
 # Detecting this box GATES the new-TUI status logic so legacy output is
@@ -582,14 +598,19 @@ class ClaudeCodeProvider(BaseProvider):
         # BACKGROUND TASK still running (GH #392): the newest TUI prints the
         # turn's text response, shows an idle ❯ box, and renders
         # "✻ Waiting for N dynamic workflow(s) to finish" — a frame that looks
-        # COMPLETED to the signature check below while work continues. Honor
-        # the wait line only while it is the NEWEST activity marker: once the
-        # backgrounded task finishes, Claude prints a fresh response and/or a
-        # real completion summary BELOW it in the rolling buffer, which
-        # re-enables the normal COMPLETED path (so a stale wait line in
-        # scrollback can never pin PROCESSING).
+        # COMPLETED to the signature check below while work continues. Two
+        # containment guards (review-hardened):
+        # 1. Region: the live wait line renders just above the input box, i.e.
+        #    within the last few lines of the rolling buffer — restrict the
+        #    match to the buffer's final 20 lines so response-body text higher
+        #    up can never trigger it.
+        # 2. Recency: honor the wait line only while it is the NEWEST activity
+        #    marker — once the task finishes, Claude prints a fresh response
+        #    and/or completion summary BELOW it, re-enabling the normal
+        #    COMPLETED path (a stale wait line can never pin PROCESSING).
+        tail_region_start = len(output) - len("\n".join(output.split("\n")[-20:]))
         last_bg_wait = None
-        for m in re.finditer(BACKGROUND_WAIT_PATTERN, output):
+        for m in BACKGROUND_WAIT_PATTERN.finditer(output, tail_region_start):
             last_bg_wait = m
         if last_bg_wait is not None and not any(
             marker.start() > last_bg_wait.start()
@@ -655,16 +676,6 @@ class ClaudeCodeProvider(BaseProvider):
         if any(NEW_TUI_BOX_SPINNER_PATTERN.search(ln) for ln in bottom):
             return TerminalStatus.PROCESSING
 
-        # Background task still running (GH #392): "✻ Waiting for N dynamic
-        # workflow(s)…" has no spinner ellipsis, so the check above misses it,
-        # while the response + boxed-prompt signature below would read
-        # COMPLETED. The composited screen shows only LIVE content — the line
-        # disappears on the finished repaint — so its mere presence in the
-        # bottom region is a safe PROCESSING signal (no staleness risk, unlike
-        # the raw rolling-buffer path).
-        if any(re.search(BACKGROUND_WAIT_PATTERN, ln) for ln in bottom):
-            return TerminalStatus.PROCESSING
-
         bottom_joined = "\n".join(bottom)
         if (
             re.search(WAITING_USER_ANSWER_PATTERN, bottom_joined)
@@ -672,6 +683,19 @@ class ClaudeCodeProvider(BaseProvider):
             and not re.search(BYPASS_PROMPT_PATTERN, joined)
         ):
             return TerminalStatus.WAITING_USER_ANSWER
+
+        # Background task still running (GH #392): "✻ Waiting for N dynamic
+        # workflow(s)…" has no spinner ellipsis, so the spinner check above
+        # misses it, while the response + boxed-prompt signature below would
+        # read COMPLETED. Checked AFTER the Ink selection footer on purpose: a
+        # permission prompt co-rendering with a wait line must surface as
+        # WAITING_USER_ANSWER (a security gate the user has to answer), never
+        # be masked as "working" — mirrors the raw path's precedence. The
+        # composited screen shows only LIVE content — the line disappears on
+        # the finished repaint — so presence in the bottom region is a safe
+        # PROCESSING signal (no staleness risk, unlike the raw buffer path).
+        if any(BACKGROUND_WAIT_PATTERN.search(ln) for ln in bottom):
+            return TerminalStatus.PROCESSING
 
         # Real input box: a prompt line with a "────" rail BOTH within 2 rows
         # above AND within 2 rows below — the "──── / ❯ / ────" box Claude pins

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -84,6 +84,16 @@ COMPLETION_SUMMARY_PATTERN = r"[✶✢✽✻✳][^\n…]*\bfor\s+\d+(?:\.\d+)?\s
 # stat lines), and only ever turns IDLE/PROCESSING into COMPLETED — the safe
 # direction — and only after the live-spinner PROCESSING checks have passed.
 GET_STATUS_COMPLETION_PATTERN = r"[✶✢✽✻✳][^\n…]*\bfor\b"
+# Background-task wait line, e.g. "✻ Waiting for 1 dynamic workflow to finish".
+# The newest TUI renders this while a backgrounded task (Workflow tool, bash
+# task) keeps running AFTER the turn's text response has printed and the input
+# box is already idle — the terminal looks "finished" (response + empty ❯ box)
+# except for this one line. It carries NO ellipsis, so every spinner-based
+# PROCESSING check misses it, and it satisfies GET_STATUS_COMPLETION_PATTERN's
+# lenient glyph+"for" match ("✻ Waiting *for* 1 …"), so without special
+# handling the whole frame reads COMPLETED while work continues (GH #392:
+# the Runs board showed "Done" with the TUI footer at "2/3 agents done").
+BACKGROUND_WAIT_PATTERN = r"[✶✢✽✻✳·*][ \t]+Waiting for\b"
 # The newest Claude Code TUI renders the ❯ input prompt BOXED between two
 # horizontal separator lines (the older TUI used a single separator ABOVE ❯).
 # Detecting this box GATES the new-TUI status logic so legacy output is
@@ -466,6 +476,8 @@ class ClaudeCodeProvider(BaseProvider):
             _tail = output[_sep_positions[-1] :]
             _last_summary = None
             for _m in re.finditer(GET_STATUS_COMPLETION_PATTERN, _tail):
+                if "Waiting" in _m.group(0):
+                    continue  # background-wait line, not a completion summary (GH #392)
                 _last_summary = _m
             # The summary only marks the turn finished if no LIVE spinner
             # renders after it. Claude prints interim summaries mid-turn
@@ -505,6 +517,8 @@ class ClaudeCodeProvider(BaseProvider):
         # after a finished turn.
         last_completion = None
         for m in re.finditer(GET_STATUS_COMPLETION_PATTERN, output):
+            if "Waiting" in m.group(0):
+                continue  # background-wait line, not a completion summary (GH #392)
             last_completion = m
 
         # FALLBACK PROCESSING: spinner visible AND no separator follows it yet
@@ -564,6 +578,26 @@ class ClaudeCodeProvider(BaseProvider):
         last_sol_response = None
         for m in re.finditer(EXTRACTION_RESPONSE_PATTERN, output):
             last_sol_response = m
+
+        # BACKGROUND TASK still running (GH #392): the newest TUI prints the
+        # turn's text response, shows an idle ❯ box, and renders
+        # "✻ Waiting for N dynamic workflow(s) to finish" — a frame that looks
+        # COMPLETED to the signature check below while work continues. Honor
+        # the wait line only while it is the NEWEST activity marker: once the
+        # backgrounded task finishes, Claude prints a fresh response and/or a
+        # real completion summary BELOW it in the rolling buffer, which
+        # re-enables the normal COMPLETED path (so a stale wait line in
+        # scrollback can never pin PROCESSING).
+        last_bg_wait = None
+        for m in re.finditer(BACKGROUND_WAIT_PATTERN, output):
+            last_bg_wait = m
+        if last_bg_wait is not None and not any(
+            marker.start() > last_bg_wait.start()
+            for marker in (last_completion, last_response, last_sol_response)
+            if marker is not None
+        ):
+            return TerminalStatus.PROCESSING
+
         if last_idle is not None and (
             last_completion is not None
             or last_sol_response is not None
@@ -619,6 +653,16 @@ class ClaudeCodeProvider(BaseProvider):
         # The raw get_status() path already switched to the tight pattern for the
         # same reason; the screen path must match.
         if any(NEW_TUI_BOX_SPINNER_PATTERN.search(ln) for ln in bottom):
+            return TerminalStatus.PROCESSING
+
+        # Background task still running (GH #392): "✻ Waiting for N dynamic
+        # workflow(s)…" has no spinner ellipsis, so the check above misses it,
+        # while the response + boxed-prompt signature below would read
+        # COMPLETED. The composited screen shows only LIVE content — the line
+        # disappears on the finished repaint — so its mere presence in the
+        # bottom region is a safe PROCESSING signal (no staleness risk, unlike
+        # the raw rolling-buffer path).
+        if any(re.search(BACKGROUND_WAIT_PATTERN, ln) for ln in bottom):
             return TerminalStatus.PROCESSING
 
         bottom_joined = "\n".join(bottom)

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1762,3 +1762,86 @@ class TestClaudeCodeBackgroundTaskNotCompleted:
             "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
         ]
         assert self._p().get_status_from_screen(screen) == TerminalStatus.COMPLETED
+
+
+class TestBackgroundWaitReviewHardening:
+    """Round-2 review of PR #393: the wait-line match must not over-reach.
+
+    The original pattern's glyph class included the markdown bullets ·/* with
+    no line anchor or tail restriction, so a settled response containing
+    "* Waiting for review" pinned the terminal at PROCESSING (denial of
+    progress via the ready-latch), and the screen path checked the wait line
+    BEFORE the permission-prompt footer, masking a security-relevant
+    WAITING_USER_ANSWER as "working". Both were confirmed by probe before the
+    fix; these tests pin the hardened behavior.
+    """
+
+    BOX = "─" * 30
+
+    def _p(self):
+        return ClaudeCodeProvider("test123", "test-session", "window-0")
+
+    def test_markdown_bullet_wait_text_is_completed_not_pinned(self):
+        """Reviewer probe 1: '* Waiting for review' in a settled response body
+        must read COMPLETED — no tail keyword, so the pattern cannot match."""
+        output = (
+            "● Review checklist posted.\n"
+            "* Waiting for review\n"
+            "· Waiting for approval\n"
+            + self.BOX
+            + "\n❯ \n"
+            + self.BOX
+            + "\n  ⏵⏵ bypass permissions on\n"
+        )
+        assert self._p().get_status(output) == TerminalStatus.COMPLETED
+
+    def test_screen_markdown_bullet_is_completed(self):
+        screen = [
+            "● Review checklist posted.",
+            "* Waiting for review",
+            "─" * 60,
+            "❯",
+            "─" * 60,
+        ]
+        assert self._p().get_status_from_screen(screen) == TerminalStatus.COMPLETED
+
+    def test_middle_dot_glyph_wait_frame_is_processing(self):
+        """The TUI cycles the glyph through '· ✢ * ✶ ✻ ✽' — a ·-glyph frame of
+        the REAL wait line (tail keyword present) must still read PROCESSING,
+        or one missed frame would false-COMPLETE and re-latch GH #392."""
+        output = (
+            "● Kicking the workflow off now.\n"
+            "· Waiting for 1 dynamic workflow to finish\n"
+            + self.BOX
+            + "\n❯ \n"
+            + self.BOX
+            + "\n  ⏵⏵ bypass permissions on\n"
+        )
+        assert self._p().get_status(output) == TerminalStatus.PROCESSING
+
+    def test_screen_permission_prompt_wins_over_background_wait(self):
+        """Reviewer probe 2: a permission prompt co-rendering with the wait
+        line is a security gate — WAITING_USER_ANSWER must win."""
+        screen = [
+            "✻ Waiting for 1 dynamic workflow to finish",
+            "Do you want to allow this tool?",
+            "❯ 1. Yes",
+            "  2. No, and tell Claude what to do differently",
+            "  ↑/↓ to navigate · Enter to select",
+        ]
+        assert self._p().get_status_from_screen(screen) == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_wait_text_outside_tail_region_is_completed(self):
+        """A wait-shaped line buried >20 lines above the buffer end (old
+        response text) is outside the live-region restriction."""
+        filler = "\n".join(f"  step {i} done" for i in range(25))
+        output = (
+            "✻ Waiting for 1 dynamic workflow to finish\n"
+            + filler
+            + "\n● All finished, results above.\n"
+            + self.BOX
+            + "\n❯ \n"
+            + self.BOX
+            + "\n  ⏵⏵ bypass permissions on\n"
+        )
+        assert self._p().get_status(output) == TerminalStatus.COMPLETED

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1673,3 +1673,92 @@ class TestClaudeCodeScreenDetection:
 
     def test_empty_screen_is_unknown(self):
         assert self._p().get_status_from_screen(["", "", ""]) == TerminalStatus.UNKNOWN
+
+
+class TestClaudeCodeBackgroundTaskNotCompleted:
+    """A backgrounded task must not read as COMPLETED (GH #392).
+
+    Real failure (first observed live on the Runs dashboard): a code_supervisor
+    launched its own backgrounded Workflow. The TUI printed the turn's text
+    response, showed an EMPTY idle ❯ box, and rendered
+    "✻ Waiting for 1 dynamic workflow to finish" above it — while the status
+    bar read "2/3 agents done". That line has no spinner ellipsis (invisible to
+    every PROCESSING check) and even matches the lenient completion pattern
+    ("✻ Waiting *for* 1 …"), so the frame read COMPLETED, the ready-latch
+    pinned it, and the dashboard showed the run as Done mid-execution.
+    """
+
+    BOX = "─" * 30
+
+    def _p(self):
+        return ClaudeCodeProvider("test123", "test-session", "window-0")
+
+    def _wait_frame(self) -> str:
+        """The exact live-frame shape from the GH #392 report."""
+        return (
+            "● Workflow(Developer agent builds a todo app; Reviewer verifies)\n"
+            "  ⎿  Running in background · /workflows to monitor and save\n"
+            "● The build is now running in the background. Here's what's happening:\n"
+            "  1. Developer agent is building a single-file todo app\n"
+            "  2. Code Reviewer agent then verifies every criterion\n"
+            "✻ Waiting for 1 dynamic workflow to finish\n"
+            + self.BOX
+            + "\n❯ \n"
+            + self.BOX
+            + "\n  ⏵⏵ bypass permissions on (shift+tab to cycle)\n"
+        )
+
+    def test_background_wait_frame_is_processing(self):
+        assert self._p().get_status(self._wait_frame()) == TerminalStatus.PROCESSING
+
+    def test_finished_after_background_wait_is_completed(self):
+        """Once the workflow finishes, a fresh response + real completion
+        summary render BELOW the (now stale, still-in-rolling-buffer) wait
+        line — the wait line must not pin PROCESSING."""
+        output = (
+            self._wait_frame()
+            + "● All 12 acceptance criteria pass — here is the artifact link.\n"
+            + "✻ Baked for 7m 48s\n"
+            + self.BOX
+            + "\n❯ \n"
+            + self.BOX
+            + "\n  ⏵⏵ bypass permissions on (shift+tab to cycle)\n"
+        )
+        assert self._p().get_status(output) == TerminalStatus.COMPLETED
+
+    def test_wait_line_after_last_separator_is_not_a_completion_summary(self):
+        """Boxless-repaint variant: the wait line lands AFTER the last
+        separator, where the lenient glyph+"for" completion match would
+        otherwise count it as a finished-turn summary."""
+        output = (
+            "● Kicking the workflow off now.\n"
+            + self.BOX
+            + "\n❯ \n"
+            + self.BOX
+            + "\n✻ Waiting for 1 dynamic workflow to finish\n"
+        )
+        assert self._p().get_status(output) == TerminalStatus.PROCESSING
+
+    def test_screen_background_wait_is_processing(self):
+        screen = [
+            "● The build is now running in the background.",
+            "✻ Waiting for 1 dynamic workflow to finish",
+            "─" * 60,
+            "❯",
+            "─" * 60,
+            "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+        ]
+        assert self._p().get_status_from_screen(screen) == TerminalStatus.PROCESSING
+
+    def test_screen_finished_frame_is_completed(self):
+        """The finished repaint no longer shows the wait line — composited
+        screens carry only live content, so COMPLETED resumes normally."""
+        screen = [
+            "● All 12 acceptance criteria pass — artifact link below.",
+            "✻ Baked for 7m 48s",
+            "─" * 60,
+            "❯",
+            "─" * 60,
+            "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+        ]
+        assert self._p().get_status_from_screen(screen) == TerminalStatus.COMPLETED


### PR DESCRIPTION
Fixes #392.

## The bug

Caught live on the Runs dashboard: a `code_supervisor` backgrounded a Workflow, and while the TUI's own status bar read **`2/3 agents done · 7m48s`** with `✻ Waiting for 1 dynamic workflow to finish` on screen, CAO reported the terminal **COMPLETED** and the run showed as **Done**.

## Root cause

The background-wait frame sits in a blind spot between two detector assumptions:

1. **Every PROCESSING check requires a spinner ellipsis (`…`)** — the wait line has none, so no PROCESSING branch fires.
2. The frame otherwise presents the classic finished-turn signature (start-of-line `●` response + idle boxed `❯` prompt) → COMPLETED, in **both** the raw-buffer path and the pyte screen path. The ready-latch then pins it.
3. Compounding: the line **matches the lenient completion pattern** `[✶✢✽✻✳][^\n…]*\bfor\b` ("✻ Waiting **for** 1 …"), so boxless repaints counted it as a completion summary outright.

Downstream this is the same hazard class as the #390 discussion: early `wait_until_terminal_status`, stale `get_output(mode=last)`, and InboxService treating a busy terminal as deliverable.

## The fix

- New `BACKGROUND_WAIT_PATTERN` (glyph + `Waiting for`).
- **Raw path:** wait lines are excluded from completion-summary matching, and a wait line that is the *newest* activity marker returns PROCESSING. Staleness-safe by construction: when the task finishes, Claude prints a fresh response and/or real completion summary *below* it in the rolling buffer, which re-enables the normal COMPLETED path — a stale wait line can never pin PROCESSING (pinned by a regression test).
- **Screen path:** the composited viewport carries only live content (the line vanishes on the finished repaint), so its presence in the bottom region returns PROCESSING directly.

`WAITING_USER_ANSWER` still takes precedence in both paths (a permission prompt during a background task needs the user).

## Testing

- Six regression tests modeled on the reported live frames: the exact wait frame (raw + screen), the finished repaint (raw + screen — the anti-pin case), and the boxless-repaint completion-pattern collision.
- Full claude_code provider suite: 116 passed. Full Python suite: 3604 passed (only the pre-existing order-dependent `TestGetServerSettings` flake, which also fails on clean `main`).