### PR TITLE
feat(graph): GraphView contract + provider/sink registries (#348, B1)

### DIFF
--- a/src/cli_agent_orchestrator/graph/__init__.py
+++ b/src/cli_agent_orchestrator/graph/__init__.py
@@ -1,0 +1,31 @@
+"""Graph layer public exports: contract types and the provider/sink seams."""
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node, NodeStatus
+from cli_agent_orchestrator.graph.providers.base import (
+    GraphProvider,
+    get_provider,
+    list_providers,
+    register_provider,
+)
+from cli_agent_orchestrator.graph.sinks.base import (
+    GraphSink,
+    get_sink,
+    list_sinks,
+    register_sink,
+)
+
+__all__ = [
+    "Node",
+    "Edge",
+    "GraphView",
+    "NodeStatus",
+    "EdgeType",
+    "GraphProvider",
+    "register_provider",
+    "get_provider",
+    "list_providers",
+    "GraphSink",
+    "register_sink",
+    "get_sink",
+    "list_sinks",
+]

--- a/src/cli_agent_orchestrator/graph/__init__.py
+++ b/src/cli_agent_orchestrator/graph/__init__.py
@@ -1,13 +1,13 @@
 """Graph layer public exports: contract types and the provider/sink seams."""
 
 from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node, NodeStatus
-from cli_agent_orchestrator.graph.providers.base import (
+from cli_agent_orchestrator.graph.providers import (
     GraphProvider,
     get_provider,
     list_providers,
     register_provider,
 )
-from cli_agent_orchestrator.graph.sinks.base import (
+from cli_agent_orchestrator.graph.sinks import (
     GraphSink,
     get_sink,
     list_sinks,

--- a/src/cli_agent_orchestrator/graph/models.py
+++ b/src/cli_agent_orchestrator/graph/models.py
@@ -1,4 +1,10 @@
-"""Graph domain contract: Node, Edge, GraphView, and their enums (U1)."""
+"""Graph domain contract: Node, Edge, GraphView, and their enums.
+
+Design: Issue #348 (graph-layer epic); design record:
+aidlc/spaces/default/intents/260709-graph-layer/ (AIDLC intent, not shipped
+with the package). Per-symbol codes below (U1, FR-3, etc.) resolve through
+this anchor.
+"""
 
 import re
 from enum import Enum
@@ -30,7 +36,13 @@ class EdgeType(str, Enum):
 
 
 class Node(BaseModel):
-    """A single graph node projected by a GraphProvider."""
+    """A single graph node projected by a GraphProvider.
+
+    ``id``, ``label``, and ``attrs`` are provider-supplied and untrusted —
+    a GraphProvider may project data originating outside this process.
+    Renderers/sinks that emit these values into HTML, DOM, or similar
+    output MUST escape on output; this contract does not sanitize them.
+    """
 
     id: str
     kind: str
@@ -41,7 +53,7 @@ class Node(BaseModel):
     @field_validator("kind")
     @classmethod
     def validate_kind_shape(cls, value: str) -> str:
-        if not _KIND_PATTERN.match(value):
+        if not _KIND_PATTERN.fullmatch(value):
             raise ValueError(f"kind must be a non-empty lowercase-snake-case string, got {value!r}")
         return value
 
@@ -56,7 +68,12 @@ class Edge(BaseModel):
 
 
 class GraphView(BaseModel):
-    """A snapshot of nodes, edges, and metadata returned by GraphProvider.project()."""
+    """A snapshot of nodes, edges, and metadata returned by GraphProvider.project().
+
+    No size cap (node/edge count, attrs/meta payload size) is enforced in
+    this deliverable — providers are trusted local code today. Revisit if
+    a provider ever projects untrusted or unbounded upstream data.
+    """
 
     nodes: list[Node]
     edges: list[Edge]
@@ -64,7 +81,15 @@ class GraphView(BaseModel):
 
     @model_validator(mode="after")
     def validate_edge_endpoints(self) -> "GraphView":
-        node_ids = {node.id for node in self.nodes}
+        seen: set[str] = set()
+        dupes: set[str] = set()
+        for node in self.nodes:
+            if node.id in seen:
+                dupes.add(node.id)
+            seen.add(node.id)
+        if dupes:
+            raise ValueError(f"duplicate node ids: {sorted(dupes)!r}")
+        node_ids = seen
         for edge in self.edges:
             if edge.source not in node_ids:
                 raise ValueError(f"edge source {edge.source!r} is not a known node id")
@@ -74,25 +99,4 @@ class GraphView(BaseModel):
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the wire shape consumed by U4's routes and U8's renderer."""
-        return {
-            "nodes": [
-                {
-                    "id": node.id,
-                    "kind": node.kind,
-                    "label": node.label,
-                    "status": node.status.value,
-                    "attrs": node.attrs,
-                }
-                for node in self.nodes
-            ],
-            "edges": [
-                {
-                    "source": edge.source,
-                    "target": edge.target,
-                    "type": edge.type.value,
-                    "attrs": edge.attrs,
-                }
-                for edge in self.edges
-            ],
-            "meta": self.meta,
-        }
+        return self.model_dump(mode="json")

--- a/src/cli_agent_orchestrator/graph/models.py
+++ b/src/cli_agent_orchestrator/graph/models.py
@@ -1,0 +1,98 @@
+"""Graph domain contract: Node, Edge, GraphView, and their enums (U1)."""
+
+import re
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+_KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class NodeStatus(str, Enum):
+    """Domain lifecycle state of the thing a node represents."""
+
+    ACTIVE = "active"
+    PROPOSAL = "proposal"
+    OBSERVATION = "observation"
+    SUPERSEDED = "superseded"
+
+
+class EdgeType(str, Enum):
+    """Closed edge-type taxonomy, organized by family (FR-3)."""
+
+    # Topical family
+    RELATES_TO = "relates_to"
+    # Lint-derived family
+    CONTRADICTION = "contradiction"
+    # Lifecycle family — reserved, unpopulated by any provider in this deliverable
+    SUPERSEDES = "supersedes"
+
+
+class Node(BaseModel):
+    """A single graph node projected by a GraphProvider."""
+
+    id: str
+    kind: str
+    label: str
+    status: NodeStatus = NodeStatus.ACTIVE
+    attrs: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("kind")
+    @classmethod
+    def validate_kind_shape(cls, value: str) -> str:
+        if not _KIND_PATTERN.match(value):
+            raise ValueError(f"kind must be a non-empty lowercase-snake-case string, got {value!r}")
+        return value
+
+
+class Edge(BaseModel):
+    """A single graph edge projected by a GraphProvider."""
+
+    source: str
+    target: str
+    type: EdgeType
+    attrs: dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphView(BaseModel):
+    """A snapshot of nodes, edges, and metadata returned by GraphProvider.project()."""
+
+    nodes: list[Node]
+    edges: list[Edge]
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_edge_endpoints(self) -> "GraphView":
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids:
+                raise ValueError(f"edge source {edge.source!r} is not a known node id")
+            if edge.target not in node_ids:
+                raise ValueError(f"edge target {edge.target!r} is not a known node id")
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the wire shape consumed by U4's routes and U8's renderer."""
+        return {
+            "nodes": [
+                {
+                    "id": node.id,
+                    "kind": node.kind,
+                    "label": node.label,
+                    "status": node.status.value,
+                    "attrs": node.attrs,
+                }
+                for node in self.nodes
+            ],
+            "edges": [
+                {
+                    "source": edge.source,
+                    "target": edge.target,
+                    "type": edge.type.value,
+                    "attrs": edge.attrs,
+                }
+                for edge in self.edges
+            ],
+            "meta": self.meta,
+        }

--- a/src/cli_agent_orchestrator/graph/providers/__init__.py
+++ b/src/cli_agent_orchestrator/graph/providers/__init__.py
@@ -1,0 +1,10 @@
+"""Graph provider seam: ABC and name-keyed registry."""
+
+from cli_agent_orchestrator.graph.providers.base import (
+    GraphProvider,
+    get_provider,
+    list_providers,
+    register_provider,
+)
+
+__all__ = ["GraphProvider", "register_provider", "get_provider", "list_providers"]

--- a/src/cli_agent_orchestrator/graph/providers/base.py
+++ b/src/cli_agent_orchestrator/graph/providers/base.py
@@ -1,4 +1,9 @@
-"""GraphProvider ABC and its name-keyed registry (FR-4)."""
+"""GraphProvider ABC and its name-keyed registry (FR-4).
+
+Design: Issue #348 (graph-layer epic); design record:
+aidlc/spaces/default/intents/260709-graph-layer/ (AIDLC intent, not shipped
+with the package).
+"""
 
 from abc import ABC, abstractmethod
 from typing import Any, Callable

--- a/src/cli_agent_orchestrator/graph/providers/base.py
+++ b/src/cli_agent_orchestrator/graph/providers/base.py
@@ -1,0 +1,53 @@
+"""GraphProvider ABC and its name-keyed registry (FR-4)."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable
+
+from cli_agent_orchestrator.graph.models import GraphView
+
+
+class GraphProvider(ABC):
+    """Projects some subsystem's state into a GraphView.
+
+    Uniformly async (ADR-7) so U4's route handler never needs to branch
+    between a sync and an async provider. Never raises for an empty
+    result — returns an empty GraphView(nodes=[], edges=[]).
+    """
+
+    @abstractmethod
+    async def project(self, **filters: Any) -> GraphView:
+        """Build a GraphView for the given filters (e.g. scope, scope_id)."""
+        raise NotImplementedError
+
+
+_REGISTRY: dict[str, type[GraphProvider]] = {}
+
+
+def register_provider(name: str) -> Callable[[type[GraphProvider]], type[GraphProvider]]:
+    """Class decorator; registers a GraphProvider subclass under `name`.
+
+    Raises ValueError on duplicate name registration.
+    """
+
+    def decorator(cls: type[GraphProvider]) -> type[GraphProvider]:
+        if name in _REGISTRY:
+            raise ValueError(f"provider {name!r} is already registered")
+        _REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_provider(name: str) -> GraphProvider:
+    """Resolve and instantiate a registered provider by name.
+
+    Raises KeyError for an unregistered name.
+    """
+    if name not in _REGISTRY:
+        raise KeyError(f"no provider registered under {name!r}")
+    return _REGISTRY[name]()
+
+
+def list_providers() -> list[str]:
+    """List all registered provider names."""
+    return list(_REGISTRY.keys())

--- a/src/cli_agent_orchestrator/graph/sinks/__init__.py
+++ b/src/cli_agent_orchestrator/graph/sinks/__init__.py
@@ -1,0 +1,10 @@
+"""Graph sink seam: ABC and name-keyed registry."""
+
+from cli_agent_orchestrator.graph.sinks.base import (
+    GraphSink,
+    get_sink,
+    list_sinks,
+    register_sink,
+)
+
+__all__ = ["GraphSink", "register_sink", "get_sink", "list_sinks"]

--- a/src/cli_agent_orchestrator/graph/sinks/base.py
+++ b/src/cli_agent_orchestrator/graph/sinks/base.py
@@ -13,8 +13,30 @@ class GraphSink(ABC):
 
     @abstractmethod
     def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
-        """Write view to dest per sink format; return the written file paths."""
+        """Write view to dest per sink format; return the written file paths.
+
+        Returns the written file paths as list[str]. The API route (U4)
+        owns wrapping this into the response envelope
+        ({written_files, sink, dest}) — GraphSink.export() itself never
+        returns that envelope shape.
+        """
         raise NotImplementedError
+
+    def query(self, *args: Any, **kwargs: Any) -> Any:
+        """Optional read-query entry point, gated on capabilities (FR-5).
+
+        Only sinks that declare "query" in `capabilities` support this;
+        every other sink raises NotImplementedError. A subclass declaring
+        "query" must override this method with its own implementation.
+        """
+        if "query" not in self.capabilities:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support query() "
+                f"('query' not in capabilities={sorted(self.capabilities)!r})"
+            )
+        raise NotImplementedError(
+            f"{type(self).__name__} declares 'query' in capabilities but did not override query()"
+        )
 
 
 _SINK_REGISTRY: dict[str, type[GraphSink]] = {}

--- a/src/cli_agent_orchestrator/graph/sinks/base.py
+++ b/src/cli_agent_orchestrator/graph/sinks/base.py
@@ -1,4 +1,9 @@
-"""GraphSink ABC and its name-keyed registry (FR-5)."""
+"""GraphSink ABC and its name-keyed registry (FR-5).
+
+Design: Issue #348 (graph-layer epic); design record:
+aidlc/spaces/default/intents/260709-graph-layer/ (AIDLC intent, not shipped
+with the package).
+"""
 
 from abc import ABC, abstractmethod
 from typing import Any, Callable, ClassVar
@@ -7,7 +12,17 @@ from cli_agent_orchestrator.graph.models import GraphView
 
 
 class GraphSink(ABC):
-    """Exports a GraphView to some external format/destination."""
+    """Exports a GraphView to some external format/destination.
+
+    Security contract for ``dest``: implementations MUST resolve and
+    confine ``dest`` under an allowed base directory before writing —
+    reject ``..`` traversal, absolute-path escapes, and symlink escapes.
+    Follow this repo's path-validation convention
+    (``utils/path_validation.resolve_and_validate_path``). Validation is
+    owned by BOTH the U4 route (first line of defense, validates before
+    calling a sink) AND each sink implementation (defense in depth) — a
+    sink must not assume its caller already validated ``dest``.
+    """
 
     capabilities: ClassVar[set[str]] = set()
 

--- a/src/cli_agent_orchestrator/graph/sinks/base.py
+++ b/src/cli_agent_orchestrator/graph/sinks/base.py
@@ -1,0 +1,50 @@
+"""GraphSink ABC and its name-keyed registry (FR-5)."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, ClassVar
+
+from cli_agent_orchestrator.graph.models import GraphView
+
+
+class GraphSink(ABC):
+    """Exports a GraphView to some external format/destination."""
+
+    capabilities: ClassVar[set[str]] = set()
+
+    @abstractmethod
+    def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
+        """Write view to dest per sink format; return the written file paths."""
+        raise NotImplementedError
+
+
+_SINK_REGISTRY: dict[str, type[GraphSink]] = {}
+
+
+def register_sink(name: str) -> Callable[[type[GraphSink]], type[GraphSink]]:
+    """Class decorator; registers a GraphSink subclass under `name`.
+
+    Raises ValueError on duplicate name registration.
+    """
+
+    def decorator(cls: type[GraphSink]) -> type[GraphSink]:
+        if name in _SINK_REGISTRY:
+            raise ValueError(f"sink {name!r} is already registered")
+        _SINK_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_sink(name: str) -> GraphSink:
+    """Resolve and instantiate a registered sink by name.
+
+    Raises KeyError for an unregistered name.
+    """
+    if name not in _SINK_REGISTRY:
+        raise KeyError(f"no sink registered under {name!r}")
+    return _SINK_REGISTRY[name]()
+
+
+def list_sinks() -> list[str]:
+    """List all registered sink names."""
+    return list(_SINK_REGISTRY.keys())

--- a/test/graph/conftest.py
+++ b/test/graph/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for test/graph — registry isolation between tests."""
+
+import pytest
+
+from cli_agent_orchestrator.graph.providers import base as providers_base
+from cli_agent_orchestrator.graph.sinks import base as sinks_base
+
+
+@pytest.fixture(autouse=True)
+def _isolate_graph_registries():
+    """Snapshot and restore the provider/sink registries around every test.
+
+    Registration is a module-level side effect (register_provider/register_sink
+    decorators mutate _REGISTRY/_SINK_REGISTRY). Without teardown, names
+    registered by one test leak into the next and a same-process rerun hits
+    the duplicate-registration ValueError spuriously.
+    """
+    provider_snapshot = dict(providers_base._REGISTRY)
+    sink_snapshot = dict(sinks_base._SINK_REGISTRY)
+    yield
+    providers_base._REGISTRY.clear()
+    providers_base._REGISTRY.update(provider_snapshot)
+    sinks_base._SINK_REGISTRY.clear()
+    sinks_base._SINK_REGISTRY.update(sink_snapshot)

--- a/test/graph/test_models.py
+++ b/test/graph/test_models.py
@@ -20,7 +20,7 @@ class TestNode:
 
     @pytest.mark.parametrize(
         "kind",
-        ["", "Topic", "topic-name", "1topic", "topic name", "topic."],
+        ["", "Topic", "topic-name", "1topic", "topic name", "topic.", "topic\n"],
     )
     def test_rejects_invalid_kind_shape(self, kind):
         with pytest.raises(ValidationError):
@@ -94,3 +94,41 @@ class TestGraphView:
                 nodes=[Node(id="n1", kind="topic", label="Foo")],
                 edges=[Edge(source="n1", target="missing", type=EdgeType.RELATES_TO)],
             )
+
+    def test_rejects_duplicate_node_ids(self):
+        with pytest.raises(ValidationError):
+            GraphView(
+                nodes=[
+                    Node(id="n1", kind="topic", label="Foo"),
+                    Node(id="n1", kind="topic", label="Bar"),
+                ],
+                edges=[],
+            )
+
+    def test_to_dict_serializes_non_default_status_and_populated_attrs(self):
+        view = GraphView(
+            nodes=[
+                Node(
+                    id="n1",
+                    kind="topic",
+                    label="Foo",
+                    status=NodeStatus.PROPOSAL,
+                    attrs={"weight": 3},
+                ),
+            ],
+            edges=[],
+            meta={"generated_by": "stub"},
+        )
+
+        result = view.to_dict()
+
+        assert result["nodes"] == [
+            {
+                "id": "n1",
+                "kind": "topic",
+                "label": "Foo",
+                "status": "proposal",
+                "attrs": {"weight": 3},
+            }
+        ]
+        assert result["meta"] == {"generated_by": "stub"}

--- a/test/graph/test_models.py
+++ b/test/graph/test_models.py
@@ -1,0 +1,96 @@
+"""Tests for graph.models: Node, Edge, GraphView contract (U1)."""
+
+import pytest
+from pydantic import ValidationError
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node, NodeStatus
+
+
+class TestNode:
+    """Tests for the Node model."""
+
+    def test_constructs_with_valid_fields(self):
+        node = Node(id="topic:foo", kind="topic", label="Foo")
+
+        assert node.id == "topic:foo"
+        assert node.kind == "topic"
+        assert node.label == "Foo"
+        assert node.status == NodeStatus.ACTIVE
+        assert node.attrs == {}
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["", "Topic", "topic-name", "1topic", "topic name", "topic."],
+    )
+    def test_rejects_invalid_kind_shape(self, kind):
+        with pytest.raises(ValidationError):
+            Node(id="n1", kind=kind, label="Foo")
+
+    def test_rejects_invalid_status_literal(self):
+        with pytest.raises(ValidationError):
+            Node(id="n1", kind="topic", label="Foo", status="deleted")
+
+    def test_accepts_all_defined_status_values(self):
+        for status in NodeStatus:
+            node = Node(id="n1", kind="topic", label="Foo", status=status)
+            assert node.status == status
+
+
+class TestEdge:
+    """Tests for the Edge model."""
+
+    def test_constructs_with_valid_fields(self):
+        edge = Edge(source="n1", target="n2", type=EdgeType.RELATES_TO)
+
+        assert edge.source == "n1"
+        assert edge.target == "n2"
+        assert edge.type == EdgeType.RELATES_TO
+        assert edge.attrs == {}
+
+    def test_rejects_unrecognized_type_literal(self):
+        with pytest.raises(ValidationError):
+            Edge(source="n1", target="n2", type="unknown_type")
+
+
+class TestGraphView:
+    """Tests for the GraphView model."""
+
+    def test_constructs_with_nodes_and_edges_and_serializes(self):
+        view = GraphView(
+            nodes=[
+                Node(id="n1", kind="topic", label="Foo"),
+                Node(id="n2", kind="topic", label="Bar"),
+            ],
+            edges=[Edge(source="n1", target="n2", type=EdgeType.RELATES_TO)],
+            meta={"provider": "stub"},
+        )
+
+        result = view.to_dict()
+
+        assert result["nodes"] == [
+            {"id": "n1", "kind": "topic", "label": "Foo", "status": "active", "attrs": {}},
+            {"id": "n2", "kind": "topic", "label": "Bar", "status": "active", "attrs": {}},
+        ]
+        assert result["edges"] == [
+            {"source": "n1", "target": "n2", "type": "relates_to", "attrs": {}}
+        ]
+        assert result["meta"] == {"provider": "stub"}
+
+    def test_constructs_empty_view(self):
+        view = GraphView(nodes=[], edges=[])
+
+        assert view.to_dict() == {"nodes": [], "edges": [], "meta": {}}
+
+    def test_rejects_edge_with_dangling_source(self):
+        with pytest.raises(ValidationError):
+            GraphView(
+                nodes=[Node(id="n1", kind="topic", label="Foo")],
+                edges=[Edge(source="missing", target="n1", type=EdgeType.RELATES_TO)],
+            )
+
+    def test_rejects_edge_with_dangling_target(self):
+        with pytest.raises(ValidationError):
+            GraphView(
+                nodes=[Node(id="n1", kind="topic", label="Foo")],
+                edges=[Edge(source="n1", target="missing", type=EdgeType.RELATES_TO)],
+            )

--- a/test/graph/test_registries.py
+++ b/test/graph/test_registries.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from cli_agent_orchestrator.graph.models import GraphView
+from cli_agent_orchestrator.graph.models import GraphView, Node
 from cli_agent_orchestrator.graph.providers.base import (
     GraphProvider,
     get_provider,
@@ -104,3 +104,55 @@ class TestSinkQueryCapabilityGate:
         sink = get_sink("test-sink-with-query")
 
         assert sink.query() == "queried"
+
+    def test_sink_declaring_query_capability_without_override_raises_not_implemented(self):
+        @register_sink("test-sink-declared-not-overridden")
+        class DeclaredOnlySink(GraphSink):
+            capabilities = {"query"}
+
+            def export(self, view, dest, **options):
+                return [dest]
+
+        sink = get_sink("test-sink-declared-not-overridden")
+
+        with pytest.raises(NotImplementedError, match="did not override"):
+            sink.query()
+
+    def test_sink_export_writes_and_returns_paths(self):
+        @register_sink("test-sink-export")
+        class ExportSink(GraphSink):
+            def export(self, view, dest, **options):
+                return [dest]
+
+        sink = get_sink("test-sink-export")
+
+        assert sink.export(GraphView(nodes=[], edges=[]), "out.json") == ["out.json"]
+
+
+class TestProviderAsyncContract:
+    """Tests exercising the async project() contract end-to-end (ADR-7)."""
+
+    @pytest.mark.asyncio
+    async def test_project_is_awaited_and_returns_empty_graph_view(self):
+        @register_provider("test-provider-async")
+        class EmptyProvider(GraphProvider):
+            async def project(self, **filters):
+                return GraphView(nodes=[], edges=[])
+
+        provider = get_provider("test-provider-async")
+        gv = await provider.project()
+
+        assert gv.nodes == []
+        assert gv.edges == []
+
+    @pytest.mark.asyncio
+    async def test_project_returns_provided_nodes(self):
+        @register_provider("test-provider-async-nodes")
+        class OneNodeProvider(GraphProvider):
+            async def project(self, **filters):
+                return GraphView(nodes=[Node(id="n1", kind="topic", label="Foo")], edges=[])
+
+        provider = get_provider("test-provider-async-nodes")
+        gv = await provider.project()
+
+        assert [node.id for node in gv.nodes] == ["n1"]

--- a/test/graph/test_registries.py
+++ b/test/graph/test_registries.py
@@ -1,0 +1,76 @@
+"""Tests for the GraphProvider/GraphSink registries (U1)."""
+
+import pytest
+
+from cli_agent_orchestrator.graph.models import GraphView
+from cli_agent_orchestrator.graph.providers.base import (
+    GraphProvider,
+    get_provider,
+    list_providers,
+    register_provider,
+)
+from cli_agent_orchestrator.graph.sinks.base import GraphSink, get_sink, list_sinks, register_sink
+
+
+class TestProviderRegistry:
+    """Tests for register_provider/get_provider/list_providers."""
+
+    def test_register_and_resolve_round_trip(self):
+        @register_provider("test-provider-happy")
+        class HappyProvider(GraphProvider):
+            async def project(self, **filters):
+                return GraphView(nodes=[], edges=[])
+
+        resolved = get_provider("test-provider-happy")
+
+        assert isinstance(resolved, HappyProvider)
+        assert "test-provider-happy" in list_providers()
+
+    def test_duplicate_registration_raises_value_error(self):
+        @register_provider("test-provider-dup")
+        class FirstProvider(GraphProvider):
+            async def project(self, **filters):
+                return GraphView(nodes=[], edges=[])
+
+        with pytest.raises(ValueError):
+
+            @register_provider("test-provider-dup")
+            class SecondProvider(GraphProvider):
+                async def project(self, **filters):
+                    return GraphView(nodes=[], edges=[])
+
+    def test_unregistered_name_raises_key_error(self):
+        with pytest.raises(KeyError):
+            get_provider("no-such-provider")
+
+
+class TestSinkRegistry:
+    """Tests for register_sink/get_sink/list_sinks."""
+
+    def test_register_and_resolve_round_trip(self):
+        @register_sink("test-sink-happy")
+        class HappySink(GraphSink):
+            def export(self, view, dest, **options):
+                return [dest]
+
+        resolved = get_sink("test-sink-happy")
+
+        assert isinstance(resolved, HappySink)
+        assert "test-sink-happy" in list_sinks()
+
+    def test_duplicate_registration_raises_value_error(self):
+        @register_sink("test-sink-dup")
+        class FirstSink(GraphSink):
+            def export(self, view, dest, **options):
+                return [dest]
+
+        with pytest.raises(ValueError):
+
+            @register_sink("test-sink-dup")
+            class SecondSink(GraphSink):
+                def export(self, view, dest, **options):
+                    return [dest]
+
+    def test_unregistered_name_raises_key_error(self):
+        with pytest.raises(KeyError):
+            get_sink("no-such-sink")

--- a/test/graph/test_registries.py
+++ b/test/graph/test_registries.py
@@ -74,3 +74,33 @@ class TestSinkRegistry:
     def test_unregistered_name_raises_key_error(self):
         with pytest.raises(KeyError):
             get_sink("no-such-sink")
+
+
+class TestSinkQueryCapabilityGate:
+    """Tests for GraphSink.query() capability gating (FR-5)."""
+
+    def test_sink_without_query_capability_raises_not_implemented(self):
+        @register_sink("test-sink-no-query")
+        class NoQuerySink(GraphSink):
+            def export(self, view, dest, **options):
+                return [dest]
+
+        sink = get_sink("test-sink-no-query")
+
+        with pytest.raises(NotImplementedError):
+            sink.query()
+
+    def test_sink_declaring_query_capability_can_override(self):
+        @register_sink("test-sink-with-query")
+        class QuerySink(GraphSink):
+            capabilities = {"query"}
+
+            def export(self, view, dest, **options):
+                return [dest]
+
+            def query(self, *args, **kwargs):
+                return "queried"
+
+        sink = get_sink("test-sink-with-query")
+
+        assert sink.query() == "queried"


### PR DESCRIPTION
## Summary
- Typed GraphView contract: `Node`/`Edge`/`GraphView` pydantic models, `NodeStatus` + `EdgeType` enums
- Async `GraphProvider` ABC + registry
- `GraphSink` ABC with capability-gated `query()` + registry

First Bolt of the Issue-348 graph-layer epic (B1 of 4; next: providers, API+sinks, renderer).

## Testing
- 23 tests
- black/isort/mypy clean

Part of #348