### PR TITLE
fix(tmux): stop logging full send_keys payloads at INFO

### DIFF
--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -284,7 +284,14 @@ class TmuxClient:
         target = f"{validated_session}:{validated_window}"
         buf_name = f"cao_{uuid.uuid4().hex[:8]}"
         try:
-            logger.info(f"send_keys: {target} - keys: {keys}")
+            # Log metadata only at INFO: the payload is the full launch
+            # command / message, which can include MCP env values (API
+            # tokens from a profile's mcpServers.env) and entire system
+            # prompts. This matches send_keys_via_paste, which logs only
+            # the text length at INFO. Full content additionally remains
+            # available here at DEBUG for local delivery troubleshooting.
+            logger.info(f"send_keys: {target} - keys length: {len(keys)}")
+            logger.debug(f"send_keys: {target} - keys: {keys}")
             if force_bracketed_paste:
                 # Wrap unconditionally and use -r (no newline→CR conversion).
                 # paste-buffer -p only adds bracketed sequences if tmux tracks

--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -145,3 +145,32 @@ class TestSendKeys:
         assert mock_subprocess.run.call_count == 4
         load_call = mock_subprocess.run.call_args_list[0]
         assert len(load_call[1]["input"]) == 50000
+
+
+class TestSendKeysLogRedaction:
+    """send_keys must not log payload content at INFO — launch commands carry
+    MCP env values (API tokens) and full system prompts. Content is DEBUG-only."""
+
+    def test_info_log_omits_payload(self, client, mock_subprocess, mock_uuid, caplog):
+        import logging
+
+        secret = "API_TOKEN=super-secret-value"
+        with caplog.at_level(logging.INFO, logger="cli_agent_orchestrator.clients.tmux"):
+            client.send_keys("sess", "win", f"launch --env {secret}")
+
+        info_text = "\n".join(r.getMessage() for r in caplog.records if r.levelno == logging.INFO)
+        assert "super-secret-value" not in info_text
+        # Metadata still logged: target and payload length.
+        assert "sess:win" in info_text
+        assert "keys length" in info_text
+
+    def test_debug_log_retains_payload_for_troubleshooting(
+        self, client, mock_subprocess, mock_uuid, caplog
+    ):
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="cli_agent_orchestrator.clients.tmux"):
+            client.send_keys("sess", "win", "visible-at-debug")
+
+        debug_text = "\n".join(r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG)
+        assert "visible-at-debug" in debug_text


### PR DESCRIPTION
## What happens

`TmuxClient.send_keys` logs the complete payload at INFO level:

```python
logger.info(f"send_keys: {target} - keys: {keys}")
```

That payload is the agent launch command or an inter-agent message, which can include every MCP server env value from the agent profile (e.g. API tokens in `mcpServers.<name>.env`) and the entire `developer_instructions` system prompt. Any token in a profile lands in CAO's logs at default verbosity.

## The fix

Log target + payload length at INFO, matching `send_keys_via_paste` (which already logs only the text length at INFO). Full content additionally remains available at DEBUG for local delivery troubleshooting — a deliberate local-only tradeoff rather than masking, consistent with the rest of the codebase.

`send_special_key`'s INFO log is intentionally unchanged: its payload is a tmux key name ("Enter", "C-c", "Escape"), never message content (verified across all callers).

## Testing

- A secret placed in the payload is asserted absent from INFO records while target and length still appear, and asserted visible at DEBUG.
- black / isort / mypy / full pytest suite green.

Follow-up to #404 — raised there in review as a pre-existing adjacent issue (full launch-command logging was flagged as a credential-hygiene concern).
