### PR TITLE
fix(fifo): self-healing pipe-pane liveness watchdog (fixes #388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- self-healing pipe-pane liveness watchdog for silently-stalled FIFO forwarding (fixes #388) (#397)
+
 ## [2.3.0] - 2026-07-12
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,7 +233,7 @@ These map to `network.*` / `auth.*` schema paths for documentation purposes, but
 
 A number of other `CAO_*` variables (runtime/process-identity vars like `CAO_TERMINAL_ID`, `CAO_SESSION_NAME`, `CAO_WORKFLOW_RUN_ID`; provider-tuning vars like `CAO_HERMES_*`, `CAO_AGENTS_DIR`, `CAO_API_HOST`/`CAO_API_PORT`, `CAO_PYTE_STATUS`, `CAO_EAGER_INBOX_DELIVERY`; and `CAO_AUTH_LOCAL_TOKEN`) are still read ad hoc via `os.getenv` at their call sites, mostly in `constants.py`, `mcp_server/server.py`, `security/auth.py`, and the `providers/*` modules. These were deliberately left out of this pass to keep the diff scoped to the two surfaces issue #357 named explicitly (`settings.json` + `config.json`); folding them into the registry is a natural follow-up but not required for config unification.
 
-The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds three more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
+The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds four more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
 
 | Env var | Default | Type | Purpose |
 |---|---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,6 +233,15 @@ These map to `network.*` / `auth.*` schema paths for documentation purposes, but
 
 A number of other `CAO_*` variables (runtime/process-identity vars like `CAO_TERMINAL_ID`, `CAO_SESSION_NAME`, `CAO_WORKFLOW_RUN_ID`; provider-tuning vars like `CAO_HERMES_*`, `CAO_AGENTS_DIR`, `CAO_API_HOST`/`CAO_API_PORT`, `CAO_PYTE_STATUS`, `CAO_EAGER_INBOX_DELIVERY`; and `CAO_AUTH_LOCAL_TOKEN`) are still read ad hoc via `os.getenv` at their call sites, mostly in `constants.py`, `mcp_server/server.py`, `security/auth.py`, and the `providers/*` modules. These were deliberately left out of this pass to keep the diff scoped to the two surfaces issue #357 named explicitly (`settings.json` + `config.json`); folding them into the registry is a natural follow-up but not required for config unification.
 
+The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds three more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
+
+| Env var | Default | Type | Purpose |
+|---|---|---|---|
+| `CAO_PIPE_LIVENESS_CHECK_INTERVAL_S` | `4.0` | float | How often the watchdog compares live pane content against FIFO delivery, per enrolled terminal. |
+| `CAO_PIPE_LIVENESS_TAIL_LINES` | `80` | int | Lines of live pane content compared each check (`capture-pane` tail size). |
+| `CAO_PIPE_LIVENESS_STALL_CHECKS` | `2` | int | Consecutive diverging checks required before re-arming a stalled forwarder. |
+| `CAO_PIPE_LIVENESS_MAX_REARM_FAILURES` | `5` | int | Consecutive failed re-arm attempts before the watchdog gives up on a terminal. |
+
 ## API Endpoints
 
 | Method | Endpoint | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,7 +233,7 @@ These map to `network.*` / `auth.*` schema paths for documentation purposes, but
 
 A number of other `CAO_*` variables (runtime/process-identity vars like `CAO_TERMINAL_ID`, `CAO_SESSION_NAME`, `CAO_WORKFLOW_RUN_ID`; provider-tuning vars like `CAO_HERMES_*`, `CAO_AGENTS_DIR`, `CAO_API_HOST`/`CAO_API_PORT`, `CAO_PYTE_STATUS`, `CAO_EAGER_INBOX_DELIVERY`; and `CAO_AUTH_LOCAL_TOKEN`) are still read ad hoc via `os.getenv` at their call sites, mostly in `constants.py`, `mcp_server/server.py`, `security/auth.py`, and the `providers/*` modules. These were deliberately left out of this pass to keep the diff scoped to the two surfaces issue #357 named explicitly (`settings.json` + `config.json`); folding them into the registry is a natural follow-up but not required for config unification.
 
-The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds four more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
+The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds six more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
 
 | Env var | Default | Type | Purpose |
 |---|---|---|---|
@@ -241,6 +241,8 @@ The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds fou
 | `CAO_PIPE_LIVENESS_TAIL_LINES` | `80` | int | Lines of live pane content compared each check (`capture-pane` tail size). |
 | `CAO_PIPE_LIVENESS_STALL_CHECKS` | `2` | int | Consecutive diverging checks required before re-arming a stalled forwarder. |
 | `CAO_PIPE_LIVENESS_MAX_REARM_FAILURES` | `5` | int | Consecutive failed re-arm attempts before the watchdog gives up on a terminal. |
+| `CAO_PIPE_LIVENESS_COLD_START_GRACE_S` | `3.0` | float | Grace period after a terminal is registered before a FIFO that has never delivered a single byte is treated as a cold-start stall (harness-control#93) instead of "still booting". |
+| `CAO_PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS` | `5` | int | Consecutive cold-start re-arm attempts (rearm() succeeded but the pipe still never delivered) before the watchdog gives up on a terminal — a separate failure class and counter from `CAO_PIPE_LIVENESS_MAX_REARM_FAILURES`, which only counts rearm() raising. |
 
 ## API Endpoints
 

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -97,6 +97,7 @@ from cli_agent_orchestrator.services.config_service import ConfigService
 from cli_agent_orchestrator.services.event_bus import bus
 from cli_agent_orchestrator.services.event_log_service import RING_CAPACITY
 from cli_agent_orchestrator.services.event_primitives import KINDS as EVENT_KINDS
+from cli_agent_orchestrator.services.fifo_reader import fifo_manager
 from cli_agent_orchestrator.services.herdr_inbox_registry import set_herdr_inbox_service
 from cli_agent_orchestrator.services.herdr_inbox_service import HerdrInboxService
 from cli_agent_orchestrator.services.inbox_service import inbox_service
@@ -514,6 +515,11 @@ async def lifespan(app: FastAPI):
         await inbox_reconcile_task
     except asyncio.CancelledError:
         pass
+
+    # Stop the pipe-pane liveness watchdog thread (issue #388). It is a plain
+    # threading.Thread (not asyncio), so join it directly rather than via
+    # asyncio.gather with the tasks above.
+    fifo_manager.stop_watchdog()
 
     await registry.teardown()
     logger.info("Shutting down CLI Agent Orchestrator server...")

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -113,6 +113,23 @@ PIPE_LIVENESS_STALL_CHECKS = _env_int("CAO_PIPE_LIVENESS_STALL_CHECKS", 2)
 # gives up on a terminal and drops its enrollment, instead of retrying forever
 # with a WARNING/exception log every failure.
 PIPE_LIVENESS_MAX_REARM_FAILURES = _env_int("CAO_PIPE_LIVENESS_MAX_REARM_FAILURES", 5)
+# Cold-start stall deadline (harness-control#93): the divergence check above
+# can ONLY ever catch a pipe that WAS delivering and then went stale — it
+# requires a change from an established "healthy" baseline. A pipe that has
+# been dead since the terminal was created never establishes one: if the
+# shell renders its prompt once and then sits idle (the common case), every
+# check sees the identical content as the last, "diverged_from_baseline" is
+# always False, and the watchdog can wait forever without ever re-arming —
+# meanwhile wait_for_shell() times out (60s default) waiting for a FIFO
+# buffer that was never going to fill. This is a separate, positive check:
+# has the FIFO delivered ANYTHING at all since the terminal was registered?
+# If not, and this much time has passed, and the live pane already has real
+# content (ruling out "still genuinely booting, nothing to show yet"), the
+# forwarder never started forwarding in the first place — re-arm immediately
+# rather than waiting on a divergence that will never arrive. Deliberately
+# much shorter than PIPE_LIVENESS_CHECK_INTERVAL_S's steady-state cadence:
+# this is a one-shot "did it ever start" deadline, not a recurring poll.
+PIPE_LIVENESS_COLD_START_GRACE_S = _env_float("CAO_PIPE_LIVENESS_COLD_START_GRACE_S", 3.0)
 
 # pyte-rendered status detection. When enabled, the StatusMonitor feeds each
 # terminal's output through a pyte terminal emulator and runs detection against

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -78,6 +78,30 @@ STATE_BUFFER_MAX = 8192
 # above the old 1024 default while still bounded.
 EVENT_BUS_MAX_QUEUE_SIZE = _env_int("CAO_EVENT_BUS_MAX_QUEUE_SIZE", 16384)
 
+# ---- pipe-pane liveness watchdog (issue #388) -------------------------------
+# tmux's own pipe-pane forwarder can silently stop delivering bytes to the FIFO
+# after a burst of alternate-screen redraws — the pane keeps rendering (visible
+# via capture-pane) but the piped copy freezes, so the FIFO reader, the
+# StatusMonitor buffer, and GET /terminals/{id}/output all stall on stale
+# content indefinitely (pane_pipe still reports 1; nothing errors). The
+# FifoManager watchdog compares tmux's live pane content against whether the
+# FIFO delivered any bytes in the same window: pane advanced + FIFO silent =
+# a stalled forwarder, which it re-arms (stop_pipe_pane then pipe_pane — a bare
+# re-pipe would just toggle the already-"piped" pane OFF).
+PIPE_LIVENESS_CHECK_INTERVAL_S = float(
+    _env_int("CAO_PIPE_LIVENESS_CHECK_INTERVAL_S", 4)
+)
+# Lines of live pane content hashed to decide whether the pane advanced. A tail
+# is enough: a stall diverges the visible screen, and hashing only the tail
+# keeps each check to one cheap capture-pane call.
+PIPE_LIVENESS_TAIL_LINES = _env_int("CAO_PIPE_LIVENESS_TAIL_LINES", 80)
+# Consecutive diverging checks (pane advanced, FIFO delivered nothing) before
+# re-arming. 1 = re-arm on first confirmed divergence: with a multi-second
+# window a healthy pipe always delivers within milliseconds of a pane change,
+# so "pane moved but not one byte arrived in the whole interval" is already a
+# strong stall signal. Raise it to trade recovery latency for extra caution.
+PIPE_LIVENESS_STALL_CHECKS = _env_int("CAO_PIPE_LIVENESS_STALL_CHECKS", 1)
+
 # pyte-rendered status detection. When enabled, the StatusMonitor feeds each
 # terminal's output through a pyte terminal emulator and runs detection against
 # the COMPOSITED screen (redraws/cursor-moves resolved) instead of the raw

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -30,6 +30,21 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _env_positive_float(name: str, default: float) -> float:
+    """Read a float env var, falling back when the value is invalid OR non-positive.
+
+    For env vars that feed a ``threading.Event.wait(timeout)``-style poll
+    interval, a non-positive value isn't just atypical, it's actually
+    invalid for the parameter's meaning: ``Event.wait(0)``/``wait(negative)``
+    returns immediately, turning a periodic poll loop into a hot spin (round-3
+    Copilot review on #397, ``PIPE_LIVENESS_CHECK_INTERVAL_S``). Treated the
+    same way ``_env_float`` already treats a malformed string — fall back to
+    the default — rather than introducing a separate arbitrary floor value.
+    """
+    value = _env_float(name, default)
+    return value if value > 0 else default
+
+
 # =============================================================================
 # Session Configuration
 # =============================================================================
@@ -96,7 +111,7 @@ EVENT_BUS_MAX_QUEUE_SIZE = _env_int("CAO_EVENT_BUS_MAX_QUEUE_SIZE", 16384)
 # FIFO delivered any bytes in the same window: pane advanced + FIFO silent =
 # a stalled forwarder, which it re-arms (stop_pipe_pane then pipe_pane — a bare
 # re-pipe would just toggle the already-"piped" pane OFF).
-PIPE_LIVENESS_CHECK_INTERVAL_S = _env_float("CAO_PIPE_LIVENESS_CHECK_INTERVAL_S", 4.0)
+PIPE_LIVENESS_CHECK_INTERVAL_S = _env_positive_float("CAO_PIPE_LIVENESS_CHECK_INTERVAL_S", 4.0)
 # Lines of live pane content compared to decide whether the pane advanced. A
 # tail is enough: a stall diverges the visible screen, and comparing only the
 # tail keeps each check to one cheap capture-pane call.

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -22,6 +22,14 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _env_float(name: str, default: float) -> float:
+    """Read a float env var, falling back when the value is invalid."""
+    try:
+        return float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
 # =============================================================================
 # Session Configuration
 # =============================================================================
@@ -88,19 +96,23 @@ EVENT_BUS_MAX_QUEUE_SIZE = _env_int("CAO_EVENT_BUS_MAX_QUEUE_SIZE", 16384)
 # FIFO delivered any bytes in the same window: pane advanced + FIFO silent =
 # a stalled forwarder, which it re-arms (stop_pipe_pane then pipe_pane — a bare
 # re-pipe would just toggle the already-"piped" pane OFF).
-PIPE_LIVENESS_CHECK_INTERVAL_S = float(
-    _env_int("CAO_PIPE_LIVENESS_CHECK_INTERVAL_S", 4)
-)
-# Lines of live pane content hashed to decide whether the pane advanced. A tail
-# is enough: a stall diverges the visible screen, and hashing only the tail
-# keeps each check to one cheap capture-pane call.
+PIPE_LIVENESS_CHECK_INTERVAL_S = _env_float("CAO_PIPE_LIVENESS_CHECK_INTERVAL_S", 4.0)
+# Lines of live pane content compared to decide whether the pane advanced. A
+# tail is enough: a stall diverges the visible screen, and comparing only the
+# tail keeps each check to one cheap capture-pane call.
 PIPE_LIVENESS_TAIL_LINES = _env_int("CAO_PIPE_LIVENESS_TAIL_LINES", 80)
 # Consecutive diverging checks (pane advanced, FIFO delivered nothing) before
-# re-arming. 1 = re-arm on first confirmed divergence: with a multi-second
-# window a healthy pipe always delivers within milliseconds of a pane change,
-# so "pane moved but not one byte arrived in the whole interval" is already a
-# strong stall signal. Raise it to trade recovery latency for extra caution.
-PIPE_LIVENESS_STALL_CHECKS = _env_int("CAO_PIPE_LIVENESS_STALL_CHECKS", 1)
+# re-arming. Default 2, not 1: a single diverging check can be a false
+# positive on a healthy-but-bursty pipe (a burst lands just before the check
+# boundary and the reader hasn't drained it yet) and the immediate
+# stop-then-start re-arm loses any bytes produced in that gap. Requiring two
+# consecutive diverging checks absorbs that race at the cost of one extra
+# interval of recovery latency on a genuine stall.
+PIPE_LIVENESS_STALL_CHECKS = _env_int("CAO_PIPE_LIVENESS_STALL_CHECKS", 2)
+# Consecutive re-arm *failures* (rearm() itself raising) before the watchdog
+# gives up on a terminal and drops its enrollment, instead of retrying forever
+# with a WARNING/exception log every failure.
+PIPE_LIVENESS_MAX_REARM_FAILURES = _env_int("CAO_PIPE_LIVENESS_MAX_REARM_FAILURES", 5)
 
 # pyte-rendered status detection. When enabled, the StatusMonitor feeds each
 # terminal's output through a pyte terminal emulator and runs detection against

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -130,6 +130,18 @@ PIPE_LIVENESS_MAX_REARM_FAILURES = _env_int("CAO_PIPE_LIVENESS_MAX_REARM_FAILURE
 # much shorter than PIPE_LIVENESS_CHECK_INTERVAL_S's steady-state cadence:
 # this is a one-shot "did it ever start" deadline, not a recurring poll.
 PIPE_LIVENESS_COLD_START_GRACE_S = _env_float("CAO_PIPE_LIVENESS_COLD_START_GRACE_S", 3.0)
+# Cap on cold-start re-arm ATTEMPTS (not exceptions — rearm() succeeding but the
+# pipe still never delivering counts here too), separate from
+# PIPE_LIVENESS_MAX_REARM_FAILURES (which only counts rearm() raising). Without
+# this, a terminal whose pipe is genuinely, permanently dead (not just racing a
+# one-time attach timing gap) would re-trigger the cold-start check every grace
+# period forever: a successful rearm() doesn't mark the FIFO as having
+# delivered — only the reader thread pulling a real byte off it does — so
+# "still False after grace period" stays true and the same terminal gets
+# re-armed and replayed indefinitely, an unbounded stop/start + replay loop.
+# After this many attempts, give up loudly and drop the terminal from the
+# watchdog, exactly like the rearm()-exception path already does.
+PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS = _env_int("CAO_PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS", 5)
 
 # pyte-rendered status detection. When enabled, the StatusMonitor feeds each
 # terminal's output through a pyte terminal emulator and runs detection against

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -93,9 +93,17 @@ class FifoManager:
         self._lock = threading.Lock()
 
         # ---- pipe-pane liveness watchdog state (issue #388) ----
-        # Monotonic timestamp of the last byte the FIFO reader delivered for a
-        # terminal. Updated by the reader thread; read by the watchdog to tell a
+        # Monotonic timestamp of the last time this terminal is considered to
+        # have delivered real, current output. Read by the watchdog to tell a
         # stalled pipe (pane moving, FIFO silent) from a genuinely idle one.
+        # Updated from two places, not just the reader thread (round-3
+        # Copilot review on #397, flagging this comment as stale): the reader
+        # thread bumps it on every real byte pulled off the FIFO, AND
+        # _rearm_stalled_pipe() also bumps it after a successful re-arm +
+        # replay — deliberately, so the check immediately following a re-arm
+        # sees "FIFO advanced" (via the replay, which bypasses the FIFO/
+        # reader thread entirely) and doesn't misread the just-fixed pipe as
+        # still stalled on the very next tick.
         self._last_data_at: Dict[str, float] = {}
         # Monotonic timestamp of when this reader was registered, and whether
         # the FIFO has EVER delivered a real byte since — the cold-start check

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -8,9 +8,13 @@ import os
 import select
 import threading
 import time
-from typing import Dict
+from typing import Callable, Dict, Optional, Tuple
 
-from cli_agent_orchestrator.constants import FIFO_DIR
+from cli_agent_orchestrator.constants import (
+    FIFO_DIR,
+    PIPE_LIVENESS_CHECK_INTERVAL_S,
+    PIPE_LIVENESS_STALL_CHECKS,
+)
 from cli_agent_orchestrator.services.event_bus import bus
 
 logger = logging.getLogger(__name__)
@@ -38,19 +42,65 @@ _COALESCE_WINDOW = 0.05
 # of ~16 back-to-back reads is fine.
 _COALESCE_MAX_BYTES = 64 * 1024
 
+# Type of the per-terminal callbacks the pipe-pane liveness watchdog needs.
+# Kept as injected callables so FifoManager stays backend-agnostic (it knows
+# nothing about tmux sessions/windows or the backend) and unit-testable with
+# fakes. terminal_service wires the real backend calls at create_reader time.
+PaneProbe = Callable[[], str]  # returns the live pane content (tmux capture-pane tail)
+RearmPipe = Callable[[], None]  # re-attaches pipe-pane (stop then start, NOT a bare toggle)
+
 
 class FifoManager:
-    """Manages FIFO lifecycle: create named pipe, start reader thread, stop and cleanup."""
+    """Manages FIFO lifecycle: create named pipe, start reader thread, stop and cleanup.
+
+    Also runs a pipe-pane liveness watchdog (issue #388): tmux can silently
+    stop forwarding a pane's output to the FIFO after a burst of alternate-screen
+    redraws — the pane keeps rendering but the piped copy freezes, and nothing
+    errors (``pane_pipe`` still reports 1, the reader thread is healthy, there is
+    simply no data to read). From inside the FIFO reader a stalled forwarder is
+    indistinguishable from a genuinely idle terminal, so the watchdog compares
+    tmux's *live* pane content against whether the FIFO delivered any bytes: pane
+    advanced + FIFO silent = a stall, which it self-heals by re-arming the pipe.
+    """
 
     def __init__(self):
         self._readers: Dict[str, threading.Event] = {}  # terminal_id -> stop flag
         self._threads: Dict[str, threading.Thread] = {}
         self._lock = threading.Lock()
+
+        # ---- pipe-pane liveness watchdog state (issue #388) ----
+        # Monotonic timestamp of the last byte the FIFO reader delivered for a
+        # terminal. Updated by the reader thread; read by the watchdog to tell a
+        # stalled pipe (pane moving, FIFO silent) from a genuinely idle one.
+        self._last_data_at: Dict[str, float] = {}
+        # Per-terminal probes/re-arm callbacks (only tmux/pipe-pane terminals
+        # register these; herdr and callers that pass none are never watched).
+        self._pane_probe: Dict[str, PaneProbe] = {}
+        self._rearm: Dict[str, RearmPipe] = {}
+        # Per-terminal watchdog bookkeeping: (last_pane_hash, last_check_monotonic,
+        # consecutive_diverging_checks).
+        self._liveness: Dict[str, Tuple[int, float, int]] = {}
+        self._watchdog_stop = threading.Event()
+        self._watchdog_thread: Optional[threading.Thread] = None
+
         FIFO_DIR.mkdir(parents=True, exist_ok=True)
 
-    def create_reader(self, terminal_id: str) -> None:
-        """Create FIFO and start reader thread."""
+    def create_reader(
+        self,
+        terminal_id: str,
+        pane_probe: Optional[PaneProbe] = None,
+        rearm: Optional[RearmPipe] = None,
+    ) -> None:
+        """Create FIFO and start reader thread.
+
+        ``pane_probe``/``rearm`` are optional and only supplied by pipe-pane
+        (tmux) callers. When both are given, the terminal is enrolled in the
+        liveness watchdog (issue #388). Callers that omit them (or backends
+        without pipe-pane) get exactly the old behavior — no watchdog.
+        """
         fifo_path = FIFO_DIR / f"{terminal_id}.fifo"
+
+        enroll = pane_probe is not None and rearm is not None
 
         with self._lock:
             if terminal_id in self._readers:
@@ -68,7 +118,16 @@ class FifoManager:
             )
             self._readers[terminal_id] = stop_flag
             self._threads[terminal_id] = thread
+            # Seed the liveness clock BEFORE pipe-pane starts so the first
+            # watchdog check has a baseline; the reader bumps it on real data.
+            self._last_data_at[terminal_id] = time.monotonic()
+            if enroll:
+                self._pane_probe[terminal_id] = pane_probe
+                self._rearm[terminal_id] = rearm
             thread.start()
+
+        if enroll:
+            self._ensure_watchdog()
 
         logger.info(f"Started FIFO reader for terminal {terminal_id}")
 
@@ -84,6 +143,12 @@ class FifoManager:
         with self._lock:
             stop_flag = self._readers.pop(terminal_id, None)
             thread = self._threads.pop(terminal_id, None)
+            # Drop watchdog bookkeeping so a re-created terminal starts clean and
+            # the watchdog stops probing a gone pane.
+            self._pane_probe.pop(terminal_id, None)
+            self._rearm.pop(terminal_id, None)
+            self._liveness.pop(terminal_id, None)
+            self._last_data_at.pop(terminal_id, None)
 
         fifo_path = FIFO_DIR / f"{terminal_id}.fifo"
 
@@ -114,8 +179,7 @@ class FifoManager:
         except OSError:
             pass
 
-    @staticmethod
-    def _reader_loop(terminal_id: str, fifo_path, stop_flag: threading.Event) -> None:
+    def _reader_loop(self, terminal_id: str, fifo_path, stop_flag: threading.Event) -> None:
         """Read chunks from FIFO and publish to the event bus.
 
         Never blocks in a FIFO ``open()`` (issue #382): the previous design
@@ -147,6 +211,11 @@ class FifoManager:
         during bursts while staying well under the status monitor's 200ms
         quiescence debounce, so detection is unaffected and consumers see
         the same bytes in the same order.
+
+        Liveness bookkeeping for the pipe-pane watchdog (issue #388) is
+        recorded independent of coalescing, right when bytes are pulled off
+        the FIFO — the watchdog only cares whether the FIFO delivered data
+        in a window, not whether/when that data was published.
         """
         topic = f"terminal.{terminal_id}.output"
         read_fd = -1
@@ -175,6 +244,14 @@ class FifoManager:
                     except BlockingIOError:
                         raw = b""
                     if raw:
+                        # Record liveness for the pipe-pane watchdog (issue
+                        # #388): the watchdog treats "pane advanced but no
+                        # byte delivered since the last check" as a stall.
+                        # This must be recorded the instant bytes are pulled
+                        # off the FIFO, independent of the coalescing/publish
+                        # schedule below — the watchdog cares whether the FIFO
+                        # delivered data, not whether/when a batch flushed.
+                        self._last_data_at[terminal_id] = time.monotonic()
                         if not pending:
                             batch_start = time.monotonic()
                         pending.extend(raw)
@@ -208,6 +285,105 @@ class FifoManager:
                         os.close(fd)
                     except OSError:
                         pass
+
+    # ---- pipe-pane liveness watchdog (issue #388) ---------------------------
+
+    def _ensure_watchdog(self) -> None:
+        """Start the single background watchdog thread on first enrolled reader."""
+        with self._lock:
+            if self._watchdog_thread is not None and self._watchdog_thread.is_alive():
+                return
+            self._watchdog_stop.clear()
+            self._watchdog_thread = threading.Thread(
+                target=self._watchdog_loop,
+                daemon=True,
+                name="fifo-pipe-watchdog",
+            )
+            self._watchdog_thread.start()
+
+    def stop_watchdog(self) -> None:
+        """Stop the watchdog thread (shutdown / tests)."""
+        self._watchdog_stop.set()
+        thread = self._watchdog_thread
+        if thread is not None:
+            thread.join(timeout=2.0)
+
+    def _watchdog_loop(self) -> None:
+        while not self._watchdog_stop.wait(PIPE_LIVENESS_CHECK_INTERVAL_S):
+            for terminal_id in list(self._pane_probe.keys()):
+                try:
+                    self._check_pipe_liveness(terminal_id)
+                except Exception:
+                    logger.exception(
+                        "pipe-pane liveness check failed for terminal %s", terminal_id
+                    )
+
+    def _check_pipe_liveness(self, terminal_id: str) -> None:
+        """One liveness check for a terminal: re-arm a stalled pipe-pane forwarder.
+
+        A stalled forwarder is invisible from inside the FIFO reader (no bytes to
+        read, exactly like an idle terminal). The only ground truth is tmux's own
+        live pane content, which keeps rendering through the stall. So:
+
+        - pane content advanced since the last check AND the FIFO delivered no
+          bytes in that same window  -> the pipe is stalled: re-arm it.
+        - pane content unchanged                                   -> idle: do nothing.
+        - FIFO delivered bytes                                     -> healthy: do nothing.
+
+        Requiring BOTH "pane advanced" and "FIFO silent" is what stops a
+        legitimately idle terminal (pane unchanged, FIFO silent) from triggering
+        a needless re-pipe. Re-arm only after ``PIPE_LIVENESS_STALL_CHECKS``
+        consecutive diverging checks (default 1).
+        """
+        probe = self._pane_probe.get(terminal_id)
+        rearm = self._rearm.get(terminal_id)
+        if probe is None or rearm is None:
+            return
+
+        content = probe()
+        now = time.monotonic()
+        current_hash = hash(content)
+        last_data_at = self._last_data_at.get(terminal_id, 0.0)
+
+        prev = self._liveness.get(terminal_id)
+        if prev is None:
+            # First observation: establish a baseline, never act on it.
+            self._liveness[terminal_id] = (current_hash, now, 0)
+            return
+        prev_hash, last_check_at, strikes = prev
+
+        pane_advanced = current_hash != prev_hash
+        # Did the reader deliver anything since the previous check?
+        fifo_advanced = last_data_at >= last_check_at
+
+        if pane_advanced and not fifo_advanced:
+            strikes += 1
+            if strikes >= PIPE_LIVENESS_STALL_CHECKS:
+                logger.warning(
+                    "pipe-pane forwarder for terminal %s appears stalled "
+                    "(pane advanced, no FIFO data for %.1fs) — re-arming",
+                    terminal_id,
+                    now - last_check_at,
+                )
+                try:
+                    rearm()
+                except Exception:
+                    logger.exception(
+                        "failed to re-arm pipe-pane for terminal %s", terminal_id
+                    )
+                else:
+                    # Bytes lost during the stall are gone (tmux never buffered
+                    # them), but the pane's *current* content is not — replay it
+                    # into the pipeline so the StatusMonitor buffer / GET output
+                    # immediately reflect the live screen instead of staying
+                    # frozen until the agent happens to emit something new.
+                    bus.publish(f"terminal.{terminal_id}.output", {"data": content})
+                    self._last_data_at[terminal_id] = time.monotonic()
+                strikes = 0
+        else:
+            strikes = 0
+
+        self._liveness[terminal_id] = (current_hash, now, strikes)
 
 
 # Module-level singleton

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -442,6 +442,18 @@ class FifoManager:
             # hash: a hash collision would make this False and mask a real
             # stall (negligible probability, but the string is just as
             # cheap to compare and collision-free).
+            #
+            # Tradeoff (round-3 review, call-me-ram): pinning the baseline
+            # means ANY one-shot pane divergence seen while the FIFO happens
+            # to be silent — not just a genuine stall — now accumulates
+            # strikes toward a re-arm, where the old previous-check
+            # comparison would have reset on the very next unchanging check.
+            # E.g. an attached client resizing the pane, causing tmux to
+            # rewrap the captured tail once, then nothing further changing.
+            # The cost of a false-positive re-arm here is mild (a
+            # stop/start on an otherwise-idle pipe plus one snapshot
+            # replay), and it's the unavoidable price of catching a stall
+            # that settles into a new static frame — accepted deliberately.
             diverged_from_baseline = content != baseline_content
 
             if diverged_from_baseline:

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -632,9 +632,11 @@ class FifoManager:
         logger.warning(
             "pipe-pane forwarder for terminal %s appears %s — re-arming",
             terminal_id,
-            "never started forwarding (cold-start, harness-control#93)"
-            if cold_start
-            else "stalled (pane advanced, no FIFO data)",
+            (
+                "never started forwarding (cold-start, harness-control#93)"
+                if cold_start
+                else "stalled (pane advanced, no FIFO data)"
+            ),
         )
         try:
             rearm()
@@ -653,6 +655,7 @@ class FifoManager:
                     self._rearm_failures.pop(terminal_id, None)
                     self._registered_at.pop(terminal_id, None)
                     self._ever_delivered.pop(terminal_id, None)
+                    self._cold_start_attempts.pop(terminal_id, None)
             if give_up:
                 # Not a silent retry-forever: a re-arm that keeps failing
                 # (e.g. the tmux pane is gone) previously re-struck and

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -61,7 +61,11 @@ class FifoManager:
     simply no data to read). From inside the FIFO reader a stalled forwarder is
     indistinguishable from a genuinely idle terminal, so the watchdog compares
     tmux's *live* pane content against whether the FIFO delivered any bytes: pane
-    advanced + FIFO silent = a stall, which it self-heals by re-arming the pipe.
+    diverged from its last known-healthy baseline + FIFO silent = a stall, which
+    it self-heals by re-arming the pipe. The baseline is pinned across checks
+    (not just the previous one) so a stall that settles into a new static frame
+    right after the burst — instead of staying visibly in flux — is still caught
+    (harness-control#148).
     """
 
     def __init__(self):
@@ -364,16 +368,32 @@ class FifoManager:
         read, exactly like an idle terminal). The only ground truth is tmux's own
         live pane content, which keeps rendering through the stall. So:
 
-        - pane content advanced since the last check AND the FIFO delivered no
-          bytes in that same window  -> the pipe is stalled: re-arm it.
-        - pane content unchanged                                   -> idle: do nothing.
-        - FIFO delivered bytes                                     -> healthy: do nothing.
+        - pane content has diverged from the last known-healthy baseline AND the
+          FIFO has delivered no bytes since        -> the pipe is stalled: re-arm.
+        - pane content matches the baseline                        -> idle: do nothing.
+        - FIFO delivered bytes since the last check       -> healthy: re-baseline.
 
-        Requiring BOTH "pane advanced" and "FIFO silent" is what stops a
+        The baseline is pinned to the pane content last observed while the FIFO
+        was confirmed delivering data (or the first-ever observation) — NOT to
+        the immediately-previous check's content. This matters for a "burst-then-
+        settle" stall: tmux can silently stop forwarding mid-burst and the pane
+        then settles into a new, different, static frame before the next poll
+        observes it (e.g. an AskUserQuestion menu finishing its render and
+        sitting idle awaiting input — harness-control#148's live repro). Comparing
+        only against the immediately-previous check's content would see exactly
+        one diverging check (baseline -> new frame) followed by unchanging checks
+        thereafter (new frame -> same new frame), resetting the strike counter to
+        0 forever — even though the FIFO-fed buffer is permanently stuck on stale
+        mid-burst content. Pinning the baseline until the FIFO actually delivers
+        data again means every check keeps comparing against the ORIGINAL
+        pre-stall content, so a settle-and-freeze keeps accumulating strikes
+        exactly like an ongoing divergence would.
+
+        Requiring BOTH "diverged from baseline" and "FIFO silent" is what stops a
         legitimately idle terminal (pane unchanged, FIFO silent) from triggering
         a needless re-pipe. Re-arm only after ``PIPE_LIVENESS_STALL_CHECKS``
-        consecutive diverging checks (default 2 — a single diverging check can be
-        a false positive on a healthy-but-bursty pipe).
+        consecutive checks confirm the divergence persists (default 2 — a single
+        diverging check can be a false positive on a healthy-but-bursty pipe).
         """
         probe = self._pane_probe.get(terminal_id)
         rearm = self._rearm.get(terminal_id)
@@ -404,17 +424,27 @@ class FifoManager:
                 # First observation: establish a baseline, never act on it.
                 self._liveness[terminal_id] = (content, now, 0)
                 return
-            prev_content, last_check_at, strikes = prev
+            baseline_content, last_check_at, strikes = prev
 
-            # Full tail string compared, not a hash: a hash collision would
-            # make pane_advanced False and mask a real stall (negligible
-            # probability, but the string is just as cheap to compare and
-            # collision-free).
-            pane_advanced = content != prev_content
             # Did the reader deliver anything since the previous check?
             fifo_advanced = last_data_at >= last_check_at
 
-            if pane_advanced and not fifo_advanced:
+            if fifo_advanced:
+                # Healthy: the pipe is confirmed delivering. Re-baseline to
+                # the current pane content and clear strikes.
+                self._liveness[terminal_id] = (content, now, 0)
+                return
+
+            # FIFO silent since the last check. Compare against the STICKY
+            # baseline (last known-healthy content), not the previous
+            # check's content — see docstring for why this matters for a
+            # burst-then-settle stall. Full tail string compared, not a
+            # hash: a hash collision would make this False and mask a real
+            # stall (negligible probability, but the string is just as
+            # cheap to compare and collision-free).
+            diverged_from_baseline = content != baseline_content
+
+            if diverged_from_baseline:
                 strikes += 1
                 if strikes >= PIPE_LIVENESS_STALL_CHECKS:
                     do_rearm = True
@@ -422,7 +452,11 @@ class FifoManager:
             else:
                 strikes = 0
 
-            self._liveness[terminal_id] = (content, now, strikes)
+            # Baseline is intentionally left unchanged (not reset to
+            # `content`) so a burst-then-settle stall keeps accumulating
+            # strikes against the original pre-stall baseline across
+            # checks where the now-static content no longer changes.
+            self._liveness[terminal_id] = (baseline_content, now, strikes)
 
         if not do_rearm:
             return

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -14,6 +14,7 @@ from cli_agent_orchestrator.constants import (
     FIFO_DIR,
     PIPE_LIVENESS_CHECK_INTERVAL_S,
     PIPE_LIVENESS_COLD_START_GRACE_S,
+    PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS,
     PIPE_LIVENESS_MAX_REARM_FAILURES,
     PIPE_LIVENESS_STALL_CHECKS,
 )
@@ -106,6 +107,15 @@ class FifoManager:
         # stays uniform; only enrolled terminals ever have it consulted.
         self._registered_at: Dict[str, float] = {}
         self._ever_delivered: Dict[str, bool] = {}
+        # Cold-start re-arm attempts (self-ROAST finding: a rearm() call that
+        # succeeds does NOT mean the FIFO actually started delivering — only
+        # the reader thread pulling a real byte off it flips _ever_delivered.
+        # A genuinely, permanently dead pipe would otherwise re-trigger the
+        # cold-start check every grace period forever. Bounded the same way
+        # the rearm()-exception path already is, via a dedicated counter so
+        # the two failure classes — "rearm() raised" vs. "rearm() succeeded
+        # but the pipe still never delivered" — don't get conflated.
+        self._cold_start_attempts: Dict[str, int] = {}
         # Per-terminal probes/re-arm callbacks (only tmux/pipe-pane terminals
         # register these; herdr and callers that pass none are never watched).
         self._pane_probe: Dict[str, PaneProbe] = {}
@@ -193,6 +203,7 @@ class FifoManager:
             self._rearm_failures.pop(terminal_id, None)
             self._registered_at.pop(terminal_id, None)
             self._ever_delivered.pop(terminal_id, None)
+            self._cold_start_attempts.pop(terminal_id, None)
 
         # Deliberately NOT stopping the watchdog thread here even when this was
         # the last enrolled terminal: doing it under a "now idle" check raced
@@ -449,6 +460,7 @@ class FifoManager:
 
         do_rearm = False
         cold_start = False
+        cold_start_give_up = False
         with self._lock:
             # stop_reader() may have unenrolled this terminal while probe()
             # was in flight above. Re-check membership before touching any
@@ -478,12 +490,44 @@ class FifoManager:
                 # The FIFO has never delivered a single byte in the grace
                 # period since registration, yet the live pane already has
                 # real content — the forwarder never started, full stop.
-                # Reset liveness bookkeeping to the post-rearm state so the
-                # divergence check starts clean on the next tick instead of
-                # possibly re-triggering off a baseline captured before rearm.
-                cold_start = True
-                do_rearm = True
-                self._liveness[terminal_id] = (content, now, 0)
+                #
+                # self-ROAST finding: a rearm() call SUCCEEDING does not mean
+                # the pipe actually started delivering — only the reader
+                # thread pulling a real byte off it flips `ever_delivered`
+                # (the replay below publishes straight to the event bus,
+                # bypassing the FIFO entirely, so it never touches that
+                # flag). Without a bound, a genuinely, permanently dead pipe
+                # would re-trigger this exact branch every grace period
+                # forever: an unbounded stop/start + replay loop, live-
+                # reproduced (5/5 checks all re-armed with a never-delivering
+                # fake FIFO). Bounded the same way the rearm()-exception path
+                # already is, via a dedicated counter/constant so the two
+                # failure classes don't get conflated.
+                attempts = self._cold_start_attempts.get(terminal_id, 0) + 1
+                if attempts > PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS:
+                    cold_start_give_up = True
+                    self._pane_probe.pop(terminal_id, None)
+                    self._rearm.pop(terminal_id, None)
+                    self._liveness.pop(terminal_id, None)
+                    self._rearm_failures.pop(terminal_id, None)
+                    self._registered_at.pop(terminal_id, None)
+                    self._ever_delivered.pop(terminal_id, None)
+                    self._cold_start_attempts.pop(terminal_id, None)
+                else:
+                    self._cold_start_attempts[terminal_id] = attempts
+                    # Reset the grace-period clock so the NEXT evaluation is
+                    # a fresh grace period after THIS attempt, not literally
+                    # the very next watchdog tick (~PIPE_LIVENESS_CHECK_
+                    # INTERVAL_S later) — gives each rearm a real chance to
+                    # start delivering before being judged again.
+                    self._registered_at[terminal_id] = now
+                    cold_start = True
+                    do_rearm = True
+                    # Reset liveness bookkeeping to the post-rearm state so
+                    # the divergence check starts clean on the next tick
+                    # instead of possibly re-triggering off a baseline
+                    # captured before rearm.
+                    self._liveness[terminal_id] = (content, now, 0)
             else:
                 prev = self._liveness.get(terminal_id)
                 if prev is None:
@@ -538,6 +582,16 @@ class FifoManager:
                         # baseline across checks where the now-static content
                         # no longer changes.
                         self._liveness[terminal_id] = (baseline_content, now, strikes)
+
+        if cold_start_give_up:
+            logger.error(
+                "pipe-pane forwarder for terminal %s never started delivering after "
+                "%d cold-start re-arm attempts — giving up and dropping it from the "
+                "liveness watchdog",
+                terminal_id,
+                PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS,
+            )
+            return
 
         if not do_rearm:
             return

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -13,6 +13,7 @@ from typing import Callable, Dict, Optional, Tuple
 from cli_agent_orchestrator.constants import (
     FIFO_DIR,
     PIPE_LIVENESS_CHECK_INTERVAL_S,
+    PIPE_LIVENESS_COLD_START_GRACE_S,
     PIPE_LIVENESS_MAX_REARM_FAILURES,
     PIPE_LIVENESS_STALL_CHECKS,
 )
@@ -66,6 +67,23 @@ class FifoManager:
     (not just the previous one) so a stall that settles into a new static frame
     right after the burst — instead of staying visibly in flux — is still caught
     (harness-control#148).
+
+    Also runs a separate cold-start check (harness-control#93): the
+    divergence logic above can only ever catch a pipe that WAS delivering
+    and then stalled — it needs a baseline to diverge from. A pipe that has
+    been dead since the terminal was created never gets one: an already-idle
+    shell prompt renders once and then never changes, so every check sees
+    identical content and "diverged" is permanently False. This is the
+    common, live-reproduced shape of #93 — a shell that IS genuinely ready,
+    sitting on a stable prompt, whose FIFO simply never forwarded anything
+    (tmux's ``pipe-pane -o`` only captures output produced after it attaches;
+    a fast shell can draw its prompt in the same instant, and the guaranteed
+    "nudge a fresh prompt through the pipe" keystroke terminal_service.py
+    already sends is not 100% reliable under load). The cold-start check is
+    independent of any baseline: has the FIFO delivered ANYTHING since
+    registration, within a short, fixed grace period? If not — and the live
+    pane already shows real content — re-arm immediately instead of waiting
+    on a divergence that structurally cannot happen.
     """
 
     def __init__(self):
@@ -78,6 +96,16 @@ class FifoManager:
         # terminal. Updated by the reader thread; read by the watchdog to tell a
         # stalled pipe (pane moving, FIFO silent) from a genuinely idle one.
         self._last_data_at: Dict[str, float] = {}
+        # Monotonic timestamp of when this reader was registered, and whether
+        # the FIFO has EVER delivered a real byte since — the cold-start check
+        # (harness-control#93) is "has anything come through, within this much
+        # time of registration", entirely independent of the baseline/diverge
+        # bookkeeping below (which presupposes at least one healthy delivery
+        # to establish a baseline against). Tracked for every reader (like
+        # _last_data_at above), not just enrolled ones, so the bookkeeping
+        # stays uniform; only enrolled terminals ever have it consulted.
+        self._registered_at: Dict[str, float] = {}
+        self._ever_delivered: Dict[str, bool] = {}
         # Per-terminal probes/re-arm callbacks (only tmux/pipe-pane terminals
         # register these; herdr and callers that pass none are never watched).
         self._pane_probe: Dict[str, PaneProbe] = {}
@@ -130,7 +158,10 @@ class FifoManager:
             self._threads[terminal_id] = thread
             # Seed the liveness clock BEFORE pipe-pane starts so the first
             # watchdog check has a baseline; the reader bumps it on real data.
-            self._last_data_at[terminal_id] = time.monotonic()
+            now = time.monotonic()
+            self._last_data_at[terminal_id] = now
+            self._registered_at[terminal_id] = now
+            self._ever_delivered[terminal_id] = False
             if enroll:
                 self._pane_probe[terminal_id] = pane_probe
                 self._rearm[terminal_id] = rearm
@@ -160,6 +191,8 @@ class FifoManager:
             self._liveness.pop(terminal_id, None)
             self._last_data_at.pop(terminal_id, None)
             self._rearm_failures.pop(terminal_id, None)
+            self._registered_at.pop(terminal_id, None)
+            self._ever_delivered.pop(terminal_id, None)
 
         # Deliberately NOT stopping the watchdog thread here even when this was
         # the last enrolled terminal: doing it under a "now idle" check raced
@@ -288,6 +321,7 @@ class FifoManager:
                         with self._lock:
                             if terminal_id in self._readers:
                                 self._last_data_at[terminal_id] = time.monotonic()
+                                self._ever_delivered[terminal_id] = True
                         if not pending:
                             batch_start = time.monotonic()
                         pending.extend(raw)
@@ -394,6 +428,13 @@ class FifoManager:
         a needless re-pipe. Re-arm only after ``PIPE_LIVENESS_STALL_CHECKS``
         consecutive checks confirm the divergence persists (default 2 — a single
         diverging check can be a false positive on a healthy-but-bursty pipe).
+
+        Before any of that, a separate cold-start check (harness-control#93)
+        runs first: has the FIFO delivered ANYTHING since the terminal was
+        registered, within ``PIPE_LIVENESS_COLD_START_GRACE_S``? This is not
+        a variant of the divergence logic — it is checked instead of it,
+        because divergence requires a healthy baseline to diverge FROM, and a
+        pipe that's been dead since t=0 never gets one. See module docstring.
         """
         probe = self._pane_probe.get(terminal_id)
         rearm = self._rearm.get(terminal_id)
@@ -407,6 +448,7 @@ class FifoManager:
         now = time.monotonic()
 
         do_rearm = False
+        cold_start = False
         with self._lock:
             # stop_reader() may have unenrolled this terminal while probe()
             # was in flight above. Re-check membership before touching any
@@ -419,64 +461,126 @@ class FifoManager:
                 return
             last_data_at = self._last_data_at.get(terminal_id, 0.0)
 
-            prev = self._liveness.get(terminal_id)
-            if prev is None:
-                # First observation: establish a baseline, never act on it.
+            # ---- cold-start check (harness-control#93) ----
+            # `.get(..., True)` / `registered_at is None` default to "not a
+            # cold start": entries created via create_reader() always have
+            # both set, but tests that poke _pane_probe/_rearm/_last_data_at
+            # directly (bypassing create_reader) leave them absent, and must
+            # keep exercising only the pre-existing divergence path.
+            ever_delivered = self._ever_delivered.get(terminal_id, True)
+            registered_at = self._registered_at.get(terminal_id)
+            if (
+                not ever_delivered
+                and registered_at is not None
+                and now - registered_at >= PIPE_LIVENESS_COLD_START_GRACE_S
+                and content.strip()
+            ):
+                # The FIFO has never delivered a single byte in the grace
+                # period since registration, yet the live pane already has
+                # real content — the forwarder never started, full stop.
+                # Reset liveness bookkeeping to the post-rearm state so the
+                # divergence check starts clean on the next tick instead of
+                # possibly re-triggering off a baseline captured before rearm.
+                cold_start = True
+                do_rearm = True
                 self._liveness[terminal_id] = (content, now, 0)
-                return
-            baseline_content, last_check_at, strikes = prev
-
-            # Did the reader deliver anything since the previous check?
-            fifo_advanced = last_data_at >= last_check_at
-
-            if fifo_advanced:
-                # Healthy: the pipe is confirmed delivering. Re-baseline to
-                # the current pane content and clear strikes.
-                self._liveness[terminal_id] = (content, now, 0)
-                return
-
-            # FIFO silent since the last check. Compare against the STICKY
-            # baseline (last known-healthy content), not the previous
-            # check's content — see docstring for why this matters for a
-            # burst-then-settle stall. Full tail string compared, not a
-            # hash: a hash collision would make this False and mask a real
-            # stall (negligible probability, but the string is just as
-            # cheap to compare and collision-free).
-            #
-            # Tradeoff (round-3 review, call-me-ram): pinning the baseline
-            # means ANY one-shot pane divergence seen while the FIFO happens
-            # to be silent — not just a genuine stall — now accumulates
-            # strikes toward a re-arm, where the old previous-check
-            # comparison would have reset on the very next unchanging check.
-            # E.g. an attached client resizing the pane, causing tmux to
-            # rewrap the captured tail once, then nothing further changing.
-            # The cost of a false-positive re-arm here is mild (a
-            # stop/start on an otherwise-idle pipe plus one snapshot
-            # replay), and it's the unavoidable price of catching a stall
-            # that settles into a new static frame — accepted deliberately.
-            diverged_from_baseline = content != baseline_content
-
-            if diverged_from_baseline:
-                strikes += 1
-                if strikes >= PIPE_LIVENESS_STALL_CHECKS:
-                    do_rearm = True
-                    strikes = 0
             else:
-                strikes = 0
+                prev = self._liveness.get(terminal_id)
+                if prev is None:
+                    # First observation: establish a baseline, never act on it.
+                    self._liveness[terminal_id] = (content, now, 0)
+                else:
+                    baseline_content, last_check_at, strikes = prev
 
-            # Baseline is intentionally left unchanged (not reset to
-            # `content`) so a burst-then-settle stall keeps accumulating
-            # strikes against the original pre-stall baseline across
-            # checks where the now-static content no longer changes.
-            self._liveness[terminal_id] = (baseline_content, now, strikes)
+                    # Did the reader deliver anything since the previous check?
+                    fifo_advanced = last_data_at >= last_check_at
+
+                    if fifo_advanced:
+                        # Healthy: the pipe is confirmed delivering. Re-baseline
+                        # to the current pane content and clear strikes.
+                        self._liveness[terminal_id] = (content, now, 0)
+                    else:
+                        # FIFO silent since the last check. Compare against the
+                        # STICKY baseline (last known-healthy content), not the
+                        # previous check's content — see docstring for why this
+                        # matters for a burst-then-settle stall. Full tail
+                        # string compared, not a hash: a hash collision would
+                        # make this False and mask a real stall (negligible
+                        # probability, but the string is just as cheap to
+                        # compare and collision-free).
+                        #
+                        # Tradeoff (round-3 review, call-me-ram): pinning the
+                        # baseline means ANY one-shot pane divergence seen
+                        # while the FIFO happens to be silent — not just a
+                        # genuine stall — now accumulates strikes toward a
+                        # re-arm, where the old previous-check comparison
+                        # would have reset on the very next unchanging check.
+                        # E.g. an attached client resizing the pane, causing
+                        # tmux to rewrap the captured tail once, then nothing
+                        # further changing. The cost of a false-positive
+                        # re-arm here is mild (a stop/start on an otherwise-
+                        # idle pipe plus one snapshot replay), and it's the
+                        # unavoidable price of catching a stall that settles
+                        # into a new static frame — accepted deliberately.
+                        diverged_from_baseline = content != baseline_content
+
+                        if diverged_from_baseline:
+                            strikes += 1
+                            if strikes >= PIPE_LIVENESS_STALL_CHECKS:
+                                do_rearm = True
+                                strikes = 0
+                        else:
+                            strikes = 0
+
+                        # Baseline is intentionally left unchanged (not reset
+                        # to `content`) so a burst-then-settle stall keeps
+                        # accumulating strikes against the original pre-stall
+                        # baseline across checks where the now-static content
+                        # no longer changes.
+                        self._liveness[terminal_id] = (baseline_content, now, strikes)
 
         if not do_rearm:
             return
 
+        self._rearm_stalled_pipe(terminal_id, content, rearm, cold_start=cold_start)
+
+    def _rearm_stalled_pipe(
+        self, terminal_id: str, content: str, rearm: RearmPipe, *, cold_start: bool
+    ) -> None:
+        """Re-arm a confirmed-stalled pipe-pane forwarder and replay the live
+        pane snapshot into the pipeline, shared by both stall checks above —
+        they differ only in HOW a stall is detected, not in what happens once
+        one is confirmed.
+
+        Bytes lost during the stall are gone (tmux never buffered them), but
+        the pane's *current* content is not — replay it into the pipeline so
+        the StatusMonitor buffer / GET output immediately reflect the live
+        screen instead of staying frozen until the agent happens to emit
+        something new. This is also what makes the cold-start case actually
+        resolve: the replay publishes straight to the event bus, bypassing
+        the FIFO reader entirely, so wait_for_shell()'s buffer read is
+        satisfied even though the FIFO itself never delivered a byte.
+
+        capture-pane output is joined with a bare "\\n" (clients/tmux.py's
+        get_history), which is linefeed-without-carriage-return. pyte's
+        screen (fed by StatusMonitor for CAO_PYTE_STATUS providers — on by
+        default, and opted into by claude_code, exactly the provider #388
+        was filed against) defaults LNM (line-feed/new-line mode) off, so a
+        bare "\\n" advances the row without returning to column 0: each
+        replayed line renders indented past the previous one
+        ("staircasing"), and the composited screen no longer matches the
+        real pane until a later cursor-addressed repaint happens to paper
+        over it — meaning status detection can stay broken after the very
+        re-arm meant to fix it. Replaying with "\\r\\n" makes pyte treat it as
+        a real newline, matching what a real terminal does with tmux's own
+        capture-pane output.
+        """
         logger.warning(
-            "pipe-pane forwarder for terminal %s appears stalled "
-            "(pane advanced, no FIFO data) — re-arming",
+            "pipe-pane forwarder for terminal %s appears %s — re-arming",
             terminal_id,
+            "never started forwarding (cold-start, harness-control#93)"
+            if cold_start
+            else "stalled (pane advanced, no FIFO data)",
         )
         try:
             rearm()
@@ -493,6 +597,8 @@ class FifoManager:
                     self._rearm.pop(terminal_id, None)
                     self._liveness.pop(terminal_id, None)
                     self._rearm_failures.pop(terminal_id, None)
+                    self._registered_at.pop(terminal_id, None)
+                    self._ever_delivered.pop(terminal_id, None)
             if give_up:
                 # Not a silent retry-forever: a re-arm that keeps failing
                 # (e.g. the tmux pane is gone) previously re-struck and
@@ -509,25 +615,6 @@ class FifoManager:
                 )
             return
 
-        # Bytes lost during the stall are gone (tmux never buffered them), but
-        # the pane's *current* content is not — replay it into the pipeline so
-        # the StatusMonitor buffer / GET output immediately reflect the live
-        # screen instead of staying frozen until the agent happens to emit
-        # something new.
-        #
-        # capture-pane output is joined with a bare "\n" (clients/tmux.py's
-        # get_history), which is linefeed-without-carriage-return. pyte's
-        # screen (fed by StatusMonitor for CAO_PYTE_STATUS providers — on by
-        # default, and opted into by claude_code, exactly the provider #388
-        # was filed against) defaults LNM (line-feed/new-line mode) off, so a
-        # bare "\n" advances the row without returning to column 0: each
-        # replayed line renders indented past the previous one
-        # ("staircasing"), and the composited screen no longer matches the
-        # real pane until a later cursor-addressed repaint happens to paper
-        # over it — meaning status detection can stay broken after the very
-        # re-arm meant to fix it. Replaying with "\r\n" makes pyte treat it as
-        # a real newline, matching what a real terminal does with tmux's own
-        # capture-pane output.
         replay = content.replace("\n", "\r\n")
         with self._lock:
             if terminal_id not in self._pane_probe:

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -275,12 +275,15 @@ class FifoManager:
                         # while this thread was mid-read, before it noticed
                         # stop_flag), writing here would resurrect a dict entry
                         # nothing will ever clean up again — a slow leak across
-                        # create/stop churn. The check is unlocked (consistent
-                        # with the watchdog loop's own lock-free dict reads
-                        # elsewhere in this class); it only needs to be right
-                        # often enough to close the common case, not atomic.
-                        if terminal_id in self._readers:
-                            self._last_data_at[terminal_id] = time.monotonic()
+                        # create/stop churn. The check-then-write must happen
+                        # under _lock as one critical section: a stop_reader()
+                        # pop between an unlocked check and the assignment
+                        # could still resurrect the entry (round-3 Copilot
+                        # review on #397). Cheap and non-blocking either way —
+                        # this is a plain dict write, not the slow tmux probe.
+                        with self._lock:
+                            if terminal_id in self._readers:
+                                self._last_data_at[terminal_id] = time.monotonic()
                         if not pending:
                             batch_start = time.monotonic()
                         pending.extend(raw)
@@ -339,7 +342,16 @@ class FifoManager:
 
     def _watchdog_loop(self) -> None:
         while not self._watchdog_stop.wait(PIPE_LIVENESS_CHECK_INTERVAL_S):
-            for terminal_id in list(self._pane_probe.keys()):
+            # Snapshot under _lock: create_reader()/stop_reader() mutate
+            # _pane_probe concurrently (enroll/unenroll), and iterating a dict
+            # while it's being resized raises RuntimeError — which would kill
+            # this thread and permanently disable the watchdog (round-3
+            # Copilot review on #397). The lock is released before calling
+            # _check_pipe_liveness(), which takes it again itself per-terminal
+            # — so no lock is held across the slow probe()/rearm() calls.
+            with self._lock:
+                terminal_ids = list(self._pane_probe.keys())
+            for terminal_id in terminal_ids:
                 try:
                     self._check_pipe_liveness(terminal_id)
                 except Exception:

--- a/src/cli_agent_orchestrator/services/fifo_reader.py
+++ b/src/cli_agent_orchestrator/services/fifo_reader.py
@@ -13,6 +13,7 @@ from typing import Callable, Dict, Optional, Tuple
 from cli_agent_orchestrator.constants import (
     FIFO_DIR,
     PIPE_LIVENESS_CHECK_INTERVAL_S,
+    PIPE_LIVENESS_MAX_REARM_FAILURES,
     PIPE_LIVENESS_STALL_CHECKS,
 )
 from cli_agent_orchestrator.services.event_bus import bus
@@ -77,9 +78,14 @@ class FifoManager:
         # register these; herdr and callers that pass none are never watched).
         self._pane_probe: Dict[str, PaneProbe] = {}
         self._rearm: Dict[str, RearmPipe] = {}
-        # Per-terminal watchdog bookkeeping: (last_pane_hash, last_check_monotonic,
-        # consecutive_diverging_checks).
-        self._liveness: Dict[str, Tuple[int, float, int]] = {}
+        # Per-terminal watchdog bookkeeping: (last_pane_content, last_check_monotonic,
+        # consecutive_diverging_checks). The full tail string (not a hash) is
+        # stored so an accidental hash collision can never mask a real stall.
+        self._liveness: Dict[str, Tuple[str, float, int]] = {}
+        # Consecutive re-arm *failures* per terminal (rearm() raised). Reset on
+        # any successful re-arm; once it hits PIPE_LIVENESS_MAX_REARM_FAILURES
+        # the terminal is dropped from the watchdog instead of retrying forever.
+        self._rearm_failures: Dict[str, int] = {}
         self._watchdog_stop = threading.Event()
         self._watchdog_thread: Optional[threading.Thread] = None
 
@@ -129,7 +135,7 @@ class FifoManager:
         if enroll:
             self._ensure_watchdog()
 
-        logger.info(f"Started FIFO reader for terminal {terminal_id}")
+        logger.info("Started FIFO reader for terminal %s", terminal_id)
 
     def stop_reader(self, terminal_id: str) -> None:
         """Stop the reader thread (if running) and delete the FIFO file.
@@ -149,7 +155,18 @@ class FifoManager:
             self._rearm.pop(terminal_id, None)
             self._liveness.pop(terminal_id, None)
             self._last_data_at.pop(terminal_id, None)
+            self._rearm_failures.pop(terminal_id, None)
 
+        # Deliberately NOT stopping the watchdog thread here even when this was
+        # the last enrolled terminal: doing it under a "now idle" check raced
+        # against a concurrent create_reader() enrolling a new terminal between
+        # this method releasing the lock and calling stop_watchdog() — the
+        # watchdog thread that create_reader's _ensure_watchdog() decided was
+        # still alive and reusable could be torn down out from under the newly
+        # enrolled terminal, leaving it silently unwatched. A single lingering
+        # thread waking every PIPE_LIVENESS_CHECK_INTERVAL_S to iterate an empty
+        # dict is a cheap, correctness-preserving tradeoff instead; it is
+        # actually torn down at process shutdown (api/main.py's lifespan).
         fifo_path = FIFO_DIR / f"{terminal_id}.fifo"
 
         if stop_flag and thread:
@@ -165,11 +182,12 @@ class FifoManager:
                 # Never silent: a leaked reader thread was how #382's wedge
                 # built up. With the non-blocking loop this should not happen.
                 logger.warning(
-                    f"FIFO reader thread for terminal {terminal_id} did not exit "
-                    "within 2s; leaking a daemon thread"
+                    "FIFO reader thread for terminal %s did not exit "
+                    "within 2s; leaking a daemon thread",
+                    terminal_id,
                 )
             else:
-                logger.info(f"Stopped FIFO reader for terminal {terminal_id}")
+                logger.info("Stopped FIFO reader for terminal %s", terminal_id)
 
         # Best-effort unlink regardless of whether a reader was tracked — when
         # none is tracked there is no active reader holding the FIFO, so removing
@@ -251,7 +269,18 @@ class FifoManager:
                         # off the FIFO, independent of the coalescing/publish
                         # schedule below — the watchdog cares whether the FIFO
                         # delivered data, not whether/when a batch flushed.
-                        self._last_data_at[terminal_id] = time.monotonic()
+                        #
+                        # Guarded by membership rather than unconditional: if
+                        # stop_reader already popped this terminal (torn down
+                        # while this thread was mid-read, before it noticed
+                        # stop_flag), writing here would resurrect a dict entry
+                        # nothing will ever clean up again — a slow leak across
+                        # create/stop churn. The check is unlocked (consistent
+                        # with the watchdog loop's own lock-free dict reads
+                        # elsewhere in this class); it only needs to be right
+                        # often enough to close the common case, not atomic.
+                        if terminal_id in self._readers:
+                            self._last_data_at[terminal_id] = time.monotonic()
                         if not pending:
                             batch_start = time.monotonic()
                         pending.extend(raw)
@@ -270,7 +299,7 @@ class FifoManager:
                     pending.clear()
         except Exception as e:
             if not stop_flag.is_set():
-                logger.error(f"FIFO reader for terminal {terminal_id} exiting on error: {e}")
+                logger.error("FIFO reader for terminal %s exiting on error: %s", terminal_id, e)
         finally:
             # Flush any unpublished bytes so the last frame of a torn-down
             # terminal isn't lost — status/log consumers may need it.
@@ -314,9 +343,7 @@ class FifoManager:
                 try:
                     self._check_pipe_liveness(terminal_id)
                 except Exception:
-                    logger.exception(
-                        "pipe-pane liveness check failed for terminal %s", terminal_id
-                    )
+                    logger.exception("pipe-pane liveness check failed for terminal %s", terminal_id)
 
     def _check_pipe_liveness(self, terminal_id: str) -> None:
         """One liveness check for a terminal: re-arm a stalled pipe-pane forwarder.
@@ -333,57 +360,124 @@ class FifoManager:
         Requiring BOTH "pane advanced" and "FIFO silent" is what stops a
         legitimately idle terminal (pane unchanged, FIFO silent) from triggering
         a needless re-pipe. Re-arm only after ``PIPE_LIVENESS_STALL_CHECKS``
-        consecutive diverging checks (default 1).
+        consecutive diverging checks (default 2 — a single diverging check can be
+        a false positive on a healthy-but-bursty pipe).
         """
         probe = self._pane_probe.get(terminal_id)
         rearm = self._rearm.get(terminal_id)
         if probe is None or rearm is None:
             return
 
+        # probe() is a slow tmux `capture-pane` call — deliberately made
+        # without holding self._lock so it never blocks stop_reader() (or
+        # other terminals' housekeeping) for its duration.
         content = probe()
         now = time.monotonic()
-        current_hash = hash(content)
-        last_data_at = self._last_data_at.get(terminal_id, 0.0)
 
-        prev = self._liveness.get(terminal_id)
-        if prev is None:
-            # First observation: establish a baseline, never act on it.
-            self._liveness[terminal_id] = (current_hash, now, 0)
-            return
-        prev_hash, last_check_at, strikes = prev
+        do_rearm = False
+        with self._lock:
+            # stop_reader() may have unenrolled this terminal while probe()
+            # was in flight above. Re-check membership before touching any
+            # per-terminal state: writing back unconditionally (the previous
+            # behavior) would resurrect dict entries for a terminal that is
+            # gone — _watchdog_loop only ever iterates _pane_probe, so a
+            # resurrected entry in _liveness/_last_data_at is never revisited
+            # and never cleaned up, leaking slowly across create/stop churn.
+            if terminal_id not in self._pane_probe:
+                return
+            last_data_at = self._last_data_at.get(terminal_id, 0.0)
 
-        pane_advanced = current_hash != prev_hash
-        # Did the reader deliver anything since the previous check?
-        fifo_advanced = last_data_at >= last_check_at
+            prev = self._liveness.get(terminal_id)
+            if prev is None:
+                # First observation: establish a baseline, never act on it.
+                self._liveness[terminal_id] = (content, now, 0)
+                return
+            prev_content, last_check_at, strikes = prev
 
-        if pane_advanced and not fifo_advanced:
-            strikes += 1
-            if strikes >= PIPE_LIVENESS_STALL_CHECKS:
-                logger.warning(
-                    "pipe-pane forwarder for terminal %s appears stalled "
-                    "(pane advanced, no FIFO data for %.1fs) — re-arming",
-                    terminal_id,
-                    now - last_check_at,
-                )
-                try:
-                    rearm()
-                except Exception:
-                    logger.exception(
-                        "failed to re-arm pipe-pane for terminal %s", terminal_id
-                    )
-                else:
-                    # Bytes lost during the stall are gone (tmux never buffered
-                    # them), but the pane's *current* content is not — replay it
-                    # into the pipeline so the StatusMonitor buffer / GET output
-                    # immediately reflect the live screen instead of staying
-                    # frozen until the agent happens to emit something new.
-                    bus.publish(f"terminal.{terminal_id}.output", {"data": content})
-                    self._last_data_at[terminal_id] = time.monotonic()
+            # Full tail string compared, not a hash: a hash collision would
+            # make pane_advanced False and mask a real stall (negligible
+            # probability, but the string is just as cheap to compare and
+            # collision-free).
+            pane_advanced = content != prev_content
+            # Did the reader deliver anything since the previous check?
+            fifo_advanced = last_data_at >= last_check_at
+
+            if pane_advanced and not fifo_advanced:
+                strikes += 1
+                if strikes >= PIPE_LIVENESS_STALL_CHECKS:
+                    do_rearm = True
+                    strikes = 0
+            else:
                 strikes = 0
-        else:
-            strikes = 0
 
-        self._liveness[terminal_id] = (current_hash, now, strikes)
+            self._liveness[terminal_id] = (content, now, strikes)
+
+        if not do_rearm:
+            return
+
+        logger.warning(
+            "pipe-pane forwarder for terminal %s appears stalled "
+            "(pane advanced, no FIFO data) — re-arming",
+            terminal_id,
+        )
+        try:
+            rearm()
+        except Exception:
+            logger.exception("failed to re-arm pipe-pane for terminal %s", terminal_id)
+            with self._lock:
+                if terminal_id not in self._pane_probe:
+                    return
+                failures = self._rearm_failures.get(terminal_id, 0) + 1
+                self._rearm_failures[terminal_id] = failures
+                give_up = failures >= PIPE_LIVENESS_MAX_REARM_FAILURES
+                if give_up:
+                    self._pane_probe.pop(terminal_id, None)
+                    self._rearm.pop(terminal_id, None)
+                    self._liveness.pop(terminal_id, None)
+                    self._rearm_failures.pop(terminal_id, None)
+            if give_up:
+                # Not a silent retry-forever: a re-arm that keeps failing
+                # (e.g. the tmux pane is gone) previously re-struck and
+                # re-attempted every ~PIPE_LIVENESS_STALL_CHECKS intervals
+                # indefinitely, each logging at WARNING/exception — bounded
+                # but noisy forever. Give up after N consecutive failures and
+                # say so loudly instead.
+                logger.error(
+                    "pipe-pane forwarder for terminal %s failed to re-arm %d "
+                    "consecutive times — giving up and dropping it from the "
+                    "liveness watchdog",
+                    terminal_id,
+                    failures,
+                )
+            return
+
+        # Bytes lost during the stall are gone (tmux never buffered them), but
+        # the pane's *current* content is not — replay it into the pipeline so
+        # the StatusMonitor buffer / GET output immediately reflect the live
+        # screen instead of staying frozen until the agent happens to emit
+        # something new.
+        #
+        # capture-pane output is joined with a bare "\n" (clients/tmux.py's
+        # get_history), which is linefeed-without-carriage-return. pyte's
+        # screen (fed by StatusMonitor for CAO_PYTE_STATUS providers — on by
+        # default, and opted into by claude_code, exactly the provider #388
+        # was filed against) defaults LNM (line-feed/new-line mode) off, so a
+        # bare "\n" advances the row without returning to column 0: each
+        # replayed line renders indented past the previous one
+        # ("staircasing"), and the composited screen no longer matches the
+        # real pane until a later cursor-addressed repaint happens to paper
+        # over it — meaning status detection can stay broken after the very
+        # re-arm meant to fix it. Replaying with "\r\n" makes pyte treat it as
+        # a real newline, matching what a real terminal does with tmux's own
+        # capture-pane output.
+        replay = content.replace("\n", "\r\n")
+        with self._lock:
+            if terminal_id not in self._pane_probe:
+                return
+            self._rearm_failures.pop(terminal_id, None)
+            self._last_data_at[terminal_id] = time.monotonic()
+
+        bus.publish(f"terminal.{terminal_id}.output", {"data": replay})
 
 
 # Module-level singleton

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -36,7 +36,12 @@ from cli_agent_orchestrator.clients.database import (
     update_last_active,
     update_terminal_shell_command,
 )
-from cli_agent_orchestrator.constants import FIFO_DIR, SESSION_PREFIX, TERMINAL_LOG_DIR
+from cli_agent_orchestrator.constants import (
+    FIFO_DIR,
+    PIPE_LIVENESS_TAIL_LINES,
+    SESSION_PREFIX,
+    TERMINAL_LOG_DIR,
+)
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.provider import ProviderType
 from cli_agent_orchestrator.models.terminal import Terminal, TerminalStatus
@@ -290,14 +295,28 @@ async def create_terminal(
         # socket events and their pipe_pane is a no-op, so skip the FIFO there and
         # rely on the herdr inbox registration below.
         if not get_backend().supports_event_inbox():
-            # Reader must exist BEFORE pipe-pane starts so it captures from the start.
-            fifo_manager.create_reader(terminal_id)
+            fifo_path = FIFO_DIR / f"{terminal_id}.fifo"
+
+            # Reader must exist BEFORE pipe-pane starts so it captures from the
+            # start. Enroll it in the pipe-pane liveness watchdog (issue #388):
+            # supply a probe for tmux's live pane content and a re-arm that
+            # re-attaches a stalled forwarder. The re-arm does stop-then-start,
+            # NOT a bare pipe_pane() — a stalled pane still reports pane_pipe=1,
+            # so the backend's ``pipe-pane -o`` toggle would just switch the
+            # dead pipe OFF instead of restarting it.
+            def _probe_pane(s=session_name, w=window_name) -> str:
+                return get_backend().get_history(s, w, tail_lines=PIPE_LIVENESS_TAIL_LINES)
+
+            def _rearm_pipe(s=session_name, w=window_name, p=str(fifo_path)) -> None:
+                get_backend().stop_pipe_pane(s, w)
+                get_backend().pipe_pane(s, w, p)
+
+            fifo_manager.create_reader(terminal_id, pane_probe=_probe_pane, rearm=_rearm_pipe)
 
             # Configure pipe-pane to stream output to the FIFO. This enables
             # real-time event-driven processing via StatusMonitor and LogWriter
             # (LogWriter writes TERMINAL_LOG_DIR/{id}.log from the FIFO). A pane
             # has a single pipe-pane target, so we pipe ONLY to the FIFO.
-            fifo_path = FIFO_DIR / f"{terminal_id}.fifo"
             get_backend().pipe_pane(session_name, window_name, str(fifo_path))
 
             # Nudge the shell so it re-renders its prompt AFTER pipe-pane attaches.

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -640,7 +640,9 @@ class TestColdStartStallDetection:
 
         manager._check_pipe_liveness("term")
 
-        assert rearm_calls == [True], "a born-stale pipe must be re-armed without waiting for divergence"
+        assert rearm_calls == [
+            True
+        ], "a born-stale pipe must be re-armed without waiting for divergence"
 
     def test_cold_start_not_triggered_before_grace_period_elapses(self, tmp_path, monkeypatch):
         """A terminal registered moments ago must get its grace period, not
@@ -687,7 +689,9 @@ class TestColdStartStallDetection:
         for _ in range(4):
             manager._check_pipe_liveness("term")  # pane never changes, FIFO silent since
 
-        assert rearm_calls == [], "a pipe that has ever delivered must use the idle/divergence path, not cold-start"
+        assert (
+            rearm_calls == []
+        ), "a pipe that has ever delivered must use the idle/divergence path, not cold-start"
 
     def test_cold_start_state_absent_falls_back_to_existing_behavior(self, tmp_path, monkeypatch):
         """Terminals enrolled directly (bypassing create_reader — exactly how
@@ -736,9 +740,7 @@ class TestColdStartStallDetection:
         content stops changing."""
         manager = self._manager(tmp_path, monkeypatch)
         try:
-            manager.create_reader(
-                "term-e2e", pane_probe=lambda: "content", rearm=lambda: None
-            )
+            manager.create_reader("term-e2e", pane_probe=lambda: "content", rearm=lambda: None)
             with manager._lock:
                 assert manager._registered_at.get("term-e2e") is not None
                 assert manager._ever_delivered.get("term-e2e") is False
@@ -756,9 +758,9 @@ class TestColdStartStallDetection:
                 time.sleep(0.02)
 
             with manager._lock:
-                assert manager._ever_delivered.get("term-e2e") is True, (
-                    "the reader thread must flip _ever_delivered once real bytes are read"
-                )
+                assert (
+                    manager._ever_delivered.get("term-e2e") is True
+                ), "the reader thread must flip _ever_delivered once real bytes are read"
         finally:
             manager.stop_reader("term-e2e")
             manager.stop_watchdog()

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -1,9 +1,14 @@
 """Tests for the FIFO reader manager."""
 
 import os
+import threading
+import time
+from unittest.mock import patch
 
+import pyte
 import pytest
 
+from cli_agent_orchestrator.services import fifo_reader as fr
 from cli_agent_orchestrator.services.fifo_reader import FifoManager
 
 pytestmark = pytest.mark.skipif(
@@ -98,10 +103,6 @@ class TestReaderThreadLifecycle:
     def test_data_received_across_writer_reconnects(self, tmp_path, monkeypatch):
         """Chunks written by successive writers (tmux re-attaching pipe-pane)
         are all published; writer disconnects must not kill the reader."""
-        import time
-
-        from cli_agent_orchestrator.services import fifo_reader as fr
-
         received = []
         monkeypatch.setattr(
             fr.bus, "publish", lambda topic, data: received.append((topic, data["data"]))
@@ -131,8 +132,6 @@ class TestReaderThreadLifecycle:
     def test_repeated_create_stop_cycles_leave_no_threads(self, tmp_path, monkeypatch):
         """Accumulation guard: the #382 report showed 26+ leaked reader threads
         after repeated session create/delete cycles."""
-        import threading as _threading
-
         manager = self._manager(tmp_path, monkeypatch)
         threads = []
         for i in range(5):
@@ -144,7 +143,7 @@ class TestReaderThreadLifecycle:
         for t in threads:
             t.join(timeout=3.0)
         assert all(not t.is_alive() for t in threads)
-        leftover = [t.name for t in _threading.enumerate() if t.name.startswith("fifo-term-cycle")]
+        leftover = [t.name for t in threading.enumerate() if t.name.startswith("fifo-term-cycle")]
         assert leftover == []
 
 
@@ -165,10 +164,6 @@ class TestReaderLoopCoalescing:
         each spinner frame was a separate publish, dropping worker completion
         events on the floor.
         """
-        import threading
-        import time
-        from unittest.mock import patch
-
         monkeypatch.setattr("cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path)
 
         fifo_path = tmp_path / "term-coalesce.fifo"
@@ -230,10 +225,6 @@ class TestReaderLoopCoalescing:
         LLM response would strand bytes in the pending buffer, leaving the
         status monitor with a stale view.
         """
-        import threading
-        import time
-        from unittest.mock import patch
-
         monkeypatch.setattr("cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path)
 
         fifo_path = tmp_path / "term-flush.fifo"
@@ -305,9 +296,11 @@ class TestPipeLivenessWatchdog:
 
     def test_stall_is_detected_and_pipe_rearmed(self, tmp_path, monkeypatch):
         """Pane advanced but the FIFO delivered nothing since the last check ->
-        the forwarder is stalled and gets re-armed."""
-        import time
-
+        the forwarder is stalled and gets re-armed once PIPE_LIVENESS_STALL_CHECKS
+        consecutive checks confirm it (monkeypatched to 1 here to isolate the
+        detect/re-arm decision from the default-threshold behavior, which
+        test_stall_requires_configured_consecutive_checks covers separately)."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_STALL_CHECKS", 1)
         manager = self._manager(tmp_path, monkeypatch)
         pane = {"content": "line0"}
         rearm_calls: list = []
@@ -326,8 +319,6 @@ class TestPipeLivenessWatchdog:
     def test_idle_terminal_is_not_rearmed(self, tmp_path, monkeypatch):
         """Pane unchanged + FIFO silent = a genuinely idle terminal, which must
         NOT trigger a needless re-pipe (the false-positive guard)."""
-        import time
-
         manager = self._manager(tmp_path, monkeypatch)
         pane = {"content": "idle prompt"}
         rearm_calls: list = []
@@ -340,8 +331,6 @@ class TestPipeLivenessWatchdog:
     def test_healthy_pipe_is_not_rearmed(self, tmp_path, monkeypatch):
         """Pane advancing AND the FIFO delivering bytes = a healthy pipe; no
         re-arm even though the screen keeps changing."""
-        import time
-
         manager = self._manager(tmp_path, monkeypatch)
         pane = {"content": "line0"}
         rearm_calls: list = []
@@ -359,10 +348,7 @@ class TestPipeLivenessWatchdog:
         """After re-arm the lost bytes are gone, but the pane's CURRENT content
         is republished so the StatusMonitor buffer / GET output stop being frozen
         instead of waiting for the agent to emit something new."""
-        import time
-
-        from cli_agent_orchestrator.services import fifo_reader as fr
-
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_STALL_CHECKS", 1)
         published: list = []
         monkeypatch.setattr(fr.bus, "publish", lambda topic, data: published.append((topic, data)))
 
@@ -376,15 +362,70 @@ class TestPipeLivenessWatchdog:
         manager._check_pipe_liveness("term")
 
         assert rearm_calls == [True]
+        # Single-line content has no "\n" to CRLF-convert, so the republished
+        # payload equals the raw pane content verbatim; the multi-line CRLF
+        # conversion itself is covered by test_rearm_replay_converts_lf_to_crlf.
         assert ("terminal.term.output", {"data": pane["content"]}) in published
+
+    def test_rearm_replay_converts_lf_to_crlf(self, tmp_path, monkeypatch):
+        """Regression for the round-2 review finding: capture-pane joins lines
+        with a bare "\\n" (clients/tmux.py's get_history), which pyte treats as
+        linefeed-without-carriage-return (LNM off by default) — replaying that
+        verbatim staircases the composited screen, so status detection for
+        CAO_PYTE_STATUS providers (claude_code, #388's own repro target) can
+        stay broken after the very re-arm meant to fix it. The replay must
+        convert each bare "\\n" to "\\r\\n" so pyte renders it as a real newline."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_STALL_CHECKS", 1)
+        published: list = []
+        monkeypatch.setattr(fr.bus, "publish", lambda topic, data: published.append((topic, data)))
+
+        manager = self._manager(tmp_path, monkeypatch)
+        multiline = "line0\nline1\nline2 (rendered but never piped)"
+        pane = {"content": "line0"}
+        rearm_calls: list = []
+        self._enroll(manager, "term", pane, rearm_calls, last_data_at=time.monotonic())
+
+        manager._check_pipe_liveness("term")  # baseline
+        pane["content"] = multiline
+        manager._check_pipe_liveness("term")
+
+        assert rearm_calls == [True]
+        assert ("terminal.term.output", {"data": multiline.replace("\n", "\r\n")}) in published
+        # And the raw bare-LF form must NOT have been published — that's
+        # exactly the payload that staircases pyte's screen.
+        assert ("terminal.term.output", {"data": multiline}) not in published
+
+    def test_pyte_screen_staircases_on_bare_lf_and_is_fixed_by_crlf(self):
+        """End-to-end confirmation (not just string equality) that bare "\\n"
+        actually breaks pyte's composited screen the way the review claimed,
+        and that "\\r\\n" fixes it — using the real pyte library, not a mock."""
+        multiline = "root@host:~$ line one\nroot@host:~$ line two\nroot@host:~$ line three"
+
+        bare_screen = pyte.Screen(80, 24)
+        pyte.Stream(bare_screen).feed(multiline)
+        bare_lines = [line for line in bare_screen.display if line.strip()]
+
+        crlf_screen = pyte.Screen(80, 24)
+        pyte.Stream(crlf_screen).feed(multiline.replace("\n", "\r\n"))
+        crlf_lines = [line for line in crlf_screen.display if line.strip()]
+
+        # With bare "\n" (LNM off), each line's cursor column carries over
+        # from the previous line's end instead of returning to 0, so
+        # "line two"/"line three" render indented ("staircased") rather than
+        # left-aligned like the first line.
+        assert not all(line.startswith("root@host") for line in bare_lines), (
+            "expected the bare-LF replay to staircase — if this now passes, "
+            "pyte's LNM default changed and the CRLF fix may be unnecessary"
+        )
+        # With "\r\n" every line starts at column 0, exactly like a real
+        # terminal rendering tmux's own output.
+        assert all(
+            line.startswith("root@host") for line in crlf_lines
+        ), "CRLF-converted replay must render each line left-aligned"
 
     def test_stall_requires_configured_consecutive_checks(self, tmp_path, monkeypatch):
         """With PIPE_LIVENESS_STALL_CHECKS > 1, a single diverging check is not
         enough — re-arm waits for the configured number of consecutive stalls."""
-        import time
-
-        from cli_agent_orchestrator.services import fifo_reader as fr
-
         monkeypatch.setattr(fr, "PIPE_LIVENESS_STALL_CHECKS", 2)
         manager = self._manager(tmp_path, monkeypatch)
         pane = {"content": "l0"}
@@ -398,6 +439,70 @@ class TestPipeLivenessWatchdog:
         pane["content"] = "l2"
         manager._check_pipe_liveness("term")  # strike 2 — re-arm
         assert rearm_calls == [True]
+
+    def test_stop_during_probe_does_not_resurrect_state(self, tmp_path, monkeypatch):
+        """Regression for the round-2 review's stop-during-probe race:
+        ``_check_pipe_liveness`` calls the injected ``probe()`` (a slow tmux
+        ``capture-pane``) without holding the lock. If ``stop_reader()`` pops a
+        terminal's watchdog state while that call is in flight, the check must
+        not write ``_liveness``/``_last_data_at`` back afterward — the old
+        unconditional write-back resurrected entries for a terminal that
+        ``_watchdog_loop`` (which only iterates ``_pane_probe``) would never
+        revisit again, leaking them for process lifetime across create/stop
+        churn."""
+        manager = self._manager(tmp_path, monkeypatch)
+
+        def slow_probe():
+            # Simulate stop_reader() completing atomically, under its own
+            # lock, while this capture-pane call is still in flight.
+            manager._pane_probe.pop("term", None)
+            manager._rearm.pop("term", None)
+            manager._liveness.pop("term", None)
+            manager._last_data_at.pop("term", None)
+            return "content"
+
+        manager._pane_probe["term"] = slow_probe
+        manager._rearm["term"] = lambda: None
+        manager._liveness["term"] = ("previous content", 0.0, 0)
+        manager._last_data_at["term"] = 0.0
+
+        manager._check_pipe_liveness("term")
+
+        assert "term" not in manager._liveness, "stopped terminal's state must not be resurrected"
+        assert (
+            "term" not in manager._last_data_at
+        ), "stopped terminal's state must not be resurrected"
+
+    def test_rearm_failures_capped_and_terminal_dropped(self, tmp_path, monkeypatch):
+        """A rearm() that keeps raising must not retry forever: after
+        PIPE_LIVENESS_MAX_REARM_FAILURES consecutive failures the terminal is
+        dropped from the watchdog instead of re-striking and logging a
+        WARNING/exception every cycle indefinitely."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_STALL_CHECKS", 1)
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_MAX_REARM_FAILURES", 3)
+
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "l0"}
+        rearm_calls: list = []
+
+        def failing_rearm():
+            rearm_calls.append(True)
+            raise RuntimeError("tmux pane gone")
+
+        manager._pane_probe["term"] = lambda: pane["content"]
+        manager._rearm["term"] = failing_rearm
+        manager._last_data_at["term"] = time.monotonic()
+
+        manager._check_pipe_liveness("term")  # baseline
+
+        for i in range(1, 4):
+            pane["content"] = f"l{i}"
+            manager._check_pipe_liveness("term")
+
+        assert len(rearm_calls) == 3, "must stop attempting after the failure cap"
+        assert "term" not in manager._pane_probe, "terminal must be dropped after repeated failures"
+        assert "term" not in manager._rearm
+        assert "term" not in manager._rearm_failures
 
     def test_create_reader_enrolls_and_starts_watchdog(self, tmp_path, monkeypatch):
         """A tmux caller passing probe+rearm enrolls the terminal and starts the

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -591,6 +591,179 @@ class TestPipeLivenessWatchdog:
             manager.stop_reader("term-plain")
 
 
+class TestColdStartStallDetection:
+    """harness-control#93: the divergence check above can ONLY ever catch a
+    pipe that WAS delivering and then stalled — it needs an established
+    "healthy" baseline to diverge from. A pipe that has been dead since the
+    terminal was created never gets one: an already-idle shell prompt renders
+    once and never changes again, so every check sees identical content and
+    "diverged_from_baseline" is permanently False — the watchdog could wait
+    forever without ever re-arming, while wait_for_shell() times out (60s)
+    waiting on a FIFO buffer that was never going to fill. Live-reproduced:
+    a real tmux pane sitting on a stable, genuinely-ready shell prompt whose
+    FIFO never delivered a single byte from the moment pipe-pane attached.
+
+    This is a positive, independent check — not a variant of the divergence
+    logic — checked BEFORE it: has the FIFO delivered anything since
+    registration, within a short grace period? If not, and the pane already
+    shows real content (ruling out "still genuinely booting"), re-arm
+    immediately.
+    """
+
+    def _manager(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path)
+        return FifoManager()
+
+    def _enroll_cold(self, manager, terminal_id, pane_holder, rearm_calls, registered_at):
+        """Register a terminal exactly as create_reader() would for a pipe
+        that has never delivered anything since ``registered_at``."""
+        manager._pane_probe[terminal_id] = lambda: pane_holder["content"]
+        manager._rearm[terminal_id] = lambda: rearm_calls.append(True)
+        manager._last_data_at[terminal_id] = registered_at
+        manager._registered_at[terminal_id] = registered_at
+        manager._ever_delivered[terminal_id] = False
+
+    def test_cold_start_stall_is_detected_and_rearmed_on_first_check(self, tmp_path, monkeypatch):
+        """The defining case: a single, static, already-rendered pane (no
+        divergence ever occurs) whose FIFO never delivered anything must
+        still be re-armed — on the VERY FIRST check, unlike the steady-state
+        path which always lets the first observation pass to establish a
+        baseline. Requiring a second check here would just re-introduce the
+        same "nothing ever changes" blind spot for a terminal whose pane
+        genuinely never changes again after this."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_COLD_START_GRACE_S", 0.0)
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "user@host:~$ "}
+        rearm_calls: list = []
+        # Registered "in the past" relative to now — grace period already elapsed.
+        self._enroll_cold(manager, "term", pane, rearm_calls, registered_at=time.monotonic() - 10)
+
+        manager._check_pipe_liveness("term")
+
+        assert rearm_calls == [True], "a born-stale pipe must be re-armed without waiting for divergence"
+
+    def test_cold_start_not_triggered_before_grace_period_elapses(self, tmp_path, monkeypatch):
+        """A terminal registered moments ago must get its grace period, not
+        an instant re-arm — the pipe may simply not have had a chance to
+        deliver its first byte yet."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_COLD_START_GRACE_S", 3.0)
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "user@host:~$ "}
+        rearm_calls: list = []
+        self._enroll_cold(manager, "term", pane, rearm_calls, registered_at=time.monotonic())
+
+        manager._check_pipe_liveness("term")
+
+        assert rearm_calls == [], "must not re-arm before the cold-start grace period elapses"
+
+    def test_cold_start_not_triggered_while_pane_still_empty(self, tmp_path, monkeypatch):
+        """A pane with no content yet (genuinely still booting — nothing has
+        rendered at all) must not be re-armed just because time passed: there
+        is nothing for a re-arm+replay to recover, and re-arming an already-
+        correct "still starting" pipe is pure churn."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_COLD_START_GRACE_S", 0.0)
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "   \n  "}  # whitespace only
+        rearm_calls: list = []
+        self._enroll_cold(manager, "term", pane, rearm_calls, registered_at=time.monotonic() - 10)
+
+        manager._check_pipe_liveness("term")
+
+        assert rearm_calls == [], "an empty pane must not be treated as a cold-start stall"
+
+    def test_cold_start_never_fires_once_fifo_has_delivered(self, tmp_path, monkeypatch):
+        """Backward compat with the steady-state path: once the FIFO has ever
+        delivered a byte, `_ever_delivered` is True and every future check —
+        including one where the pane happens to be unchanged — must go
+        through the ordinary divergence logic (idle, no re-arm), never the
+        cold-start branch, even though content never diverges here either."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_COLD_START_GRACE_S", 0.0)
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "user@host:~$ "}
+        rearm_calls: list = []
+        self._enroll_cold(manager, "term", pane, rearm_calls, registered_at=time.monotonic() - 10)
+        manager._ever_delivered["term"] = True  # the FIFO has delivered at least once
+
+        for _ in range(4):
+            manager._check_pipe_liveness("term")  # pane never changes, FIFO silent since
+
+        assert rearm_calls == [], "a pipe that has ever delivered must use the idle/divergence path, not cold-start"
+
+    def test_cold_start_state_absent_falls_back_to_existing_behavior(self, tmp_path, monkeypatch):
+        """Terminals enrolled directly (bypassing create_reader — exactly how
+        TestPipeLivenessWatchdog's own `_enroll` helper works) never populate
+        `_ever_delivered`/`_registered_at`. The cold-start check must default
+        to "not a cold start" rather than crashing or misfiring, so every
+        pre-existing test in TestPipeLivenessWatchdog keeps exercising only
+        the divergence path unchanged."""
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "line0"}
+        rearm_calls: list = []
+        manager._pane_probe["term"] = lambda: pane["content"]
+        manager._rearm["term"] = lambda: rearm_calls.append(True)
+        manager._last_data_at["term"] = time.monotonic()
+        # Deliberately NOT setting _ever_delivered / _registered_at.
+
+        manager._check_pipe_liveness("term")  # must not raise, must not rearm (baseline only)
+
+        assert rearm_calls == []
+        assert "term" in manager._liveness
+
+    def test_cold_start_rearm_replays_live_pane_into_pipeline(self, tmp_path, monkeypatch):
+        """Same recovery mechanism as the steady-state stall: the pane's
+        current snapshot is republished directly to the event bus, bypassing
+        the FIFO/reader thread entirely — this is what actually unblocks
+        wait_for_shell() even though the FIFO itself never delivered a byte."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_COLD_START_GRACE_S", 0.0)
+        published: list = []
+        monkeypatch.setattr(fr.bus, "publish", lambda topic, data: published.append((topic, data)))
+
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "user@host:~$ "}
+        rearm_calls: list = []
+        self._enroll_cold(manager, "term", pane, rearm_calls, registered_at=time.monotonic() - 10)
+
+        manager._check_pipe_liveness("term")
+
+        assert rearm_calls == [True]
+        assert ("terminal.term.output", {"data": pane["content"]}) in published
+
+    def test_cold_start_end_to_end_via_real_reader_thread(self, tmp_path, monkeypatch):
+        """Integration-level: create_reader() seeds the cold-start state
+        correctly, and a real reader thread flips `_ever_delivered` to True
+        the moment actual bytes flow through the FIFO — after which the
+        cold-start check must never fire again for this terminal, even if
+        content stops changing."""
+        manager = self._manager(tmp_path, monkeypatch)
+        try:
+            manager.create_reader(
+                "term-e2e", pane_probe=lambda: "content", rearm=lambda: None
+            )
+            with manager._lock:
+                assert manager._registered_at.get("term-e2e") is not None
+                assert manager._ever_delivered.get("term-e2e") is False
+
+            fifo_path = tmp_path / "term-e2e.fifo"
+            wfd = os.open(fifo_path, os.O_WRONLY | os.O_NONBLOCK)
+            os.write(wfd, b"real bytes")
+            os.close(wfd)
+
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                with manager._lock:
+                    if manager._ever_delivered.get("term-e2e") is True:
+                        break
+                time.sleep(0.02)
+
+            with manager._lock:
+                assert manager._ever_delivered.get("term-e2e") is True, (
+                    "the reader thread must flip _ever_delivered once real bytes are read"
+                )
+        finally:
+            manager.stop_reader("term-e2e")
+            manager.stop_watchdog()
+
+
 class TestConcurrencyRaces:
     """Round-3 Copilot review on #397: two lock-scope gaps in code the round-2
     review had already touched.

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -763,6 +763,73 @@ class TestColdStartStallDetection:
             manager.stop_reader("term-e2e")
             manager.stop_watchdog()
 
+    def test_cold_start_gives_up_after_max_attempts_instead_of_retrying_forever(
+        self, tmp_path, monkeypatch
+    ):
+        """Self-ROAST regression: a rearm() call SUCCEEDING does not mean the
+        pipe actually started delivering — only the reader thread pulling a
+        real byte off it flips `_ever_delivered` (the cold-start replay
+        publishes straight to the event bus, bypassing the FIFO entirely, so
+        it never touches that flag). Before this test existed, a genuinely,
+        permanently dead pipe (rearm() never raises, but nothing ever
+        actually flows) re-triggered the cold-start branch on literally every
+        watchdog check with no bound at all — live-reproduced directly: 5
+        consecutive checks against a fake FIFO that never delivers produced 5
+        re-arms, `_ever_delivered` still False, and `_rearm_failures` never
+        touched (the exception-based give-up mechanism has no visibility into
+        this failure class). This must now bound to
+        PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS and then stop — dropping the
+        terminal from the watchdog entirely, exactly like the rearm()-
+        exception give-up path already does."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_COLD_START_GRACE_S", 0.0)
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS", 3)
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "user@host:~$ "}  # never changes, FIFO never delivers
+        rearm_calls: list = []
+        self._enroll_cold(manager, "term", pane, rearm_calls, registered_at=time.monotonic() - 10)
+
+        # Attempts 1-3 (<= max) must still re-arm.
+        for _ in range(3):
+            manager._check_pipe_liveness("term")
+        assert rearm_calls == [True, True, True]
+        assert "term" in manager._pane_probe, "must still be enrolled within the attempt budget"
+
+        # The 4th check crosses the budget: give up, do NOT re-arm again, and
+        # fully unenroll the terminal (matching the exception-path give-up).
+        manager._check_pipe_liveness("term")
+        assert rearm_calls == [True, True, True], "must not re-arm past the attempt cap"
+        assert "term" not in manager._pane_probe
+        assert "term" not in manager._rearm
+        assert "term" not in manager._liveness
+
+        # Further checks on an unenrolled terminal must be silent no-ops, not
+        # errors and not further re-arms (probe/rearm are gone).
+        manager._check_pipe_liveness("term")
+        assert rearm_calls == [True, True, True]
+
+    def test_cold_start_attempt_counter_resets_the_grace_clock_between_tries(
+        self, tmp_path, monkeypatch
+    ):
+        """Each cold-start attempt gets its own fresh grace period rather than
+        re-firing on literally the next watchdog tick — `_registered_at` is
+        bumped forward on every attempt, so a second check immediately after
+        the first (before a new grace period has elapsed) must not re-arm
+        again yet."""
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_COLD_START_GRACE_S", 100.0)
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "user@host:~$ "}
+        rearm_calls: list = []
+        # Grace period already elapsed for the FIRST attempt only.
+        self._enroll_cold(manager, "term", pane, rearm_calls, registered_at=time.monotonic() - 200)
+
+        manager._check_pipe_liveness("term")
+        assert rearm_calls == [True]
+
+        # Immediately after: _registered_at was just reset to "now", so the
+        # 100s grace period has NOT elapsed again yet.
+        manager._check_pipe_liveness("term")
+        assert rearm_calls == [True], "must wait out a fresh grace period before re-arming again"
+
 
 class TestConcurrencyRaces:
     """Round-3 Copilot review on #397: two lock-scope gaps in code the round-2

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -536,3 +536,173 @@ class TestPipeLivenessWatchdog:
             assert manager._watchdog_thread is None
         finally:
             manager.stop_reader("term-plain")
+
+
+class TestConcurrencyRaces:
+    """Round-3 Copilot review on #397: two lock-scope gaps in code the round-2
+    review had already touched.
+
+    True interpreter-level race conditions (a context switch landing in the
+    exact unlucky spot) can't be forced deterministically in a unit test the
+    way the round-2 ``test_stop_during_probe_does_not_resurrect_state`` could
+    (that one worked because the injected ``probe()`` callback gave us a hook
+    to run the "concurrent" mutation synchronously, in-line, at the precise
+    moment). Neither gap here has an equivalent injection point, so these
+    tests use real threads and a synchronization barrier (for the first) and
+    a real-thread churn stress test (for the second) to raise confidence
+    rather than guarantee a repro on every run.
+    """
+
+    def test_reader_loop_last_data_at_write_is_atomic_with_stop(self, tmp_path, monkeypatch):
+        """The reader loop's ``if terminal_id in self._readers:
+        self._last_data_at[terminal_id] = time.monotonic()`` must check and
+        write under the same ``_lock`` acquisition. If the check and the write
+        are not atomic, a ``stop_reader()`` that pops both dicts between them
+        resurrects ``_last_data_at[terminal_id]`` after teardown — a slow leak
+        across create/stop churn that ``_watchdog_loop`` (which only iterates
+        ``_pane_probe``) will never revisit or clean up.
+
+        This forces the exact interleaving via a synchronization barrier
+        (blocking ``time.monotonic()`` while the reader thread holds the lock
+        for the write) instead of relying on timing luck, and additionally
+        asserts that ``stop_reader()`` is provably blocked on the held lock
+        during that window — a mechanical proof the two sections share a
+        critical section, not just a probabilistic absence of the bug.
+        """
+        monkeypatch.setattr("cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path)
+        fifo_path = tmp_path / "term-race.fifo"
+        os.mkfifo(fifo_path)
+
+        manager = FifoManager()
+        terminal_id = "term-race"
+        # Enroll by hand (no create_reader/watchdog needed for this race).
+        manager._readers[terminal_id] = threading.Event()
+        manager._last_data_at[terminal_id] = 0.0
+
+        entered_write_section = threading.Event()
+        release_write_section = threading.Event()
+        real_monotonic = time.monotonic
+
+        def blocking_monotonic():
+            entered_write_section.set()
+            release_write_section.wait(timeout=2.0)
+            return real_monotonic()
+
+        stop_flag = threading.Event()
+
+        with patch("cli_agent_orchestrator.services.fifo_reader.bus.publish"), patch(
+            "cli_agent_orchestrator.services.fifo_reader.time.monotonic",
+            side_effect=blocking_monotonic,
+        ):
+            reader = threading.Thread(
+                target=manager._reader_loop,
+                args=(terminal_id, fifo_path, stop_flag),
+                daemon=True,
+            )
+            reader.start()
+            time.sleep(0.1)  # let the reader open its fds
+
+            wfd = os.open(fifo_path, os.O_WRONLY | os.O_NONBLOCK)
+            try:
+                os.write(wfd, b"x")
+                assert entered_write_section.wait(timeout=2.0), (
+                    "reader thread never reached the _last_data_at write — "
+                    "test setup is broken, not exercising the race"
+                )
+
+                stopper = threading.Thread(target=manager.stop_reader, args=(terminal_id,))
+                stopper.start()
+                # If the check-then-write is atomic under _lock, stop_reader
+                # must block trying to acquire it (held by the reader thread,
+                # parked in blocking_monotonic) rather than racing ahead.
+                time.sleep(0.1)
+                assert stopper.is_alive(), (
+                    "stop_reader must be blocked on the lock held by the reader "
+                    "thread's check-then-write, not proceeding concurrently"
+                )
+
+                release_write_section.set()
+                stopper.join(timeout=2.0)
+            finally:
+                os.close(wfd)
+                stop_flag.set()
+                reader.join(timeout=2.0)
+
+        assert terminal_id not in manager._last_data_at, (
+            "stop_reader's pop must win the race — an atomic check-then-write "
+            "must not resurrect the entry after teardown"
+        )
+        assert terminal_id not in manager._readers
+
+    def test_watchdog_loop_survives_concurrent_enroll_unenroll_churn(self, tmp_path, monkeypatch):
+        """``_watchdog_loop`` must snapshot ``_pane_probe.keys()`` under
+        ``_lock``. Taken unlocked, concurrent create_reader()/stop_reader()
+        calls resizing the dict mid-snapshot can raise ``RuntimeError:
+        dictionary changed size during iteration`` inside the watchdog
+        thread's target — an unhandled exception there kills the thread
+        outright (it's not inside the loop's own try/except, which only
+        wraps ``_check_pipe_liveness``), permanently disabling self-healing
+        for the rest of the process's life.
+
+        Stress test: hammer real enroll/unenroll churn from several threads
+        while the real ``_watchdog_loop`` runs with a tiny check interval,
+        with the OS thread-switch interval lowered to maximize the chance of
+        an unlucky interleaving. Confirms the watchdog thread is still alive
+        immediately before being told to stop — if it had already died from
+        an unhandled exception, it would be observably not-alive at that
+        point instead of only after ``stop_watchdog()``.
+        """
+        import sys
+
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_CHECK_INTERVAL_S", 0.005)
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path
+        )
+        manager = FifoManager()
+        # Keep _check_pipe_liveness cheap and side-effect-free: this test is
+        # about the snapshot line racing churn, not probe/rearm behavior
+        # (covered by TestPipeLivenessWatchdog).
+        monkeypatch.setattr(manager, "_check_pipe_liveness", lambda terminal_id: None)
+
+        manager._watchdog_stop.clear()
+        watchdog = threading.Thread(target=manager._watchdog_loop, daemon=True)
+
+        stop_churn = threading.Event()
+
+        def churn():
+            i = 0
+            while not stop_churn.is_set():
+                tid = f"term-{i % 8}"
+                manager._pane_probe[tid] = lambda: "content"
+                manager._rearm[tid] = lambda: None
+                manager._pane_probe.pop(tid, None)
+                manager._rearm.pop(tid, None)
+                i += 1
+
+        churners = [threading.Thread(target=churn) for _ in range(6)]
+
+        original_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-5)
+        try:
+            watchdog.start()
+            for t in churners:
+                t.start()
+
+            time.sleep(0.5)
+
+            still_alive_before_stop = watchdog.is_alive()
+
+            stop_churn.set()
+            for t in churners:
+                t.join(timeout=2.0)
+        finally:
+            sys.setswitchinterval(original_interval)
+            manager._watchdog_stop.set()
+            watchdog.join(timeout=2.0)
+
+        assert still_alive_before_stop, (
+            "watchdog thread died before being told to stop — an unlocked "
+            "dict-keys snapshot racing concurrent enroll/unenroll churn is "
+            "exactly the kind of unhandled RuntimeError that would kill it"
+        )
+        assert not watchdog.is_alive(), "watchdog thread must exit cleanly once stopped"

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -440,6 +440,59 @@ class TestPipeLivenessWatchdog:
         manager._check_pipe_liveness("term")  # strike 2 — re-arm
         assert rearm_calls == [True]
 
+    def test_burst_then_settle_stall_is_still_detected(self, tmp_path, monkeypatch):
+        """Regression for harness-control#148's live repro: a stall that occurs
+        mid-burst and then settles into a NEW static frame before the next poll
+        (e.g. an AskUserQuestion menu finishing its render and sitting idle) must
+        still be caught, not just an ongoing/ever-changing divergence.
+
+        Before the fix, ``_check_pipe_liveness`` compared each check's content
+        only against the IMMEDIATELY PREVIOUS check's content. That works for a
+        stall that's actively churning while polled, but a single clean
+        transition into a new static frame produced exactly one diverging check
+        (baseline -> new frame) followed by unchanging checks thereafter (new
+        frame -> same new frame each time), resetting the strike counter to 0
+        forever — even though the FIFO-fed buffer was permanently stuck on stale
+        mid-burst content. The fix pins the comparison baseline to the last
+        known-healthy content (not the previous check) so a settle-and-freeze
+        keeps accumulating strikes exactly like an ongoing divergence would.
+        """
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_STALL_CHECKS", 2)  # production default
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "idle prompt"}
+        rearm_calls: list = []
+        self._enroll(manager, "term", pane, rearm_calls, last_data_at=time.monotonic())
+
+        manager._check_pipe_liveness("term")  # baseline
+        assert rearm_calls == []
+
+        # The pipe silently stalls right now (no further last_data_at bumps in
+        # this test — the FIFO never delivers anything again). The pane renders
+        # a burst of redraws that settles into ONE new static frame before the
+        # next poll observes it — a single clean transition, not an ongoing
+        # divergence.
+        pane["content"] = "1) yes\n2) no\n3) cancel  (menu fully rendered, now static)"
+
+        manager._check_pipe_liveness("term")  # strike 1: diverged from baseline
+        assert rearm_calls == [], "a single diverging check must not re-arm yet"
+
+        # Pane is now static — unchanged from the previous check — but still
+        # diverged from the pre-stall baseline. This is the exact shape that
+        # evaded detection pre-fix.
+        manager._check_pipe_liveness("term")  # strike 2: still diverged -> re-arm
+        assert rearm_calls == [True], (
+            "a stall that settles into a new static frame after one clean "
+            "transition must still be re-armed once the configured number of "
+            "checks confirm the divergence persists"
+        )
+
+        # And it must not keep re-arming on every subsequent check once healthy
+        # again (rearm() bumps _last_data_at in the real code path via the
+        # replay publish; simulate that here).
+        manager._last_data_at["term"] = time.monotonic()
+        manager._check_pipe_liveness("term")
+        assert rearm_calls == [True], "must not spuriously re-arm again once healthy"
+
     def test_stop_during_probe_does_not_resurrect_state(self, tmp_path, monkeypatch):
         """Regression for the round-2 review's stop-during-probe race:
         ``_check_pipe_liveness`` calls the injected ``probe()`` (a slow tmux

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -179,13 +179,17 @@ class TestReaderLoopCoalescing:
         def fake_publish(topic, payload):
             published.append({"topic": topic, "data": payload["data"]})
 
+        # _reader_loop is an instance method (it records per-terminal liveness
+        # on self for the #388 watchdog), so it needs a bound manager, not the
+        # bare unbound function.
+        manager = FifoManager()
         stop_flag = threading.Event()
         with patch(
             "cli_agent_orchestrator.services.fifo_reader.bus.publish",
             side_effect=fake_publish,
         ):
             reader = threading.Thread(
-                target=FifoManager._reader_loop,
+                target=manager._reader_loop,
                 args=("term-coalesce", fifo_path, stop_flag),
                 daemon=True,
             )
@@ -240,13 +244,17 @@ class TestReaderLoopCoalescing:
         def fake_publish(topic, payload):
             published.append({"topic": topic, "data": payload["data"]})
 
+        # _reader_loop is an instance method (it records per-terminal liveness
+        # on self for the #388 watchdog), so it needs a bound manager, not the
+        # bare unbound function.
+        manager = FifoManager()
         stop_flag = threading.Event()
         with patch(
             "cli_agent_orchestrator.services.fifo_reader.bus.publish",
             side_effect=fake_publish,
         ):
             reader = threading.Thread(
-                target=FifoManager._reader_loop,
+                target=manager._reader_loop,
                 args=("term-flush", fifo_path, stop_flag),
                 daemon=True,
             )
@@ -269,3 +277,157 @@ class TestReaderLoopCoalescing:
         assert len(published) >= 1, "Pending data was never flushed"
         combined = "".join(p["data"] for p in published)
         assert "lonely-chunk" in combined
+
+
+class TestPipeLivenessWatchdog:
+    """Issue #388: tmux's pipe-pane forwarder can silently stop delivering bytes
+    to the FIFO after an alternate-screen redraw burst — the pane keeps
+    rendering (visible via capture-pane) but the piped copy freezes, so the FIFO
+    reader, the StatusMonitor buffer, and GET /terminals/{id}/output stall on
+    stale content indefinitely. The watchdog compares tmux's live pane content
+    against whether the FIFO delivered any bytes and re-arms a stalled forwarder.
+
+    These drive ``_check_pipe_liveness`` directly (no real tmux, no timing) so
+    the detect/idle/healthy branches are deterministic. Enrollment/threading is
+    covered separately below.
+    """
+
+    def _manager(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path)
+        return FifoManager()
+
+    def _enroll(self, manager, terminal_id, pane_holder, rearm_calls, last_data_at):
+        """Register a terminal with fake probe/rearm WITHOUT starting the reader
+        thread or the real watchdog — we call _check_pipe_liveness by hand."""
+        manager._pane_probe[terminal_id] = lambda: pane_holder["content"]
+        manager._rearm[terminal_id] = lambda: rearm_calls.append(True)
+        manager._last_data_at[terminal_id] = last_data_at
+
+    def test_stall_is_detected_and_pipe_rearmed(self, tmp_path, monkeypatch):
+        """Pane advanced but the FIFO delivered nothing since the last check ->
+        the forwarder is stalled and gets re-armed."""
+        import time
+
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "line0"}
+        rearm_calls: list = []
+        # FIFO's last delivery is in the past — it has been silent.
+        self._enroll(manager, "term", pane, rearm_calls, last_data_at=time.monotonic())
+
+        # First check just establishes a baseline, never acts.
+        manager._check_pipe_liveness("term")
+        assert rearm_calls == []
+
+        # Pane advances (redraw) while the FIFO stays silent -> stall.
+        pane["content"] = "line0\nline1 (rendered but never piped)"
+        manager._check_pipe_liveness("term")
+        assert rearm_calls == [True], "a stalled pipe-pane forwarder must be re-armed"
+
+    def test_idle_terminal_is_not_rearmed(self, tmp_path, monkeypatch):
+        """Pane unchanged + FIFO silent = a genuinely idle terminal, which must
+        NOT trigger a needless re-pipe (the false-positive guard)."""
+        import time
+
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "idle prompt"}
+        rearm_calls: list = []
+        self._enroll(manager, "term", pane, rearm_calls, last_data_at=time.monotonic())
+
+        for _ in range(4):
+            manager._check_pipe_liveness("term")  # pane never changes
+        assert rearm_calls == [], "an idle terminal must never be re-armed"
+
+    def test_healthy_pipe_is_not_rearmed(self, tmp_path, monkeypatch):
+        """Pane advancing AND the FIFO delivering bytes = a healthy pipe; no
+        re-arm even though the screen keeps changing."""
+        import time
+
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "line0"}
+        rearm_calls: list = []
+        self._enroll(manager, "term", pane, rearm_calls, last_data_at=time.monotonic())
+
+        manager._check_pipe_liveness("term")  # baseline
+        for i in range(1, 4):
+            pane["content"] = f"line{i}"
+            # Simulate the reader delivering a byte right before this check.
+            manager._last_data_at["term"] = time.monotonic()
+            manager._check_pipe_liveness("term")
+        assert rearm_calls == [], "a healthy, delivering pipe must never be re-armed"
+
+    def test_rearm_replays_live_pane_into_pipeline(self, tmp_path, monkeypatch):
+        """After re-arm the lost bytes are gone, but the pane's CURRENT content
+        is republished so the StatusMonitor buffer / GET output stop being frozen
+        instead of waiting for the agent to emit something new."""
+        import time
+
+        from cli_agent_orchestrator.services import fifo_reader as fr
+
+        published: list = []
+        monkeypatch.setattr(fr.bus, "publish", lambda topic, data: published.append((topic, data)))
+
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "before"}
+        rearm_calls: list = []
+        self._enroll(manager, "term", pane, rearm_calls, last_data_at=time.monotonic())
+
+        manager._check_pipe_liveness("term")  # baseline
+        pane["content"] = "current live screen the pipe never forwarded"
+        manager._check_pipe_liveness("term")
+
+        assert rearm_calls == [True]
+        assert ("terminal.term.output", {"data": pane["content"]}) in published
+
+    def test_stall_requires_configured_consecutive_checks(self, tmp_path, monkeypatch):
+        """With PIPE_LIVENESS_STALL_CHECKS > 1, a single diverging check is not
+        enough — re-arm waits for the configured number of consecutive stalls."""
+        import time
+
+        from cli_agent_orchestrator.services import fifo_reader as fr
+
+        monkeypatch.setattr(fr, "PIPE_LIVENESS_STALL_CHECKS", 2)
+        manager = self._manager(tmp_path, monkeypatch)
+        pane = {"content": "l0"}
+        rearm_calls: list = []
+        self._enroll(manager, "term", pane, rearm_calls, last_data_at=time.monotonic())
+
+        manager._check_pipe_liveness("term")  # baseline
+        pane["content"] = "l1"
+        manager._check_pipe_liveness("term")  # strike 1 — not yet
+        assert rearm_calls == []
+        pane["content"] = "l2"
+        manager._check_pipe_liveness("term")  # strike 2 — re-arm
+        assert rearm_calls == [True]
+
+    def test_create_reader_enrolls_and_starts_watchdog(self, tmp_path, monkeypatch):
+        """A tmux caller passing probe+rearm enrolls the terminal and starts the
+        watchdog; stop_reader unenrolls it and clears its liveness state."""
+        manager = self._manager(tmp_path, monkeypatch)
+        try:
+            manager.create_reader(
+                "term-enroll",
+                pane_probe=lambda: "content",
+                rearm=lambda: None,
+            )
+            assert "term-enroll" in manager._pane_probe
+            assert "term-enroll" in manager._rearm
+            assert manager._watchdog_thread is not None
+            assert manager._watchdog_thread.is_alive()
+
+            manager.stop_reader("term-enroll")
+            assert "term-enroll" not in manager._pane_probe
+            assert "term-enroll" not in manager._rearm
+            assert "term-enroll" not in manager._liveness
+        finally:
+            manager.stop_watchdog()
+
+    def test_create_reader_without_callbacks_is_not_watched(self, tmp_path, monkeypatch):
+        """Backward compat: callers that omit probe/rearm (or backends without
+        pipe-pane) get the old behavior — no enrollment, no watchdog thread."""
+        manager = self._manager(tmp_path, monkeypatch)
+        manager.create_reader("term-plain")
+        try:
+            assert "term-plain" not in manager._pane_probe
+            assert manager._watchdog_thread is None
+        finally:
+            manager.stop_reader("term-plain")

--- a/test/services/test_fifo_reader.py
+++ b/test/services/test_fifo_reader.py
@@ -643,9 +643,12 @@ class TestConcurrencyRaces:
 
         stop_flag = threading.Event()
 
-        with patch("cli_agent_orchestrator.services.fifo_reader.bus.publish"), patch(
-            "cli_agent_orchestrator.services.fifo_reader.time.monotonic",
-            side_effect=blocking_monotonic,
+        with (
+            patch("cli_agent_orchestrator.services.fifo_reader.bus.publish"),
+            patch(
+                "cli_agent_orchestrator.services.fifo_reader.time.monotonic",
+                side_effect=blocking_monotonic,
+            ),
         ):
             reader = threading.Thread(
                 target=manager._reader_loop,
@@ -708,9 +711,7 @@ class TestConcurrencyRaces:
         import sys
 
         monkeypatch.setattr(fr, "PIPE_LIVENESS_CHECK_INTERVAL_S", 0.005)
-        monkeypatch.setattr(
-            "cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path
-        )
+        monkeypatch.setattr("cli_agent_orchestrator.services.fifo_reader.FIFO_DIR", tmp_path)
         manager = FifoManager()
         # Keep _check_pipe_liveness cheap and side-effect-free: this test is
         # about the snapshot line racing churn, not probe/rearm behavior

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -244,6 +244,51 @@ class TestAddLocalCorsOrigins:
         assert "http://2001:db8::1:9889" not in mod.CORS_ORIGINS
 
 
+class TestPipeLivenessCheckIntervalClamp:
+    """Regression for the round-3 Copilot review on #397: PIPE_LIVENESS_CHECK_INTERVAL_S
+    feeds ``threading.Event.wait(timeout)`` in the watchdog's poll loop
+    (services/fifo_reader.py's ``_watchdog_loop``) — a non-positive value makes
+    ``wait()`` return immediately every iteration, turning the periodic poll
+    into a hot spin (high CPU + a tmux ``capture-pane`` call as fast as the
+    loop can run). A non-positive value here is invalid for the parameter's
+    meaning, not just atypical, so it's treated the same way an unparseable
+    string already is: fall back to the default.
+    """
+
+    def _reload_constants(self, env_overrides):
+        import importlib
+        import os
+
+        env_copy = os.environ.copy()
+        env_copy.pop("CAO_PIPE_LIVENESS_CHECK_INTERVAL_S", None)
+        env_copy.update(env_overrides)
+        with patch.dict("os.environ", env_copy, clear=True):
+            import cli_agent_orchestrator.constants as constants_module
+
+            importlib.reload(constants_module)
+            return constants_module
+
+    def test_zero_falls_back_to_default(self):
+        mod = self._reload_constants({"CAO_PIPE_LIVENESS_CHECK_INTERVAL_S": "0"})
+        assert mod.PIPE_LIVENESS_CHECK_INTERVAL_S == 4.0
+
+    def test_negative_falls_back_to_default(self):
+        mod = self._reload_constants({"CAO_PIPE_LIVENESS_CHECK_INTERVAL_S": "-1.5"})
+        assert mod.PIPE_LIVENESS_CHECK_INTERVAL_S == 4.0
+
+    def test_non_numeric_falls_back_to_default(self):
+        mod = self._reload_constants({"CAO_PIPE_LIVENESS_CHECK_INTERVAL_S": "not-a-number"})
+        assert mod.PIPE_LIVENESS_CHECK_INTERVAL_S == 4.0
+
+    def test_positive_value_is_honored(self):
+        mod = self._reload_constants({"CAO_PIPE_LIVENESS_CHECK_INTERVAL_S": "0.5"})
+        assert mod.PIPE_LIVENESS_CHECK_INTERVAL_S == 0.5
+
+    def test_default_when_env_not_set(self):
+        mod = self._reload_constants({})
+        assert mod.PIPE_LIVENESS_CHECK_INTERVAL_S == 4.0
+
+
 class TestCaoHomeDir:
     """Tests for CAO home directory constants."""
 


### PR DESCRIPTION
Fixes #388.

## Problem
After an alternate-screen redraw burst, piped pane output can silently freeze: the tmux pane keeps rendering (`capture-pane` shows fresh content, `pane_pipe` stays `1`), but no bytes reach the `pipe-pane` FIFO, so `GET /terminals/{id}/output` and status detection stall on stale content until the agent next emits output. This matches the diagnostics in #388.

## Fix
A self-healing **pipe-pane liveness watchdog** inside `FifoManager` (the direction suggested in the issue). A background check periodically compares tmux's live pane content against whether the FIFO delivered any bytes in the window:

- **pane advanced AND FIFO silent → stalled →** re-arm and republish the live pane so output un-freezes immediately;
- **pane unchanged →** idle → no-op (guards against re-piping idle terminals);
- **FIFO delivering →** healthy → no-op.

The re-arm is **stop-then-start**, not a bare `pipe_pane()` toggle: a stalled pane still reports `pane_pipe=1`, so a plain `pipe-pane -o` would switch the dead pipe **off** instead of restarting it (the recovery gotcha noted in the issue).

`FifoManager` stays backend-agnostic — the tmux probe and re-arm are injected as callbacks, so any caller that omits them keeps the exact previous behavior (no watchdog).

Tunables in `constants.py`: `CAO_PIPE_LIVENESS_CHECK_INTERVAL_S` (4s), tail lines (80), stall-checks threshold (1).

## Reproduction
The wild trigger (tmux spontaneously halting forwarding) isn't deterministically reproducible, as the reporter noted. The symptom is reproduced deterministically by `SIGSTOP`-ing the `pipe-pane` reader process: `pane_pipe` stays `1`, the pane keeps rendering, the FIFO freezes — then the watchdog detects the divergence and re-arms. Sequence observed: healthy → stall → re-arm ("appears stalled … re-arming") → restored.

## Tests
- New `TestPipeLivenessWatchdog` regression tests (healthy no-op, idle no-op, stall→re-arm, republish).
- Full suite green aside from 2 pre-existing, environment-related failures in `test_project_identity.py` (git detection) that fail identically without this change.

## Validation in a real downstream
Beyond unit tests, this was validated end-to-end under a downstream that consumes cao-server: a real authenticated CLI-agent session was launched via the HTTP API, driven through the alt-screen startup burst, then forced into the stalled state — and the patched server's watchdog auto-recovered `GET /output` while the FIFO reader was frozen.

Happy to adjust the interval defaults, logging, or the probe strategy to match your preferences.
