### PR TITLE
feat(workflow): script linter + run-step env guard (#312 B2: U1+U2)

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -28,9 +28,12 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from pydantic import BaseModel, Field, field_validator
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from cli_agent_orchestrator.backends import TerminalNotFoundError
 from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
@@ -54,6 +57,8 @@ from cli_agent_orchestrator.constants import (
     SERVER_VERSION,
     TERMINALS_RUN_STEP_ROUTE,
     TRUSTED_FORWARDER_IPS,
+    WORKFLOW_ENV_ALLOWLIST,
+    WORKFLOW_ENV_VALUE_MAX_LEN,
     WS_ALLOWED_CLIENTS,
     add_local_cors_origins,
 )
@@ -98,6 +103,7 @@ from cli_agent_orchestrator.services.inbox_service import inbox_service
 from cli_agent_orchestrator.services.install_service import InstallResult, install_agent
 from cli_agent_orchestrator.services.log_writer import log_writer
 from cli_agent_orchestrator.services.status_monitor import status_monitor
+from cli_agent_orchestrator.services.step_output_store import _validate_key_part
 from cli_agent_orchestrator.services.terminal_service import OutputMode, TerminalInputBlockedError
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile, resolve_provider
 from cli_agent_orchestrator.utils.logging import setup_logging
@@ -200,6 +206,87 @@ class RunStepRequest(BaseModel):
         default=None,
         description="Resolved allowed-tools list for a freshly created terminal (handoff inheritance)",
     )
+    env_vars: Optional[Dict[str, str]] = Field(
+        default=None,
+        description=(
+            "Workflow identity env vars injected into a freshly created terminal. "
+            "Keys are restricted to the WORKFLOW_ENV_ALLOWLIST (NFR-SEC-4); "
+            "values are validated but never echoed in error bodies."
+        ),
+    )
+
+    @field_validator("env_vars")
+    @classmethod
+    def validate_env_vars(cls, v: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
+        """Per-key checks for the env-var injection surface (U2/C6, A2).
+
+        Check order is load-bearing (security-requirements.md): allowlist ->
+        length cap -> control chars -> shared validator. Error messages name
+        the KEY and the violated rule only — the supplied VALUE is never
+        echoed into a 422 body (NFR-SEC-2 extended to the error path).
+        """
+        if v is None:
+            return v
+        for key, value in v.items():
+            if key not in WORKFLOW_ENV_ALLOWLIST:
+                raise ValueError(
+                    f"env var key '{key}' not in allowlist "
+                    f"{{{', '.join(sorted(WORKFLOW_ENV_ALLOWLIST))}}}"
+                )
+            # Pre-regex defense-in-depth, NOT redundancy: bounds the input
+            # O(1) before any regex evaluation and bounds what can be staged
+            # into a terminal environment regardless of future regex changes.
+            # Do not simplify away as duplicate validation (the effective
+            # accepted length is 64 via WORKFLOW_NAME_RE downstream).
+            if len(value) > WORKFLOW_ENV_VALUE_MAX_LEN:
+                raise ValueError(
+                    f"value for '{key}' exceeds the {WORKFLOW_ENV_VALUE_MAX_LEN}-char cap"
+                )
+            # Values land in a tmux session environment — escape-sequence
+            # injection into a terminal is the concrete threat.
+            if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+                raise ValueError(f"value for '{key}' contains control characters")
+            try:
+                _validate_key_part(value, key)
+            except ValueError:
+                # The shared validator's message interpolates the VALUE;
+                # re-raise with a key-name-only message so the supplied value
+                # never round-trips into the 422 body (NFR-SEC-4 sanitized
+                # error rule). `from None` drops the value-bearing cause.
+                raise ValueError(
+                    f"value for '{key}' is invalid (must be a 1-64 char "
+                    "[A-Za-z0-9_-] identifier)"
+                ) from None
+        return v
+
+    @model_validator(mode="after")
+    def validate_env_var_shape(self) -> "RunStepRequest":
+        """Cross-field checks (U2/C6, A3) — all surface as FastAPI-native 422s.
+
+        RUN_ID <-> GENERATION is a symmetric required pair (ADR-9/10): an
+        unanchored generation token — or a run id without its fence — would
+        silently no-op the stale-generation fence. STEP_ID requires RUN_ID
+        (a step key with no run to journal under is meaningless; RUN_ID
+        without STEP_ID is allowed for run-row-level calls).
+        """
+        keys = set(self.env_vars or {})
+        has_run = "CAO_WORKFLOW_RUN_ID" in keys
+        has_gen = "CAO_WORKFLOW_GENERATION" in keys
+        if has_run and not has_gen:
+            raise ValueError("CAO_WORKFLOW_RUN_ID requires CAO_WORKFLOW_GENERATION (required pair)")
+        if has_gen and not has_run:
+            raise ValueError("CAO_WORKFLOW_GENERATION requires CAO_WORKFLOW_RUN_ID (required pair)")
+        if "CAO_WORKFLOW_STEP_ID" in keys and not has_run:
+            raise ValueError("CAO_WORKFLOW_STEP_ID requires CAO_WORKFLOW_RUN_ID")
+        if self.env_vars and self.reuse_terminal_id:
+            # run_agent_step documents env injection as ignored on reused
+            # terminals — a silently dropped RUN_ID/GENERATION fence token is
+            # the quiet identity failure NFR-SEC-4 exists to prevent (BR-8).
+            raise ValueError(
+                "env_vars cannot be injected into a reused terminal "
+                "(env injection only applies to freshly created terminals)"
+            )
+        return self
 
 
 class RunStepResponse(BaseModel):
@@ -469,6 +556,33 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(RequestValidationError)
+async def _redact_env_vars_validation_error(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Redact ``env_vars`` VALUES from 422 bodies (U2, NFR-SEC-4).
+
+    FastAPI's default 422 envelope echoes the offending ``input`` back to the
+    caller. For ``env_vars`` violations the values are agent- or
+    attacker-supplied and must never round-trip into a response body — the
+    validator messages already name only the key and the rule, so the echoed
+    ``input``/``ctx`` are dropped for those entries. Every other field's 422
+    keeps FastAPI's stock shape byte-identical.
+    """
+    errors = []
+    for err in exc.errors():
+        # Field-validator errors anchor at ("body", "env_vars"); model-validator
+        # errors anchor at ("body",) with the WHOLE body echoed as input — both
+        # shapes can carry env_vars values, so both are redacted.
+        echoes_env_vars = "env_vars" in err.get("loc", ()) or (
+            isinstance(err.get("input"), dict) and "env_vars" in err["input"]
+        )
+        if echoes_env_vars:
+            err = {k: v for k, v in err.items() if k not in ("input", "ctx")}
+        errors.append(err)
+    return JSONResponse(status_code=422, content={"detail": jsonable_encoder(errors)})
 
 
 @app.get("/.well-known/oauth-protected-resource")
@@ -1232,6 +1346,7 @@ async def run_step(
             caller_id=body.caller_id,
             allowed_tools=body.allowed_tools,
             registry=get_plugin_registry(request),
+            env_vars=body.env_vars,
         )
         return RunStepResponse(
             terminal_id=result.terminal_id,

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -430,3 +430,31 @@ WORKFLOW_STEP_TIMEOUT = 600.0
 # flat 30s and covers any plausible multi-step, multi-minute workflow; an operator
 # running near the 100-step ceiling can raise it via the env override if needed.
 WORKFLOW_RUN_REQUEST_TIMEOUT = (WORKFLOW_STEP_TIMEOUT + 120.0) * 12 + 180.0  # = 8820.0s (~2.45h)
+
+# Script-linter rule inputs (Bolt 2, U1/C2, FR-1.3 / U1-BR-8). Import prefixes
+# whose first dotted segment marks a CAO-internal import — scripts reach CAO
+# over HTTP only (C-1). The ``cao_workflow`` shim (U6, ADR-6) is the sanctioned
+# import surface and is deliberately ABSENT from this set (U1-BR-3). Frozensets:
+# the prohibition list cannot drift within a process lifetime; extending it is a
+# reviewed constants.py diff, never a linter-local edit.
+SCRIPT_LINT_DISALLOWED_IMPORT_PREFIXES = frozenset({"cli_agent_orchestrator"})
+
+# Modules whose import earns a nondeterminism WARNING (U1-A3, Q3=A): resume
+# replays journaled calls and requires deterministic re-execution. Import-level
+# only — no call-site analysis. A warning never fails a script (FR-1.7).
+SCRIPT_LINT_NONDETERMINISM_MODULES = frozenset({"random", "secrets", "uuid", "time", "datetime"})
+
+# Env-var injection allowlist for POST /terminals/run-step (Bolt 2, U2/C6,
+# NFR-SEC-4 BINDING). Deny-by-default: the injection surface into a tmux
+# terminal environment is exactly these three documented identity keys.
+# Extending it is a constants.py + gate decision, never a route-local edit.
+WORKFLOW_ENV_ALLOWLIST = frozenset(
+    {"CAO_WORKFLOW_RUN_ID", "CAO_WORKFLOW_STEP_ID", "CAO_WORKFLOW_GENERATION"}
+)
+
+# Pre-regex length cap on run-step env-var VALUES (U2-BR-2). Defense-in-depth,
+# not redundancy: bounds the input O(1) before any regex evaluation and bounds
+# what can be staged into a terminal environment regardless of future regex
+# changes — do not simplify away as duplicate validation (the effective
+# accepted length is 64 via WORKFLOW_NAME_RE; this cap is the outer fence).
+WORKFLOW_ENV_VALUE_MAX_LEN = 256

--- a/src/cli_agent_orchestrator/models/workflow.py
+++ b/src/cli_agent_orchestrator/models/workflow.py
@@ -294,6 +294,36 @@ class ValidationResult(BaseModel):
     errors: List[str] = Field(default_factory=list)
 
 
+class LintFinding(BaseModel):
+    """One script-lint observation (Bolt 2, U1/C2 — the FR-2.3 findings shape).
+
+    Every finding carries all four fields; ``line`` is a REQUIRED 1-based
+    source anchor (FR-2.3 — no finding may omit it).
+    """
+
+    rule_id: Literal["syntax", "disallowed-import", "nondeterminism", "dynamic-import"]
+    severity: Literal["error", "warning"]
+    line: int
+    message: str
+
+
+class ScriptValidationResult(ValidationResult):
+    """The script tier's validate outcome — additive over ``ValidationResult``.
+
+    Subclasses the shipped base (U1-BR-7, Q4=A) so YAML validate output stays
+    byte-identical (FR-5.1) and every base-vocabulary consumer renders a
+    script result unmodified. ``status`` is INHERITED unnarrowed; a script
+    result is never ``pass_reserved`` — enforced by construction in
+    ``lint_script`` (only ``pass``/``fail`` are ever emitted), not by
+    re-typing the field. ``errors`` carries the Q5=A mirror: one
+    ``"line N: [rule_id] message"`` string per ERROR finding; warnings appear
+    ONLY in ``findings``.
+    """
+
+    tier: Literal["script"] = "script"
+    findings: List[LintFinding] = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/src/cli_agent_orchestrator/services/script_lint.py
+++ b/src/cli_agent_orchestrator/services/script_lint.py
@@ -1,0 +1,187 @@
+"""Static script linter (issue #312, Bolt 2 / U1, C2).
+
+A pure, dependency-free function of the source text: one ``ast.parse`` plus
+exactly one ``ast.walk`` — no filesystem, no network, no state, and **no
+import and no execution of the target** (FR-2.1, the M2 no-execution
+guarantee). Path safety is the caller's job; ``display_path`` is used only
+for message rendering. ``lint_script`` never raises on bad input — a syntax
+error is a finding, not an exception (U1-BR-6).
+
+Rule catalogue (U1 business-rules.md):
+- ``syntax`` (ERROR) — ``ast.parse`` failed; anchored at ``e.lineno`` or 1.
+- ``disallowed-import`` (ERROR) — static or literal-string dynamic import
+  whose first dotted segment is in ``SCRIPT_LINT_DISALLOWED_IMPORT_PREFIXES``
+  (scripts reach CAO over HTTP only; the ``cao_workflow`` shim is the
+  sanctioned surface and is not in the set).
+- ``dynamic-import`` (WARNING) — ``importlib.import_module``/``__import__``
+  with a non-literal target: static analysis cannot verify it (Q1=A).
+  Best-effort boundary: a keyword-form literal call
+  (``import_module(name="...")``) downgrades to this WARNING rather than the
+  literal ERROR path, and aliased importlib (``import importlib as il``) is
+  not tracked at all.
+- ``nondeterminism`` (WARNING) — import of a module in
+  ``SCRIPT_LINT_NONDETERMINISM_MODULES``; resume replays journaled calls and
+  requires deterministic re-execution (FR-1.7 — a warning never blocks).
+
+``status == "fail"`` iff at least one ERROR finding (U1-BR-1); ERRORs are
+mirrored into the legacy ``errors`` list as ``"line N: [rule_id] message"``
+(Q5=A); warnings are never mirrored. ``pass_reserved`` is never emitted —
+a YAML reserved-construct concept with no script analogue.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from typing import List, Literal
+
+from cli_agent_orchestrator.constants import (
+    SCRIPT_LINT_DISALLOWED_IMPORT_PREFIXES,
+    SCRIPT_LINT_NONDETERMINISM_MODULES,
+)
+from cli_agent_orchestrator.models.workflow import LintFinding, ScriptValidationResult
+
+logger = logging.getLogger(__name__)
+
+
+def lint_script(source: str, display_path: str) -> ScriptValidationResult:
+    """Lint a workflow script's source text. Total: never raises on input content.
+
+    The only operation that can raise on input content is ``ast.parse``; it is
+    wrapped once with exactly three narrow arms (no broad except — totality by
+    construction, proven by the hypothesis property test).
+    """
+    findings: List[LintFinding] = []
+    try:
+        tree = ast.parse(source, filename=display_path)
+    except SyntaxError as e:
+        # Unparsable tree cannot be walked — the syntax finding is the sole
+        # finding. e.lineno may be None on pathological inputs; anchor line 1.
+        logger.warning("syntax error parsing %s: %s", display_path, e.msg)
+        findings.append(
+            LintFinding(
+                rule_id="syntax",
+                severity="error",
+                line=e.lineno or 1,
+                message=e.msg or "invalid syntax",
+            )
+        )
+        return _build_result(findings)
+    except ValueError:
+        # CPython <=3.11: null bytes raise ValueError ("source code string
+        # cannot contain null bytes"); 3.12+ reclassified this as SyntaxError
+        # (gh-96670), delivered via the arm above. CI floor is 3.10, so this
+        # arm is load-bearing there; tests assert totality, never which arm.
+        logger.warning("unparsable source (ValueError) for %s", display_path)
+        findings.append(
+            LintFinding(
+                rule_id="syntax",
+                severity="error",
+                line=1,
+                message="source contains bytes the parser cannot process",
+            )
+        )
+        return _build_result(findings)
+    except RecursionError:
+        logger.warning("recursion limit hit parsing %s", display_path)
+        findings.append(
+            LintFinding(
+                rule_id="syntax",
+                severity="error",
+                line=1,
+                message="source is too deeply nested to parse",
+            )
+        )
+        return _build_result(findings)
+
+    _walk_imports(tree, findings)
+    return _build_result(findings)
+
+
+def _walk_imports(tree: ast.AST, findings: List[LintFinding]) -> None:
+    """One ``ast.walk`` classifying import-shaped nodes (U1-A2/A3)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _check_module(alias.name, node.lineno, findings)
+        elif isinstance(node, ast.ImportFrom):
+            # level>0 (relative import) cannot name an absolute CAO path.
+            if node.level == 0 and node.module:
+                _check_module(node.module, node.lineno, findings)
+        elif isinstance(node, ast.Call) and _is_dynamic_import_call(node.func):
+            if (
+                node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                # Literal target — fully static, judged like a static import.
+                _check_module(node.args[0].value, node.lineno, findings)
+            else:
+                findings.append(
+                    LintFinding(
+                        rule_id="dynamic-import",
+                        severity="warning",
+                        line=node.lineno,
+                        message=(
+                            "dynamic import with a non-literal target cannot be "
+                            "verified against the CAO-internal import prohibition"
+                        ),
+                    )
+                )
+
+
+def _is_dynamic_import_call(func: ast.expr) -> bool:
+    """Match ``importlib.import_module(...)``, bare ``import_module(...)``
+    (from-import shape), and ``__import__(...)`` on a best-effort static basis."""
+    if isinstance(func, ast.Attribute):
+        return (
+            func.attr == "import_module"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "importlib"
+        )
+    if isinstance(func, ast.Name):
+        return func.id in ("__import__", "import_module")
+    return False
+
+
+def _check_module(dotted: str, lineno: int, findings: List[LintFinding]) -> None:
+    """Classify one dotted module path against the two constants.py frozensets."""
+    first = dotted.split(".")[0]
+    if first in SCRIPT_LINT_DISALLOWED_IMPORT_PREFIXES:
+        findings.append(
+            LintFinding(
+                rule_id="disallowed-import",
+                severity="error",
+                line=lineno,
+                message=(
+                    f"import of CAO internal module '{dotted}' is not allowed — "
+                    "scripts reach CAO over HTTP only (see the authoring guide)"
+                ),
+            )
+        )
+    elif first in SCRIPT_LINT_NONDETERMINISM_MODULES:
+        findings.append(
+            LintFinding(
+                rule_id="nondeterminism",
+                severity="warning",
+                line=lineno,
+                message=(
+                    f"importing '{first}' may make this script non-resumable; "
+                    "resume replays journaled calls and requires deterministic "
+                    "re-execution (see the determinism obligation in the "
+                    "authoring guide)"
+                ),
+            )
+        )
+
+
+def _build_result(findings: List[LintFinding]) -> ScriptValidationResult:
+    """Derive status/errors from findings (U1-A4). Only ever emits pass/fail —
+    ``pass_reserved`` never appears for the script tier, by construction."""
+    status: Literal["pass", "fail"] = (
+        "fail" if any(f.severity == "error" for f in findings) else "pass"
+    )
+    errors = [
+        f"line {f.line}: [{f.rule_id}] {f.message}" for f in findings if f.severity == "error"
+    ]
+    return ScriptValidationResult(status=status, errors=errors, findings=findings)

--- a/test/api/test_run_step_env_guard.py
+++ b/test/api/test_run_step_env_guard.py
@@ -1,0 +1,193 @@
+"""Tests for the run-step env-var guard (issue #312, Bolt 2 / U2, C6).
+
+Every request-shape violation surfaces as FastAPI's standard 422 envelope
+(Q2=A — validators raise ValueError, no HTTPException in U2 code). Error
+bodies name the KEY and the rule only; the supplied VALUE is never echoed
+(NFR-SEC-4 sanitized-error rule — pinned by the sentinel tests, one per
+validator arm).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from cli_agent_orchestrator.constants import TERMINALS_RUN_STEP_ROUTE
+from cli_agent_orchestrator.models.terminal import AgentStepResult, TerminalStatus
+
+_RUN_STEP = "cli_agent_orchestrator.api.main.run_agent_step"
+
+_ALL_KEYS = {
+    "CAO_WORKFLOW_RUN_ID": "run-abc123",
+    "CAO_WORKFLOW_STEP_ID": "step-1",
+    "CAO_WORKFLOW_GENERATION": "2",
+}
+
+
+def _body(**overrides):
+    base = {"provider": "kiro_cli", "agent": "developer", "prompt": "do it"}
+    base.update(overrides)
+    return base
+
+
+def _ok_result():
+    return AgentStepResult(
+        terminal_id="abc12345", last_message="done", status=TerminalStatus.COMPLETED
+    )
+
+
+class TestForwarding:
+    def test_all_three_allowlisted_keys_forward_to_run_agent_step(self, client):
+        with patch(_RUN_STEP, new=AsyncMock(return_value=_ok_result())) as m_run:
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=_ALL_KEYS))
+        assert resp.status_code == 200
+        # BR-14: forwarded verbatim — no rewriting, no defaults, no merging.
+        assert m_run.await_args.kwargs["env_vars"] == _ALL_KEYS
+
+    def test_absent_env_vars_preserves_base_behavior(self, client):
+        # BR-15: omitted field forwards None — existing callers unaffected.
+        with patch(_RUN_STEP, new=AsyncMock(return_value=_ok_result())) as m_run:
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body())
+        assert resp.status_code == 200
+        assert m_run.await_args.kwargs["env_vars"] is None
+
+    def test_run_id_with_generation_but_no_step_id_is_allowed(self, client):
+        # BR-7: RUN_ID without STEP_ID is a valid run-row-level call.
+        env = {"CAO_WORKFLOW_RUN_ID": "run-abc", "CAO_WORKFLOW_GENERATION": "1"}
+        with patch(_RUN_STEP, new=AsyncMock(return_value=_ok_result())):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 200
+
+    def test_happy_path_values_at_the_64_char_regex_ceiling(self, client):
+        # The effective accepted value length is 64 (WORKFLOW_NAME_RE).
+        env = {
+            "CAO_WORKFLOW_RUN_ID": "r" * 64,
+            "CAO_WORKFLOW_GENERATION": "g" * 64,
+        }
+        with patch(_RUN_STEP, new=AsyncMock(return_value=_ok_result())):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 200
+
+
+class TestPerKeyRejections:
+    def test_non_allowlisted_key_is_422_naming_key_and_allowlist(self, client):
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars={"PATH": "/usr/bin"}))
+        assert resp.status_code == 422
+        body = resp.text
+        assert "PATH" in body
+        assert "CAO_WORKFLOW_RUN_ID" in body  # allowlist named for debuggability
+
+    def test_value_over_256_cap_is_422(self, client):
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID="x" * 300)
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+        assert "256" in resp.text
+
+    def test_value_over_64_chars_rejected_by_regex_arm(self, client):
+        # Under the 256 cap but over WORKFLOW_NAME_RE's 64 — the shared
+        # validator arm fires.
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID="x" * 65)
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+
+    def test_control_character_value_is_422(self, client):
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID="run\x1b[31m")
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+        assert "control characters" in resp.text
+
+    def test_traversal_token_value_is_422(self, client):
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID="..")
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+
+
+class TestCrossFieldRejections:
+    def test_run_id_without_generation_is_422(self, client):
+        env = {"CAO_WORKFLOW_RUN_ID": "run-abc"}
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+        assert "CAO_WORKFLOW_GENERATION" in resp.text
+
+    def test_generation_without_run_id_is_422(self, client):
+        # Symmetric direction (BR-6): an unanchored generation token would
+        # silently no-op the fence.
+        env = {"CAO_WORKFLOW_GENERATION": "2"}
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+        assert "CAO_WORKFLOW_RUN_ID" in resp.text
+
+    def test_step_id_without_run_id_is_422(self, client):
+        env = {"CAO_WORKFLOW_STEP_ID": "step-1"}
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+        assert "CAO_WORKFLOW_RUN_ID" in resp.text
+
+    def test_env_vars_with_reuse_terminal_id_is_422(self, client):
+        # BR-8: env injection is ignored on reused terminals — silently
+        # dropping fence tokens is a Forbidden silent failure.
+        resp = client.post(
+            TERMINALS_RUN_STEP_ROUTE,
+            json=_body(env_vars=_ALL_KEYS, reuse_terminal_id="abc12345"),
+        )
+        assert resp.status_code == 422
+        assert "reused terminal" in resp.text
+
+    def test_empty_env_vars_with_reuse_terminal_id_is_allowed(self, client):
+        # BR-8 fires on NON-EMPTY env_vars only — {} drops nothing.
+        with patch(_RUN_STEP, new=AsyncMock(return_value=_ok_result())):
+            resp = client.post(
+                TERMINALS_RUN_STEP_ROUTE,
+                json=_body(env_vars={}, reuse_terminal_id="abc12345"),
+            )
+        assert resp.status_code == 200
+
+
+class TestSentinelNeverEchoed:
+    """One sentinel test per validator arm that sees a VALUE: the supplied
+    value must never appear anywhere in a 422 body (NFR-SEC-4)."""
+
+    SENTINEL = "SENTINEL_zzz"
+
+    def _assert_422_without_sentinel(self, client, env, value_sentinel):
+        resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env))
+        assert resp.status_code == 422
+        assert value_sentinel not in resp.text
+
+    def test_cap_arm_never_echoes_value(self, client):
+        value = self.SENTINEL + "x" * 300
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID=value)
+        self._assert_422_without_sentinel(client, env, self.SENTINEL)
+
+    def test_control_char_arm_never_echoes_value(self, client):
+        value = self.SENTINEL + "\x07"
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID=value)
+        self._assert_422_without_sentinel(client, env, self.SENTINEL)
+
+    def test_shared_validator_arm_never_echoes_value(self, client):
+        # Invalid chars for WORKFLOW_NAME_RE but no control chars, under cap —
+        # only the wrapped _validate_key_part arm fires. Its native message
+        # interpolates the value; the wrapper must have stripped it.
+        value = self.SENTINEL + "/../etc"
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID=value)
+        self._assert_422_without_sentinel(client, env, self.SENTINEL)
+
+    def test_allowlist_arm_never_echoes_value(self, client):
+        env = {"NOT_ALLOWED": self.SENTINEL}
+        self._assert_422_without_sentinel(client, env, self.SENTINEL)
+
+    def test_cross_field_arm_never_echoes_value(self, client):
+        # Model-validator errors anchor at ("body",) with the WHOLE request
+        # body echoed as input — the redaction handler's `"env_vars" in
+        # err["input"]` branch must drop it. The value passes every per-key
+        # arm (fits WORKFLOW_NAME_RE) so ONLY the cross-field validator fires;
+        # a loc-only redaction "simplification" would leak it.
+        env = {"CAO_WORKFLOW_RUN_ID": "SENTINELzzz"}
+        self._assert_422_without_sentinel(client, env, "SENTINELzzz")
+
+    def test_reuse_terminal_arm_never_echoes_value(self, client):
+        # Same whole-body-echo shape via the BR-8 model validator.
+        env = dict(_ALL_KEYS, CAO_WORKFLOW_RUN_ID="SENTINELzzz")
+        resp = client.post(
+            TERMINALS_RUN_STEP_ROUTE,
+            json=_body(env_vars=env, reuse_terminal_id="abc12345"),
+        )
+        assert resp.status_code == 422
+        assert "SENTINELzzz" not in resp.text

--- a/test/services/test_script_lint.py
+++ b/test/services/test_script_lint.py
@@ -15,6 +15,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from cli_agent_orchestrator.models.workflow import LintFinding, ScriptValidationResult
+from cli_agent_orchestrator.services import script_lint as script_lint_module
 from cli_agent_orchestrator.services.script_lint import lint_script
 
 
@@ -72,13 +73,35 @@ class TestSyntaxRule:
         assert result.findings[0].line == 1
 
     def test_deeply_nested_expression_is_total(self):
-        # Deep attribute chains overflow the AST constructor's recursion —
-        # the RecursionError arm converts it to a fail-closed syntax ERROR.
+        # Deep attribute chains MAY overflow the parser's recursion (3.10/3.11)
+        # or MAY parse cleanly (3.12+ raised its limits, and CPython's C parser
+        # is not gated by sys.setrecursionlimit). Per the never-assert-which-arm
+        # rule (gh-96670), assert only totality: a result is returned, the status
+        # is in-domain, and any failure is fail-closed as a syntax ERROR.
         source = "a" + ".b" * 200_000 + "\n"
         result = lint_script(source, "deep.py")
         assert isinstance(result, ScriptValidationResult)
+        assert result.status in ("pass", "fail")
+        if result.status == "fail":
+            f = result.findings[0]
+            assert f.rule_id == "syntax"
+            assert f.severity == "error"
+
+    def test_recursion_error_arm_is_fail_closed_syntax(self, monkeypatch):
+        # Deterministic coverage of the RecursionError arm on ALL supported
+        # versions: sys.setrecursionlimit does not gate CPython's C parser, so
+        # instead force ast.parse to raise RecursionError and assert the arm
+        # converts it to a fail-closed syntax ERROR anchored at line 1.
+        def _raise(*args, **kwargs):
+            raise RecursionError("maximum recursion depth exceeded")
+
+        monkeypatch.setattr(script_lint_module.ast, "parse", _raise)
+        result = lint_script("a.b.c\n", "deep.py")
         assert result.status == "fail"
-        assert result.findings[0].rule_id == "syntax"
+        f = result.findings[0]
+        assert f.rule_id == "syntax"
+        assert f.severity == "error"
+        assert f.line == 1
 
 
 class TestDisallowedImportRule:

--- a/test/services/test_script_lint.py
+++ b/test/services/test_script_lint.py
@@ -1,0 +1,235 @@
+"""Tests for the static script linter (issue #312, Bolt 2 / U1, C2).
+
+Deterministic fixtures are the primary suite (verdict correctness); the
+hypothesis property test is the safety net proving totality (BR-6
+never-raises) over the input space fixtures can't enumerate. Tests assert on
+rule_id/line/severity, never on parser message prose (it varies by CPython
+minor), and never on WHICH catch arm fired (the null-byte case moved from
+ValueError to SyntaxError in 3.12, gh-96670 — totality is the invariant).
+"""
+
+import time
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from cli_agent_orchestrator.models.workflow import LintFinding, ScriptValidationResult
+from cli_agent_orchestrator.services.script_lint import lint_script
+
+
+def _findings_by_rule(result: ScriptValidationResult, rule_id: str) -> list:
+    return [f for f in result.findings if f.rule_id == rule_id]
+
+
+class TestHappyPath:
+    def test_clean_script_passes(self):
+        source = "import json\nimport cao_workflow\n\nprint(json.dumps({}))\n"
+        result = lint_script(source, "clean.py")
+        assert result.status == "pass"
+        assert result.findings == []
+        assert result.errors == []
+        assert result.tier == "script"
+
+    def test_cao_workflow_shim_is_allowed(self):
+        # BR-3: the shim is the sanctioned import surface, never flagged.
+        result = lint_script("from cao_workflow import run_step\n", "shim.py")
+        assert result.status == "pass"
+        assert result.findings == []
+
+    def test_relative_import_is_skipped(self):
+        # level>0 cannot name an absolute CAO path.
+        result = lint_script("from . import helpers\n", "rel.py")
+        assert result.status == "pass"
+        assert result.findings == []
+
+
+class TestSyntaxRule:
+    def test_syntax_error_fails_with_line_anchor(self):
+        result = lint_script("def broken(:\n    pass\n", "broken.py")
+        assert result.status == "fail"
+        assert len(result.findings) == 1
+        f = result.findings[0]
+        assert f.rule_id == "syntax"
+        assert f.severity == "error"
+        assert f.line >= 1
+
+    def test_syntax_error_short_circuits_walk(self):
+        # The disallowed import after the syntax error is never reported —
+        # an unparsable tree cannot be walked.
+        source = "def broken(:\nimport cli_agent_orchestrator\n"
+        result = lint_script(source, "broken.py")
+        assert [f.rule_id for f in result.findings] == ["syntax"]
+
+    def test_null_byte_input_is_total(self):
+        # Version skew: ValueError on <=3.11, SyntaxError on 3.12+ — assert
+        # totality and the fail-closed verdict, NOT which arm fired.
+        result = lint_script("x = 1\x00", "null.py")
+        assert isinstance(result, ScriptValidationResult)
+        assert result.status == "fail"
+        assert result.findings[0].rule_id == "syntax"
+        assert result.findings[0].severity == "error"
+        assert result.findings[0].line == 1
+
+    def test_deeply_nested_expression_is_total(self):
+        # Deep attribute chains overflow the AST constructor's recursion —
+        # the RecursionError arm converts it to a fail-closed syntax ERROR.
+        source = "a" + ".b" * 200_000 + "\n"
+        result = lint_script(source, "deep.py")
+        assert isinstance(result, ScriptValidationResult)
+        assert result.status == "fail"
+        assert result.findings[0].rule_id == "syntax"
+
+
+class TestDisallowedImportRule:
+    def test_static_import_is_error(self):
+        result = lint_script("import cli_agent_orchestrator\n", "bad.py")
+        assert result.status == "fail"
+        f = result.findings[0]
+        assert f.rule_id == "disallowed-import"
+        assert f.severity == "error"
+        assert f.line == 1
+        assert "cli_agent_orchestrator" in f.message
+
+    def test_submodule_from_import_is_error(self):
+        # Q2=A: prefix match on the first dotted segment catches submodules.
+        source = "from cli_agent_orchestrator.services import agent_step\n"
+        result = lint_script(source, "bad.py")
+        assert result.status == "fail"
+        f = result.findings[0]
+        assert f.rule_id == "disallowed-import"
+        assert "cli_agent_orchestrator.services" in f.message
+
+    def test_literal_importlib_is_error(self):
+        source = "import importlib\nimportlib.import_module('cli_agent_orchestrator.clients')\n"
+        result = lint_script(source, "dyn.py")
+        assert result.status == "fail"
+        errors = _findings_by_rule(result, "disallowed-import")
+        assert len(errors) == 1
+        assert errors[0].line == 2
+
+    def test_literal_dunder_import_is_error(self):
+        result = lint_script("__import__('cli_agent_orchestrator')\n", "dyn.py")
+        assert result.status == "fail"
+        assert _findings_by_rule(result, "disallowed-import")
+
+    def test_literal_from_imported_import_module_is_error(self):
+        source = "from importlib import import_module\nimport_module('cli_agent_orchestrator')\n"
+        result = lint_script(source, "dyn.py")
+        assert result.status == "fail"
+        errors = _findings_by_rule(result, "disallowed-import")
+        assert errors and errors[0].line == 2
+
+
+class TestNondeterminismRule:
+    @pytest.mark.parametrize("module", ["random", "secrets", "uuid", "time", "datetime"])
+    def test_nondeterminism_import_warns_but_passes(self, module):
+        result = lint_script(f"import {module}\n", "warn.py")
+        assert result.status == "pass"  # FR-1.7: warnings never fail
+        f = result.findings[0]
+        assert f.rule_id == "nondeterminism"
+        assert f.severity == "warning"
+        assert f.line == 1
+        assert module in f.message
+        assert result.errors == []  # warnings never mirrored (BR-2)
+
+    def test_literal_dynamic_import_of_nondeterminism_module_warns(self):
+        source = "import importlib\nimportlib.import_module('random')\n"
+        result = lint_script(source, "warn.py")
+        assert result.status == "pass"
+        warns = _findings_by_rule(result, "nondeterminism")
+        assert warns and warns[0].line == 2
+
+
+class TestDynamicImportRule:
+    def test_non_literal_target_warns(self):
+        source = "import importlib\nname = 'os'\nimportlib.import_module(name)\n"
+        result = lint_script(source, "dyn.py")
+        assert result.status == "pass"  # a warning, not an error (Q1=A)
+        f = _findings_by_rule(result, "dynamic-import")[0]
+        assert f.severity == "warning"
+        assert f.line == 3
+
+    def test_non_literal_dunder_import_warns(self):
+        result = lint_script("mod = 'os'\n__import__(mod)\n", "dyn.py")
+        warns = _findings_by_rule(result, "dynamic-import")
+        assert warns and warns[0].line == 2
+
+    def test_keyword_form_literal_downgrades_to_dynamic_import_warning(self):
+        # Documented best-effort boundary: only positional-literal targets are
+        # judged like static imports; import_module(name="...") has no
+        # positional args, so it falls through to the dynamic-import WARNING —
+        # a deliberate downgrade, not an ERROR, even for a disallowed prefix.
+        source = (
+            "import importlib\n" "importlib.import_module(name='cli_agent_orchestrator.clients')\n"
+        )
+        result = lint_script(source, "dyn.py")
+        assert result.status == "pass"
+        assert not _findings_by_rule(result, "disallowed-import")
+        warns = _findings_by_rule(result, "dynamic-import")
+        assert warns and warns[0].line == 2
+
+
+class TestResultAssembly:
+    def test_errors_field_mirrors_only_errors(self):
+        # Q5=A: "line N: [rule_id] message" per ERROR; warnings only in findings.
+        source = "import random\nimport cli_agent_orchestrator\n"
+        result = lint_script(source, "mixed.py")
+        assert result.status == "fail"
+        assert len(result.errors) == 1
+        assert result.errors[0].startswith("line 2: [disallowed-import]")
+        assert len(result.findings) == 2
+
+    def test_findings_ordered_by_walk(self):
+        source = "import cli_agent_orchestrator\nimport random\n"
+        result = lint_script(source, "order.py")
+        assert [f.line for f in result.findings] == [1, 2]
+
+    def test_never_pass_reserved_and_reserved_notes_empty(self):
+        for source in ("", "import random\n", "import cli_agent_orchestrator\n", "bad(:\n"):
+            result = lint_script(source, "any.py")
+            assert result.status in ("pass", "fail")
+            assert result.reserved_notes == []
+
+    def test_finding_fields_are_complete(self):
+        result = lint_script("import cli_agent_orchestrator\n", "f.py")
+        f = result.findings[0]
+        assert isinstance(f, LintFinding)
+        assert f.rule_id and f.severity and f.message
+        assert isinstance(f.line, int) and f.line >= 1
+
+
+class TestTotalityProperty:
+    @given(st.text())
+    def test_lint_script_never_raises(self, source):
+        # BR-6 proven over arbitrary unicode incl. null bytes / surrogates /
+        # control chars. Asserts type + status domain only, never which arm.
+        result = lint_script(source, "prop.py")
+        assert isinstance(result, ScriptValidationResult)
+        assert result.status in ("pass", "fail")
+
+    @given(st.text(alphabet="([{)]}\n "))
+    def test_nesting_heavy_input_never_raises(self, source):
+        # Biased toward the RecursionError arm without a hand-written fixture.
+        result = lint_script(source, "nest.py")
+        assert isinstance(result, ScriptValidationResult)
+        assert result.status in ("pass", "fail")
+
+
+class TestPerformanceSanity:
+    def test_thousand_line_script_under_one_second(self):
+        # The proportionate bound from performance-requirements.md: a sanity
+        # ceiling against an accidental quadratic re-walk, not a tuned budget.
+        lines = []
+        for i in range(250):
+            lines.append(f"import json  # block {i}")
+            lines.append(f"def f_{i}(x):")
+            lines.append(f"    return x + {i}")
+            lines.append(f"v_{i} = f_{i}({i})")
+        source = "\n".join(lines) + "\n"
+        assert source.count("\n") == 1000
+        start = time.monotonic()
+        result = lint_script(source, "big.py")
+        elapsed = time.monotonic() - start
+        assert result.status == "pass"
+        assert elapsed < 1.0


### PR DESCRIPTION
## Summary
Bolt B2 of the #312 script-as-spec plan (units U1, U2 of 6).

- **U1 ScriptLinter**: pure-ast lint_script — syntax / disallowed-import / nondeterminism / dynamic-import findings; never executes a line of the target; total function (narrow SyntaxError/ValueError/RecursionError arms — the ValueError arm covers the CPython ≤3.11 null-byte skew, gh-96670).
- **U2 RunStepEnvGuard**: RunStepRequest.env_vars with allowlist guard (CAO_WORKFLOW_RUN_ID/STEP_ID/GENERATION), layered value validation reusing _validate_key_part, symmetric RUN_ID⇔GENERATION 422, env_vars+reuse_terminal_id reject (silent fence-token drop prevention), and a 422 redaction handler so env_vars values never echo in error bodies.

B1/U3 landed via #391; next B3 (U4 ScriptRunner), B4 (U5+U6).

## Testing
- 48 new tests across the two units (28 U1 + 20 U2), all green.
- Full non-E2E suite: 3644 passed; only the 7 known pre-existing failures (test_info ×2, answer_user_prompt ×2, TestWaitForShell ×3) — none introduced by this diff.
- black/isort clean; mypy: no new errors.
- Coverage on new surfaces: script_lint.py 92% (missed lines are the ≤3.11-only arm, exercised by CI's 3.10/3.11 legs), api/main.py changed lines 97.8%, models 100%.