### PR TITLE
fix(codex): match reworded trust dialog on codex-cli 0.144.1 (#410)

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -75,8 +75,16 @@ TUI_FOOTER_PATTERN = r"(?:\?\s+for shortcuts|context left|\d+%\s+left|·\s+[~/])
 # ASSISTANT_PREFIX_PATTERN and the TUI footer › matches idle prompt).
 TUI_PROGRESS_PATTERN = r"•.*\(\d+s\s*•\s*esc to interrupt\)"
 
-# Workspace trust/approval prompt shown when Codex opens a new directory
-TRUST_PROMPT_PATTERN = r"allow Codex to work in this folder"
+# Workspace trust/approval prompt shown when Codex opens a new directory.
+# codex-cli has reworded this dialog across versions, so match either phrasing:
+#   older:   "… allow Codex to work in this folder without asking for approval"
+#   0.144.1: "Do you trust the contents of this directory? … › 1. Yes, continue"
+# A stale single-phrase pattern silently stops matching on a CLI update, which
+# lets the worker hang on the unanswered prompt (it never auto-accepts).
+TRUST_PROMPT_PATTERN = (
+    r"allow Codex to work in this folder"
+    r"|Do you trust the contents of this (?:directory|folder)"
+)
 # Codex welcome banner indicating normal startup (no trust prompt)
 CODEX_WELCOME_PATTERN = r"OpenAI Codex"
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -1484,6 +1484,32 @@ class TestCodexProviderTrustPrompt:
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_handle_trust_prompt_detected_and_accepted_new_wording(self, mock_tmux):
+        """codex-cli reworded the trust dialog (observed on 0.144.1): "Do you
+        trust the contents of this directory? … › 1. Yes, continue / 2. No,
+        quit". The handler must still detect it and auto-accept, otherwise the
+        worker hangs on the unanswered prompt until it times out.
+        """
+        mock_tmux.return_value.get_history.return_value = (
+            "> You are in /Users/test/project\n"
+            "\n"
+            "  Do you trust the contents of this directory? Working with "
+            "untrusted contents comes with higher risk of prompt injection. "
+            "Trusting the directory allows project-local config, hooks, and "
+            "exec policies to load.\n"
+            "› 1. Yes, continue\n"
+            "  2. No, quit\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(timeout=2.0)
+
+        mock_tmux.return_value.send_special_key.assert_called_once_with(
+            "test-session", "window-0", "Enter"
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_not_needed(self, mock_tmux):
         """Test early return when Codex starts without trust prompt."""
         mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)\n› "
@@ -1505,6 +1531,20 @@ class TestCodexProviderTrustPrompt:
         status = provider.get_status(output)
 
         # Should be WAITING_USER_ANSWER (not PROCESSING despite "running" in text)
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_trust_prompt_new_wording_is_waiting_user_answer(self):
+        """The reworded trust dialog (codex-cli 0.144.1) must also report
+        WAITING_USER_ANSWER so the terminal isn't mistaken for PROCESSING."""
+        output = (
+            "> You are in /Users/test/project\n"
+            "Do you trust the contents of this directory?\n"
+            "› 1. Yes, continue\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Match reworded Codex trust dialog (codex-cli 0.144.1)

Fixes #410.

### Problem
codex-cli **0.144.1** reworded its workspace-trust dialog from
"… allow Codex to work in this folder …" to
"Do you trust the contents of this directory? … › 1. Yes, continue".

`TRUST_PROMPT_PATTERN` only matched the old phrasing, so `_handle_trust_prompt`
stopped auto-accepting and a Codex worker **hangs on the unanswered trust
prompt** the first time it opens an untrusted directory. In a `handoff`/`assign`
flow the supervisor then blocks forever. `get_status` (which shares the pattern)
also stopped classifying the dialog as `WAITING_USER_ANSWER`.

### Change
- Broaden `TRUST_PROMPT_PATTERN` (`providers/codex.py`) to match **both** the old
  and the 0.144.1 wording, with a comment explaining the version drift.
- The welcome-banner pattern (`OpenAI Codex`) is still valid on 0.144.1 and is
  left unchanged.

### Tests
- New `test_handle_trust_prompt_detected_and_accepted_new_wording` — the 0.144.1
  dialog is detected and auto-accepted (Enter sent).
- New `test_get_status_trust_prompt_new_wording_is_waiting_user_answer` — the
  reworded dialog reports `WAITING_USER_ANSWER`.
- Existing old-wording trust-prompt tests still pass (`110 passed`).

### Verification
Launched a Codex worker via CAO in a **fresh untrusted directory** on codex-cli
0.144.1: with the fix, CAO auto-accepts the trust dialog and Codex proceeds to
answer (`Mean: 8`) within ~5s, instead of hanging at the prompt.
