### PR TITLE
fix(codex): validate MCP server names and env keys in -c override paths

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -181,7 +181,10 @@ def _validate_config_key(key: Any, *, source: str, allow_dots: bool = False) -> 
             "a single TOML bare key over [A-Za-z0-9_-] (no dots -- a dot "
             "would nest the entry under the wrong TOML table)"
         )
-    if not isinstance(key, str) or not pattern.match(key):
+    # fullmatch, not match: with ``$`` alone, re.match accepts a TRAILING
+    # newline ("srv\n" passes ^...$), which is exactly the bug class this
+    # validation exists to close.
+    if not isinstance(key, str) or not pattern.fullmatch(key):
         raise ValueError(f"Invalid {source} key {key!r}: must be {expected}")
     return key
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -149,23 +149,51 @@ def _toml_scalar(value: Any) -> str:
     return f'"{escaped}"'
 
 
+# codexConfig keys are dotted CONFIG PATHS ("features.fast_mode") — dots are
+# the path separator and intentional. MCP server names and env keys are single
+# TOML BARE KEYS: a dot there would silently create a NESTED table
+# (mcp_servers.my.srv.command → mcp_servers['my']['srv'], not
+# mcp_servers['my.srv']), so codex would never find the server.
 _CODEX_CONFIG_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+_CODEX_BARE_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _validate_config_key(key: Any, *, source: str, allow_dots: bool = False) -> str:
+    """Validate a key that is interpolated into a Codex ``-c`` override path.
+
+    Spaces, ``=``, quotes, or control characters are rejected so a
+    misconfigured profile fails fast with a clear error instead of silently
+    emitting a malformed ``-c`` override (an unescaped quote or newline in the
+    KEY half would corrupt the TOML the same way an unescaped value would).
+
+    ``allow_dots=True`` permits dotted config paths (codexConfig keys like
+    ``features.fast_mode``). MCP server names and env keys must be single
+    TOML bare keys: a dot there would nest the entry under the wrong TOML
+    table (see pattern comment above). ``source`` names the profile field
+    for the error message.
+    """
+    if allow_dots:
+        pattern = _CODEX_CONFIG_KEY_PATTERN
+        expected = "a dotted config path over [A-Za-z0-9_.-] (e.g. 'features.fast_mode')"
+    else:
+        pattern = _CODEX_BARE_KEY_PATTERN
+        expected = (
+            "a single TOML bare key over [A-Za-z0-9_-] (no dots -- a dot "
+            "would nest the entry under the wrong TOML table)"
+        )
+    if not isinstance(key, str) or not pattern.match(key):
+        raise ValueError(f"Invalid {source} key {key!r}: must be {expected}")
+    return key
 
 
 def _toml_override(key: str, value: Any) -> str:
     """Build one ``key=<toml-scalar>`` Codex ``-c`` override, validating the key.
 
-    Keys must be non-empty dotted config paths over ``[A-Za-z0-9_.-]`` (e.g.
-    ``features.fast_mode``); spaces, ``=``, quotes, or control characters are
-    rejected so a misconfigured profile fails fast instead of silently emitting
-    a malformed ``-c`` override. Value-serialization failures from
-    :func:`_toml_scalar` are re-raised with the offending key for context.
+    Key validation is delegated to :func:`_validate_config_key`.
+    Value-serialization failures from :func:`_toml_scalar` are re-raised with
+    the offending key for context.
     """
-    if not isinstance(key, str) or not _CODEX_CONFIG_KEY_PATTERN.match(key):
-        raise ValueError(
-            f"Invalid codexConfig key {key!r}: must be a dotted config path over "
-            "[A-Za-z0-9_.-] (e.g. 'features.fast_mode')"
-        )
+    _validate_config_key(key, source="codexConfig", allow_dots=True)
     try:
         return f"{key}={_toml_scalar(value)}"
     except TypeError as exc:
@@ -275,6 +303,13 @@ class CodexProvider(BaseProvider):
             # Each server field is set via dotted path: mcp_servers.<name>.<field>=<value>
             if profile.mcpServers:
                 for server_name, server_config in profile.mcpServers.items():
+                    # Codex-only validation: the server name becomes part of
+                    # the -c override PATH (a TOML dotted path), so it must be
+                    # a single bare key — a quote/newline would corrupt the
+                    # TOML and a dot would nest the server under the wrong
+                    # table. Other providers write JSON configs where any
+                    # string key is valid, so they don't need this.
+                    _validate_config_key(server_name, source="mcpServers name")
                     prefix = f"mcp_servers.{server_name}"
                     if isinstance(server_config, dict):
                         cfg = dict(server_config)
@@ -292,6 +327,7 @@ class CodexProvider(BaseProvider):
                         command_parts.extend(["-c", f"{prefix}.args={args_toml}"])
                     if "env" in cfg and cfg["env"]:
                         for env_key, env_val in cfg["env"].items():
+                            _validate_config_key(env_key, source="mcpServers env")
                             command_parts.extend(
                                 ["-c", f"{prefix}.env.{env_key}={_toml_scalar(str(env_val))}"]
                             )

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -596,7 +596,7 @@ class TestTomlOverride:
         assert _toml_override("features.fast_mode", True) == "features.fast_mode=true"
         assert _toml_override("model_reasoning_effort", "xhigh") == 'model_reasoning_effort="xhigh"'
 
-    @pytest.mark.parametrize("key", ["bad key", "a=b", 'k"x', "key\ninjected", "", "a/b"])
+    @pytest.mark.parametrize("key", ["bad key", "a=b", 'k"x', "key\ninjected", "key\n", "", "a/b"])
     def test_rejects_unsafe_key(self, key):
         # Unsafe keys would produce a malformed -c override or split the tmux
         # command across lines; fail fast instead.
@@ -625,7 +625,7 @@ class TestMcpKeyValidation:
         return mock_profile
 
     @pytest.mark.parametrize(
-        "name", ['srv"x', "srv\ninjected", "bad name", "a=b", "", "srv.dotted"]
+        "name", ['srv"x', "srv\ninjected", "srv\n", "bad name", "a=b", "", "srv.dotted"]
     )
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
     def test_rejects_unsafe_server_name(self, mock_load, name):
@@ -634,7 +634,7 @@ class TestMcpKeyValidation:
         with pytest.raises(ValueError, match="Invalid mcpServers name key"):
             provider._build_codex_command()
 
-    @pytest.mark.parametrize("env_key", ['K"X', "K\nY", "BAD KEY", "a=b", "", "K.DOTTED"])
+    @pytest.mark.parametrize("env_key", ['K"X', "K\nY", "K\n", "BAD KEY", "a=b", "", "K.DOTTED"])
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
     def test_rejects_unsafe_env_key(self, mock_load, env_key):
         mock_load.return_value = self._profile_with(

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -608,6 +608,53 @@ class TestTomlOverride:
             _toml_override("features.x", {"nested": 1})
 
 
+class TestMcpKeyValidation:
+    """MCP server names and env keys are validated before interpolation into
+    the ``-c mcp_servers.<name>.<field>`` override path — a quote or newline
+    in the KEY half would corrupt the TOML the same way an unescaped value
+    would."""
+
+    @staticmethod
+    def _profile_with(servers):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = servers
+        mock_profile.codexProfile = None
+        mock_profile.codexConfig = None
+        return mock_profile
+
+    @pytest.mark.parametrize(
+        "name", ['srv"x', "srv\ninjected", "bad name", "a=b", "", "srv.dotted"]
+    )
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_rejects_unsafe_server_name(self, mock_load, name):
+        mock_load.return_value = self._profile_with({name: {"command": "cmd", "args": []}})
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        with pytest.raises(ValueError, match="Invalid mcpServers name key"):
+            provider._build_codex_command()
+
+    @pytest.mark.parametrize("env_key", ['K"X', "K\nY", "BAD KEY", "a=b", "", "K.DOTTED"])
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_rejects_unsafe_env_key(self, mock_load, env_key):
+        mock_load.return_value = self._profile_with(
+            {"srv": {"command": "cmd", "args": [], "env": {env_key: "value"}}}
+        )
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        with pytest.raises(ValueError, match="Invalid mcpServers env key"):
+            provider._build_codex_command()
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_accepts_normal_names_and_env_keys(self, mock_load):
+        mock_load.return_value = self._profile_with(
+            {"cao-mcp-server": {"command": "cmd", "args": [], "env": {"API_KEY": "v"}}}
+        )
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        command = provider._build_codex_command()
+        assert "mcp_servers.cao-mcp-server.command=" in command
+        assert "mcp_servers.cao-mcp-server.env.API_KEY=" in command
+
+
 class TestCodexProviderCodexConfig:
     """Tests that profile.codexConfig emits inline ``-c key=value`` overrides."""
 


### PR DESCRIPTION
## What happens

The Codex provider interpolates each MCP server's **name** and **env keys** into the `-c mcp_servers.<name>.<field>` override PATH without validation, while the VALUES on the other side of the `=` are TOML-escaped (#404). Two failure modes:

1. A name/key containing a quote or newline produces malformed TOML — the same bug class #404 fixed for values, on the KEY half.
2. A name/key containing a **dot** silently lands the entry under the wrong TOML table: `mcp_servers.my.srv.command` parses as `mcp_servers['my']['srv']`, not `mcp_servers['my.srv']`, so Codex never finds the server and it silently fails to register.

Keys come from operator-installed profiles, so the practical risk is a confusing silent failure rather than injection.

## The fix

Lift the existing codexConfig key check into a shared `_validate_config_key(key, source=..., allow_dots=...)` helper and apply it to mcpServers names and env keys:

- codexConfig keys keep allowing dots (they are dotted config paths by design, e.g. `features.fast_mode`).
- MCP server names and env keys must be single TOML bare keys (`[A-Za-z0-9_-]`); the error message explains the dot/nesting hazard specifically.

**Behavior note:** a profile with a dotted server name previously "worked" (launched) while silently misconfiguring Codex; it now fails fast at launch-command build time with an error naming the offending field. This validation is Codex-only on purpose — other providers materialize mcpServers as JSON, where any string key is valid (noted in a code comment).

## Testing

- Parametrized rejection tests for server names and env keys: quote, newline, space, `=`, empty, and dotted forms.
- Happy-path test asserting normal names/env keys still emit their overrides.
- Existing codexConfig tests confirm dotted config paths still validate.
- black / isort / mypy / full pytest suite green.

Follow-up to #404 — raised there in review as a pre-existing adjacent issue.
