### PR TITLE
fix(terminal): roll back DB terminal row when create_terminal fails

### DIFF
--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -410,6 +410,16 @@ async def create_terminal(
             provider_manager.cleanup_provider(terminal_id)
         except Exception:
             pass  # Ignore cleanup errors
+        # Roll back the DB terminal row so a failed create does not leave an
+        # orphan record: the stale row would still be listed for the session
+        # and report UNKNOWN status even though nothing is running. Idempotent
+        # (DELETE ... WHERE id = ?), so it is a no-op when the failure happened
+        # before the row was written. Runs regardless of session_created so a
+        # pre-existing session keeps its live terminals but loses the dead row.
+        try:
+            db_delete_terminal(terminal_id)
+        except Exception:
+            pass  # Ignore cleanup errors
         if session_created and session_name:
             try:
                 get_backend().kill_session(session_name)

--- a/test/services/test_terminal_service_coverage.py
+++ b/test/services/test_terminal_service_coverage.py
@@ -20,6 +20,7 @@ class TestCreateTerminalCleanup:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
         "cli_agent_orchestrator.services.terminal_service.generate_window_name", return_value="w1"
@@ -35,13 +36,15 @@ class TestCreateTerminalCleanup:
         mock_tid,
         mock_wname,
         mock_db_create,
+        mock_db_delete,
         mock_pm,
         mock_tmux,
         mock_log_dir,
         mock_fifo_manager,
         mock_status_monitor,
     ):
-        """When provider.initialize() fails, cleanup should kill session and cleanup provider."""
+        """When provider.initialize() fails, cleanup should kill session, cleanup
+        provider, AND roll back the DB terminal row."""
         from cli_agent_orchestrator.services.terminal_service import create_terminal
 
         mock_tmux.session_exists.return_value = False
@@ -64,6 +67,7 @@ class TestCreateTerminalCleanup:
 
         mock_pm.cleanup_provider.assert_called_once_with("tid1")
         mock_tmux.kill_session.assert_called_once()
+        mock_db_delete.assert_called_once_with("tid1")
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
@@ -71,6 +75,7 @@ class TestCreateTerminalCleanup:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
         "cli_agent_orchestrator.services.terminal_service.generate_window_name", return_value="w1"
@@ -86,13 +91,16 @@ class TestCreateTerminalCleanup:
         mock_tid,
         mock_wname,
         mock_db_create,
+        mock_db_delete,
         mock_pm,
         mock_tmux,
         mock_log_dir,
         mock_fifo_manager,
         mock_status_monitor,
     ):
-        """When new_session=False, cleanup should NOT kill the session."""
+        """When new_session=False, cleanup rolls back the DB terminal row but must
+        NOT kill the pre-existing session. The regression guard for "delete DB
+        row, don't kill session."."""
         from cli_agent_orchestrator.services.terminal_service import create_terminal
 
         mock_tmux.session_exists.return_value = True
@@ -114,6 +122,7 @@ class TestCreateTerminalCleanup:
             )
 
         mock_pm.cleanup_provider.assert_called_once()
+        mock_db_delete.assert_called_once_with("tid1")
         mock_tmux.kill_session.assert_not_called()
 
     @pytest.mark.asyncio
@@ -122,6 +131,7 @@ class TestCreateTerminalCleanup:
     @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
     @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
     @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
     @patch(
         "cli_agent_orchestrator.services.terminal_service.generate_window_name", return_value="w1"
@@ -137,13 +147,16 @@ class TestCreateTerminalCleanup:
         mock_tid,
         mock_wname,
         mock_db_create,
+        mock_db_delete,
         mock_pm,
         mock_tmux,
         mock_log_dir,
         mock_fifo_manager,
         mock_status_monitor,
     ):
-        """Cleanup errors should be swallowed, original error re-raised."""
+        """Cleanup errors should be swallowed, original error re-raised. The DB
+        rollback still runs after cleanup_provider raises, and its own error is
+        swallowed too."""
         from cli_agent_orchestrator.services.terminal_service import create_terminal
 
         mock_tmux.session_exists.return_value = False
@@ -155,6 +168,7 @@ class TestCreateTerminalCleanup:
         mock_provider.initialize = AsyncMock(side_effect=Exception("original error"))
         mock_pm.create_provider.return_value = mock_provider
         mock_pm.cleanup_provider.side_effect = Exception("cleanup error")
+        mock_db_delete.side_effect = Exception("db delete error")
         mock_tmux.kill_session.side_effect = Exception("kill error")
 
         with pytest.raises(Exception, match="original error"):
@@ -165,6 +179,9 @@ class TestCreateTerminalCleanup:
                 new_session=True,
                 allowed_tools=["*"],
             )
+
+        # DB rollback runs even though cleanup_provider raised first.
+        mock_db_delete.assert_called_once_with("tid1")
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")


### PR DESCRIPTION

### Problem

`create_terminal` writes the terminal row to the database before constructing and
initializing the provider. When a later step raises (provider construction or
initialization failure), the exception path stops the FIFO reader, clears the status
monitor, cleans up the provider, and kills the session it created — but never deletes
the database row.

The orphan row is then returned by `list_terminals_by_session`, so the session lists a
terminal that reports `UNKNOWN` status although nothing is running. For a worker that
failed while being added to an existing session, the dead row lingers alongside the
session's live terminals indefinitely.

### Fix

Delete the row in the failure path, best-effort like the neighboring cleanup steps
(wrapped in its own `try/except Exception: pass`, so a rollback failure can never mask
the original exception — the trailing bare `raise` still re-raises it).

- Idempotent: `delete_terminal` is `DELETE ... WHERE id = ?`, a no-op when the failure
  happened before the row was written.
- Placed before the `session_created` guard, so it runs for failures in both
  newly-created and pre-existing sessions — a pre-existing session keeps its live
  terminals but loses the dead row.

### Tests

Extends the three existing `TestCreateTerminalCleanup` cases to assert the rollback:

1. provider-init failure in a new session → row deleted, session killed;
2. provider-init failure joining an existing session → row deleted, session NOT killed;
3. cleanup errors swallowed → rollback still runs after `cleanup_provider` raised, its
   own error is swallowed, and the original exception re-raises.

`db_delete_terminal` is patched in these mocked failure-path tests so they stay hermetic
(no touch of the configured database).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://claude.ai/code/session_01KfHLBjJbQD2A2m326qSoqS
