### PR TITLE
fix(codex): TOML-escape MCP command/args/env in -c overrides

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -267,10 +267,9 @@ class CodexProvider(BaseProvider):
                 # Escape backslashes, double quotes, and newlines for TOML basic string.
                 # Newlines must become literal \n to prevent tmux send_keys from
                 # splitting the command across multiple lines.
-                escaped_prompt = (
-                    system_prompt.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+                command_parts.extend(
+                    ["-c", f"developer_instructions={_toml_scalar(system_prompt)}"]
                 )
-                command_parts.extend(["-c", f'developer_instructions="{escaped_prompt}"'])
 
             # Add MCP servers via -c config overrides (per-session, no global config changes).
             # Each server field is set via dotted path: mcp_servers.<name>.<field>=<value>
@@ -285,13 +284,17 @@ class CodexProvider(BaseProvider):
                     # PATH-independent invocation.
                     cfg = resolve_mcp_server_config(cfg)
                     if "command" in cfg:
-                        command_parts.extend(["-c", f'{prefix}.command="{cfg["command"]}"'])
+                        command_parts.extend(
+                            ["-c", f"{prefix}.command={_toml_scalar(cfg['command'])}"]
+                        )
                     if "args" in cfg:
-                        args_toml = "[" + ", ".join(f'"{a}"' for a in cfg["args"]) + "]"
+                        args_toml = "[" + ", ".join(_toml_scalar(a) for a in cfg["args"]) + "]"
                         command_parts.extend(["-c", f"{prefix}.args={args_toml}"])
                     if "env" in cfg and cfg["env"]:
                         for env_key, env_val in cfg["env"].items():
-                            command_parts.extend(["-c", f'{prefix}.env.{env_key}="{env_val}"'])
+                            command_parts.extend(
+                                ["-c", f"{prefix}.env.{env_key}={_toml_scalar(str(env_val))}"]
+                            )
                     # Forward CAO_TERMINAL_ID so MCP servers (e.g. cao-mcp-server)
                     # can identify the current session for handoff/assign operations.
                     # Codex does not forward env vars to MCP subprocesses by default;
@@ -299,7 +302,7 @@ class CodexProvider(BaseProvider):
                     env_vars = cfg.get("env_vars", [])
                     if "CAO_TERMINAL_ID" not in env_vars:
                         env_vars = list(env_vars) + ["CAO_TERMINAL_ID"]
-                    env_vars_toml = "[" + ", ".join(f'"{v}"' for v in env_vars) + "]"
+                    env_vars_toml = "[" + ", ".join(_toml_scalar(v) for v in env_vars) + "]"
                     command_parts.extend(["-c", f"{prefix}.env_vars={env_vars_toml}"])
                     # Set a generous tool timeout for MCP calls like handoff, which
                     # create a new terminal, initialize the provider, send a message,

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -205,6 +205,88 @@ class TestCodexBuildCommand:
         assert mock_resolve.called
         assert 'mcp_servers.cao-mcp-server.command="/home/u/.local/bin/cao-mcp-server"' in command
 
+    @patch("cli_agent_orchestrator.providers.codex.resolve_mcp_server_config")
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_mcp_server_command_field_is_toml_escaped(self, mock_load_profile, mock_resolve):
+        """A resolved command containing TOML-special chars is escaped so the
+        -c override stays a valid TOML basic string."""
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = "You are a supervisor."
+        mock_profile.mcpServers = {
+            "cao-mcp-server": {"type": "stdio", "command": "cao-mcp-server", "args": []}
+        }
+        mock_profile.codexProfile = None
+        mock_load_profile.return_value = mock_profile
+        # Simulate a resolved path containing a backslash and a quote.
+        mock_resolve.side_effect = lambda cfg: {
+            **cfg,
+            "command": r'/tmp/we"ird\path/cao-mcp-server',
+            "args": [],
+        }
+
+        provider = CodexProvider("test1234", "test-session", "window-0", "code_supervisor")
+        command = provider._build_codex_command()
+
+        # The backslash and quote are TOML-escaped in the emitted override.
+        assert r"/tmp/we\"ird\\path/cao-mcp-server" in command
+        # The raw (unescaped) form must NOT appear -- that would break TOML.
+        assert '"/tmp/we"ird' not in command
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_mcp_server_args_and_env_are_toml_escaped(self, mock_load_profile):
+        """Args and env values containing TOML-special chars are escaped."""
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = ""
+        mock_profile.mcpServers = {
+            "test-server": {
+                "command": "runner",
+                "args": [r'--flag="C:\data"'],
+                "env": {"TOKEN": 'se"cret\nvalue'},
+            }
+        }
+        mock_profile.codexProfile = None
+        mock_load_profile.return_value = mock_profile
+
+        provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
+        command = provider._build_codex_command()
+
+        # Arg: quote and backslash escaped inside the TOML array element.
+        assert r"--flag=\"C:\\data\"" in command
+        # Env value: quote escaped, literal newline escaped to \n.
+        assert r"se\"cret\nvalue" in command
+        assert "\n" not in command
+        # The raw (unescaped) forms must NOT appear -- that would break TOML.
+        assert r'--flag="C:\data"' not in command
+        assert 'se"cret' not in command
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_mcp_env_vars_non_string_entry_fails_fast(self, mock_load_profile):
+        """A non-string env_vars entry raises TypeError (intentional fail-fast).
+
+        _toml_scalar rejects non-scalar values so a malformed profile fails at
+        launch-command build time with a clear error instead of emitting a
+        silently-broken override. Previously the entry was rendered via a raw
+        f-string and never raised; the fail-fast is a deliberate change.
+        """
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = ""
+        mock_profile.mcpServers = {
+            "test-server": {
+                "command": "runner",
+                "args": [],
+                "env_vars": [{"not": "a-string"}],
+            }
+        }
+        mock_profile.codexProfile = None
+        mock_load_profile.return_value = mock_profile
+
+        provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
+        with pytest.raises(TypeError, match="scalars"):
+            provider._build_codex_command()
+
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
     def test_build_command_with_mcp_servers_env(self, mock_load_profile):
         mock_profile = MagicMock()


### PR DESCRIPTION
## What happens

The Codex provider injects each MCP server's command, args, and env into the launch command as `-c mcp_servers.<name>.<field>="<value>"` TOML overrides, but interpolated the values without escaping. A value containing a double-quote or backslash produces a malformed TOML string (the quote closes the string early), and a literal newline would split the tmux `send_keys` command across lines.

This matters more after #403: the resolved `cao-mcp-server` command becomes an absolute path, and env values are caller-supplied, so TOML-special characters can reach these overrides.

## The fix

Reuse the existing `_toml_scalar` helper (already used for `codexConfig` overrides; escapes backslash, quote, tab, CR, and newline) for the MCP command, each arg, each env value, and the `env_vars` list, and switch the inline `developer_instructions` escaping to it as well, so the file has a single TOML-string escaping path.

A non-string `env_vars` entry now raises `TypeError` at launch-command build time (previously it was silently interpolated raw). This fail-fast is intentional — a malformed profile fails with a clear error instead of emitting a silently-broken override — and is covered by a dedicated test.

## History

Originally stacked on #403 per the maintainers' preference to keep the escaping fix separate; now that #403 is merged, this PR is rebased onto main and the diff is `providers/codex.py` + `test/providers/test_codex_provider_unit.py` only.

## Testing

- Unit tests: a resolved command containing a backslash and quote is escaped (raw form asserted absent); args and env values with TOML-special characters are escaped (raw forms asserted absent); literal newlines never reach the launch command; a non-string `env_vars` entry raises `TypeError` (documented fail-fast).
- black / isort / mypy / full pytest suite green.
