### PR TITLE
feat(graph): memory + stub providers (#348 B2)

### DIFF
--- a/src/cli_agent_orchestrator/graph/providers/__init__.py
+++ b/src/cli_agent_orchestrator/graph/providers/__init__.py
@@ -1,4 +1,4 @@
-"""Graph provider seam: ABC and name-keyed registry."""
+"""Graph provider seam: ABC, name-keyed registry, and built-in providers."""
 
 from cli_agent_orchestrator.graph.providers.base import (
     GraphProvider,
@@ -7,4 +7,16 @@ from cli_agent_orchestrator.graph.providers.base import (
     register_provider,
 )
 
-__all__ = ["GraphProvider", "register_provider", "get_provider", "list_providers"]
+# Import-time registration: importing this package registers the built-in
+# providers ("memory", "stub") via their @register_provider decorators.
+from cli_agent_orchestrator.graph.providers.memory import MemoryGraphProvider
+from cli_agent_orchestrator.graph.providers.stub import StubGraphProvider
+
+__all__ = [
+    "GraphProvider",
+    "register_provider",
+    "get_provider",
+    "list_providers",
+    "MemoryGraphProvider",
+    "StubGraphProvider",
+]

--- a/src/cli_agent_orchestrator/graph/providers/memory.py
+++ b/src/cli_agent_orchestrator/graph/providers/memory.py
@@ -91,10 +91,14 @@ class MemoryGraphProvider(GraphProvider):
         # Lint findings — awaited directly in-request (ADR-7); no SQL or LLM
         # calls beyond what run_lint itself performs (FR-7, C-1). A lint
         # failure degrades to a lint-free graph rather than a 500.
+        import asyncio
+
         try:
             issues = await wiki_lint.run_lint(scope_id or scope, scope=scope)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            logger.warning(f"memory graph provider: run_lint failed: {e}")
+            logger.warning("memory graph provider: run_lint failed: %r", e, exc_info=True)
             meta["lint_error"] = type(e).__name__
             issues = []
 

--- a/src/cli_agent_orchestrator/graph/providers/memory.py
+++ b/src/cli_agent_orchestrator/graph/providers/memory.py
@@ -1,0 +1,141 @@
+"""Memory wiki GraphProvider (U2, Issue #348).
+
+Projects one memory scope's wiki into a GraphView by calling the
+memory-service internals directly (ADR-1: no facade, no MemoryBackend
+ABC, no edits to memory_service/wiki_lint) and awaiting
+``wiki_lint.run_lint`` in-request (ADR-7).
+"""
+
+import logging
+from typing import Any, Optional
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
+from cli_agent_orchestrator.graph.providers.base import GraphProvider, register_provider
+from cli_agent_orchestrator.services import wiki_lint
+from cli_agent_orchestrator.services.memory_service import MemoryService
+
+logger = logging.getLogger(__name__)
+
+
+@register_provider("memory")
+class MemoryGraphProvider(GraphProvider):
+    """Projects a (scope, scope_id) memory wiki into nodes and edges.
+
+    Nodes: one kind="topic" node per key in the scope's index (FR-6),
+    plus one per orphan_page lint finding — orphans are by definition
+    absent from the index, so without an added node the is_orphan
+    attribute (FR-8) could never land anywhere. Edges: related_keys rows
+    (FR-7a) and contradiction lint findings; stale_claim /
+    poison_frequency / lint_error findings are dropped (ADR-2). Edges
+    never cross the (scope, scope_id) boundary (FR-9).
+    """
+
+    def __init__(self, memory_service: Optional[MemoryService] = None) -> None:
+        self._svc = memory_service or MemoryService()
+
+    async def project(self, **filters: Any) -> GraphView:
+        scope = str(filters.get("scope", "global"))
+        raw_scope_id = filters.get("scope_id")
+        scope_id: Optional[str] = None if raw_scope_id is None else str(raw_scope_id)
+        meta: dict[str, Any] = {"provider": "memory", "scope": scope, "scope_id": scope_id}
+
+        # Resolve + parse the scope's index. A scope with no wiki on disk
+        # (or an unresolvable scope/scope_id) is an empty graph, not an error.
+        try:
+            index_path = self._svc.get_index_path(scope, scope_id)
+        except ValueError:
+            return GraphView(nodes=[], edges=[], meta=meta)
+        if not index_path.exists():
+            return GraphView(nodes=[], edges=[], meta=meta)
+        try:
+            entries = self._svc._parse_index(index_path)
+        except OSError:
+            return GraphView(nodes=[], edges=[], meta=meta)
+
+        # session/agent indexes are shared per container with scope_id
+        # encoded in each entry's path; project/global indexes are already
+        # per-container, so their entries carry no scope_id.
+        keys: list[str] = []
+        seen: set[str] = set()
+        for entry in entries:
+            if entry["scope"] != scope:
+                continue
+            if scope in ("session", "agent") and entry["scope_id"] != scope_id:
+                continue
+            if entry["key"] not in seen:
+                seen.add(entry["key"])
+                keys.append(entry["key"])
+
+        nodes: dict[str, Node] = {
+            key: Node(id=key, kind="topic", label=key, attrs={"status": "active"}) for key in keys
+        }
+        edges: list[Edge] = []
+
+        # related_keys edges (FR-7a). related_keys carries no relevance
+        # score, so edge attrs stay score-free. A target outside this
+        # scope's key set is dropped — never a cross-scope edge (FR-9).
+        related_raw = self._svc._related_keys_lookup(keys, scope, scope_id)
+        for key in keys:
+            for target in MemoryService._parse_related_keys(related_raw.get(key), scope):
+                if target not in nodes or target == key:
+                    continue
+                edges.append(
+                    Edge(
+                        source=key,
+                        target=target,
+                        type=EdgeType.RELATES_TO,
+                        attrs={"source": "related_keys"},
+                    )
+                )
+
+        # Lint findings — awaited directly in-request (ADR-7); no SQL or LLM
+        # calls beyond what run_lint itself performs (FR-7, C-1). A lint
+        # failure degrades to a lint-free graph rather than a 500.
+        try:
+            issues = await wiki_lint.run_lint(scope_id or scope, scope=scope)
+        except Exception as e:
+            logger.warning(f"memory graph provider: run_lint failed: {e}")
+            meta["lint_error"] = type(e).__name__
+            issues = []
+
+        for issue in issues:
+            if issue.issue_type == "orphan_page":
+                # run_lint reports findings across every container of the
+                # scope; keep only this container's (FR-9).
+                if issue.scope_id != scope_id:
+                    continue
+                node = nodes.get(issue.key)
+                if node is None:
+                    node = Node(
+                        id=issue.key,
+                        kind="topic",
+                        label=issue.key,
+                        attrs={"status": "active"},
+                    )
+                    nodes[issue.key] = node
+                node.attrs["is_orphan"] = True
+            elif issue.issue_type == "graph_density":
+                # graph_density findings carry no scope_id; membership in
+                # this container's key set is the only available guard, so
+                # a same-named hub in another container of this scope can
+                # mis-mark this one. Fixing it needs wiki_lint to emit
+                # scope_id, which ADR-1 forbids editing — tracked follow-up.
+                node = nodes.get(issue.key)
+                if node is not None:
+                    node.attrs["is_hub"] = True
+            elif issue.issue_type == "contradiction":
+                if issue.scope_id != scope_id or issue.related_key is None:
+                    continue
+                if issue.key not in nodes or issue.related_key not in nodes:
+                    continue
+                edges.append(
+                    Edge(
+                        source=issue.key,
+                        target=issue.related_key,
+                        type=EdgeType.CONTRADICTION,
+                        attrs={"source": "wiki_lint", "summary": issue.description},
+                    )
+                )
+            # stale_claim / poison_frequency / lint_error → dropped (ADR-2).
+
+        return GraphView(nodes=list(nodes.values()), edges=edges, meta=meta)

--- a/src/cli_agent_orchestrator/graph/providers/memory.py
+++ b/src/cli_agent_orchestrator/graph/providers/memory.py
@@ -6,6 +6,7 @@ ABC, no edits to memory_service/wiki_lint) and awaiting
 ``wiki_lint.run_lint`` in-request (ADR-7).
 """
 
+import asyncio
 import logging
 from typing import Any, Optional
 
@@ -24,7 +25,8 @@ class MemoryGraphProvider(GraphProvider):
     Nodes: one kind="topic" node per key in the scope's index (FR-6),
     plus one per orphan_page lint finding — orphans are by definition
     absent from the index, so without an added node the is_orphan
-    attribute (FR-8) could never land anywhere. Edges: related_keys rows
+    attribute (FR-8) could never land anywhere. graph_density findings
+    map to an existing node's is_hub attribute. Edges: related_keys rows
     (FR-7a) and contradiction lint findings; stale_claim /
     poison_frequency / lint_error findings are dropped (ADR-2). Edges
     never cross the (scope, scope_id) boundary (FR-9).
@@ -66,9 +68,7 @@ class MemoryGraphProvider(GraphProvider):
                 seen.add(entry["key"])
                 keys.append(entry["key"])
 
-        nodes: dict[str, Node] = {
-            key: Node(id=key, kind="topic", label=key, attrs={"status": "active"}) for key in keys
-        }
+        nodes: dict[str, Node] = {key: Node(id=key, kind="topic", label=key) for key in keys}
         edges: list[Edge] = []
 
         # related_keys edges (FR-7a). related_keys carries no relevance
@@ -91,9 +91,10 @@ class MemoryGraphProvider(GraphProvider):
         # Lint findings — awaited directly in-request (ADR-7); no SQL or LLM
         # calls beyond what run_lint itself performs (FR-7, C-1). A lint
         # failure degrades to a lint-free graph rather than a 500.
-        import asyncio
-
         try:
+            # project_hash arg is only used for run_lint's audit log, not for
+            # lookup — `project()` has no cwd/terminal_context to resolve the
+            # real project id (resolve_project_id), so this is a placeholder.
             issues = await wiki_lint.run_lint(scope_id or scope, scope=scope)
         except asyncio.CancelledError:
             raise
@@ -110,12 +111,7 @@ class MemoryGraphProvider(GraphProvider):
                     continue
                 node = nodes.get(issue.key)
                 if node is None:
-                    node = Node(
-                        id=issue.key,
-                        kind="topic",
-                        label=issue.key,
-                        attrs={"status": "active"},
-                    )
+                    node = Node(id=issue.key, kind="topic", label=issue.key)
                     nodes[issue.key] = node
                 node.attrs["is_orphan"] = True
             elif issue.issue_type == "graph_density":

--- a/src/cli_agent_orchestrator/graph/providers/stub.py
+++ b/src/cli_agent_orchestrator/graph/providers/stub.py
@@ -1,0 +1,27 @@
+"""Stub GraphProvider (U3, Issue #348).
+
+A minimal dependency-free provider proving the provider seam is
+heterogeneous: every node kind is "stub" (never "topic"), and nothing
+here imports memory_service, wiki_lint, or SQLite. ``project()`` is
+declared async per the uniform-async contract (ADR-7) but awaits
+nothing — the async tax at zero cost.
+"""
+
+from typing import Any
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
+from cli_agent_orchestrator.graph.providers.base import GraphProvider, register_provider
+
+
+@register_provider("stub")
+class StubGraphProvider(GraphProvider):
+    """Projects a small fixed graph; ignores all filters."""
+
+    async def project(self, **filters: Any) -> GraphView:
+        nodes = [
+            Node(id="stub-a", kind="stub", label="Stub A"),
+            Node(id="stub-b", kind="stub", label="Stub B"),
+            Node(id="stub-c", kind="stub", label="Stub C"),
+        ]
+        edges = [Edge(source="stub-a", target="stub-b", type=EdgeType.RELATES_TO)]
+        return GraphView(nodes=nodes, edges=edges, meta={"provider": "stub"})

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -6,6 +6,7 @@ timing assertion for NFR-1. Fixtures use a real tmp_path wiki + SQLite
 engine (no mocking of the memory internals); the lint LLM is stubbed.
 """
 
+import asyncio
 import json
 import time
 
@@ -17,7 +18,7 @@ from cli_agent_orchestrator.clients.database import Base, MemoryMetadataModel
 from cli_agent_orchestrator.graph.models import EdgeType, GraphView
 from cli_agent_orchestrator.graph.providers import get_provider
 from cli_agent_orchestrator.graph.providers.memory import MemoryGraphProvider
-from cli_agent_orchestrator.services import wiki_lint
+from cli_agent_orchestrator.services import settings_service, wiki_lint
 from cli_agent_orchestrator.services.memory_service import MemoryService
 from cli_agent_orchestrator.services.wiki_lint import LintIssue
 
@@ -97,6 +98,9 @@ def _patch_lint_env(monkeypatch, db_engine, svc) -> None:
 
     monkeypatch.setattr(db_mod, "SessionLocal", sessionmaker(bind=db_engine))
     monkeypatch.setattr(ms_mod, "MEMORY_BASE_DIR", svc.base_dir)
+    # Hermeticity: run_lint short-circuits on is_memory_enabled() — pin it so
+    # a CAO_MEMORY_ENABLED=0 environment can't fail these tests (N3).
+    monkeypatch.setattr(settings_service, "is_memory_enabled", lambda: True)
 
 
 def _stub_llm_contradicts(monkeypatch) -> None:
@@ -154,6 +158,19 @@ class TestMemoryProviderEdgeCases:
         provider = MemoryGraphProvider(memory_service=svc)
 
         view = await provider.project(scope="project", scope_id="nonexistent123")
+
+        assert isinstance(view, GraphView)
+        assert view.nodes == [] and view.edges == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_scope_id_returns_empty_view(self, svc):
+        """get_index_path raises ValueError for a scope_id containing a path
+        separator (validate_path_component rejects it before any join); the
+        ValueError branch must degrade to an empty GraphView, not raise.
+        """
+        provider = MemoryGraphProvider(memory_service=svc)
+
+        view = await provider.project(scope="project", scope_id="../evil")
 
         assert isinstance(view, GraphView)
         assert view.nodes == [] and view.edges == []
@@ -262,3 +279,35 @@ class TestMemoryProviderEdgeCases:
 
         # Soft NFR-1 bound; loosen rather than gate CI on it if it flakes.
         assert elapsed < 2.0, f"project() took {elapsed:.2f}s (soft NFR-1 bound)"
+
+    @pytest.mark.asyncio
+    async def test_run_lint_failure_degrades_to_lint_free_graph(self, populated_scope, monkeypatch):
+        """A run_lint failure must degrade to a lint-free graph (topic nodes
+        still returned) with meta["lint_error"] set, rather than raising.
+        """
+
+        async def _raise_runtime_error(project_hash, *, scope=None, **kw):
+            raise RuntimeError("lint backend unavailable")
+
+        monkeypatch.setattr(wiki_lint, "run_lint", _raise_runtime_error)
+        provider = MemoryGraphProvider(memory_service=populated_scope)
+
+        view = await provider.project(scope="global")
+
+        assert {n.id for n in view.nodes} >= {"a", "b", "c"}
+        assert view.meta["lint_error"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_run_lint_cancelled_error_propagates(self, populated_scope, monkeypatch):
+        """asyncio.CancelledError from run_lint must propagate, not be
+        swallowed by the general lint-failure handler.
+        """
+
+        async def _raise_cancelled(project_hash, *, scope=None, **kw):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(wiki_lint, "run_lint", _raise_cancelled)
+        provider = MemoryGraphProvider(memory_service=populated_scope)
+
+        with pytest.raises(asyncio.CancelledError):
+            await provider.project(scope="global")

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -127,8 +127,7 @@ class TestMemoryProviderHappyPath:
 
         assert {n.id for n in view.nodes} >= {"a", "b", "c"}
         assert all(n.kind == "topic" for n in view.nodes)
-        assert all(n.attrs["status"] == "active" for n in view.nodes)
-
+        assert all(n.status.value == "active" for n in view.nodes)
         related = [e for e in view.edges if e.type == EdgeType.RELATES_TO]
         assert [(e.source, e.target) for e in related] == [("a", "b")]
         assert related[0].attrs["source"] == "related_keys"

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -1,0 +1,265 @@
+"""Tests for MemoryGraphProvider (U2, Issue #348).
+
+Covers AC 1-6: topic nodes from the index, related_keys + contradiction
+edges, cross-scope edge filtering, empty-scope behaviour, and a SOFT
+timing assertion for NFR-1. Fixtures use a real tmp_path wiki + SQLite
+engine (no mocking of the memory internals); the lint LLM is stubbed.
+"""
+
+import json
+import time
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cli_agent_orchestrator.clients.database import Base, MemoryMetadataModel
+from cli_agent_orchestrator.graph.models import EdgeType, GraphView
+from cli_agent_orchestrator.graph.providers import get_provider
+from cli_agent_orchestrator.graph.providers.memory import MemoryGraphProvider
+from cli_agent_orchestrator.services import wiki_lint
+from cli_agent_orchestrator.services.memory_service import MemoryService
+from cli_agent_orchestrator.services.wiki_lint import LintIssue
+
+BODY = "A reasonably long article body so contradiction pairing engages." + " filler" * 10
+
+
+@pytest.fixture
+def db_engine(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+@pytest.fixture
+def svc(tmp_path, db_engine):
+    return MemoryService(base_dir=tmp_path, db_engine=db_engine)
+
+
+def _write_topic(svc: MemoryService, key: str, *, content: str = BODY) -> str:
+    path = svc.get_wiki_path("global", None, key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def _write_index(svc: MemoryService, keys: list) -> None:
+    index_path = svc.get_index_path("global", None)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["# Memory Index", "", "## global", ""]
+    for key in keys:
+        lines.append(
+            f"- [{key}](global/{key}.md) — type:project tags:t ~10tok "
+            f"updated:2026-01-01T00:00:00Z"
+        )
+    index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _insert_row(db_engine, key: str, file_path: str, *, tags: str = "t", related_keys=None):
+    Session = sessionmaker(bind=db_engine)
+    session = Session()
+    try:
+        session.add(
+            MemoryMetadataModel(
+                key=key,
+                memory_type="project",
+                scope="global",
+                scope_id=None,
+                file_path=file_path,
+                tags=tags,
+                related_keys=related_keys,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def populated_scope(svc, db_engine, monkeypatch):
+    """Three global topics: a→b via related_keys, a/b share a tag (pairable)."""
+    paths = {key: _write_topic(svc, key) for key in ("a", "b", "c")}
+    _write_index(svc, ["a", "b", "c"])
+    _insert_row(db_engine, "a", paths["a"], tags="t", related_keys="b")
+    _insert_row(db_engine, "b", paths["b"], tags="t")
+    _insert_row(db_engine, "c", paths["c"], tags="other")
+
+    # run_lint constructs MemoryService() and SessionLocal() internally —
+    # point both at the test fixtures.
+    _patch_lint_env(monkeypatch, db_engine, svc)
+    return svc
+
+
+def _patch_lint_env(monkeypatch, db_engine, svc) -> None:
+    from cli_agent_orchestrator.clients import database as db_mod
+    from cli_agent_orchestrator.services import memory_service as ms_mod
+
+    monkeypatch.setattr(db_mod, "SessionLocal", sessionmaker(bind=db_engine))
+    monkeypatch.setattr(ms_mod, "MEMORY_BASE_DIR", svc.base_dir)
+
+
+def _stub_llm_contradicts(monkeypatch) -> None:
+    """Make the contradiction detector report every pair as contradictory."""
+    monkeypatch.setattr(wiki_lint, "_build_llm_client", lambda: object())
+
+    async def _fake(_client, system, user, *, timeout_s):
+        return json.dumps({"contradicts": True, "summary": "a and b disagree."})
+
+    monkeypatch.setattr(wiki_lint, "_llm_call", _fake)
+
+
+def _disable_llm(monkeypatch) -> None:
+    monkeypatch.setattr(wiki_lint, "_build_llm_client", lambda: None)
+
+
+class TestMemoryProviderHappyPath:
+    @pytest.mark.asyncio
+    async def test_nodes_edges_from_populated_scope(self, populated_scope, monkeypatch):
+        """AC 1-4: topic nodes for every index key; related_keys edge with
+        source attr; contradiction edge from the lint finding; no edge
+        outside the scope's node set.
+        """
+        _stub_llm_contradicts(monkeypatch)
+        provider = MemoryGraphProvider(memory_service=populated_scope)
+
+        view = await provider.project(scope="global")
+
+        assert {n.id for n in view.nodes} >= {"a", "b", "c"}
+        assert all(n.kind == "topic" for n in view.nodes)
+        assert all(n.attrs["status"] == "active" for n in view.nodes)
+
+        related = [e for e in view.edges if e.type == EdgeType.RELATES_TO]
+        assert [(e.source, e.target) for e in related] == [("a", "b")]
+        assert related[0].attrs["source"] == "related_keys"
+        # related_keys carries no relevance score — none must be invented.
+        assert "score" not in related[0].attrs and "relevance" not in related[0].attrs
+
+        contradictions = [e for e in view.edges if e.type == EdgeType.CONTRADICTION]
+        assert len(contradictions) == 1
+        assert {contradictions[0].source, contradictions[0].target} == {"a", "b"}
+
+        node_ids = {n.id for n in view.nodes}
+        for edge in view.edges:
+            assert edge.source in node_ids and edge.target in node_ids
+
+    @pytest.mark.asyncio
+    async def test_resolvable_from_registry(self):
+        assert isinstance(get_provider("memory"), MemoryGraphProvider)
+
+
+class TestMemoryProviderEdgeCases:
+    @pytest.mark.asyncio
+    async def test_empty_scope_returns_empty_view(self, svc):
+        """AC 5: a scope with no wiki on disk → empty GraphView, not an error."""
+        provider = MemoryGraphProvider(memory_service=svc)
+
+        view = await provider.project(scope="project", scope_id="nonexistent123")
+
+        assert isinstance(view, GraphView)
+        assert view.nodes == [] and view.edges == []
+
+    @pytest.mark.asyncio
+    async def test_cross_scope_related_key_does_not_leak(self, svc, db_engine, monkeypatch):
+        """AC 4: a related_keys row pointing outside (scope, scope_id) must
+        not produce a cross-scope edge.
+        """
+        path_a = _write_topic(svc, "a")
+        _write_index(svc, ["a"])
+        # "other-scope-key" exists only in a different scope's index — from
+        # this scope's perspective it is not a node, so no edge may appear.
+        _insert_row(db_engine, "a", path_a, related_keys="other-scope-key")
+        _disable_llm(monkeypatch)
+        _patch_lint_env(monkeypatch, db_engine, svc)
+        provider = MemoryGraphProvider(memory_service=svc)
+
+        view = await provider.project(scope="global")
+
+        assert {n.id for n in view.nodes} >= {"a"}
+        assert view.edges == []
+
+    @pytest.mark.asyncio
+    async def test_session_scope_id_filters_shared_index(self, svc, db_engine, monkeypatch):
+        """FR-9(c): session/agent entries live in the shared global index
+        with scope_id embedded in the entry path; projecting one session
+        must not surface another session's keys.
+        """
+        index_path = svc.get_index_path("session", "term-a")
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(
+            "\n".join(
+                [
+                    "# Memory Index",
+                    "",
+                    "## session",
+                    "",
+                    "- [k1](session/term-a/k1.md) — type:project tags:t ~10tok "
+                    "updated:2026-01-01T00:00:00Z",
+                    "- [k2](session/term-b/k2.md) — type:project tags:t ~10tok "
+                    "updated:2026-01-01T00:00:00Z",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        _disable_llm(monkeypatch)
+        _patch_lint_env(monkeypatch, db_engine, svc)
+        provider = MemoryGraphProvider(memory_service=svc)
+
+        view = await provider.project(scope="session", scope_id="term-a")
+
+        # term-b's k2 must not leak into term-a's graph.
+        assert {n.id for n in view.nodes} == {"k1"}
+
+    @pytest.mark.asyncio
+    async def test_lint_finding_mapping(self, populated_scope, monkeypatch):
+        """orphan_page/graph_density become node attrs (not edges);
+        stale_claim/poison_frequency/lint_error are dropped (ADR-2);
+        contradiction findings from another container are filtered (FR-9).
+        """
+
+        async def _fake_run_lint(project_hash, *, scope=None, **kw):
+            return [
+                LintIssue(issue_type="orphan_page", key="lonely", scope_id=None),
+                LintIssue(issue_type="graph_density", key="a", description="hub"),
+                LintIssue(issue_type="stale_claim", key="a", description="drop me"),
+                LintIssue(issue_type="poison_frequency", key="b", severity="error"),
+                LintIssue(issue_type="lint_error", key="run_lint", severity="info"),
+                # Same-key contradiction from ANOTHER container — must not leak.
+                LintIssue(
+                    issue_type="contradiction",
+                    key="a",
+                    related_key="b",
+                    severity="error",
+                    scope_id="other-container",
+                ),
+            ]
+
+        monkeypatch.setattr(wiki_lint, "run_lint", _fake_run_lint)
+        provider = MemoryGraphProvider(memory_service=populated_scope)
+
+        view = await provider.project(scope="global")
+
+        by_id = {n.id: n for n in view.nodes}
+        assert by_id["lonely"].attrs["is_orphan"] is True
+        assert by_id["lonely"].kind == "topic"
+        assert by_id["a"].attrs["is_hub"] is True
+        # Cross-container contradiction filtered; only the related_keys edge remains.
+        assert [e.type for e in view.edges] == [EdgeType.RELATES_TO]
+        # EdgeType has no orphan/hub/stale/poison members.
+        assert {t.value for t in EdgeType} == {"relates_to", "contradiction", "supersedes"}
+
+    @pytest.mark.asyncio
+    async def test_project_completes_under_two_seconds(self, populated_scope, monkeypatch):
+        """AC 6 / NFR-1: SOFT timing assertion (not a hard CI gate) — a small
+        scope with the LLM detector disabled projects well under 2s.
+        """
+        _disable_llm(monkeypatch)
+        provider = MemoryGraphProvider(memory_service=populated_scope)
+
+        start = time.monotonic()
+        await provider.project(scope="global")
+        elapsed = time.monotonic() - start
+
+        # Soft NFR-1 bound; loosen rather than gate CI on it if it flakes.
+        assert elapsed < 2.0, f"project() took {elapsed:.2f}s (soft NFR-1 bound)"

--- a/test/graph/providers/test_stub_provider.py
+++ b/test/graph/providers/test_stub_provider.py
@@ -1,0 +1,75 @@
+"""Tests for StubGraphProvider (U3, Issue #348).
+
+Covers AC 1-2: registry resolution to a valid GraphView with no memory
+dependency, and kind heterogeneity (never "topic").
+"""
+
+import ast
+import inspect
+
+import pytest
+
+from cli_agent_orchestrator.graph.models import GraphView
+from cli_agent_orchestrator.graph.providers import get_provider, list_providers
+from cli_agent_orchestrator.graph.providers import stub as stub_module
+from cli_agent_orchestrator.graph.providers.stub import StubGraphProvider
+
+
+class TestStubProvider:
+    @pytest.mark.asyncio
+    async def test_resolvable_and_returns_valid_graph_view(self):
+        """AC 1: resolvable from the registry by name, returns a valid view."""
+        assert "stub" in list_providers()
+        provider = get_provider("stub")
+        assert isinstance(provider, StubGraphProvider)
+
+        view = await provider.project()
+
+        assert isinstance(view, GraphView)
+        assert len(view.nodes) >= 1
+        node_ids = {n.id for n in view.nodes}
+        for edge in view.edges:
+            assert edge.source in node_ids and edge.target in node_ids
+
+    @pytest.mark.asyncio
+    async def test_every_node_kind_differs_from_topic(self):
+        """AC 2: kind heterogeneity — every node is kind="stub", never "topic"."""
+        view = await get_provider("stub").project()
+
+        assert all(n.kind == "stub" for n in view.nodes)
+        assert all(n.kind != "topic" for n in view.nodes)
+
+    @pytest.mark.asyncio
+    async def test_arbitrary_filters_are_ignored(self):
+        """Edge 1: arbitrary **filters pass through without error or effect."""
+        bare = await get_provider("stub").project()
+        filtered = await get_provider("stub").project(
+            scope="global", scope_id="abc", bogus=object(), depth=99
+        )
+
+        assert filtered.model_dump() == bare.model_dump()
+
+    def test_stub_module_imports_no_memory_internals(self):
+        """Edge 2: static assertion — stub.py's import statements reference
+        neither memory_service nor wiki_lint nor sqlite.
+        """
+        tree = ast.parse(inspect.getsource(stub_module))
+        imported: list = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.append(node.module or "")
+                imported.extend(alias.name for alias in node.names)
+        forbidden = ("memory_service", "wiki_lint", "sqlite")
+        for name in imported:
+            assert not any(f in name.lower() for f in forbidden), name
+
+    def test_project_body_contains_no_await(self):
+        """ADR-7: project() is async but awaits nothing (uniform-async tax
+        at zero cost).
+        """
+        source = inspect.getsource(StubGraphProvider.project)
+        func = ast.parse(source.strip()).body[0]
+        awaits = [n for n in ast.walk(func) if isinstance(n, ast.Await)]
+        assert awaits == []


### PR DESCRIPTION
Bolt B2 of the generic knowledge-graph layer (#348). Depends on B1 (U1 contract & registries, PR #402, already on main).

## What
- **U2 — MemoryGraphProvider** (`graph/providers/memory.py`, registered `"memory"`): projects wiki topics `(key, scope, scope_id)` as a `GraphView`. Reuses existing `memory_service` / `wiki_lint` functions — no new SQL or LLM calls (C-1, ADR-1: no edits to those modules). Edges: `related_keys` rows (`attrs["source"]="related_keys"`), `contradiction` findings → `EdgeType.CONTRADICTION`; `orphan_page`/`graph_density` → node `attrs["is_orphan"]`/`["is_hub"]`; `stale_claim`/`poison_frequency`/`lint_error` dropped (ADR-2). Edges never cross `(scope, scope_id)` (FR-9). `async project()` directly awaits `run_lint` (ADR-7).
- **U3 — StubGraphProvider** (`graph/providers/stub.py`, registered `"stub"`): fixture-only provider with `kind="stub"` nodes, proving the registry seam is not memory-specific (FR-10).

## Tests
10 new tests (happy path + ≥2 edge/error cases each), including FR-9 session/agent scope-isolation and AST checks that the stub imports no memory internals. `test/graph/` = 42 passed. black / isort / mypy(graph/) clean.

## Notes
- Known follow-up (not in scope): `graph_density` lint findings carry no `scope_id`, so a same-named hub in another container could mis-mark a node's `is_hub` in a multi-container scope. Clean fix needs `wiki_lint` to emit `scope_id` (ADR-1 forbids that edit here). Commented in code as a tracked follow-up.

Reviewed via the CAO supervisor→reviewer loop; one round (test-coverage blocker on FR-9 session isolation), resolved.