### PR TITLE
Potential fix for code scanning alert no. 142: Clear-text storage of sensitive information

### DIFF
--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -667,21 +667,30 @@ class MemoryService:
         MemoryScope(scope)
         MemoryType(memory_type)
 
-        # Writes are credential-gated for EVERY scope. Memory content is
-        # persisted as clear text on disk (no encryption-at-rest), so
-        # credential-shaped content must be rejected before any write reaches
-        # the filesystem — otherwise a secret pasted into any scope lands in a
-        # plaintext wiki file (CodeQL py/clear-text-storage-sensitive-data,
-        # alert #142). The gate previously covered only the federated tier; it
-        # now applies uniformly. The log line carries the pattern NAME only, and
-        # the raised message is generic — never content bytes.
+        # Writes are credential-gated for EVERY scope, across every field that
+        # is persisted. Memory is stored as clear-text markdown on disk (no
+        # encryption-at-rest — agents and humans read these files directly), so
+        # credential-shaped input must be rejected before any write reaches the
+        # filesystem; otherwise a secret in any scope lands in a plaintext wiki
+        # file (CodeQL py/clear-text-storage-sensitive-data / CWE-312, alert
+        # #142). The gate previously covered only the federated tier and only
+        # ``content``. It now applies to every scope and scans ``content`` (body),
+        # ``key`` (header + filename) and ``tags`` (header + index) — every
+        # caller-supplied value that reaches ``new_content``/disk. Fail closed on
+        # the first match. The log line carries the pattern NAME only, and the
+        # raised message names the offending FIELD and pattern, never the bytes.
         from cli_agent_orchestrator.services.secret_gate import scan_for_secrets
 
-        hit = scan_for_secrets(content)
-        if hit:
-            # Do not log detector output; emit only a constant event marker.
-            logger.warning("memory_secret_rejected")
-            raise ValueError(f"memory write rejected: matched credential pattern {hit!r}")
+        for field_name, field_value in (("content", content), ("key", key), ("tags", tags)):
+            if not field_value:
+                continue
+            hit = scan_for_secrets(field_value)
+            if hit:
+                # Do not log detector output; emit only a constant event marker.
+                logger.warning("memory_secret_rejected field=%s", field_name)
+                raise ValueError(
+                    f"memory write rejected: {field_name} matched credential pattern {hit!r}"
+                )
 
         # Store-time cross-scope write guard. A caller may
         # only write a scope it is authorised for (SCOPE_RANK). The caller

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -804,6 +804,11 @@ class MemoryService:
             # AND merges) or a value older than the topic's latest section
             # is clamped to now(), with provenance preserved as a first
             # body line. occurred_at=None keeps the pre-#345 bytes exactly.
+            # Reject credential-like content before any plaintext persistence.
+            # This prevents cleartext-at-rest of likely secrets across all scopes.
+            if self.scan_for_secrets(content):
+                raise ValueError("Memory content appears to contain sensitive credentials and was rejected.")
+
             entry_body = content
             if occurred_at is not None:
                 if self._occurred_at_would_clamp(occurred_at, latest_section_at, now):
@@ -829,20 +834,9 @@ class MemoryService:
             # This is always the immediate, durable result of store(). LLM
             # compaction (below) is deferred and rewrites the file later.
             #
-            # CodeQL note (py/clear-text-storage-sensitive-data): this write is
-            # flagged only because ``new_content`` embeds the topic ``key`` and
-            # CodeQL's name-based heuristic classifies any variable named
-            # ``key`` as a secret. It is a FALSE POSITIVE, not a leak: ``key``
-            # is a user-authored topic slug (see ``_sanitize_key``), never a
-            # credential. The memory wiki is intentionally human-readable
-            # plaintext markdown — that is the product contract, and encrypting
-            # it would defeat the feature (agents and humans read these files
-            # directly). No secret is persisted here. Dismiss the alert as
-            # "won't fix / by-design" in the Security tab with this rationale;
-            # do NOT add encryption. As an additional safeguard, content
-            # written to the machine-wide federated tier is screened by the
-            # secret gate (``scan_for_secrets``) earlier in ``store()`` and
-            # rejected if it matches a credential pattern.
+            # Plaintext wiki storage is intentional for product usability, but
+            # `store()` now rejects credential-like content via `scan_for_secrets`
+            # before reaching this write path.
             tmp_path = wiki_path.parent / f".{wiki_path.stem}.tmp"
             tmp_path.write_text(new_content, encoding="utf-8")
             os.replace(str(tmp_path), str(wiki_path))

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -677,20 +677,24 @@ class MemoryService:
         # ``content``. It now applies to every scope and scans ``content`` (body),
         # ``key`` (header + filename) and ``tags`` (header + index) — every
         # caller-supplied value that reaches ``new_content``/disk. Fail closed on
-        # the first match. The log line carries the pattern NAME only, and the
-        # raised message names the offending FIELD and pattern, never the bytes.
+        # the first match. Neither the log line nor the raised message echoes any
+        # input — they carry only the fixed FIELD name (content/key/tags).
         from cli_agent_orchestrator.services.secret_gate import scan_for_secrets
 
         for field_name, field_value in (("content", content), ("key", key), ("tags", tags)):
             if not field_value:
                 continue
-            hit = scan_for_secrets(field_value)
-            if hit:
-                # ``hit`` is the matched pattern NAME (e.g. "aws_access_key"),
-                # never the offending bytes — safe to log for diagnosability.
-                logger.warning("memory_secret_rejected field=%s pattern=%s", field_name, hit)
+            if scan_for_secrets(field_value):
+                # Log and raise using ONLY the hardcoded field name. The matched
+                # pattern name from scan_for_secrets is derived from the secret
+                # input, and CodeQL's taint tracker flags it as clear-text
+                # logging of sensitive information (py/clear-text-logging) even
+                # though it is only a pattern label — so we deliberately do not
+                # surface it. ``field_name`` is a fixed literal (content/key/tags),
+                # never tainted, and tells the caller which field to fix.
+                logger.warning("memory_secret_rejected field=%s", field_name)
                 raise ValueError(
-                    f"memory write rejected: {field_name} matched credential pattern {hit!r}"
+                    f"memory write rejected: {field_name} matched a credential pattern"
                 )
 
         # Store-time cross-scope write guard. A caller may

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -667,17 +667,21 @@ class MemoryService:
         MemoryScope(scope)
         MemoryType(memory_type)
 
-        # Federated writes are credential-gated. The machine-wide shared
-        # tier rejects content matching common secret patterns. The log
-        # line carries the pattern NAME only — never content bytes.
-        if scope == MemoryScope.FEDERATED.value:
-            from cli_agent_orchestrator.services.secret_gate import scan_for_secrets
+        # Writes are credential-gated for EVERY scope. Memory content is
+        # persisted as clear text on disk (no encryption-at-rest), so
+        # credential-shaped content must be rejected before any write reaches
+        # the filesystem — otherwise a secret pasted into any scope lands in a
+        # plaintext wiki file (CodeQL py/clear-text-storage-sensitive-data,
+        # alert #142). The gate previously covered only the federated tier; it
+        # now applies uniformly. The log line carries the pattern NAME only, and
+        # the raised message is generic — never content bytes.
+        from cli_agent_orchestrator.services.secret_gate import scan_for_secrets
 
-            hit = scan_for_secrets(content)
-            if hit:
-                # Do not log detector output; emit only a constant event marker.
-                logger.warning("federated_secret_rejected")
-                raise ValueError(f"federated write rejected: matched credential pattern {hit!r}")
+        hit = scan_for_secrets(content)
+        if hit:
+            # Do not log detector output; emit only a constant event marker.
+            logger.warning("memory_secret_rejected")
+            raise ValueError(f"memory write rejected: matched credential pattern {hit!r}")
 
         # Store-time cross-scope write guard. A caller may
         # only write a scope it is authorised for (SCOPE_RANK). The caller
@@ -804,11 +808,6 @@ class MemoryService:
             # AND merges) or a value older than the topic's latest section
             # is clamped to now(), with provenance preserved as a first
             # body line. occurred_at=None keeps the pre-#345 bytes exactly.
-            # Reject credential-like content before any plaintext persistence.
-            # This prevents cleartext-at-rest of likely secrets across all scopes.
-            if self.scan_for_secrets(content):
-                raise ValueError("Memory content appears to contain sensitive credentials and was rejected.")
-
             entry_body = content
             if occurred_at is not None:
                 if self._occurred_at_would_clamp(occurred_at, latest_section_at, now):

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -686,8 +686,9 @@ class MemoryService:
                 continue
             hit = scan_for_secrets(field_value)
             if hit:
-                # Do not log detector output; emit only a constant event marker.
-                logger.warning("memory_secret_rejected field=%s", field_name)
+                # ``hit`` is the matched pattern NAME (e.g. "aws_access_key"),
+                # never the offending bytes — safe to log for diagnosability.
+                logger.warning("memory_secret_rejected field=%s pattern=%s", field_name, hit)
                 raise ValueError(
                     f"memory write rejected: {field_name} matched credential pattern {hit!r}"
                 )

--- a/test/services/test_memory_archive_okf_export.py
+++ b/test/services/test_memory_archive_okf_export.py
@@ -10,6 +10,7 @@ import asyncio
 import os
 import tarfile
 from datetime import datetime
+from pathlib import Path
 
 import frontmatter
 import pytest
@@ -59,6 +60,26 @@ def _store(svc, key, content, scope="global", memory_type="reference", tags="", 
             terminal_context=ctx,
         )
     )
+
+
+def _plant_secret_on_disk(svc, key, secret_content, scope="global", memory_type="reference"):
+    """Seed a secret-bearing wiki file directly on disk, bypassing store()'s
+    credential gate.
+
+    store() now rejects credential-shaped input at write time for every scope
+    (CWE-312 fix). The export/import secret handling is DEFENSE-IN-DEPTH for
+    files that are already on disk — e.g. memories written before the store
+    gate existed, or a hand-edited wiki file. This helper reproduces exactly
+    that state: store a clean placeholder (so the wiki file, index.md entry and
+    DB row are laid out the way store() produces them), then overwrite the wiki
+    file's section body with the secret. The export reader parses the file from
+    disk, so the on-disk layout is what matters.
+    """
+    mem = _store(svc, key, "placeholder body", scope=scope, memory_type=memory_type)
+    wiki_path = Path(mem.file_path)
+    text = wiki_path.read_text(encoding="utf-8")
+    wiki_path.write_text(text.replace("placeholder body", secret_content), encoding="utf-8")
+    return mem
 
 
 def _frontmatter(path):
@@ -167,7 +188,7 @@ class TestSecretGate:
 
     def test_default_skips_topic_with_pattern_name_only(self, svc, backend, dest, caplog):
         _store(svc, "clean-topic", "Nothing sensitive here.")
-        _store(svc, "leaky-topic", f"My key is {PLANTED_AWS_KEY} do not share.")
+        _plant_secret_on_disk(svc, "leaky-topic", f"My key is {PLANTED_AWS_KEY} do not share.")
         with caplog.at_level("DEBUG"):
             report = backend.export_bundle("global", None, dest, False, False)
         assert report.exported == 1
@@ -179,7 +200,7 @@ class TestSecretGate:
         assert PLANTED_AWS_KEY not in caplog.text
 
     def test_redact_exports_with_marker(self, svc, backend, dest):
-        _store(svc, "leaky-topic", f"My key is {PLANTED_AWS_KEY} do not share.")
+        _plant_secret_on_disk(svc, "leaky-topic", f"My key is {PLANTED_AWS_KEY} do not share.")
         report = backend.export_bundle("global", None, dest, False, True)
         assert report.redacted == 1
         assert report.skipped_secret == 0
@@ -188,7 +209,7 @@ class TestSecretGate:
         assert "[REDACTED:aws_access_key]" in text
 
     def test_skipped_topic_absent_from_index(self, svc, backend, dest):
-        _store(svc, "leaky-topic", f"key {PLANTED_AWS_KEY}")
+        _plant_secret_on_disk(svc, "leaky-topic", f"key {PLANTED_AWS_KEY}")
         _store(svc, "clean-topic", "fine")
         backend.export_bundle("global", None, dest, False, False)
         index = (dest / "index.md").read_text(encoding="utf-8")
@@ -196,8 +217,19 @@ class TestSecretGate:
         assert "clean-topic" in index
 
     def test_history_sections_gated_when_included(self, svc, backend, dest):
-        _store(svc, "old-leak", f"old entry with {PLANTED_AWS_KEY}")
-        _store(svc, "old-leak", "latest entry is clean")
+        # A clean latest section on disk, with an OLDER leaky history section
+        # injected before it (simulating a secret that predates the store gate).
+        # store() lays out the file + index + row; we then splice a leaky
+        # earlier ``## <ts>`` section ahead of the latest one.
+        mem = _store(svc, "old-leak", "latest entry is clean")
+        wiki_path = Path(mem.file_path)
+        text = wiki_path.read_text(encoding="utf-8")
+        marker = "\n## "
+        head, _, latest_section = text.partition(marker)
+        leaky_section = f"2000-01-01T00:00:00Z\nold entry with {PLANTED_AWS_KEY}\n"
+        wiki_path.write_text(
+            head + marker + leaky_section + marker + latest_section, encoding="utf-8"
+        )
         # Without history the latest-only content is clean → exports.
         report = backend.export_bundle("global", None, dest, False, False)
         assert report.exported == 1
@@ -341,7 +373,7 @@ class TestSeeAlso:
 
     def test_link_to_skipped_topic_degrades_to_text(self, svc, backend, dest):
         _store(svc, "source-topic", "links out")
-        _store(svc, "secret-topic", f"key {PLANTED_AWS_KEY}")
+        _plant_secret_on_disk(svc, "secret-topic", f"key {PLANTED_AWS_KEY}")
         self._append_see_also(svc, "source-topic", "secret-topic")
         report = backend.export_bundle("global", None, dest, False, False)
         assert report.links_dropped == 1
@@ -391,8 +423,6 @@ class TestTamperedIndex:
 
 class TestDestValidation:
     def test_blocked_system_dest_rejected(self, backend):
-        from pathlib import Path
-
         with pytest.raises(ValueError, match="not allowed"):
             backend.export_bundle("global", None, Path("/etc/new-bundle"), False, False)
 

--- a/test/services/test_memory_archive_okf_export.py
+++ b/test/services/test_memory_archive_okf_export.py
@@ -11,6 +11,7 @@ import os
 import tarfile
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import frontmatter
 import pytest
@@ -63,23 +64,23 @@ def _store(svc, key, content, scope="global", memory_type="reference", tags="", 
 
 
 def _plant_secret_on_disk(svc, key, secret_content, scope="global", memory_type="reference"):
-    """Seed a secret-bearing wiki file directly on disk, bypassing store()'s
-    credential gate.
+    """Seed a secret-bearing wiki file on disk, bypassing store()'s credential
+    gate for fixture setup only.
 
     store() now rejects credential-shaped input at write time for every scope
     (CWE-312 fix). The export/import secret handling is DEFENSE-IN-DEPTH for
-    files that are already on disk — e.g. memories written before the store
-    gate existed, or a hand-edited wiki file. This helper reproduces exactly
-    that state: store a clean placeholder (so the wiki file, index.md entry and
-    DB row are laid out the way store() produces them), then overwrite the wiki
-    file's section body with the secret. The export reader parses the file from
-    disk, so the on-disk layout is what matters.
+    files ALREADY on disk — memories written before the store gate existed, or a
+    hand-edited wiki. To reproduce that state we still write through the real
+    ``store()`` (so the wiki file, index.md entry and DB row are laid out exactly
+    as in production), but disable the gate for the duration of the plant by
+    patching ``scan_for_secrets`` to report "clean". Doing it this way keeps the
+    clear-text write inside product code (the path already covered by alert #142)
+    rather than introducing a second write sink in test code.
     """
-    mem = _store(svc, key, "placeholder body", scope=scope, memory_type=memory_type)
-    wiki_path = Path(mem.file_path)
-    text = wiki_path.read_text(encoding="utf-8")
-    wiki_path.write_text(text.replace("placeholder body", secret_content), encoding="utf-8")
-    return mem
+    from cli_agent_orchestrator.services import secret_gate
+
+    with patch.object(secret_gate, "scan_for_secrets", return_value=None):
+        return _store(svc, key, secret_content, scope=scope, memory_type=memory_type)
 
 
 def _frontmatter(path):
@@ -217,19 +218,12 @@ class TestSecretGate:
         assert "clean-topic" in index
 
     def test_history_sections_gated_when_included(self, svc, backend, dest):
-        # A clean latest section on disk, with an OLDER leaky history section
-        # injected before it (simulating a secret that predates the store gate).
-        # store() lays out the file + index + row; we then splice a leaky
-        # earlier ``## <ts>`` section ahead of the latest one.
-        mem = _store(svc, "old-leak", "latest entry is clean")
-        wiki_path = Path(mem.file_path)
-        text = wiki_path.read_text(encoding="utf-8")
-        marker = "\n## "
-        head, _, latest_section = text.partition(marker)
-        leaky_section = f"2000-01-01T00:00:00Z\nold entry with {PLANTED_AWS_KEY}\n"
-        wiki_path.write_text(
-            head + marker + leaky_section + marker + latest_section, encoding="utf-8"
-        )
+        # An OLDER leaky section followed by a clean latest section, both written
+        # through the real store() append path (gate patched off for the leaky
+        # seed, as with pre-gate on-disk data). The second clean store() appends
+        # a newer section, so the leak becomes history, not the latest.
+        _plant_secret_on_disk(svc, "old-leak", f"old entry with {PLANTED_AWS_KEY}")
+        _store(svc, "old-leak", "latest entry is clean")
         # Without history the latest-only content is clean → exports.
         report = backend.export_bundle("global", None, dest, False, False)
         assert report.exported == 1

--- a/test/services/test_memory_service.py
+++ b/test/services/test_memory_service.py
@@ -1383,20 +1383,20 @@ class TestFederatedScope:
         assert not wiki.exists()
         assert _fed_row(engine, "fed-secret") is None
 
-    def test_same_secret_content_allowed_at_global_scope(self, tmp_path: Path):
-        """The gate is federated-only: identical AKIA-bearing content stores
-        fine at scope=global.
-        """
+    def test_same_secret_content_rejected_at_global_scope(self, tmp_path: Path):
+        """Credential-like content is rejected for global scope as well."""
         svc = MemoryService(base_dir=tmp_path)
         ctx = _make_terminal_context()
         secret = "deploy creds AKIAIOSFODNN7EXAMPLE here"
-        mem = _run(
-            svc.store(
-                content=secret,
-                scope="global",
-                memory_type="reference",
-                key="glob-secret-ok",
-                terminal_context=ctx,
+        with pytest.raises(ValueError):
+            _run(
+                svc.store(
+                    content=secret,
+                    scope="global",
+                    memory_type="reference",
+                    key="glob-secret-ok",
+                    terminal_context=ctx,
+                )
             )
-        )
-        assert Path(mem.file_path).exists()
+        wiki = tmp_path / "global" / "wiki" / "global" / "glob-secret-ok.md"
+        assert not wiki.exists()

--- a/test/services/test_memory_service.py
+++ b/test/services/test_memory_service.py
@@ -1383,20 +1383,61 @@ class TestFederatedScope:
         assert not wiki.exists()
         assert _fed_row(engine, "fed-secret") is None
 
-    def test_same_secret_content_rejected_at_global_scope(self, tmp_path: Path):
-        """Credential-like content is rejected for global scope as well."""
+    def test_same_secret_content_rejected_at_global_scope(self, tmp_path: Path, caplog):
+        """Credential-like content is rejected for global scope as well, nothing
+        is written, and neither the raised error nor the logs echo the secret."""
         svc = MemoryService(base_dir=tmp_path)
         ctx = _make_terminal_context()
         secret = "deploy creds AKIAIOSFODNN7EXAMPLE here"
-        with pytest.raises(ValueError):
+        with caplog.at_level("WARNING", logger="cli_agent_orchestrator.services.memory_service"):
+            with pytest.raises(ValueError) as exc_info:
+                _run(
+                    svc.store(
+                        content=secret,
+                        scope="global",
+                        memory_type="reference",
+                        key="glob-secret-ok",
+                        terminal_context=ctx,
+                    )
+                )
+        # No secret bytes in the raised message...
+        assert "AKIAIOSFODNN7EXAMPLE" not in str(exc_info.value)
+        # ...nor in any log record.
+        for rec in caplog.records:
+            assert "AKIAIOSFODNN7EXAMPLE" not in rec.getMessage()
+        # Nothing persisted.
+        wiki = tmp_path / "global" / "wiki" / "global" / "glob-secret-ok.md"
+        assert not wiki.exists()
+
+    def test_secret_in_key_or_tags_rejected(self, tmp_path: Path):
+        """The gate scans every persisted field: a credential in ``key`` or
+        ``tags`` (not just ``content``) is rejected before any write."""
+        svc = MemoryService(base_dir=tmp_path)
+        ctx = _make_terminal_context()
+        # Secret smuggled via tags.
+        with pytest.raises(ValueError) as exc_tags:
             _run(
                 svc.store(
-                    content=secret,
+                    content="clean body",
                     scope="global",
                     memory_type="reference",
-                    key="glob-secret-ok",
+                    key="clean-key",
+                    tags="env,AKIAIOSFODNN7EXAMPLE",
                     terminal_context=ctx,
                 )
             )
-        wiki = tmp_path / "global" / "wiki" / "global" / "glob-secret-ok.md"
-        assert not wiki.exists()
+        assert "AKIAIOSFODNN7EXAMPLE" not in str(exc_tags.value)
+        assert not list(tmp_path.rglob("clean-key.md"))
+        # Secret smuggled via key (ghp_ GitHub PAT shape).
+        pat_key = "ghp_" + "A" * 36
+        with pytest.raises(ValueError):
+            _run(
+                svc.store(
+                    content="clean body",
+                    scope="global",
+                    memory_type="reference",
+                    key=pat_key,
+                    terminal_context=ctx,
+                )
+            )
+        assert not list(tmp_path.rglob(f"{pat_key}.md"))

--- a/test/services/test_memory_service.py
+++ b/test/services/test_memory_service.py
@@ -1427,8 +1427,19 @@ class TestFederatedScope:
                 )
             )
         assert "AKIAIOSFODNN7EXAMPLE" not in str(exc_tags.value)
-        assert not list(tmp_path.rglob("clean-key.md"))
-        # Secret smuggled via key (ghp_ GitHub PAT shape).
+
+        def _wiki_files():
+            # Any wiki article written under base_dir (index.md is not a topic).
+            return [p for p in tmp_path.rglob("*.md") if p.name != "index.md"]
+
+        # No topic file written for the tags rejection. Assert on the whole
+        # tree, not a specific filename: store() sanitizes the key before
+        # building the path, so a regression could write under a DIFFERENT name
+        # than the one passed in — a name-specific rglob would miss it.
+        assert _wiki_files() == []
+        # Secret smuggled via key (ghp_ GitHub PAT shape). ``key`` is sanitized
+        # before the path is built, so check that NO topic file exists at all
+        # rather than the unsanitized ``pat_key`` name.
         pat_key = "ghp_" + "A" * 36
         with pytest.raises(ValueError):
             _run(
@@ -1440,4 +1451,4 @@ class TestFederatedScope:
                     terminal_context=ctx,
                 )
             )
-        assert not list(tmp_path.rglob(f"{pat_key}.md"))
+        assert _wiki_files() == []


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/cli-agent-orchestrator/security/code-scanning/142](https://github.com/awslabs/cli-agent-orchestrator/security/code-scanning/142)

General fix: prevent storage of credential-like sensitive content before any filesystem write, unless you implement encryption-at-rest (which would change behavior substantially here). The safest behavior-preserving security fix is to apply an existing secret scan consistently to all scopes and fail closed on detection, while keeping error/log messages secret-safe.

Best single fix in this code: in `MemoryService.store(...)` (`src/cli_agent_orchestrator/services/memory_service.py`), extend the existing secret-gate logic (currently federated-only per tests/comments) so `content` is scanned for secrets for every scope before constructing/writing `new_content`. If a secret is detected, raise `ValueError` with a generic message that does not echo the secret. This addresses all alert variants at line 847 because tainted secret-bearing `content` will no longer reach `write_text`.

Also update tests in `test/services/test_memory_service.py` to match the tightened policy: replace the test that currently expects global scope to allow AKIA-bearing content with one that expects rejection and no file write.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
