### PR TITLE
feat(graph): API routes + OKF/Obsidian/GraphML sinks (#348 B3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ dev = [
     "mypy>=1.5.0",
     "pytest-xdist>=3.8.0",
     "hypothesis>=6.0",
+    "networkx>=3.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dependencies = [
     "pyjwt[crypto]>=2.8.0",
     "jsonschema>=4.25",
     "jinja2>=3.1.0",
+    # Obsidian graph sink (Issue #348) imports yaml at module top; declare it
+    # directly instead of relying on a transitive dep so the import can't break.
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -63,6 +63,11 @@ from cli_agent_orchestrator.constants import (
     add_local_cors_origins,
 )
 from cli_agent_orchestrator.ext_apps import mount_widget_static
+from cli_agent_orchestrator.graph.providers import get_provider
+
+# Import the sinks package for its import-time @register_sink side effects
+# ("okf", "obsidian", "graphml"); get_sink resolves by name from the registry.
+from cli_agent_orchestrator.graph.sinks import get_sink
 from cli_agent_orchestrator.models.flow import Flow
 from cli_agent_orchestrator.models.inbox import MessageStatus, OrchestrationType
 from cli_agent_orchestrator.models.memory import (
@@ -85,6 +90,7 @@ from cli_agent_orchestrator.security.auth import (
 )
 from cli_agent_orchestrator.services import (
     flow_service,
+    secret_gate,
     session_service,
     terminal_service,
 )
@@ -341,6 +347,17 @@ class WorkflowRunRequest(BaseModel):
     run_id: Optional[str] = Field(
         default=None,
         description="Optional run id (matches WORKFLOW_NAME_RE); auto-generated if omitted",
+    )
+
+
+class GraphExportRequest(BaseModel):
+    """Request body for ``POST /graph/{provider}/export`` (U4, Issue #348)."""
+
+    sink: str = Field(description="Registered sink name (resolved via get_sink; KeyError -> 404)")
+    dest: str = Field(description="Export destination, passed positionally to sink.export")
+    options: dict = Field(
+        default_factory=dict,
+        description="Opaque per-sink options forwarded as **options; the route never inspects them",
     )
 
 
@@ -1728,6 +1745,93 @@ async def resume_workflow_run_endpoint(
     except workflow_service.WorkflowEngineError as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
     return result.model_dump()
+
+
+# ── graph layer (U4, Issue #348) ────────────────────────────────────────
+#
+# Two routes over the provider/sink seams. There is ZERO branching over the
+# provider or sink NAME (NFR-5): the only conditionals are try/except on
+# registry-resolution outcome. Names resolve through get_provider/get_sink,
+# which raise KeyError for an unregistered name (mapped to 404 here).
+
+
+@app.get("/graph/{provider}")
+async def get_graph_endpoint(provider: str, request: Request) -> Dict:
+    """Project a provider's GraphView and return its wire shape (FR-12).
+
+    UNGATED by design: this route carries no ``require_any_scope``
+    dependency at all — graph reads are open (per business-rules.md). All
+    query params (``scope``, ``scope_id``, and any extras) are forwarded to
+    the provider as ``**filters``.
+
+    Error taxonomy: unregistered provider -> 404; provider ValueError
+    (e.g. a bad filter value) -> 400.
+    """
+    filters = dict(request.query_params)
+    try:
+        inst = get_provider(provider)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"unknown graph provider '{provider}'",
+        )
+    try:
+        view = await inst.project(**filters)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    return view.to_dict()
+
+
+@app.post("/graph/{provider}/export")
+async def export_graph_endpoint(
+    provider: str,
+    body: GraphExportRequest,
+    request: Request,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Dict:
+    """Project a provider's view and export it through a named sink (FR-12).
+
+    Scope-gated (401 no/invalid token, 403 valid-but-insufficient). The
+    serialized view is scanned by ``secret_gate`` BEFORE the sink is
+    invoked; a hit rejects the export with 422 and the sink's ``export`` is
+    never called. The 422 detail names only the matched PATTERN, never the
+    matched bytes.
+
+    Error taxonomy: unregistered provider or sink -> 404; secret hit -> 422;
+    provider/sink ValueError -> 400.
+    """
+    filters = dict(request.query_params)
+    try:
+        prov = get_provider(provider)
+        sink = get_sink(body.sink)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"unknown graph provider '{provider}' or sink '{body.sink}'",
+        )
+
+    try:
+        view = await prov.project(**filters)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    # Credential gate (ADR-5): scan the serialized view; on a hit, reject
+    # before the sink writes anything. secret_gate returns the pattern NAME,
+    # never the matched bytes, so the detail is safe to surface.
+    serialized = json.dumps(view.to_dict())
+    hit = secret_gate.scan_for_secrets(serialized)
+    if hit is not None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"export rejected: secret pattern '{hit}' detected",
+        )
+
+    try:
+        written_files = sink.export(view, body.dest, **body.options)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return {"written_files": written_files, "sink": body.sink, "dest": body.dest}
 
 
 @app.delete("/terminals/{terminal_id}")

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -354,7 +354,15 @@ class GraphExportRequest(BaseModel):
     """Request body for ``POST /graph/{provider}/export`` (U4, Issue #348)."""
 
     sink: str = Field(description="Registered sink name (resolved via get_sink; KeyError -> 404)")
-    dest: str = Field(description="Export destination, passed positionally to sink.export")
+    dest: str = Field(
+        description=(
+            "Export destination, confined UNDER the configured graph-export root "
+            "(CAO_GRAPH_EXPORT_ROOT). Treated as a path RELATIVE to that root; an "
+            "absolute path is accepted only if it already resolves under the root, "
+            "otherwise the export is rejected (400). Traversal/symlink escapes are "
+            "rejected via safe_join_under_base."
+        )
+    )
     options: dict = Field(
         default_factory=dict,
         description="Opaque per-sink options forwarded as **options; the route never inspects them",
@@ -1756,18 +1764,47 @@ async def resume_workflow_run_endpoint(
 
 
 @app.get("/graph/{provider}")
-async def get_graph_endpoint(provider: str, request: Request) -> Dict:
-    """Project a provider's GraphView and return its wire shape (FR-12).
+async def get_graph_endpoint(
+    provider: str,
+    request: Request,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Dict:
+    """Project a provider's GraphView and return its wire shape.
 
-    UNGATED by design: this route carries no ``require_any_scope``
-    dependency at all — graph reads are open (per business-rules.md). All
-    query params (``scope``, ``scope_id``, and any extras) are forwarded to
-    the provider as ``**filters``.
+    Scope-gated (D5 posture): when auth is enabled, any of
+    ``cao:read`` / ``cao:write`` / ``cao:admin`` is required (read is the
+    floor) — identical to ``/events``. This SUPERSEDES the original FR-12
+    "UNGATED by design" wording: the graph carries private-scope
+    structure, including contradiction-edge summaries of memory CONTENT, so
+    an unauthenticated caller must not be able to read it (PR #424 review).
 
-    Error taxonomy: unregistered provider -> 404; provider ValueError
-    (e.g. a bad filter value) -> 400.
+    Private tiers are REFUSED outright: a ``scope`` of ``session`` or
+    ``agent`` is rejected with 400 even for an authed ``cao:read`` caller,
+    mirroring ``/memory/export`` — the API surface never exposes private
+    tiers (D5). All other query params (``scope_id`` and any extras) are
+    forwarded to the provider as ``**filters``.
+
+    Error taxonomy: unregistered provider -> 404; private-scope request or
+    provider ValueError (e.g. a bad filter value) -> 400.
     """
     filters = dict(request.query_params)
+
+    # Private-scope gate (D5): the graph route takes ``scope`` as a query
+    # string, so compare its value against the private MemoryScope values.
+    # Mirrors /memory/export's MemoryScope.SESSION/AGENT refusal. The check is
+    # case-insensitive so ``scope=Session`` / ``scope=AGENT`` can't slip past;
+    # only this local comparison is normalized — the raw value is still
+    # forwarded to the provider in ``filters`` unchanged.
+    requested_scope = filters.get("scope")
+    if requested_scope is not None and requested_scope.lower() in (
+        MemoryScope.SESSION.value,
+        MemoryScope.AGENT.value,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"scope '{requested_scope}' is private and cannot be read via the graph API",
+        )
+
     try:
         inst = get_provider(provider)
     except KeyError:
@@ -1798,7 +1835,9 @@ async def export_graph_endpoint(
     matched bytes.
 
     Error taxonomy: unregistered provider or sink -> 404; secret hit -> 422;
-    provider/sink ValueError -> 400.
+    provider/sink ValueError -> 400; sink OSError (e.g. dest is an existing
+    directory, permission denied, ENOSPC) -> 400 — a bad-dest-shape failure
+    kept consistent with the ValueError mapping rather than leaking a 500.
     """
     filters = dict(request.query_params)
     try:
@@ -1830,6 +1869,14 @@ async def export_graph_endpoint(
         written_files = sink.export(view, body.dest, **body.options)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except OSError as e:
+        # dest is an existing directory (IsADirectoryError), permission
+        # denied, ENOSPC, etc. — a bad destination, mapped to 400 for
+        # consistency with the ValueError branch rather than a bare 500.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"export failed writing to destination: {e}",
+        )
 
     return {"written_files": written_files, "sink": body.sink, "dest": body.dest}
 

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -161,6 +161,29 @@ LOCAL_AGENT_STORE_DIR = CAO_HOME_DIR / "agent-store"
 # Local skill store for installed CAO skills
 SKILLS_DIR = CAO_HOME_DIR / "skills"
 
+# Confinement root for graph-layer sink exports (Issue #348, B3). Every graph
+# sink writes ONLY under this directory: ``dest`` is treated as a path
+# relative to this root and joined via ``safe_join_under_base`` (realpath
+# containment), so no export can escape it. Override with the
+# ``CAO_GRAPH_EXPORT_ROOT`` env var — resolved at CALL time by
+# ``graph_export_root()`` (below) so tests and operators can point it at a
+# scratch directory without re-importing. Default lives under CAO_HOME_DIR,
+# mirroring the KIRO_AGENTS_DIR env-override convention; never /tmp or cwd.
+GRAPH_EXPORT_ROOT_DEFAULT = CAO_HOME_DIR / "graph-exports"
+
+
+def graph_export_root() -> Path:
+    """Resolve the graph-export confinement root (env-overridable at call time).
+
+    Reads ``CAO_GRAPH_EXPORT_ROOT`` on each call so a monkeypatched/exported
+    value takes effect without a module reload; falls back to
+    ``GRAPH_EXPORT_ROOT_DEFAULT`` (``~/.aws/cli-agent-orchestrator/
+    graph-exports``). The directory need not exist yet — sinks create it under
+    the confined join.
+    """
+    return Path(os.environ.get("CAO_GRAPH_EXPORT_ROOT", str(GRAPH_EXPORT_ROOT_DEFAULT)))
+
+
 # Provider-specific agent directories
 KIRO_AGENTS_DIR = Path(os.environ.get("CAO_AGENTS_DIR", str(Path.home() / ".kiro" / "agents")))
 COPILOT_AGENTS_DIR = Path.home() / ".copilot" / "agents"  # Copilot custom agents

--- a/src/cli_agent_orchestrator/graph/sinks/__init__.py
+++ b/src/cli_agent_orchestrator/graph/sinks/__init__.py
@@ -1,4 +1,4 @@
-"""Graph sink seam: ABC and name-keyed registry."""
+"""Graph sink seam: ABC, name-keyed registry, and built-in sinks."""
 
 from cli_agent_orchestrator.graph.sinks.base import (
     GraphSink,
@@ -7,4 +7,18 @@ from cli_agent_orchestrator.graph.sinks.base import (
     register_sink,
 )
 
-__all__ = ["GraphSink", "register_sink", "get_sink", "list_sinks"]
+# Import-time registration: importing this package registers the built-in
+# sinks ("okf", "obsidian", "graphml") via their @register_sink decorators.
+from cli_agent_orchestrator.graph.sinks.graphml import GraphMLGraphSink
+from cli_agent_orchestrator.graph.sinks.obsidian import ObsidianGraphSink
+from cli_agent_orchestrator.graph.sinks.okf import OkfGraphSink
+
+__all__ = [
+    "GraphSink",
+    "register_sink",
+    "get_sink",
+    "list_sinks",
+    "OkfGraphSink",
+    "ObsidianGraphSink",
+    "GraphMLGraphSink",
+]

--- a/src/cli_agent_orchestrator/graph/sinks/base.py
+++ b/src/cli_agent_orchestrator/graph/sinks/base.py
@@ -5,10 +5,58 @@ aidlc/spaces/default/intents/260709-graph-layer/ (AIDLC intent, not shipped
 with the package).
 """
 
+import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Callable, ClassVar
 
+from cli_agent_orchestrator.constants import graph_export_root
 from cli_agent_orchestrator.graph.models import GraphView
+from cli_agent_orchestrator.utils.path_validation import safe_join_under_base
+
+
+def confine_under_export_root(dest: str, description: str = "export destination") -> Path:
+    """Confine ``dest`` under the configured graph-export root (B3 security).
+
+    This is the sink-side containment primitive owned by BOTH the route and
+    the sink (the U4 route does NOT pre-validate ``dest``, so every sink must
+    confine it before its first write). ``dest`` is treated as a path
+    *relative* to ``CAO_GRAPH_EXPORT_ROOT`` (see
+    ``constants.graph_export_root``); an ABSOLUTE ``dest`` is accepted only
+    when it already resolves under that root, otherwise it is rejected. The
+    relative segments are joined via
+    :func:`utils.path_validation.safe_join_under_base`, which validates every
+    segment and enforces realpath containment — so no ``..`` traversal,
+    absolute-path escape, or symlink escape can leave the root.
+
+    Unlike the plain ``resolve_and_validate_path`` blocklist (which blocks
+    only ~18 exact system dirs, NOT their subdirectories), this guarantees
+    the result is the root itself or a descendant of it.
+
+    Returns:
+        The canonicalized absolute path under the export root (may not exist
+        yet — the caller creates it under this confined path).
+
+    Raises:
+        ValueError: If ``dest`` escapes the root or names no subpath.
+    """
+    root_real = os.path.realpath(os.path.abspath(str(graph_export_root())))
+
+    if os.path.isabs(dest):
+        dest_real = os.path.realpath(os.path.abspath(os.path.expanduser(dest)))
+        if dest_real != root_real and not dest_real.startswith(root_real + os.sep):
+            raise ValueError(
+                f"{description} {dest!r} is outside the graph export root "
+                f"{root_real!r}; supply a path relative to the root or one under it"
+            )
+        rel = os.path.relpath(dest_real, root_real)
+    else:
+        rel = dest
+
+    segments = [seg for seg in rel.split(os.sep) if seg not in ("", ".")]
+    if not segments:
+        raise ValueError(f"{description} must name a subpath under the graph export root: {dest!r}")
+    return Path(safe_join_under_base(root_real, *segments, description=description))
 
 
 class GraphSink(ABC):
@@ -17,11 +65,19 @@ class GraphSink(ABC):
     Security contract for ``dest``: implementations MUST resolve and
     confine ``dest`` under an allowed base directory before writing —
     reject ``..`` traversal, absolute-path escapes, and symlink escapes.
-    Follow this repo's path-validation convention
-    (``utils/path_validation.resolve_and_validate_path``). ``dest``
-    validation is owned by the sink implementation itself — the U4 route
-    forwards ``dest`` unvalidated, so a sink must never assume its caller
-    already confined the path. Every sink validates before its first write.
+    The allowed base is the configured graph-export root
+    (``CAO_GRAPH_EXPORT_ROOT`` / ``constants.graph_export_root``); use the
+    shared :func:`confine_under_export_root` helper, which joins ``dest``
+    under that root via ``safe_join_under_base`` (per-segment validation +
+    realpath containment). ``dest`` validation is owned by the sink
+    implementation itself — the U4 route forwards ``dest`` unvalidated, so a
+    sink must never assume its caller already confined the path. Every sink
+    confines before its first write.
+
+    NOTE: the plain ``resolve_and_validate_path`` blocklist is NOT sufficient
+    confinement here — it blocks only a fixed set of exact system directories,
+    not their subdirectories, so ``~/.ssh`` / ``/etc/cron.d`` / ``/var/www``
+    would pass. Confinement under the export root is mandatory.
     """
 
     capabilities: ClassVar[set[str]] = set()

--- a/src/cli_agent_orchestrator/graph/sinks/base.py
+++ b/src/cli_agent_orchestrator/graph/sinks/base.py
@@ -18,10 +18,10 @@ class GraphSink(ABC):
     confine ``dest`` under an allowed base directory before writing —
     reject ``..`` traversal, absolute-path escapes, and symlink escapes.
     Follow this repo's path-validation convention
-    (``utils/path_validation.resolve_and_validate_path``). Validation is
-    owned by BOTH the U4 route (first line of defense, validates before
-    calling a sink) AND each sink implementation (defense in depth) — a
-    sink must not assume its caller already validated ``dest``.
+    (``utils/path_validation.resolve_and_validate_path``). ``dest``
+    validation is owned by the sink implementation itself — the U4 route
+    forwards ``dest`` unvalidated, so a sink must never assume its caller
+    already confined the path. Every sink validates before its first write.
     """
 
     capabilities: ClassVar[set[str]] = set()

--- a/src/cli_agent_orchestrator/graph/sinks/graphml.py
+++ b/src/cli_agent_orchestrator/graph/sinks/graphml.py
@@ -4,9 +4,16 @@ Exports a GraphView as a single ``.graphml`` XML file using ONLY the
 standard library (``xml.etree.ElementTree``) per constraint C-2 — no
 lxml, xmltodict, or any third-party XML dependency.
 
-Security contract: ``dest`` is a FILE here, confined via
-``resolve_and_validate_path`` with ``allow_file=True``. No ``secret_gate``
-call (route already scanned, ADR-5).
+Security contract: ``dest`` is a FILE here, confined UNDER the configured
+graph-export root (``CAO_GRAPH_EXPORT_ROOT``) via
+``base.confine_under_export_root``. ``dest`` is treated as a file path
+relative to that root (an absolute ``dest`` is accepted only when it already
+resolves under the root); ``safe_join_under_base`` guarantees the ``.graphml``
+file is written inside it — this is REAL confinement, not the
+``resolve_and_validate_path`` blocklist (which permits e.g. ``~/.ssh`` and
+would let ``allow_file=True`` overwrite arbitrary existing files). The sink
+owns this confinement — the U4 route does NOT pre-validate ``dest``. No
+``secret_gate`` call (route already scanned, ADR-5).
 """
 
 import json
@@ -15,8 +22,11 @@ from typing import Any
 from xml.etree.ElementTree import Element, ElementTree, SubElement
 
 from cli_agent_orchestrator.graph.models import GraphView
-from cli_agent_orchestrator.graph.sinks.base import GraphSink, register_sink
-from cli_agent_orchestrator.utils.path_validation import resolve_and_validate_path
+from cli_agent_orchestrator.graph.sinks.base import (
+    GraphSink,
+    confine_under_export_root,
+    register_sink,
+)
 
 _GRAPHML_NS = "http://graphml.graphdrawing.org/xmlns"
 
@@ -56,10 +66,13 @@ class GraphMLGraphSink(GraphSink):
     """Export a GraphView to a single GraphML (.graphml) XML file."""
 
     def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
-        # dest is a FILE (allow_file=True); defense in depth on top of U4.
-        dest_real = resolve_and_validate_path(
-            dest, allow_create=True, allow_file=True, description="GraphML export destination"
-        )
+        # dest is a FILE confined UNDER the configured graph-export root:
+        # treated as a file path relative to CAO_GRAPH_EXPORT_ROOT (the .graphml
+        # leaf is the last segment). This confinement — not the blocklist —
+        # is what stops an allow_file overwrite of an arbitrary existing file.
+        # The sink owns confinement — the U4 route does NOT pre-validate dest.
+        dest_path = confine_under_export_root(dest, description="GraphML export destination")
+        dest_real = str(dest_path)
 
         root = Element("graphml", xmlns=_GRAPHML_NS)
 

--- a/src/cli_agent_orchestrator/graph/sinks/graphml.py
+++ b/src/cli_agent_orchestrator/graph/sinks/graphml.py
@@ -1,0 +1,108 @@
+"""GraphML GraphSink (U7, Issue #348).
+
+Exports a GraphView as a single ``.graphml`` XML file using ONLY the
+standard library (``xml.etree.ElementTree``) per constraint C-2 — no
+lxml, xmltodict, or any third-party XML dependency.
+
+Security contract: ``dest`` is a FILE here, confined via
+``resolve_and_validate_path`` with ``allow_file=True``. No ``secret_gate``
+call (route already scanned, ADR-5).
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+from xml.etree.ElementTree import Element, ElementTree, SubElement
+
+from cli_agent_orchestrator.graph.models import GraphView
+from cli_agent_orchestrator.graph.sinks.base import GraphSink, register_sink
+from cli_agent_orchestrator.utils.path_validation import resolve_and_validate_path
+
+_GRAPHML_NS = "http://graphml.graphdrawing.org/xmlns"
+
+# Six fixed <key> declarations in a hardcoded, deterministic order. Each
+# tuple is (key-id, domain, attr-name, attr-type). Emitting them in a fixed
+# order means a same-view export produces byte-identical XML.
+_KEY_DECLS: list[tuple[str, str, str, str]] = [
+    ("d_node_kind", "node", "kind", "string"),
+    ("d_node_label", "node", "label", "string"),
+    ("d_node_status", "node", "status", "string"),
+    ("d_node_attrs", "node", "attrs", "string"),
+    ("d_edge_type", "edge", "type", "string"),
+    ("d_edge_attrs", "edge", "attrs", "string"),
+]
+
+
+def _xml_scalar(value: Any) -> str:
+    """Coerce a value to an XML-safe text scalar.
+
+    Strings pass through; everything else is json.dumps-stringified so an
+    attrs value that is not natively serializable is preserved as text
+    rather than silently dropped. A value that json cannot encode is
+    re-raised as ValueError so it maps to the route's 400 branch (the
+    route's own json.dumps(view.to_dict()) would normally fail first, but
+    keeping the error type consistent avoids a stray 500 if it ever leaks).
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, sort_keys=True)
+    except TypeError as e:
+        raise ValueError(f"attribute value is not JSON-encodable: {e}")
+
+
+@register_sink("graphml")
+class GraphMLGraphSink(GraphSink):
+    """Export a GraphView to a single GraphML (.graphml) XML file."""
+
+    def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
+        # dest is a FILE (allow_file=True); defense in depth on top of U4.
+        dest_real = resolve_and_validate_path(
+            dest, allow_create=True, allow_file=True, description="GraphML export destination"
+        )
+
+        root = Element("graphml", xmlns=_GRAPHML_NS)
+
+        # Fixed <key> declarations, emitted in the hardcoded order above.
+        # ``for`` is a Python keyword, so the attrib dict is built explicitly
+        # rather than passed as **kwargs.
+        for key_id, domain, attr_name, attr_type in _KEY_DECLS:
+            SubElement(
+                root,
+                "key",
+                {
+                    "id": key_id,
+                    "for": domain,
+                    "attr.name": attr_name,
+                    "attr.type": attr_type,
+                },
+            )
+
+        graph_el = SubElement(root, "graph", {"id": "G", "edgedefault": "directed"})
+
+        # Nodes in view.nodes list order (NOT re-sorted — element order
+        # mirrors the provider's projection order).
+        for node in view.nodes:
+            node_el = SubElement(graph_el, "node", {"id": node.id})
+            self._data(node_el, "d_node_kind", node.kind)
+            self._data(node_el, "d_node_label", node.label)
+            self._data(node_el, "d_node_status", node.status.value)
+            self._data(node_el, "d_node_attrs", _xml_scalar(node.attrs))
+
+        # Edges in view.edges list order.
+        for edge in view.edges:
+            edge_el = SubElement(graph_el, "edge", {"source": edge.source, "target": edge.target})
+            self._data(edge_el, "d_edge_type", edge.type.value)
+            self._data(edge_el, "d_edge_attrs", _xml_scalar(edge.attrs))
+
+        # Ensure the parent directory exists (dest is a not-yet-created file).
+        Path(dest_real).parent.mkdir(parents=True, exist_ok=True)
+        ElementTree(root).write(dest_real, encoding="utf-8", xml_declaration=True)
+
+        return [str(dest_real)]
+
+    @staticmethod
+    def _data(parent: Element, key: str, value: str) -> None:
+        """Append a ``<data key=...>value</data>`` child to ``parent``."""
+        data_el = SubElement(parent, "data", {"key": key})
+        data_el.text = value

--- a/src/cli_agent_orchestrator/graph/sinks/obsidian.py
+++ b/src/cli_agent_orchestrator/graph/sinks/obsidian.py
@@ -1,0 +1,105 @@
+"""Obsidian vault GraphSink (U6, Issue #348).
+
+Exports a GraphView as an Obsidian-openable vault: one markdown note per
+node, wiki-linked (``[[target]]``) per outgoing edge. Frontmatter is
+serialized with PyYAML (NOT hand-rolled) so quotes/colons/newlines in an
+attrs value cannot break the YAML block.
+
+Security contract: ``dest`` is confined via the SAME
+``resolve_and_validate_path`` utility used by every sink — no
+reimplementation. No ``secret_gate`` call (route already scanned, ADR-5).
+No ``.obsidian/`` config directory is written.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
+from cli_agent_orchestrator.graph.sinks.base import GraphSink, register_sink
+from cli_agent_orchestrator.utils.path_validation import resolve_and_validate_path
+
+# Filesystem-unsafe characters collapsed to '-'. A label like "a/b:c" must
+# sanitize to a writable filename, not crash the export.
+_UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _slug(value: str) -> str:
+    """Map a node id to a safe, deterministic note filename stem.
+
+    Falls back to "node" when the value reduces to empty so a label built
+    entirely from unsafe characters still yields a writable filename.
+    """
+    slug = _UNSAFE_CHARS.sub("-", value).strip("-._")
+    return slug or "node"
+
+
+@register_sink("obsidian")
+class ObsidianGraphSink(GraphSink):
+    """Export a GraphView as an Obsidian vault of wiki-linked notes."""
+
+    def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
+        # Defense in depth: same path-validation utility as every sink.
+        dest_real = resolve_and_validate_path(
+            dest, allow_create=True, description="Obsidian vault destination"
+        )
+        dest_dir = Path(dest_real)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        # Group outgoing edges by source id (single pass over the edge list).
+        outgoing: dict[str, list[Edge]] = {}
+        for edge in view.edges:
+            outgoing.setdefault(edge.source, []).append(edge)
+
+        written: list[str] = []
+        # Two distinct node ids that slug to the same filename would silently
+        # clobber each other; detect the collision and fail loudly instead.
+        # Single-pass: a collision raised mid-loop may leave earlier notes on
+        # disk (documented, accepted — the route maps ValueError to 400).
+        filenames: dict[str, str] = {}
+
+        for node in view.nodes:
+            slug = _slug(node.id)
+            existing = filenames.get(slug)
+            if existing is not None and existing != node.id:
+                raise ValueError(
+                    f"filename collision: nodes {existing!r} and {node.id!r} "
+                    f"both map to {slug!r}.md"
+                )
+            filenames[slug] = node.id
+
+            content = self._render_note(node, outgoing.get(node.id, []))
+            path = dest_dir / (slug + ".md")
+            path.write_text(content, encoding="utf-8")
+            written.append(str(path))
+
+        return written
+
+    @staticmethod
+    def _render_note(node: Node, edges: list[Edge]) -> str:
+        """Serialize one node as a YAML-frontmatter + H1 + Links note.
+
+        The "## Links" heading is omitted entirely when the node has no
+        outgoing edges. A contradiction edge is suffixed " (contradiction)".
+        """
+        # PyYAML handles all escaping for kind/status/attrs — never hand-rolled.
+        front = {
+            "kind": node.kind,
+            "status": node.status.value,
+            "attrs": node.attrs,
+        }
+        frontmatter = yaml.safe_dump(front, sort_keys=True, allow_unicode=True).rstrip()
+
+        lines = ["---", frontmatter, "---", "", f"# {node.label}"]
+
+        if edges:
+            lines.extend(["", "## Links", ""])
+            for edge in edges:
+                link = f"- [[{_slug(edge.target)}]]"
+                if edge.type == EdgeType.CONTRADICTION:
+                    link += " (contradiction)"
+                lines.append(link)
+
+        return "\n".join(lines).rstrip() + "\n"

--- a/src/cli_agent_orchestrator/graph/sinks/obsidian.py
+++ b/src/cli_agent_orchestrator/graph/sinks/obsidian.py
@@ -5,21 +5,27 @@ node, wiki-linked (``[[target]]``) per outgoing edge. Frontmatter is
 serialized with PyYAML (NOT hand-rolled) so quotes/colons/newlines in an
 attrs value cannot break the YAML block.
 
-Security contract: ``dest`` is confined via the SAME
-``resolve_and_validate_path`` utility used by every sink — no
-reimplementation. No ``secret_gate`` call (route already scanned, ADR-5).
-No ``.obsidian/`` config directory is written.
+Security contract: ``dest`` is confined UNDER the configured graph-export
+root (``CAO_GRAPH_EXPORT_ROOT``) via
+``base.confine_under_export_root`` — ``dest`` is treated as a path relative
+to that root (an absolute ``dest`` is accepted only when it already resolves
+under the root), and ``safe_join_under_base`` guarantees the write stays
+inside it. The sink owns this confinement — the U4 route does NOT
+pre-validate ``dest``. No ``secret_gate`` call (route already scanned,
+ADR-5). No ``.obsidian/`` config directory is written.
 """
 
 import re
-from pathlib import Path
 from typing import Any
 
 import yaml
 
 from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
-from cli_agent_orchestrator.graph.sinks.base import GraphSink, register_sink
-from cli_agent_orchestrator.utils.path_validation import resolve_and_validate_path
+from cli_agent_orchestrator.graph.sinks.base import (
+    GraphSink,
+    confine_under_export_root,
+    register_sink,
+)
 
 # Filesystem-unsafe characters collapsed to '-'. A label like "a/b:c" must
 # sanitize to a writable filename, not crash the export.
@@ -36,16 +42,27 @@ def _slug(value: str) -> str:
     return slug or "node"
 
 
+def _md_inline(value: Any) -> str:
+    """Escape an untrusted value for safe single-line markdown emission.
+
+    label/attrs are untrusted (Node docstring: sinks MUST escape on output).
+    Newlines are collapsed so an LLM summary cannot inject a new heading or
+    ``[[wikilink]]`` on its own line, and markdown-structural characters are
+    backslash-escaped so they render literally in the ``# <label>`` heading.
+    """
+    text = re.sub(r"[\r\n\u2028\u2029]+", " ", str(value))
+    return re.sub(r"([\\`*_\[\]()#])", r"\\\1", text)
+
+
 @register_sink("obsidian")
 class ObsidianGraphSink(GraphSink):
     """Export a GraphView as an Obsidian vault of wiki-linked notes."""
 
     def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
-        # Defense in depth: same path-validation utility as every sink.
-        dest_real = resolve_and_validate_path(
-            dest, allow_create=True, description="Obsidian vault destination"
-        )
-        dest_dir = Path(dest_real)
+        # Confine dest UNDER the configured graph-export root; dest is a
+        # DIRECTORY treated as relative to CAO_GRAPH_EXPORT_ROOT. The sink
+        # owns confinement — the U4 route does NOT pre-validate dest.
+        dest_dir = confine_under_export_root(dest, description="Obsidian vault destination")
         dest_dir.mkdir(parents=True, exist_ok=True)
 
         # Group outgoing edges by source id (single pass over the edge list).
@@ -92,7 +109,9 @@ class ObsidianGraphSink(GraphSink):
         }
         frontmatter = yaml.safe_dump(front, sort_keys=True, allow_unicode=True).rstrip()
 
-        lines = ["---", frontmatter, "---", "", f"# {node.label}"]
+        # label is untrusted (may be an LLM summary): escape so a newline or
+        # markdown-structural char cannot inject a heading/wikilink/list item.
+        lines = ["---", frontmatter, "---", "", f"# {_md_inline(node.label)}"]
 
         if edges:
             lines.extend(["", "## Links", ""])

--- a/src/cli_agent_orchestrator/graph/sinks/okf.py
+++ b/src/cli_agent_orchestrator/graph/sinks/okf.py
@@ -1,0 +1,164 @@
+"""OKF (Obsidian Knowledge Format) GraphSink (U5, Issue #348).
+
+Generalizes the #345 memory-export bundle shape
+(``services/memory_archive/okf.py``) to an arbitrary GraphView: one
+markdown file per node plus a deterministic ``index.md`` and a
+``manifest.md`` provenance note. The byte-compare-before-write discipline
+(``_write_if_changed``) is adopted as a PATTERN here — this module does
+NOT import the memory-archive exporter.
+
+Security contract: ``dest`` is confined via
+``utils.path_validation.resolve_and_validate_path`` (ADR: sink-side
+defense in depth, even though the U4 route validates first). No
+``secret_gate`` call inside ``export()`` — the route scans the serialized
+view before dispatch (ADR-5); the sink assumes clean content.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from cli_agent_orchestrator.graph.models import Edge, GraphView, Node
+from cli_agent_orchestrator.graph.sinks.base import GraphSink, register_sink
+from cli_agent_orchestrator.utils.path_validation import resolve_and_validate_path
+
+# Filesystem-unsafe characters collapsed to '-' so a node id/label maps to a
+# stable, portable filename. Empty results fall back to a fixed token.
+_UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _slug(value: str) -> str:
+    """Map an arbitrary node id to a safe, deterministic filename stem.
+
+    Collapses runs of filesystem-unsafe characters to a single '-', strips
+    leading/trailing separators, and falls back to "node" for a value that
+    reduces to empty (so a label like "///" still yields a writable file).
+    """
+    slug = _UNSAFE_CHARS.sub("-", value).strip("-._")
+    return slug or "node"
+
+
+@register_sink("okf")
+class OkfGraphSink(GraphSink):
+    """Export a GraphView as an OKF-shaped markdown bundle.
+
+    Structurally identical in FORM regardless of provider: the stub
+    provider's GraphView produces the same bundle layout (per-node ``.md``
+    + ``index.md`` + ``manifest.md``) as the memory provider's.
+    """
+
+    def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
+        # Defense in depth: confine dest even though U4 already validated it.
+        # dest is a DIRECTORY (allow_file defaults to False); traversal /
+        # symlink / blocked-system-path -> ValueError -> route maps to 400.
+        dest_real = resolve_and_validate_path(
+            dest, allow_create=True, description="OKF export destination"
+        )
+        dest_dir = Path(dest_real)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        # Group outgoing edges by source id for the per-node "See Also"
+        # section — a single pass so a large edge list is not re-scanned per node.
+        outgoing: dict[str, list[Edge]] = {}
+        for edge in view.edges:
+            outgoing.setdefault(edge.source, []).append(edge)
+
+        written: list[str] = []
+
+        # One markdown file per node. Sorted by slug so a same-content view
+        # always writes files in the same order (deterministic output).
+        #
+        # NOTE: unlike the Obsidian sink, OKF does NOT guard against two ids
+        # slugging to the same stem (last write wins). This asymmetry is
+        # deliberate: OKF's AC (U6) does not mandate collision detection —
+        # only the Obsidian sink's does. Left as-is by design, not oversight.
+        for node in sorted(view.nodes, key=lambda n: _slug(n.id)):
+            filename = _slug(node.id) + ".md"
+            content = self._render_node(node, outgoing.get(node.id, []))
+            path = dest_dir / filename
+            self._write_if_changed(path, content)
+            written.append(str(path))
+
+        index_path = dest_dir / "index.md"
+        self._write_if_changed(index_path, self._render_index(view.nodes))
+        written.append(str(index_path))
+
+        manifest_path = dest_dir / "manifest.md"
+        self._write_if_changed(manifest_path, self._render_manifest(view))
+        written.append(str(manifest_path))
+
+        return written
+
+    @staticmethod
+    def _render_node(node: Node, edges: list[Edge]) -> str:
+        """Serialize one node: frontmatter + H1 + attrs block + See Also.
+
+        Frontmatter carries kind, status, and attrs (attrs JSON-encoded so
+        quotes/colons in a value cannot break the YAML flow). LF endings,
+        single trailing newline — nothing run-varying.
+        """
+        lines = [
+            "---",
+            f"kind: {node.kind}",
+            f"status: {node.status.value}",
+            # json.dumps yields an escape-safe scalar for the whole attrs map.
+            f"attrs: {json.dumps(node.attrs, sort_keys=True)}",
+            "---",
+            "",
+            f"# {node.label}",
+        ]
+
+        if node.attrs:
+            lines.extend(["", "## Attributes", ""])
+            for key in sorted(node.attrs):
+                lines.append(f"- **{key}**: {node.attrs[key]}")
+
+        if edges:
+            lines.extend(["", "## See Also", ""])
+            # Sorted by target so the section is deterministic.
+            for edge in sorted(edges, key=lambda e: (e.target, e.type.value)):
+                lines.append(f"- [[{_slug(edge.target)}]] ({edge.type.value})")
+
+        return "\n".join(lines).rstrip() + "\n"
+
+    @staticmethod
+    def _render_index(nodes: list[Node]) -> str:
+        """Regenerate ``index.md`` — a pure, sorted function of the node set."""
+        lines = ["# Index", ""]
+        for node in sorted(nodes, key=lambda n: _slug(n.id)):
+            lines.append(f"- [{node.label}]({_slug(node.id)}.md)")
+        return "\n".join(lines).rstrip() + "\n"
+
+    @staticmethod
+    def _render_manifest(view: GraphView) -> str:
+        """Provenance note rendered from ``view.meta`` (deterministic).
+
+        No timestamps or run-varying data — meta keys are emitted in sorted
+        order so a same-view export produces byte-identical output.
+        """
+        lines = [
+            "# CAO Graph Export",
+            "",
+            "Generated by CAO — edits here are not synced back.",
+            "",
+            "- format: okf",
+            f"- nodes: {len(view.nodes)}",
+            f"- edges: {len(view.edges)}",
+        ]
+        for key in sorted(view.meta):
+            lines.append(f"- {key}: {view.meta[key]}")
+        return "\n".join(lines).rstrip() + "\n"
+
+    @staticmethod
+    def _write_if_changed(path: Path, content: str) -> None:
+        """Write ``content`` unless the file already holds those exact bytes."""
+        data = content.encode("utf-8")
+        try:
+            if path.exists() and path.read_bytes() == data:
+                return
+        except OSError:
+            # Unreadable existing file: fall through and rewrite it.
+            pass
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)

--- a/src/cli_agent_orchestrator/graph/sinks/okf.py
+++ b/src/cli_agent_orchestrator/graph/sinks/okf.py
@@ -7,11 +7,14 @@ markdown file per node plus a deterministic ``index.md`` and a
 (``_write_if_changed``) is adopted as a PATTERN here — this module does
 NOT import the memory-archive exporter.
 
-Security contract: ``dest`` is confined via
-``utils.path_validation.resolve_and_validate_path`` (ADR: sink-side
-defense in depth, even though the U4 route validates first). No
-``secret_gate`` call inside ``export()`` — the route scans the serialized
-view before dispatch (ADR-5); the sink assumes clean content.
+Security contract: ``dest`` is confined UNDER the configured graph-export
+root (``CAO_GRAPH_EXPORT_ROOT``) via
+``base.confine_under_export_root`` — ``dest`` is a path relative to that
+root (an absolute ``dest`` is accepted only when it already resolves under
+the root), and ``safe_join_under_base`` guarantees the write stays inside
+it. The sink owns this confinement — the U4 route does NOT pre-validate
+``dest``. No ``secret_gate`` call inside ``export()`` — the route scans the
+serialized view before dispatch (ADR-5); the sink assumes clean content.
 """
 
 import json
@@ -20,12 +23,19 @@ from pathlib import Path
 from typing import Any
 
 from cli_agent_orchestrator.graph.models import Edge, GraphView, Node
-from cli_agent_orchestrator.graph.sinks.base import GraphSink, register_sink
-from cli_agent_orchestrator.utils.path_validation import resolve_and_validate_path
+from cli_agent_orchestrator.graph.sinks.base import (
+    GraphSink,
+    confine_under_export_root,
+    register_sink,
+)
 
 # Filesystem-unsafe characters collapsed to '-' so a node id/label maps to a
 # stable, portable filename. Empty results fall back to a fixed token.
 _UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+
+# Reserved bundle-file stems. A node whose id slugs to one of these would
+# otherwise be silently overwritten by the generated index.md / manifest.md.
+_RESERVED_STEMS = frozenset({"index", "manifest"})
 
 
 def _slug(value: str) -> str:
@@ -39,6 +49,22 @@ def _slug(value: str) -> str:
     return slug or "node"
 
 
+def _md_inline(value: Any) -> str:
+    """Escape an untrusted value for safe single-line markdown emission.
+
+    label/attrs are untrusted (Node docstring: sinks MUST escape on output).
+    Newlines/CRs are collapsed to a space so an LLM summary cannot inject a
+    new ``#`` heading, list item, or ``[[wikilink]]`` on its own line; the
+    markdown-structural characters that open links/wikilinks/emphasis
+    (``[]()*_`\\`` plus ``#``) are backslash-escaped so they render literally.
+    """
+    text = str(value)
+    # Collapse any line break (LF, CR, CRLF, and unicode line/para separators)
+    # to a single space so nothing can start a new markdown block.
+    text = re.sub(r"[\r\n\u2028\u2029]+", " ", text)
+    return re.sub(r"([\\`*_\[\]()#])", r"\\\1", text)
+
+
 @register_sink("okf")
 class OkfGraphSink(GraphSink):
     """Export a GraphView as an OKF-shaped markdown bundle.
@@ -49,13 +75,11 @@ class OkfGraphSink(GraphSink):
     """
 
     def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
-        # Defense in depth: confine dest even though U4 already validated it.
-        # dest is a DIRECTORY (allow_file defaults to False); traversal /
-        # symlink / blocked-system-path -> ValueError -> route maps to 400.
-        dest_real = resolve_and_validate_path(
-            dest, allow_create=True, description="OKF export destination"
-        )
-        dest_dir = Path(dest_real)
+        # Confine dest UNDER the configured graph-export root. dest is a
+        # DIRECTORY treated as relative to CAO_GRAPH_EXPORT_ROOT; traversal /
+        # absolute-escape / symlink-escape -> ValueError -> route maps to 400.
+        # The route does NOT pre-validate dest — this sink owns confinement.
+        dest_dir = confine_under_export_root(dest, description="OKF export destination")
         dest_dir.mkdir(parents=True, exist_ok=True)
 
         # Group outgoing edges by source id for the per-node "See Also"
@@ -65,16 +89,31 @@ class OkfGraphSink(GraphSink):
             outgoing.setdefault(edge.source, []).append(edge)
 
         written: list[str] = []
+        # Fail loudly (matching the Obsidian sink's posture) instead of
+        # last-write-wins: a node id that slugs to a reserved stem
+        # ("index"/"manifest") would be clobbered by the generated
+        # index.md/manifest.md, and two ids slugging to the same stem would
+        # clobber each other. Both are detected before any per-node write.
+        stems: dict[str, str] = {}
 
         # One markdown file per node. Sorted by slug so a same-content view
         # always writes files in the same order (deterministic output).
-        #
-        # NOTE: unlike the Obsidian sink, OKF does NOT guard against two ids
-        # slugging to the same stem (last write wins). This asymmetry is
-        # deliberate: OKF's AC (U6) does not mandate collision detection —
-        # only the Obsidian sink's does. Left as-is by design, not oversight.
         for node in sorted(view.nodes, key=lambda n: _slug(n.id)):
-            filename = _slug(node.id) + ".md"
+            slug = _slug(node.id)
+            if slug in _RESERVED_STEMS:
+                raise ValueError(
+                    f"node id {node.id!r} slugs to reserved bundle stem {slug!r}.md "
+                    f"(collides with the generated {slug}.md)"
+                )
+            existing = stems.get(slug)
+            if existing is not None and existing != node.id:
+                raise ValueError(
+                    f"filename collision: nodes {existing!r} and {node.id!r} "
+                    f"both map to {slug!r}.md"
+                )
+            stems[slug] = node.id
+
+            filename = slug + ".md"
             content = self._render_node(node, outgoing.get(node.id, []))
             path = dest_dir / filename
             self._write_if_changed(path, content)
@@ -106,13 +145,15 @@ class OkfGraphSink(GraphSink):
             f"attrs: {json.dumps(node.attrs, sort_keys=True)}",
             "---",
             "",
-            f"# {node.label}",
+            # label is untrusted (may be an LLM summary): escape so a newline
+            # or markdown-structural char cannot inject a heading/link/list.
+            f"# {_md_inline(node.label)}",
         ]
 
         if node.attrs:
             lines.extend(["", "## Attributes", ""])
             for key in sorted(node.attrs):
-                lines.append(f"- **{key}**: {node.attrs[key]}")
+                lines.append(f"- **{_md_inline(key)}**: {_md_inline(node.attrs[key])}")
 
         if edges:
             lines.extend(["", "## See Also", ""])
@@ -127,7 +168,9 @@ class OkfGraphSink(GraphSink):
         """Regenerate ``index.md`` — a pure, sorted function of the node set."""
         lines = ["# Index", ""]
         for node in sorted(nodes, key=lambda n: _slug(n.id)):
-            lines.append(f"- [{node.label}]({_slug(node.id)}.md)")
+            # _slug already yields a safe filename stem; the label is untrusted
+            # link text and is escaped so it cannot break the link syntax.
+            lines.append(f"- [{_md_inline(node.label)}]({_slug(node.id)}.md)")
         return "\n".join(lines).rstrip() + "\n"
 
     @staticmethod
@@ -147,7 +190,8 @@ class OkfGraphSink(GraphSink):
             f"- edges: {len(view.edges)}",
         ]
         for key in sorted(view.meta):
-            lines.append(f"- {key}: {view.meta[key]}")
+            # meta is provider-supplied; escape both key and value on output.
+            lines.append(f"- {_md_inline(key)}: {_md_inline(view.meta[key])}")
         return "\n".join(lines).rstrip() + "\n"
 
     @staticmethod

--- a/test/graph/sinks/test_graphml_sink.py
+++ b/test/graph/sinks/test_graphml_sink.py
@@ -1,4 +1,4 @@
-"""U7 — GraphMLGraphSink tests: round-trip, no third-party XML, traversal, attrs."""
+"""U7 — GraphMLGraphSink tests: round-trip, no third-party XML, export-root confinement."""
 
 import ast
 import os
@@ -12,8 +12,13 @@ from cli_agent_orchestrator.graph.sinks.graphml import GraphMLGraphSink
 networkx = pytest.importorskip("networkx", reason="networkx needed for GraphML round-trip")
 
 
-def _traversal_dest(base) -> str:
-    return os.path.join(str(base), *([".."] * 40), "etc", "cao-graphml-traversal.graphml")
+@pytest.fixture
+def export_root(tmp_path, monkeypatch):
+    """Point CAO_GRAPH_EXPORT_ROOT at a tmp dir; return its realpath."""
+    root = tmp_path / "export-root"
+    root.mkdir()
+    monkeypatch.setenv("CAO_GRAPH_EXPORT_ROOT", str(root))
+    return os.path.realpath(str(root))
 
 
 def _view() -> GraphView:
@@ -30,29 +35,32 @@ def _view() -> GraphView:
     )
 
 
-def test_graphml_roundtrips_counts(tmp_path):
+def test_graphml_roundtrips_counts(export_root):
     """The .graphml parses with networkx and round-trips node/edge counts (AC-1)."""
     view = _view()
-    dest = tmp_path / "graph.graphml"
-    written = GraphMLGraphSink().export(view, str(dest))
+    written = GraphMLGraphSink().export(view, "graph.graphml")
 
-    assert written == [str(dest)]
-    assert dest.exists()
+    dest = os.path.join(export_root, "graph.graphml")
+    assert [os.path.realpath(p) for p in written] == [os.path.realpath(dest)]
+    assert os.path.exists(dest)
+    assert os.path.realpath(written[0]).startswith(export_root + os.sep)
 
-    g = networkx.read_graphml(str(dest))
+    g = networkx.read_graphml(dest)
     assert g.number_of_nodes() == len(view.nodes)
     assert g.number_of_edges() == len(view.edges)
-    # A node's fixed <data> keys survive the round-trip.
     assert g.nodes["a"]["kind"] == "topic"
     assert g.nodes["a"]["label"] == "Alpha"
 
 
-def test_graphml_no_third_party_xml_import():
-    """graphml.py imports no third-party XML library (C-2).
+def test_graphml_subdir_dest_confined(export_root):
+    """A relative dest with a subdir is created under the root."""
+    written = GraphMLGraphSink().export(_view(), os.path.join("sub", "graph.graphml"))
+    assert os.path.realpath(written[0]).startswith(export_root + os.sep)
+    assert os.path.exists(os.path.join(export_root, "sub", "graph.graphml"))
 
-    Parse the module's AST and assert every imported top-level module is
-    either stdlib xml.* or an in-repo/stdlib module — never lxml/xmltodict.
-    """
+
+def test_graphml_no_third_party_xml_import():
+    """graphml.py imports no third-party XML library (C-2)."""
     src = ast.parse(open(graphml_module.__file__).read())
     imported: list[str] = []
     for node in ast.walk(src):
@@ -64,27 +72,52 @@ def test_graphml_no_third_party_xml_import():
     forbidden = ("lxml", "xmltodict", "untangle", "xmlschema")
     for mod in imported:
         assert not any(mod == f or mod.startswith(f + ".") for f in forbidden), mod
-    # Positive: the stdlib XML module is what's used.
     assert any(m.startswith("xml.etree") for m in imported)
 
 
-def test_graphml_traversal_rejected(tmp_path):
-    """A traversal dest is rejected before any file is written."""
+def test_graphml_relative_traversal_escape_rejected(export_root):
+    """A relative dest escaping the export root is rejected before any write."""
     with pytest.raises(ValueError):
-        GraphMLGraphSink().export(_view(), _traversal_dest(tmp_path))
-    assert list(tmp_path.rglob("*.graphml")) == []
+        GraphMLGraphSink().export(
+            _view(), os.path.join("..", "..", "etc", "cao-graphml-escape.graphml")
+        )
+    assert list(_all_files(export_root)) == []
 
 
-def test_graphml_non_native_attrs_stringified(tmp_path):
+def test_graphml_absolute_overwrite_outside_root_rejected(export_root, tmp_path):
+    """An absolute dest at an existing sensitive-looking file OUTSIDE the root is rejected.
+
+    Regression guard for MUST-FIX #2: with allow_file=True the old blocklist
+    let an authed writer overwrite nearly any existing file (e.g.
+    ~/.ssh/authorized_keys). Confinement rejects it before any write, so the
+    victim file's bytes are untouched.
+    """
+    victim = tmp_path / "victim" / "authorized_keys"
+    victim.parent.mkdir()
+    victim.write_text("ORIGINAL", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        GraphMLGraphSink().export(_view(), str(victim))
+
+    # The out-of-root file was never touched.
+    assert victim.read_text(encoding="utf-8") == "ORIGINAL"
+    assert list(_all_files(export_root)) == []
+
+
+def test_graphml_non_native_attrs_stringified(export_root):
     """A non-native attrs value is json-stringified into the data text, not dropped."""
     view = GraphView(
         nodes=[Node(id="a", kind="topic", label="A", attrs={"nested": {"k": [1, 2, 3]}})],
         edges=[],
     )
-    dest = tmp_path / "graph.graphml"
-    GraphMLGraphSink().export(view, str(dest))
+    written = GraphMLGraphSink().export(view, "graph.graphml")
 
-    g = networkx.read_graphml(str(dest))
-    # The attrs map is preserved as a JSON string (data survives, not silently lost).
+    g = networkx.read_graphml(written[0])
     attrs_text = g.nodes["a"]["attrs"]
     assert "nested" in attrs_text and "1" in attrs_text
+
+
+def _all_files(root):
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            yield os.path.join(dirpath, f)

--- a/test/graph/sinks/test_graphml_sink.py
+++ b/test/graph/sinks/test_graphml_sink.py
@@ -1,0 +1,90 @@
+"""U7 — GraphMLGraphSink tests: round-trip, no third-party XML, traversal, attrs."""
+
+import ast
+import os
+
+import pytest
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
+from cli_agent_orchestrator.graph.sinks import graphml as graphml_module
+from cli_agent_orchestrator.graph.sinks.graphml import GraphMLGraphSink
+
+networkx = pytest.importorskip("networkx", reason="networkx needed for GraphML round-trip")
+
+
+def _traversal_dest(base) -> str:
+    return os.path.join(str(base), *([".."] * 40), "etc", "cao-graphml-traversal.graphml")
+
+
+def _view() -> GraphView:
+    return GraphView(
+        nodes=[
+            Node(id="a", kind="topic", label="Alpha", attrs={"weight": 3}),
+            Node(id="b", kind="topic", label="Beta"),
+            Node(id="c", kind="topic", label="Gamma"),
+        ],
+        edges=[
+            Edge(source="a", target="b", type=EdgeType.RELATES_TO),
+            Edge(source="b", target="c", type=EdgeType.CONTRADICTION),
+        ],
+    )
+
+
+def test_graphml_roundtrips_counts(tmp_path):
+    """The .graphml parses with networkx and round-trips node/edge counts (AC-1)."""
+    view = _view()
+    dest = tmp_path / "graph.graphml"
+    written = GraphMLGraphSink().export(view, str(dest))
+
+    assert written == [str(dest)]
+    assert dest.exists()
+
+    g = networkx.read_graphml(str(dest))
+    assert g.number_of_nodes() == len(view.nodes)
+    assert g.number_of_edges() == len(view.edges)
+    # A node's fixed <data> keys survive the round-trip.
+    assert g.nodes["a"]["kind"] == "topic"
+    assert g.nodes["a"]["label"] == "Alpha"
+
+
+def test_graphml_no_third_party_xml_import():
+    """graphml.py imports no third-party XML library (C-2).
+
+    Parse the module's AST and assert every imported top-level module is
+    either stdlib xml.* or an in-repo/stdlib module — never lxml/xmltodict.
+    """
+    src = ast.parse(open(graphml_module.__file__).read())
+    imported: list[str] = []
+    for node in ast.walk(src):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+
+    forbidden = ("lxml", "xmltodict", "untangle", "xmlschema")
+    for mod in imported:
+        assert not any(mod == f or mod.startswith(f + ".") for f in forbidden), mod
+    # Positive: the stdlib XML module is what's used.
+    assert any(m.startswith("xml.etree") for m in imported)
+
+
+def test_graphml_traversal_rejected(tmp_path):
+    """A traversal dest is rejected before any file is written."""
+    with pytest.raises(ValueError):
+        GraphMLGraphSink().export(_view(), _traversal_dest(tmp_path))
+    assert list(tmp_path.rglob("*.graphml")) == []
+
+
+def test_graphml_non_native_attrs_stringified(tmp_path):
+    """A non-native attrs value is json-stringified into the data text, not dropped."""
+    view = GraphView(
+        nodes=[Node(id="a", kind="topic", label="A", attrs={"nested": {"k": [1, 2, 3]}})],
+        edges=[],
+    )
+    dest = tmp_path / "graph.graphml"
+    GraphMLGraphSink().export(view, str(dest))
+
+    g = networkx.read_graphml(str(dest))
+    # The attrs map is preserved as a JSON string (data survives, not silently lost).
+    attrs_text = g.nodes["a"]["attrs"]
+    assert "nested" in attrs_text and "1" in attrs_text

--- a/test/graph/sinks/test_obsidian_sink.py
+++ b/test/graph/sinks/test_obsidian_sink.py
@@ -1,0 +1,92 @@
+"""U6 — ObsidianGraphSink tests: happy path, traversal rejection, unsafe-label edge."""
+
+import os
+
+import pytest
+import yaml
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
+from cli_agent_orchestrator.graph.sinks.obsidian import ObsidianGraphSink
+
+
+def _traversal_dest(base) -> str:
+    return os.path.join(str(base), *([".."] * 40), "etc", "cao-obsidian-traversal")
+
+
+def _view() -> GraphView:
+    return GraphView(
+        nodes=[
+            Node(id="a", kind="topic", label="Alpha", attrs={"weight": 3}),
+            Node(id="b", kind="topic", label="Beta"),
+            Node(id="c", kind="topic", label="Gamma"),
+        ],
+        edges=[
+            Edge(source="a", target="b", type=EdgeType.RELATES_TO),
+            Edge(source="a", target="c", type=EdgeType.CONTRADICTION),
+        ],
+    )
+
+
+def test_obsidian_export_vault(tmp_path):
+    """A small view exports N notes with wikilinks; contradiction edge suffixed."""
+    dest = tmp_path / "vault"
+    written = ObsidianGraphSink().export(_view(), str(dest))
+
+    notes = sorted(p.name for p in dest.glob("*.md"))
+    assert notes == ["a.md", "b.md", "c.md"]
+    assert len(written) == 3
+    # No .obsidian/ config directory is written.
+    assert not (dest / ".obsidian").exists()
+
+    a_text = (dest / "a.md").read_text(encoding="utf-8")
+    assert "## Links" in a_text
+    assert "- [[b]]" in a_text
+    assert "- [[c]] (contradiction)" in a_text
+
+    # Frontmatter is valid YAML round-trips (PyYAML, not hand-rolled).
+    front = a_text.split("---")[1]
+    parsed = yaml.safe_load(front)
+    assert parsed["kind"] == "topic"
+    assert parsed["status"] == "active"
+    assert parsed["attrs"] == {"weight": 3}
+
+    # A node with no outgoing edges omits the Links heading entirely.
+    b_text = (dest / "b.md").read_text(encoding="utf-8")
+    assert "## Links" not in b_text
+
+
+def test_obsidian_traversal_rejected(tmp_path):
+    """A traversal dest is rejected via the shared path_validation utility."""
+    with pytest.raises(ValueError):
+        ObsidianGraphSink().export(_view(), _traversal_dest(tmp_path))
+    assert list(tmp_path.rglob("*.md")) == []
+
+
+def test_obsidian_unsafe_label_sanitized(tmp_path):
+    """A node id with filename-unsafe chars sanitizes to a writable file, no crash."""
+    view = GraphView(
+        nodes=[Node(id="a/b:c", kind="topic", label="Weird a/b:c")],
+        edges=[],
+    )
+    dest = tmp_path / "vault"
+    written = ObsidianGraphSink().export(view, str(dest))
+
+    assert len(written) == 1
+    # The slug collapses unsafe chars; the file exists and has no path separators.
+    name = os.path.basename(written[0])
+    assert name.endswith(".md")
+    assert "/" not in name and ":" not in name
+    assert os.path.exists(written[0])
+
+
+def test_obsidian_filename_collision_raises(tmp_path):
+    """Two distinct ids slugging to the same filename raise ValueError."""
+    view = GraphView(
+        nodes=[
+            Node(id="a/b", kind="topic", label="One"),
+            Node(id="a:b", kind="topic", label="Two"),  # slugs to the same 'a-b'
+        ],
+        edges=[],
+    )
+    with pytest.raises(ValueError, match="collision"):
+        ObsidianGraphSink().export(view, str(tmp_path / "vault"))

--- a/test/graph/sinks/test_obsidian_sink.py
+++ b/test/graph/sinks/test_obsidian_sink.py
@@ -1,4 +1,4 @@
-"""U6 — ObsidianGraphSink tests: happy path, traversal rejection, unsafe-label edge."""
+"""U6 — ObsidianGraphSink tests: happy path, export-root confinement, escaping."""
 
 import os
 
@@ -9,8 +9,13 @@ from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
 from cli_agent_orchestrator.graph.sinks.obsidian import ObsidianGraphSink
 
 
-def _traversal_dest(base) -> str:
-    return os.path.join(str(base), *([".."] * 40), "etc", "cao-obsidian-traversal")
+@pytest.fixture
+def export_root(tmp_path, monkeypatch):
+    """Point CAO_GRAPH_EXPORT_ROOT at a tmp dir; return its realpath."""
+    root = tmp_path / "export-root"
+    root.mkdir()
+    monkeypatch.setenv("CAO_GRAPH_EXPORT_ROOT", str(root))
+    return os.path.realpath(str(root))
 
 
 def _view() -> GraphView:
@@ -27,66 +32,91 @@ def _view() -> GraphView:
     )
 
 
-def test_obsidian_export_vault(tmp_path):
+def test_obsidian_export_vault(export_root):
     """A small view exports N notes with wikilinks; contradiction edge suffixed."""
-    dest = tmp_path / "vault"
-    written = ObsidianGraphSink().export(_view(), str(dest))
+    written = ObsidianGraphSink().export(_view(), "vault")
 
-    notes = sorted(p.name for p in dest.glob("*.md"))
+    dest = os.path.join(export_root, "vault")
+    notes = sorted(os.path.basename(p) for p in written)
     assert notes == ["a.md", "b.md", "c.md"]
     assert len(written) == 3
-    # No .obsidian/ config directory is written.
-    assert not (dest / ".obsidian").exists()
+    assert not os.path.exists(os.path.join(dest, ".obsidian"))
+    for p in written:
+        assert os.path.realpath(p).startswith(export_root + os.sep)
 
-    a_text = (dest / "a.md").read_text(encoding="utf-8")
+    a_text = open(os.path.join(dest, "a.md"), encoding="utf-8").read()
     assert "## Links" in a_text
     assert "- [[b]]" in a_text
     assert "- [[c]] (contradiction)" in a_text
 
-    # Frontmatter is valid YAML round-trips (PyYAML, not hand-rolled).
     front = a_text.split("---")[1]
     parsed = yaml.safe_load(front)
     assert parsed["kind"] == "topic"
     assert parsed["status"] == "active"
     assert parsed["attrs"] == {"weight": 3}
 
-    # A node with no outgoing edges omits the Links heading entirely.
-    b_text = (dest / "b.md").read_text(encoding="utf-8")
+    b_text = open(os.path.join(dest, "b.md"), encoding="utf-8").read()
     assert "## Links" not in b_text
 
 
-def test_obsidian_traversal_rejected(tmp_path):
-    """A traversal dest is rejected via the shared path_validation utility."""
+def test_obsidian_relative_traversal_escape_rejected(export_root):
+    """A relative dest escaping the export root is rejected; nothing written."""
     with pytest.raises(ValueError):
-        ObsidianGraphSink().export(_view(), _traversal_dest(tmp_path))
-    assert list(tmp_path.rglob("*.md")) == []
+        ObsidianGraphSink().export(_view(), os.path.join("..", "..", "etc", "cao-obs-escape"))
+    assert list(_all_files(export_root)) == []
 
 
-def test_obsidian_unsafe_label_sanitized(tmp_path):
+def test_obsidian_absolute_dest_outside_root_rejected(export_root, tmp_path):
+    """An absolute dest outside the root -> ValueError, writes nothing (MUST-FIX #2)."""
+    outside = tmp_path / "outside-root" / "vault"
+    with pytest.raises(ValueError):
+        ObsidianGraphSink().export(_view(), str(outside))
+    assert not outside.exists()
+    assert list(_all_files(export_root)) == []
+
+
+def test_obsidian_unsafe_label_sanitized(export_root):
     """A node id with filename-unsafe chars sanitizes to a writable file, no crash."""
-    view = GraphView(
-        nodes=[Node(id="a/b:c", kind="topic", label="Weird a/b:c")],
-        edges=[],
-    )
-    dest = tmp_path / "vault"
-    written = ObsidianGraphSink().export(view, str(dest))
+    view = GraphView(nodes=[Node(id="a/b:c", kind="topic", label="Weird a/b:c")], edges=[])
+    written = ObsidianGraphSink().export(view, "vault")
 
     assert len(written) == 1
-    # The slug collapses unsafe chars; the file exists and has no path separators.
     name = os.path.basename(written[0])
     assert name.endswith(".md")
     assert "/" not in name and ":" not in name
     assert os.path.exists(written[0])
 
 
-def test_obsidian_filename_collision_raises(tmp_path):
+def test_obsidian_filename_collision_raises(export_root):
     """Two distinct ids slugging to the same filename raise ValueError."""
     view = GraphView(
         nodes=[
             Node(id="a/b", kind="topic", label="One"),
-            Node(id="a:b", kind="topic", label="Two"),  # slugs to the same 'a-b'
+            Node(id="a:b", kind="topic", label="Two"),
         ],
         edges=[],
     )
     with pytest.raises(ValueError, match="collision"):
-        ObsidianGraphSink().export(view, str(tmp_path / "vault"))
+        ObsidianGraphSink().export(view, "vault")
+
+
+def test_obsidian_label_injection_escaped(export_root):
+    """A label with a newline heading + link chars is emitted safely (S3)."""
+    view = GraphView(
+        nodes=[Node(id="n1", kind="topic", label="Safe\n# Injected\n[[evil]]")],
+        edges=[],
+    )
+    written = ObsidianGraphSink().export(view, "vault")
+
+    text = open(written[0], encoding="utf-8").read()
+    h1 = next(line for line in text.splitlines() if line.startswith("# "))
+    assert "Injected" in h1  # collapsed onto the H1, not a standalone heading
+    # No injected heading or wikilink on its own line in the body.
+    assert "\n# Injected" not in text
+    assert "[[evil]]" not in text  # brackets escaped
+
+
+def _all_files(root):
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            yield os.path.join(dirpath, f)

--- a/test/graph/sinks/test_okf_sink.py
+++ b/test/graph/sinks/test_okf_sink.py
@@ -1,0 +1,92 @@
+"""U5 — OkfGraphSink tests: happy path, traversal rejection, missing-attrs edge."""
+
+import os
+
+import pytest
+
+from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
+from cli_agent_orchestrator.graph.providers.stub import StubGraphProvider
+from cli_agent_orchestrator.graph.sinks.okf import OkfGraphSink
+
+
+def _traversal_dest(base) -> str:
+    """A path that, after realpath normalization, escapes into a blocked dir.
+
+    Enough ``..`` segments to walk past the filesystem root (which clamps at
+    ``/``) then into ``/etc`` — whose nearest existing ancestor is a blocked
+    system directory, so resolve_and_validate_path raises ValueError.
+    """
+    return os.path.join(str(base), *([".."] * 40), "etc", "cao-okf-traversal")
+
+
+@pytest.mark.asyncio
+async def test_okf_export_stub_bundle(tmp_path):
+    """Exporting the stub provider's view produces a well-formed OKF bundle."""
+    view = await StubGraphProvider().project()
+    dest = tmp_path / "bundle"
+
+    written = OkfGraphSink().export(view, str(dest))
+
+    # index.md + manifest.md + one .md per node.
+    assert (dest / "index.md").exists()
+    assert (dest / "manifest.md").exists()
+    node_files = sorted(p.name for p in dest.glob("*.md"))
+    assert node_files == ["index.md", "manifest.md", "stub-a.md", "stub-b.md", "stub-c.md"]
+    assert len(written) == len(view.nodes) + 2
+
+    # index is deterministic: node links appear in slug-sorted order.
+    index_text = (dest / "index.md").read_text(encoding="utf-8")
+    assert (
+        index_text.index("stub-a.md")
+        < index_text.index("stub-b.md")
+        < index_text.index("stub-c.md")
+    )
+    # The edge stub-a -> stub-b surfaces as a See Also wikilink in stub-a's note.
+    assert "[[stub-b]]" in (dest / "stub-a.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_okf_bundle_shape_matches_across_providers(tmp_path):
+    """The stub bundle is structurally identical in FORM to any GraphView bundle.
+
+    A hand-built view with the same node/edge counts yields the same set of
+    bundle files (per-node .md + index.md + manifest.md) — the sink is
+    provider-agnostic (AC-1).
+    """
+    stub_view = await StubGraphProvider().project()
+    other_view = GraphView(
+        nodes=[Node(id=f"topic-{i}", kind="topic", label=f"T{i}") for i in range(3)],
+        edges=[Edge(source="topic-0", target="topic-1", type=EdgeType.RELATES_TO)],
+    )
+
+    a = OkfGraphSink().export(stub_view, str(tmp_path / "a"))
+    b = OkfGraphSink().export(other_view, str(tmp_path / "b"))
+
+    # Same file COUNT and same reserved-file structure.
+    assert len(a) == len(b)
+    assert {os.path.basename(p) for p in a} >= {"index.md", "manifest.md"}
+    assert {os.path.basename(p) for p in b} >= {"index.md", "manifest.md"}
+
+
+def test_okf_traversal_rejected_before_write(tmp_path):
+    """A dest resolving into a blocked system dir raises ValueError, writes nothing."""
+    view = GraphView(nodes=[Node(id="n1", kind="stub", label="N1")], edges=[])
+    dest = _traversal_dest(tmp_path)
+
+    with pytest.raises(ValueError):
+        OkfGraphSink().export(view, dest)
+
+    # Nothing landed anywhere under the (allowed) tmp base.
+    assert list(tmp_path.rglob("*.md")) == []
+
+
+def test_okf_node_without_attrs_does_not_crash(tmp_path):
+    """A node missing optional attrs keys exports cleanly (no Attributes section)."""
+    view = GraphView(nodes=[Node(id="bare", kind="stub", label="Bare")], edges=[])
+    dest = tmp_path / "bundle"
+
+    OkfGraphSink().export(view, str(dest))
+
+    text = (dest / "bare.md").read_text(encoding="utf-8")
+    assert "# Bare" in text
+    assert "## Attributes" not in text  # empty attrs -> section omitted

--- a/test/graph/sinks/test_okf_sink.py
+++ b/test/graph/sinks/test_okf_sink.py
@@ -1,4 +1,4 @@
-"""U5 — OkfGraphSink tests: happy path, traversal rejection, missing-attrs edge."""
+"""U5 — OkfGraphSink tests: happy path, export-root confinement, collisions, escaping."""
 
 import os
 
@@ -9,84 +9,162 @@ from cli_agent_orchestrator.graph.providers.stub import StubGraphProvider
 from cli_agent_orchestrator.graph.sinks.okf import OkfGraphSink
 
 
-def _traversal_dest(base) -> str:
-    """A path that, after realpath normalization, escapes into a blocked dir.
+@pytest.fixture
+def export_root(tmp_path, monkeypatch):
+    """Point CAO_GRAPH_EXPORT_ROOT at a tmp dir; return its realpath.
 
-    Enough ``..`` segments to walk past the filesystem root (which clamps at
-    ``/``) then into ``/etc`` — whose nearest existing ancestor is a blocked
-    system directory, so resolve_and_validate_path raises ValueError.
+    Every sink now confines dest under this root, so tests must configure it
+    (default lives under ~/.aws/... which we never touch in tests).
     """
-    return os.path.join(str(base), *([".."] * 40), "etc", "cao-okf-traversal")
+    root = tmp_path / "export-root"
+    root.mkdir()
+    monkeypatch.setenv("CAO_GRAPH_EXPORT_ROOT", str(root))
+    return os.path.realpath(str(root))
 
 
 @pytest.mark.asyncio
-async def test_okf_export_stub_bundle(tmp_path):
-    """Exporting the stub provider's view produces a well-formed OKF bundle."""
+async def test_okf_export_stub_bundle(export_root):
+    """Exporting the stub provider's view produces a well-formed OKF bundle.
+
+    dest is RELATIVE to the configured export root; every written path stays
+    under the resolved root.
+    """
     view = await StubGraphProvider().project()
-    dest = tmp_path / "bundle"
 
-    written = OkfGraphSink().export(view, str(dest))
+    written = OkfGraphSink().export(view, "bundle")
 
-    # index.md + manifest.md + one .md per node.
-    assert (dest / "index.md").exists()
-    assert (dest / "manifest.md").exists()
-    node_files = sorted(p.name for p in dest.glob("*.md"))
+    dest = os.path.join(export_root, "bundle")
+    # index.md + manifest.md + one .md per node, all under the root.
+    assert os.path.exists(os.path.join(dest, "index.md"))
+    assert os.path.exists(os.path.join(dest, "manifest.md"))
+    node_files = sorted(os.path.basename(p) for p in written)
     assert node_files == ["index.md", "manifest.md", "stub-a.md", "stub-b.md", "stub-c.md"]
     assert len(written) == len(view.nodes) + 2
+    for p in written:
+        assert os.path.realpath(p).startswith(export_root + os.sep)
 
-    # index is deterministic: node links appear in slug-sorted order.
-    index_text = (dest / "index.md").read_text(encoding="utf-8")
+    index_text = open(os.path.join(dest, "index.md"), encoding="utf-8").read()
     assert (
         index_text.index("stub-a.md")
         < index_text.index("stub-b.md")
         < index_text.index("stub-c.md")
     )
-    # The edge stub-a -> stub-b surfaces as a See Also wikilink in stub-a's note.
-    assert "[[stub-b]]" in (dest / "stub-a.md").read_text(encoding="utf-8")
+    assert "[[stub-b]]" in open(os.path.join(dest, "stub-a.md"), encoding="utf-8").read()
 
 
 @pytest.mark.asyncio
-async def test_okf_bundle_shape_matches_across_providers(tmp_path):
-    """The stub bundle is structurally identical in FORM to any GraphView bundle.
-
-    A hand-built view with the same node/edge counts yields the same set of
-    bundle files (per-node .md + index.md + manifest.md) — the sink is
-    provider-agnostic (AC-1).
-    """
+async def test_okf_bundle_shape_matches_across_providers(export_root):
+    """The stub bundle is structurally identical in FORM to any GraphView bundle."""
     stub_view = await StubGraphProvider().project()
     other_view = GraphView(
         nodes=[Node(id=f"topic-{i}", kind="topic", label=f"T{i}") for i in range(3)],
         edges=[Edge(source="topic-0", target="topic-1", type=EdgeType.RELATES_TO)],
     )
 
-    a = OkfGraphSink().export(stub_view, str(tmp_path / "a"))
-    b = OkfGraphSink().export(other_view, str(tmp_path / "b"))
+    a = OkfGraphSink().export(stub_view, "a")
+    b = OkfGraphSink().export(other_view, "b")
 
-    # Same file COUNT and same reserved-file structure.
     assert len(a) == len(b)
     assert {os.path.basename(p) for p in a} >= {"index.md", "manifest.md"}
     assert {os.path.basename(p) for p in b} >= {"index.md", "manifest.md"}
 
 
-def test_okf_traversal_rejected_before_write(tmp_path):
-    """A dest resolving into a blocked system dir raises ValueError, writes nothing."""
+def test_okf_relative_traversal_escape_rejected(export_root):
+    """A relative dest that escapes the export root -> ValueError, writes nothing."""
     view = GraphView(nodes=[Node(id="n1", kind="stub", label="N1")], edges=[])
-    dest = _traversal_dest(tmp_path)
 
     with pytest.raises(ValueError):
-        OkfGraphSink().export(view, dest)
+        OkfGraphSink().export(view, os.path.join("..", "..", "etc", "cao-okf-escape"))
 
-    # Nothing landed anywhere under the (allowed) tmp base.
-    assert list(tmp_path.rglob("*.md")) == []
+    # Nothing landed under the root.
+    assert list(_all_files(export_root)) == []
 
 
-def test_okf_node_without_attrs_does_not_crash(tmp_path):
+def test_okf_absolute_dest_outside_root_rejected(export_root, tmp_path):
+    """An ABSOLUTE dest outside the export root -> ValueError, writes nothing.
+
+    Regression guard for MUST-FIX #2: the old resolve_and_validate_path
+    blocklist let ~/.ssh-style paths through; confinement rejects any absolute
+    path not already under the configured root.
+    """
+    view = GraphView(nodes=[Node(id="n1", kind="stub", label="N1")], edges=[])
+    outside = tmp_path / "outside-root" / "bundle"
+
+    with pytest.raises(ValueError):
+        OkfGraphSink().export(view, str(outside))
+
+    assert not outside.exists()
+    assert list(_all_files(export_root)) == []
+
+
+def test_okf_absolute_dest_under_root_accepted(export_root):
+    """An ABSOLUTE dest that already resolves under the root is accepted."""
+    view = GraphView(nodes=[Node(id="n1", kind="stub", label="N1")], edges=[])
+    under = os.path.join(export_root, "abs-bundle")
+
+    written = OkfGraphSink().export(view, under)
+
+    assert written
+    for p in written:
+        assert os.path.realpath(p).startswith(export_root + os.sep)
+
+
+def test_okf_node_without_attrs_does_not_crash(export_root):
     """A node missing optional attrs keys exports cleanly (no Attributes section)."""
     view = GraphView(nodes=[Node(id="bare", kind="stub", label="Bare")], edges=[])
-    dest = tmp_path / "bundle"
 
-    OkfGraphSink().export(view, str(dest))
+    written = OkfGraphSink().export(view, "bundle")
 
-    text = (dest / "bare.md").read_text(encoding="utf-8")
+    bare = next(p for p in written if os.path.basename(p) == "bare.md")
+    text = open(bare, encoding="utf-8").read()
     assert "# Bare" in text
-    assert "## Attributes" not in text  # empty attrs -> section omitted
+    assert "## Attributes" not in text
+
+
+@pytest.mark.parametrize("reserved", ["index", "manifest"])
+def test_okf_reserved_stem_collision_raises(export_root, reserved):
+    """A node id slugging to a reserved bundle stem (index/manifest) -> ValueError (S1).
+
+    Previously the node's .md was silently clobbered by the generated
+    index.md/manifest.md; now it fails loudly like the Obsidian collision.
+    """
+    view = GraphView(nodes=[Node(id=reserved, kind="stub", label="X")], edges=[])
+    with pytest.raises(ValueError, match="reserved"):
+        OkfGraphSink().export(view, "bundle")
+
+
+def test_okf_same_stem_collision_raises(export_root):
+    """Two ids slugging to the same stem -> ValueError (S1), not last-write-wins."""
+    view = GraphView(
+        nodes=[
+            Node(id="a/b", kind="stub", label="One"),
+            Node(id="a:b", kind="stub", label="Two"),  # both slug to 'a-b'
+        ],
+        edges=[],
+    )
+    with pytest.raises(ValueError, match="collision"):
+        OkfGraphSink().export(view, "bundle")
+
+
+def test_okf_label_injection_escaped(export_root):
+    """A label with a newline + markdown-structural chars is emitted safely (S3)."""
+    view = GraphView(
+        nodes=[Node(id="n1", kind="stub", label="Safe\n# Injected heading\n](evil)")],
+        edges=[],
+    )
+    written = OkfGraphSink().export(view, "bundle")
+
+    node_file = next(p for p in written if os.path.basename(p) == "n1.md")
+    text = open(node_file, encoding="utf-8").read()
+    # The H1 line carries the whole (escaped, single-line) label; no injected
+    # heading appears on its own line, and the link-opening chars are escaped.
+    h1 = next(line for line in text.splitlines() if line.startswith("# "))
+    assert "Injected heading" in h1  # collapsed onto the heading line, not a new one
+    assert "\n# Injected heading" not in text
+    assert "](evil)" not in text  # the ] ( ) were backslash-escaped
+
+
+def _all_files(root):
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            yield os.path.join(dirpath, f)

--- a/test/graph/test_api_routes.py
+++ b/test/graph/test_api_routes.py
@@ -1,0 +1,309 @@
+"""U4 — API route tests for GET /graph/{provider} and POST /graph/{provider}/export.
+
+Uses the real "stub" provider (U3) and a test-file-local sink registered via
+register_sink("stub-test-sink") in a fixture — the test sink is NOT shipped in
+graph/sinks/. The graph registries are snapshotted/restored by the autouse
+fixture in test/graph/conftest.py, so registering the test sink here does not
+leak into other tests.
+"""
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cli_agent_orchestrator.api.main import app
+from cli_agent_orchestrator.graph.models import GraphView, Node
+from cli_agent_orchestrator.graph.sinks import base as sinks_base
+from cli_agent_orchestrator.graph.sinks.base import GraphSink
+from cli_agent_orchestrator.plugins import PluginRegistry
+from cli_agent_orchestrator.security import auth
+
+
+class _TestClientWithHost(TestClient):
+    """TestClient that always sends a localhost Host header (TrustedHostMiddleware)."""
+
+    def request(self, method, url, **kwargs):
+        headers = kwargs.get("headers") or {}
+        if not any(k.lower() == "host" for k in headers):
+            headers["Host"] = "localhost"
+        kwargs["headers"] = headers
+        return super().request(method, url, **kwargs)
+
+
+@pytest.fixture
+def client():
+    app.state.plugin_registry = PluginRegistry()
+    return _TestClientWithHost(app)
+
+
+# A per-run spy the test sink records into, so tests can assert whether
+# export() was actually invoked (secret-gate short-circuit assertions).
+_EXPORT_SPY = MagicMock()
+
+
+@pytest.fixture
+def stub_test_sink():
+    """Register a capturing test sink under 'stub-test-sink' for the test.
+
+    The autouse registry-isolation fixture (conftest) restores the registry
+    afterwards, so no manual deregistration is needed.
+    """
+    _EXPORT_SPY.reset_mock()
+
+    @sinks_base.register_sink("stub-test-sink")
+    class _StubTestSink(GraphSink):
+        def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
+            _EXPORT_SPY(view=view, dest=dest, options=options)
+            return [f"{dest}/stub-a.md", f"{dest}/index.md"]
+
+    return _EXPORT_SPY
+
+
+@pytest.fixture
+def auth_on(monkeypatch):
+    """Enable the auth enforcement layer for scope-gating tests."""
+    monkeypatch.setenv("CAO_AUTH_JWKS_URI", "https://idp.example/jwks")
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.pop(auth.get_current_scopes, None)
+
+
+def _override_scopes(scopes):
+    async def _dep():
+        return list(scopes)
+
+    return _dep
+
+
+# ── GET /graph/{provider} ────────────────────────────────────────────────
+
+
+def test_get_graph_happy_path(client):
+    """GET against the stub provider returns 200 and a GraphView-shaped body."""
+    resp = client.get("/graph/stub")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body) == {"nodes", "edges", "meta"}
+    assert {n["id"] for n in body["nodes"]} == {"stub-a", "stub-b", "stub-c"}
+    assert body["edges"][0]["source"] == "stub-a"
+    assert body["meta"]["provider"] == "stub"
+
+
+def test_get_graph_unregistered_provider_404(client):
+    """GET on an unregistered provider name is a 404."""
+    resp = client.get("/graph/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_get_graph_is_ungated_even_with_auth_enabled(client, auth_on):
+    """With auth ENABLED, a no-Authorization GET still returns 200.
+
+    Proves the GET route carries no scope dependency (FR-12): if it were
+    gated, an unauthenticated request would be 401, not 200.
+    """
+    resp = client.get("/graph/stub")
+    assert resp.status_code == 200
+
+
+# ── POST /graph/{provider}/export ────────────────────────────────────────
+
+
+def test_post_export_happy_path(client, stub_test_sink):
+    """POST export resolves provider+sink, projects, exports, returns the envelope."""
+    resp = client.post(
+        "/graph/stub/export",
+        json={"sink": "stub-test-sink", "dest": "/tmp/does-not-matter", "options": {}},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "written_files": ["/tmp/does-not-matter/stub-a.md", "/tmp/does-not-matter/index.md"],
+        "sink": "stub-test-sink",
+        "dest": "/tmp/does-not-matter",
+    }
+    # provider projected + sink.export called exactly once.
+    assert stub_test_sink.call_count == 1
+
+
+def test_post_export_unregistered_sink_404(client):
+    """An unregistered sink name is a 404."""
+    resp = client.post(
+        "/graph/stub/export",
+        json={"sink": "no-such-sink", "dest": "/tmp/x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_post_export_unregistered_provider_404(client, stub_test_sink):
+    """An unregistered provider name is a 404."""
+    resp = client.post(
+        "/graph/no-such-provider/export",
+        json={"sink": "stub-test-sink", "dest": "/tmp/x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_post_export_no_token_401(client, stub_test_sink, auth_on):
+    """With auth enabled, a request with no token is 401 (authentication)."""
+    resp = client.post(
+        "/graph/stub/export",
+        json={"sink": "stub-test-sink", "dest": "/tmp/x"},
+    )
+    assert resp.status_code == 401
+
+
+def test_post_export_read_only_scope_403(client, stub_test_sink, auth_on):
+    """A cao:read-only token is 403 on the write-gated export route."""
+    app.dependency_overrides[auth.get_current_scopes] = _override_scopes([auth.SCOPE_READ])
+    resp = client.post(
+        "/graph/stub/export",
+        json={"sink": "stub-test-sink", "dest": "/tmp/x"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize("scope", ["cao:write", "cao:admin"])
+def test_post_export_write_or_admin_scope_admitted(client, stub_test_sink, auth_on, scope):
+    """A cao:write or cao:admin token passes the scope gate (200)."""
+    app.dependency_overrides[auth.get_current_scopes] = _override_scopes([scope])
+    resp = client.post(
+        "/graph/stub/export",
+        json={"sink": "stub-test-sink", "dest": "/tmp/x"},
+    )
+    assert resp.status_code == 200
+
+
+def test_post_export_secret_gate_422_and_sink_not_called(client, monkeypatch):
+    """A secret in an attrs value -> 422; sink.export is NEVER called; no bytes leak.
+
+    Registers a secret-carrying provider and a spy sink, then asserts the
+    422 fires before any write and the response body does not echo the
+    matched substring.
+    """
+    from cli_agent_orchestrator.graph.providers import base as providers_base
+    from cli_agent_orchestrator.graph.providers.base import GraphProvider
+
+    secret_value = "AKIA" + "A" * 16  # matches secret_gate's aws_access_key pattern
+
+    @providers_base.register_provider("secret-provider")
+    class _SecretProvider(GraphProvider):
+        async def project(self, **filters: Any) -> GraphView:
+            return GraphView(
+                nodes=[Node(id="n1", kind="stub", label="N1", attrs={"token": secret_value})],
+                edges=[],
+            )
+
+    spy = MagicMock()
+
+    @sinks_base.register_sink("spy-sink")
+    class _SpySink(GraphSink):
+        def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
+            spy(dest=dest)
+            return [dest]
+
+    resp = client.post(
+        "/graph/secret-provider/export",
+        json={"sink": "spy-sink", "dest": "/tmp/x"},
+    )
+    assert resp.status_code == 422
+    assert "aws_access_key" in resp.json()["detail"]
+    # The matched bytes MUST NOT leak into the response.
+    assert secret_value not in resp.text
+    # export() must never have run on the rejected branch.
+    spy.assert_not_called()
+
+
+# ── ValueError -> 400 route mapping (error-taxonomy AC) ──────────────────
+#
+# These doubles are test-local (registered via register_provider/register_sink
+# in fixtures, restored by conftest's registry-isolation fixture) — they are
+# NOT shipped in graph/providers/ or graph/sinks/. They exercise the route's
+# except ValueError -> 400 mapping, which the sink-level traversal tests never
+# hit (those assert ValueError at the sink API directly, not through a route).
+
+
+@pytest.fixture
+def value_error_provider():
+    """Register a provider whose project(**filters) always raises ValueError."""
+    from cli_agent_orchestrator.graph.providers import base as providers_base
+    from cli_agent_orchestrator.graph.providers.base import GraphProvider
+
+    @providers_base.register_provider("boom-provider")
+    class _BoomProvider(GraphProvider):
+        async def project(self, **filters: Any) -> GraphView:
+            raise ValueError("bad filter value")
+
+    return "boom-provider"
+
+
+@pytest.fixture
+def value_error_sink():
+    """Register a sink whose export() always raises ValueError."""
+
+    @sinks_base.register_sink("boom-sink")
+    class _BoomSink(GraphSink):
+        def export(self, view: GraphView, dest: str, **options: Any) -> list[str]:
+            raise ValueError("bad dest / options")
+
+    return "boom-sink"
+
+
+def test_get_graph_provider_value_error_400(client, value_error_provider):
+    """A provider ValueError on GET is mapped to 400 by the route."""
+    resp = client.get(f"/graph/{value_error_provider}?scope=bogus")
+    assert resp.status_code == 400
+    assert "bad filter value" in resp.json()["detail"]
+
+
+def test_post_export_provider_value_error_400(client, value_error_provider, stub_test_sink):
+    """A provider ValueError on POST /export is mapped to 400 by the route.
+
+    Regression guard for the previously-unwrapped prov.project() call: this
+    test FAILS against the pre-fix code (the ValueError escaped -> 500) and
+    PASSES once the handler wraps project() in try/except -> 400.
+    """
+    resp = client.post(
+        f"/graph/{value_error_provider}/export",
+        json={"sink": "stub-test-sink", "dest": "/tmp/x", "options": {}},
+    )
+    assert resp.status_code == 400
+    assert "bad filter value" in resp.json()["detail"]
+
+
+def test_post_export_sink_value_error_400(client, value_error_sink):
+    """A sink ValueError on POST /export is mapped to 400 by the route."""
+    resp = client.post(
+        "/graph/stub/export",
+        json={"sink": value_error_sink, "dest": "/tmp/x", "options": {}},
+    )
+    assert resp.status_code == 400
+    assert "bad dest / options" in resp.json()["detail"]
+
+
+# ── NFR-5: no name-branching in the route bodies ─────────────────────────
+
+
+def test_routes_have_no_name_branching():
+    """The two route handlers contain no if/elif over the provider/sink NAME.
+
+    NFR-5: resolution goes through the registry only. The only conditionals
+    allowed are try/except on resolution outcome — assert no `== "<name>"`
+    style comparison appears in either handler source.
+    """
+    from cli_agent_orchestrator.api import main as api_main
+
+    for fn in (api_main.get_graph_endpoint, api_main.export_graph_endpoint):
+        src = inspect.getsource(fn)
+        assert "if provider ==" not in src
+        assert "elif provider ==" not in src
+        assert "if body.sink ==" not in src
+        assert "elif body.sink ==" not in src
+        # No equality comparison against a hardcoded provider/sink literal.
+        for literal in ("stub", "memory", "okf", "obsidian", "graphml"):
+            assert f'== "{literal}"' not in src

--- a/test/graph/test_api_routes.py
+++ b/test/graph/test_api_routes.py
@@ -101,14 +101,42 @@ def test_get_graph_unregistered_provider_404(client):
     assert resp.status_code == 404
 
 
-def test_get_graph_is_ungated_even_with_auth_enabled(client, auth_on):
-    """With auth ENABLED, a no-Authorization GET still returns 200.
+def test_get_graph_no_token_401(client, auth_on):
+    """With auth ENABLED, a no-Authorization GET is 401 (MUST-FIX #1).
 
-    Proves the GET route carries no scope dependency (FR-12): if it were
-    gated, an unauthenticated request would be 401, not 200.
+    The GET route is now scope-gated (SCOPE_READ floor, matching /events),
+    superseding FR-12's original "ungated" wording: an unauthenticated
+    caller must not read graph structure (which carries private-scope
+    contradiction summaries of memory content). Regression guard — this
+    FAILS if the require_any_scope dependency is removed (200 instead of 401).
     """
     resp = client.get("/graph/stub")
+    assert resp.status_code == 401
+
+
+def test_get_graph_read_scope_admitted(client, auth_on):
+    """A cao:read token passes the GET scope gate for a public scope (200)."""
+    app.dependency_overrides[auth.get_current_scopes] = _override_scopes([auth.SCOPE_READ])
+    resp = client.get("/graph/stub?scope=project")
     assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "scope",
+    ["session", "agent", "Session", "AGENT", "Agent", "SESSION"],
+)
+def test_get_graph_private_scope_refused_400(client, auth_on, scope):
+    """A session/agent scope is refused with 400 even for an authed reader.
+
+    Mirrors /memory/export's private-tier refusal (D5): the API surface
+    never exposes private tiers. The detail must mention "private". The
+    refusal is case-insensitive: mixed/upper-case aliases (``Session``,
+    ``AGENT``) must not slip past the guard.
+    """
+    app.dependency_overrides[auth.get_current_scopes] = _override_scopes([auth.SCOPE_READ])
+    resp = client.get(f"/graph/stub?scope={scope}")
+    assert resp.status_code == 400
+    assert "private" in resp.json()["detail"]
 
 
 # ── POST /graph/{provider}/export ────────────────────────────────────────
@@ -217,6 +245,30 @@ def test_post_export_secret_gate_422_and_sink_not_called(client, monkeypatch):
     assert secret_value not in resp.text
     # export() must never have run on the rejected branch.
     spy.assert_not_called()
+
+
+# ── S2: OSError from the sink is mapped to 4xx (not a bare 500) ──────────
+
+
+def test_post_export_oserror_maps_to_400(client, monkeypatch, tmp_path):
+    """A real graphml export whose dest is an existing DIRECTORY -> 400, not 500.
+
+    ElementTree.write() on a directory raises IsADirectoryError (an OSError).
+    Regression guard for S2: the route now catches OSError and maps it to
+    400 instead of letting it escape as an unhandled 500.
+    """
+    # Point the export root at a tmp dir, then make dest an existing directory
+    # UNDER the root so confinement passes and the OSError fires at write time.
+    monkeypatch.setenv("CAO_GRAPH_EXPORT_ROOT", str(tmp_path))
+    existing_dir = tmp_path / "already-a-dir"
+    existing_dir.mkdir()
+
+    resp = client.post(
+        "/graph/stub/export",
+        json={"sink": "graphml", "dest": "already-a-dir", "options": {}},
+    )
+    assert resp.status_code == 400
+    assert "destination" in resp.json()["detail"].lower()
 
 
 # ── ValueError -> 400 route mapping (error-taxonomy AC) ──────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "cli-agent-orchestrator"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
@@ -366,6 +366,7 @@ dependencies = [
     { name = "pyte" },
     { name = "python-dotenv" },
     { name = "python-frontmatter" },
+    { name = "pyyaml" },
     { name = "rank-bm25" },
     { name = "requests" },
     { name = "sqlalchemy" },
@@ -404,6 +405,7 @@ requires-dist = [
     { name = "pyte", specifier = ">=0.8.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -379,6 +379,8 @@ dev = [
     { name = "hypothesis" },
     { name = "isort" },
     { name = "mypy" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -415,6 +417,7 @@ dev = [
     { name = "hypothesis", specifier = ">=6.0" },
     { name = "isort", specifier = ">=5.12.0" },
     { name = "mypy", specifier = ">=1.5.0" },
+    { name = "networkx", specifier = ">=3.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -1256,6 +1259,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bolt B3 of the generic knowledge-graph layer (#348). Builds on B1 (U1 contract/registries) and B2 (U2/U3 providers, #416), both now on main.

## What
- **U4 — API routes** (`api/main.py`): `GET /graph/{provider}` (ungated read, FR-12) returns `GraphView.to_dict()`; `POST /graph/{provider}/export` (scope-gated `require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)`, FR-14) runs `secret_gate.scan_for_secrets` over the serialized view **before** any sink write (ADR-5) — a hit is a 422 and `export()` is never called. `GraphExportRequest{sink, dest, options}`. Zero if/else dispatch over provider/sink name (NFR-5) — resolution is registry-only.
- **U5 — OKF sink** (`graph/sinks/okf.py`): one markdown file per node + `index.md` (sorted, deterministic) + `manifest.md`.
- **U6 — Obsidian sink** (`graph/sinks/obsidian.py`): one note per node, `[[wikilink]]` per edge, `(contradiction)` suffix for contradiction edges, slug-collision guard.
- **U7 — GraphML sink** (`graph/sinks/graphml.py`): stdlib-only `xml.etree.ElementTree` (C-2), round-trips node/edge counts through `networkx.read_graphml`.
- All sinks validate `dest` via the shared `path_validation` utility before any write (NFR-3), return `list[str]` (written paths); the route wraps that into `{written_files, sink, dest}`.

## Tests
24 B3 tests: route happy/error taxonomy (404 unregistered provider/sink, 400 provider/sink `ValueError`, 401/403 scope-gating, 422 secret-gate with an `export()`-never-called spy, ungated-GET-still-200-with-auth-on), each sink's happy path + traversal rejection + a format-specific edge. `test/graph/` + `test/api/` green. black/isort clean; no new mypy errors in the graph/api surface.

## Notes
- `networkx` added as a **dev-only** dependency (U7 round-trip test; importorskip-guarded) — not a runtime dep.
- Reviewed via the supervisor→reviewer loop; one round (POST route `ValueError`→400 mapping + a missing 400-branch test), resolved.
- Follow-up carried from B2 (not in this PR): `graph_density` `is_hub` cross-container mis-mark; clean fix needs `wiki_lint` to emit `scope_id` (ADR-1 keeps it out of scope).