### PR TITLE
fix(ci): sync devcontainer feature version with pyproject.toml on release

### DIFF
--- a/.devcontainer/features/cao/devcontainer-feature.json
+++ b/.devcontainer/features/cao/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "cao",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "name": "CLI Agent Orchestrator",
     "description": "Multi-agent orchestration framework for CLI-based AI coding agents",
     "options": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml CHANGELOG.md
+          git add pyproject.toml CHANGELOG.md .devcontainer/features/cao/devcontainer-feature.json
           git commit -m "chore: release v${{ steps.bump.outputs.version }}"
           git tag "v${{ steps.bump.outputs.version }}"
           git push && git push --tags

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
+DEVCONTAINER_FEATURE = ROOT / ".devcontainer" / "features" / "cao" / "devcontainer-feature.json"
 
 
 def get_version() -> str:
@@ -30,6 +31,12 @@ def update_pyproject(new_version: str) -> None:
     content = PYPROJECT.read_text()
     content = re.sub(r'version = "[^"]+"', f'version = "{new_version}"', content)
     PYPROJECT.write_text(content)
+
+
+def update_devcontainer_feature(new_version: str) -> None:
+    content = DEVCONTAINER_FEATURE.read_text()
+    content = re.sub(r'"version": "[^"]+"', f'"version": "{new_version}"', content, count=1)
+    DEVCONTAINER_FEATURE.write_text(content)
 
 
 def generate_changelog(new_version: str) -> None:
@@ -68,11 +75,12 @@ def main() -> None:
     new = bump(sys.argv[1], old)
 
     update_pyproject(new)
+    update_devcontainer_feature(new)
     generate_changelog(new)
 
     print(f"Bumped {old} -> {new}")
     print(f"\nNext steps:")
-    print(f"  1. git add pyproject.toml CHANGELOG.md")
+    print(f"  1. git add pyproject.toml CHANGELOG.md {DEVCONTAINER_FEATURE.relative_to(ROOT)}")
     print(f"  2. git commit -m 'chore: release v{new}'")
     print(f"  3. git tag v{new}")
     print(f"  4. git push && git push --tags")


### PR DESCRIPTION
## Summary
- CI on `main` broke after the v2.3.0 release bump: `test_feature_manifest_version_matches_project_version` asserts `.devcontainer/features/cao/devcontainer-feature.json`'s `version` matches `pyproject.toml`, but `scripts/bump_version.py` never updated that file.
- Bumps the devcontainer feature manifest to `2.3.0` to fix `main` now.
- Adds `update_devcontainer_feature()` to `bump_version.py` and includes the file in `release.yml`'s commit step, so future releases stay in sync automatically.

## Test plan
- [x] `pytest test/test_devcontainer_feature.py` — 7/7 pass locally
- [ ] CI green on this PR