### PR TITLE
fix: allow containerized/wrapped provider agents to initialize (#400)

### DIFF
--- a/docs/agent-profile.md
+++ b/docs/agent-profile.md
@@ -39,6 +39,8 @@ Define the agent's role, responsibilities, and behavior here.
 - `codexConfig` (object, `codex` only): Inline Codex config overrides passed as `-c key=value` at launch (e.g. `model_reasoning_effort`, `service_tier`, `features.fast_mode`). Keys may be dotted config paths; values become TOML scalars. See [Inline Codex Config Overrides](codex-cli.md#inline-codex-config-overrides).
 - `hermesProfile` (string, `hermes` only): Optional Hermes profile wrapper command CAO should launch instead of the default `hermes`, for example one created with `hermes profile alias test-worker`. This is intentionally separate from `codexProfile`: Codex consumes profile names via `codex --profile <name>`, while Hermes aliases are executable commands launched directly as `<alias> chat ...`. See [Hermes Provider](hermes.md).
 - `prompt` (string): Additional prompt text
+- `container` (object): Host-to-guest path mappings for an agent whose CLI runs wrapped inside a container (`podman exec`, `docker exec`, `nerdctl exec`, a devcontainer, etc.). See [Container-Wrapped Agents](#container-wrapped-agents).
+- `provider_init_timeout` (int, seconds): Per-profile override for the provider initialization timeout, replacing the server-wide `provider_init_timeout` default (60s — see [Configuration](configuration.md#server-server)) for this agent only. Also the outer cap on the startup-prompt handler (Claude Code, Kimi, Antigravity). Use this for containerized profiles whose wrapped CLI takes far longer to reach IDLE than a native launch.
 
 ## Tool Restrictions
 
@@ -135,6 +137,28 @@ You review code for quality and correctness.
 ```
 
 > **Note:** The `cao launch --provider` CLI flag is an explicit override and always takes precedence over the profile's `provider` key for the initial session.
+
+## Container-Wrapped Agents
+
+When a CLI agent runs inside a container (via a wrapper command like `podman exec`, `docker exec`, or `nerdctl exec`), the files CAO writes to the host filesystem — the per-terminal system-prompt file and MCP config JSON under `~/.aws/cli-agent-orchestrator/tmp/` — are not visible to the process at their host paths. The `container.path_maps` field declares the bind-mount contract so CAO can translate a host path to the corresponding guest path before passing it as a CLI flag.
+
+```markdown
+---
+name: containerized-worker
+description: Agent running inside a podman container
+container:
+  path_maps:
+    - host: /home/user/.aws/cli-agent-orchestrator/tmp
+      guest: /workspace/cao-tmp
+provider_init_timeout: 180
+---
+
+You are a containerized worker agent.
+```
+
+- `container.path_maps` (array of `{host, guest}`): Host-prefix-to-guest-prefix mappings. When CAO builds a temp-file path (system prompt, MCP config) that starts with a mapped `host` prefix, the path is rewritten to the corresponding `guest` prefix using longest-prefix-match — if multiple entries match, the one with the longest `host` prefix wins. A path with no matching prefix is passed through unchanged. The container must actually bind-mount `host` to `guest` (e.g. `podman run -v /home/user/.aws/cli-agent-orchestrator/tmp:/workspace/cao-tmp`) for the translated path to resolve inside the container — CAO only rewrites the string, it does not configure the mount.
+- Currently wired into the `claude_code` provider only (the temp prompt file and `--mcp-config` path). Other providers pass their config inline or via different mechanisms and do not consume `path_maps`.
+- Pair `container.path_maps` with `provider_init_timeout` (see [Optional Fields](#optional-fields)): a wrapped launch (cold container start, image pull, nested process supervision) routinely takes longer to reach IDLE than a native one, and the per-profile override raises the cap without changing the server-wide default for every other agent.
 
 ## Installation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,8 +116,8 @@ Timeouts and buffer sizes used by the CAO runtime. All values have safe defaults
 |---------|---------|--------------|
 | `mcp_request_timeout` | `30` | Seconds to wait for HTTP calls between the MCP server process and the CAO API. |
 | `event_bus_max_queue_size` | `1024` | Max events buffered per subscriber queue in the internal event bus. |
-| `provider_init_timeout` | `60` | Seconds to wait for the initial shell prompt before launching a CLI provider. |
-| `startup_prompt_handler_timeout` | `20` | Seconds the Claude Code startup prompt handler waits for workspace trust dialogs. |
+| `provider_init_timeout` | `60` | Seconds to wait for a CLI agent to reach IDLE. Also the hard outer cap on total time a startup-prompt handler (Claude Code, Kimi, Antigravity) may run. Overridable per-profile via `provider_init_timeout` in the agent profile — see [Agent Profile Format](agent-profile.md#optional-fields). |
+| `startup_prompt_handler_timeout` | `20` | Idle gap, in seconds, between consecutive startup prompts (e.g. workspace trust / bypass dialogs, Kimi's upgrade dialog, Antigravity's trust/survey dialogs). The handler polls and resets this timer each time it answers a prompt; it only starts counting once the FIRST prompt has been handled, so a first dialog arriving later than this value (e.g. a cold/containerized start) is still caught — before any prompt is seen, only `provider_init_timeout` bounds the wait. Once at least one prompt has been handled, the handler exits after this many seconds pass with no further prompt. |
 
 ### Memory (`memory`)
 

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -567,10 +567,17 @@ class HerdrBackend(TerminalBackend):
         - blocked  -> WAITING_USER_ANSWER
         - done     -> COMPLETED
         - idle     -> IDLE  (caller disambiguates IDLE vs COMPLETED via _task_dispatched)
-        - unknown  -> ERROR  (pane exists but no agent registered yet)
+        - unknown  -> None  (herdr has no agent registered for the pane)
 
-        Returns None only on backend errors (command failure, parse error) so
-        the caller can fall through to buffer analysis as a last resort.
+        "unknown" maps to None (not ERROR) because a wrapped launch command
+        (e.g. ``podman exec`` / ``docker exec``) makes herdr's foreground
+        process the wrapper, not the nested agent CLI, so herdr never registers
+        the agent and reports "unknown" indefinitely. None signals
+        "unknown/unresolvable at the backend level" and lets the caller resolve
+        status another way rather than flagging a healthy pane as ERROR.
+
+        Returns None on backend errors (command failure, parse error) and for
+        an "unknown"/unrecognized agent_status.
         """
         try:
             pane_id = self._resolve_pane_id_from_window(session_name, window_name)
@@ -596,8 +603,8 @@ class HerdrBackend(TerminalBackend):
             return TerminalStatus.COMPLETED
         if agent_status == "idle":
             return TerminalStatus.IDLE
-        # "unknown" and any unrecognized value
-        return TerminalStatus.ERROR
+        # "unknown" and any unrecognized value: unresolvable at backend level.
+        return None
 
     def get_pane_id(self, terminal_id: str, session_name: str = "", window_name: str = "") -> str:
         """Resolve CAO terminal_id to herdr pane_id.

--- a/src/cli_agent_orchestrator/models/agent_profile.py
+++ b/src/cli_agent_orchestrator/models/agent_profile.py
@@ -17,6 +17,19 @@ class McpServer(BaseModel):
     timeout: Optional[int] = None
 
 
+class ContainerPathMap(BaseModel):
+    """Single host->guest path mapping for container environments."""
+
+    host: str
+    guest: str
+
+
+class ContainerConfig(BaseModel):
+    """Container environment configuration."""
+
+    path_maps: Optional[List[ContainerPathMap]] = None
+
+
 class AgentProfile(BaseModel):
     """Agent profile configuration with Q CLI agent fields."""
 
@@ -32,6 +45,17 @@ class AgentProfile(BaseModel):
     # the full catalog (backward-compatible); [] = no skills advertised. Consumed
     # by CAO when composing the prompt, not passed through to provider JSON.
     skills: Optional[List[str]] = None
+
+    # CAO-native. Host->guest path maps for container-backed agents. Consumed by
+    # the provider layer to translate host paths (e.g. temp prompt/MCP files)
+    # into the guest paths the containerized CLI sees; not passed to provider JSON.
+    container: Optional[ContainerConfig] = None
+
+    # CAO-native. Per-profile override for provider initialization timeout (seconds).
+    # When set, this value is used as the hard outer cap for CLI agent initialization
+    # instead of the server default (60s from settings_service). Allows containerized
+    # profiles to declare longer init times (e.g., 180s) without changing global config.
+    provider_init_timeout: Optional[int] = None
 
     # Q CLI agent fields (all optional, will be passed through to JSON)
     prompt: Optional[str] = None

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -382,7 +382,7 @@ class AntigravityCliProvider(BaseProvider):
             # names behind and block terminal teardown.
             self._mcp_server_names = []
 
-    def _handle_startup_dialog(self, timeout: Optional[float] = None) -> None:
+    def _handle_startup_dialog(self, idle_gap: Optional[float] = None) -> None:
         """Dismiss agy's blocking startup dialogs (workspace-trust, survey).
 
         Mirrors ClaudeCodeProvider._handle_startup_prompts / KimiCliProvider.
@@ -393,14 +393,35 @@ class AntigravityCliProvider(BaseProvider):
         dismissal continues the loop rather than returning. Exits once agy is
         at its ready footer with no dialog on screen — the survey renders ON
         TOP of the footer, so the survey check must run before the idle exit.
+
+        Idle-gap semantics (see issue #400): a cold or containerized start can
+        render these dialogs LATE and in sequence, past the old fixed ~20s
+        window. Rather than a total-window budget, ``idle_gap`` is the maximum
+        quiet stretch tolerated BETWEEN prompts: answering a dialog resets the
+        idle timer, and the loop exits once no new prompt appears for
+        ``idle_gap`` seconds (or agy reaches its ready footer). Total runtime is
+        hard-capped by ``provider_init_timeout``.
+
+        Args:
+            idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
+                to the ``startup_prompt_handler_timeout`` setting.
         """
-        if timeout is None:
-            timeout = get_server_settings()["startup_prompt_handler_timeout"]
+        if idle_gap is None:
+            idle_gap = get_server_settings()["startup_prompt_handler_timeout"]
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
-        start_time = time.time()
+        outer_deadline = time.monotonic() + get_server_settings()["provider_init_timeout"]
+        last_prompt_time = time.monotonic()
         trust_done = survey_done = False
-        while time.time() - start_time < timeout:
+        while True:
+            now = time.monotonic()
+            if now >= outer_deadline:
+                logger.warning(
+                    "Antigravity startup dialog handler hit provider_init_timeout outer cap"
+                )
+                return
+            if now - last_prompt_time >= idle_gap:
+                return  # no new prompt within the idle gap — startup settled
             output = get_backend().get_history(self.session_name, self.window_name)
             if output:
                 clean = strip_terminal_escapes(output)
@@ -409,6 +430,7 @@ class AntigravityCliProvider(BaseProvider):
                     status_monitor.notify_input_sent(self.terminal_id)
                     get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                     trust_done = True
+                    last_prompt_time = time.monotonic()  # reset idle timer — survey may follow
                     time.sleep(1.0)
                     continue
                 if not survey_done and re.search(SURVEY_PROMPT_PATTERN, clean):
@@ -418,6 +440,7 @@ class AntigravityCliProvider(BaseProvider):
                     time.sleep(0.5)
                     get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                     survey_done = True
+                    last_prompt_time = time.monotonic()  # reset idle timer
                     time.sleep(1.0)
                     continue
                 # At the ready footer with no dialog pending → done.
@@ -483,7 +506,7 @@ class AntigravityCliProvider(BaseProvider):
         """
         # Native status (herdr): trust the backend's agent state when available;
         # on herdr the buffer is never fed, so buffer parsing can't leave UNKNOWN.
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -510,6 +510,9 @@ class AntigravityCliProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -220,6 +220,24 @@ class AntigravityCliProvider(BaseProvider):
     # Launch
     # ------------------------------------------------------------------ #
 
+    def _try_load_profile(self):
+        """Best-effort profile load for timeout resolution only.
+
+        Returns None on any load failure instead of raising -- unlike
+        ``_build_agy_command``'s inline load, which legitimately raises
+        ``ProviderError`` on a broken profile. This helper only feeds
+        ``BaseProvider.get_init_timeout``, so a missing/unloadable profile
+        should fall back to the server default here, not abort init before
+        the real (error-raising) load in ``_build_agy_command`` gets a chance
+        to report the actual problem.
+        """
+        if self._agent_profile is None:
+            return None
+        try:
+            return load_agent_profile(self._agent_profile)
+        except Exception:
+            return None
+
     def _mcp_config_path(self) -> Path:
         """Path to agy's MCP config file (shared ~/.gemini/config/mcp_config.json)."""
         return Path.home() / ".gemini" / "config" / "mcp_config.json"
@@ -382,7 +400,9 @@ class AntigravityCliProvider(BaseProvider):
             # names behind and block terminal teardown.
             self._mcp_server_names = []
 
-    def _handle_startup_dialog(self, idle_gap: Optional[float] = None) -> None:
+    def _handle_startup_dialog(
+        self, idle_gap: Optional[float] = None, outer_timeout: Optional[float] = None
+    ) -> None:
         """Dismiss agy's blocking startup dialogs (workspace-trust, survey).
 
         Mirrors ClaudeCodeProvider._handle_startup_prompts / KimiCliProvider.
@@ -400,18 +420,31 @@ class AntigravityCliProvider(BaseProvider):
         quiet stretch tolerated BETWEEN prompts: answering a dialog resets the
         idle timer, and the loop exits once no new prompt appears for
         ``idle_gap`` seconds (or agy reaches its ready footer). Total runtime is
-        hard-capped by ``provider_init_timeout``.
+        hard-capped by ``outer_timeout``.
+
+        The idle-gap exit only starts counting once the first dialog has been
+        handled -- until then, a first dialog arriving later than ``idle_gap``
+        (the scenario issue #400 itself reports) would otherwise be missed: the
+        loop would exit at the idle-gap boundary having never seen it. Before
+        any dialog is observed, only ``outer_timeout`` can end the loop.
 
         Args:
             idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
                 to the ``startup_prompt_handler_timeout`` setting.
+            outer_timeout: Hard cap (seconds) on total handler runtime. Defaults
+                to the ``provider_init_timeout`` setting; initialize() passes the
+                per-profile-resolved value so a containerized profile's longer
+                init budget also governs this handler (mirrors ClaudeCodeProvider).
         """
         if idle_gap is None:
             idle_gap = get_server_settings()["startup_prompt_handler_timeout"]
+        if outer_timeout is None:
+            outer_timeout = get_server_settings()["provider_init_timeout"]
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
-        outer_deadline = time.monotonic() + get_server_settings()["provider_init_timeout"]
+        outer_deadline = time.monotonic() + outer_timeout
         last_prompt_time = time.monotonic()
+        any_prompt_handled = False
         trust_done = survey_done = False
         while True:
             now = time.monotonic()
@@ -420,7 +453,7 @@ class AntigravityCliProvider(BaseProvider):
                     "Antigravity startup dialog handler hit provider_init_timeout outer cap"
                 )
                 return
-            if now - last_prompt_time >= idle_gap:
+            if any_prompt_handled and now - last_prompt_time >= idle_gap:
                 return  # no new prompt within the idle gap — startup settled
             output = get_backend().get_history(self.session_name, self.window_name)
             if output:
@@ -430,6 +463,7 @@ class AntigravityCliProvider(BaseProvider):
                     status_monitor.notify_input_sent(self.terminal_id)
                     get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                     trust_done = True
+                    any_prompt_handled = True
                     last_prompt_time = time.monotonic()  # reset idle timer — survey may follow
                     time.sleep(1.0)
                     continue
@@ -440,6 +474,7 @@ class AntigravityCliProvider(BaseProvider):
                     time.sleep(0.5)
                     get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                     survey_done = True
+                    any_prompt_handled = True
                     last_prompt_time = time.monotonic()  # reset idle timer
                     time.sleep(1.0)
                     continue
@@ -471,18 +506,30 @@ class AntigravityCliProvider(BaseProvider):
         status_monitor.notify_input_sent(self.terminal_id)
         get_backend().send_keys(self.session_name, self.window_name, command)
 
+        # Resolve the per-profile provider_init_timeout override (if any) so it
+        # governs both the startup-dialog handler's outer cap and the readiness
+        # wait below, mirroring ClaudeCodeProvider. Best-effort: a missing/
+        # unloadable profile falls back to the 180s default here;
+        # _build_agy_command above already raised its own ProviderError on a
+        # genuine load failure before this point.
+        init_timeout = self.get_init_timeout(self._try_load_profile())
+        default_ready_timeout = 180.0
+
         # Accept the workspace-trust dialog if agy shows one (first launch in an
         # untrusted cwd). Unanswered it blocks init — the picker never reads IDLE.
-        self._handle_startup_dialog()
+        self._handle_startup_dialog(outer_timeout=max(default_ready_timeout, init_timeout))
 
         # agy startup + first MCP connection + the -i acknowledgment can take
         # a while.
+        ready_timeout = max(default_ready_timeout, init_timeout)
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=180.0,
+            timeout=ready_timeout,
         ):
-            raise TimeoutError("Antigravity CLI initialization timed out after 180 seconds")
+            raise TimeoutError(
+                f"Antigravity CLI initialization timed out after {ready_timeout} seconds"
+            )
 
         self._initialized = True
         return True

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -23,9 +23,12 @@ import logging
 import re
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+if TYPE_CHECKING:
+    from cli_agent_orchestrator.models.agent_profile import AgentProfile
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +47,12 @@ class BaseProvider(ABC):
         _status: Internal status cache (use get_status() for current status)
         _allowed_tools: CAO-vocabulary tool names this agent is allowed to use
     """
+
+    # Seconds after task dispatch that an unresolvable native status (herdr
+    # "unknown" with an empty buffer) is treated as optimistic PROCESSING.
+    # Past this, the agent is presumed wedged and reported ERROR. See the
+    # native-None matrix in _resolve_native_status().
+    _TASK_DISPATCH_STALENESS_TIMEOUT = 120
 
     def __init__(
         self,
@@ -264,7 +273,7 @@ class BaseProvider(ABC):
         self._done_first_detected = 0.0
         self._idle_first_detected = 0.0
 
-    def _resolve_native_status(self) -> Optional[TerminalStatus]:
+    def _resolve_native_status(self, buffer: Optional[str]) -> Optional[TerminalStatus]:
         """Resolve status from the backend's native agent state, if available.
 
         On the herdr backend, ``pipe_pane`` is a no-op so the StatusMonitor
@@ -272,17 +281,38 @@ class BaseProvider(ABC):
         rather than buffer parsing. Every provider calls this at the top of
         ``get_status()``; when it returns non-None the buffer path is skipped.
 
-        The tmux backend returns None from ``get_native_status()``, so this
-        returns None and the caller falls through to its buffer analysis
-        unchanged.
+        ``get_native_status()`` returns None in two distinct situations, which
+        ``buffer`` disambiguates:
 
-        The only ambiguous native state is IDLE: herdr reports "idle" both
-        before any task has been dispatched AND after a task completed (e.g. the
-        user focused the tab, resetting "done" -> "idle"). ``_task_dispatched``
-        (set by mark_input_received()) disambiguates. COMPLETED ("done") and
-        IDLE-post-dispatch both wait 10s from first detection for the pane buffer
-        to flush before reporting COMPLETED, so extract_last_message sees settled
-        output; the idle path gives up (reports COMPLETED) 300s after dispatch.
+        - tmux backend: always None, and the StatusMonitor ``buffer`` is
+          populated. This method returns None so the caller falls through to
+          buffer analysis unchanged.
+        - herdr backend, "unknown" agent_status: None with an empty ``buffer``
+          (a wrapped ``podman``/``docker exec`` launch hides the agent CLI from
+          herdr). Buffer parsing cannot help, so status is inferred from
+          dispatch state per the matrix below.
+
+        Native-None resolution matrix:
+
+        | buffer      | _task_dispatched      | Result                    |
+        |-------------|-----------------------|---------------------------|
+        | non-empty   | *                     | None (fall to buffer)     |
+        | empty       | False                 | IDLE                      |
+        | empty       | True, fresh (<120s)   | PROCESSING (optimistic)   |
+        | empty       | True, stale (>=120s)  | ERROR (+ warning log)     |
+
+        The only ambiguous non-None native state is IDLE: herdr reports "idle"
+        both before any task has been dispatched AND after a task completed
+        (e.g. the user focused the tab, resetting "done" -> "idle").
+        ``_task_dispatched`` (set by mark_input_received()) disambiguates.
+        COMPLETED ("done") and IDLE-post-dispatch both wait 10s from first
+        detection for the pane buffer to flush before reporting COMPLETED, so
+        extract_last_message sees settled output; the idle path gives up
+        (reports COMPLETED) 300s after dispatch.
+
+        Args:
+            buffer: The StatusMonitor output buffer for this terminal. Empty (or
+                None) on the herdr backend; populated on tmux.
         """
         from cli_agent_orchestrator.backends.registry import get_backend
 
@@ -293,7 +323,30 @@ class BaseProvider(ABC):
             native.value if native is not None else None,
         )
         if native is None:
-            return None
+            # Native status unresolvable. On tmux the buffer is populated —
+            # fall through to buffer analysis. On herdr "unknown" the buffer is
+            # empty (wrapped exec hides the agent), so infer from dispatch state.
+            if buffer:
+                return None
+            if not self._task_dispatched:
+                return TerminalStatus.IDLE
+            elapsed = time.time() - self._last_dispatch_time
+            if elapsed < self._TASK_DISPATCH_STALENESS_TIMEOUT:
+                logger.debug(
+                    "[get_status] terminal=%s -> PROCESSING "
+                    "(native unresolved, %.0fs since dispatch, optimistic)",
+                    self.terminal_id,
+                    elapsed,
+                )
+                return TerminalStatus.PROCESSING
+            logger.warning(
+                "[get_status] terminal=%s -> ERROR "
+                "(native unresolved, %.0fs since dispatch exceeds %ds staleness timeout)",
+                self.terminal_id,
+                elapsed,
+                self._TASK_DISPATCH_STALENESS_TIMEOUT,
+            )
+            return TerminalStatus.ERROR
         if native == TerminalStatus.PROCESSING:
             # Reset flush-wait timers — herdr is actively working, so any
             # previously stamped idle/done timestamp is from a pre-work gap
@@ -439,6 +492,50 @@ class BaseProvider(ABC):
         if system_prompt:
             return f"{system_prompt}\n\n{self._skill_prompt}"
         return self._skill_prompt
+
+    def get_init_timeout(self, profile: Optional["AgentProfile"] = None) -> int:
+        """Resolve the provider initialization timeout (seconds).
+
+        Returns the per-profile ``provider_init_timeout`` override when the
+        profile declares one, else the server default from
+        ``get_server_settings()`` (60s). Lets containerized profiles, whose
+        wrapped CLI can take far longer to reach IDLE, declare a longer init
+        cap without changing global config.
+
+        Passed the loaded profile as a parameter (like ``_translate_path``)
+        rather than reading ``self`` — subclasses store a profile *name string*
+        in ``self._agent_profile``, not an ``AgentProfile`` object.
+        """
+        from cli_agent_orchestrator.services.settings_service import get_server_settings
+
+        if profile is not None and profile.provider_init_timeout is not None:
+            return profile.provider_init_timeout
+        return int(get_server_settings()["provider_init_timeout"])
+
+    def _translate_path(self, path: str, profile: Optional["AgentProfile"] = None) -> str:
+        """Translate a host path to a container guest path using profile path_maps.
+
+        Uses longest-prefix-match: if multiple path_maps match, the one with the
+        longest host prefix wins.  If no map matches, returns the path unchanged.
+        """
+        if profile is None or profile.container is None or not profile.container.path_maps:
+            return path
+
+        best_match = None
+        best_len = 0
+        for mapping in profile.container.path_maps:
+            host_prefix = mapping.host.rstrip("/")
+            if path == host_prefix or path.startswith(host_prefix + "/"):
+                if len(host_prefix) > best_len:
+                    best_match = mapping
+                    best_len = len(host_prefix)
+
+        if best_match is None:
+            return path
+
+        host_prefix = best_match.host.rstrip("/")
+        guest_prefix = best_match.guest.rstrip("/")
+        return guest_prefix + path[best_len:]
 
     def _update_status(self, status: TerminalStatus) -> None:
         """Update internal status."""

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -48,12 +48,6 @@ class BaseProvider(ABC):
         _allowed_tools: CAO-vocabulary tool names this agent is allowed to use
     """
 
-    # Seconds after task dispatch that an unresolvable native status (herdr
-    # "unknown" with an empty buffer) is treated as optimistic PROCESSING.
-    # Past this, the agent is presumed wedged and reported ERROR. See the
-    # native-None matrix in _resolve_native_status().
-    _TASK_DISPATCH_STALENESS_TIMEOUT = 120
-
     def __init__(
         self,
         terminal_id: str,
@@ -273,7 +267,7 @@ class BaseProvider(ABC):
         self._done_first_detected = 0.0
         self._idle_first_detected = 0.0
 
-    def _resolve_native_status(self, buffer: Optional[str]) -> Optional[TerminalStatus]:
+    def _resolve_native_status(self, buffer: Optional[str] = None) -> Optional[TerminalStatus]:
         """Resolve status from the backend's native agent state, if available.
 
         On the herdr backend, ``pipe_pane`` is a no-op so the StatusMonitor
@@ -281,25 +275,17 @@ class BaseProvider(ABC):
         rather than buffer parsing. Every provider calls this at the top of
         ``get_status()``; when it returns non-None the buffer path is skipped.
 
-        ``get_native_status()`` returns None in two distinct situations, which
-        ``buffer`` disambiguates:
-
-        - tmux backend: always None, and the StatusMonitor ``buffer`` is
-          populated. This method returns None so the caller falls through to
-          buffer analysis unchanged.
-        - herdr backend, "unknown" agent_status: None with an empty ``buffer``
-          (a wrapped ``podman``/``docker exec`` launch hides the agent CLI from
-          herdr). Buffer parsing cannot help, so status is inferred from
-          dispatch state per the matrix below.
-
-        Native-None resolution matrix:
-
-        | buffer      | _task_dispatched      | Result                    |
-        |-------------|-----------------------|---------------------------|
-        | non-empty   | *                     | None (fall to buffer)     |
-        | empty       | False                 | IDLE                      |
-        | empty       | True, fresh (<120s)   | PROCESSING (optimistic)   |
-        | empty       | True, stale (>=120s)  | ERROR (+ warning log)     |
+        ``get_native_status()`` returns None when the backend cannot resolve a
+        real agent state — always on tmux, and on herdr when the agent_status
+        is "unknown" (a wrapped ``podman``/``docker exec`` launch hides the
+        agent CLI from herdr). In both cases this returns None unconditionally
+        so the caller falls through to buffer analysis via ``_resolve_buffer()``
+        — never a guess derived from dispatch timing. A guess here previously
+        traded fail-fast init detection (a dead/wedged launch reported ERROR)
+        for optimistic PROCESSING/IDLE, which silently masked real failures
+        until a hardcoded staleness window elapsed. Buffer analysis on real
+        pane content (see ``_resolve_buffer``) restores both fail-fast ERROR
+        detection and a real COMPLETED path without that tradeoff.
 
         The only ambiguous non-None native state is IDLE: herdr reports "idle"
         both before any task has been dispatched AND after a task completed
@@ -311,8 +297,8 @@ class BaseProvider(ABC):
         (reports COMPLETED) 300s after dispatch.
 
         Args:
-            buffer: The StatusMonitor output buffer for this terminal. Empty (or
-                None) on the herdr backend; populated on tmux.
+            buffer: Unused; retained so existing call sites (``self.
+                _resolve_native_status(output)``) do not need updating.
         """
         from cli_agent_orchestrator.backends.registry import get_backend
 
@@ -323,30 +309,9 @@ class BaseProvider(ABC):
             native.value if native is not None else None,
         )
         if native is None:
-            # Native status unresolvable. On tmux the buffer is populated —
-            # fall through to buffer analysis. On herdr "unknown" the buffer is
-            # empty (wrapped exec hides the agent), so infer from dispatch state.
-            if buffer:
-                return None
-            if not self._task_dispatched:
-                return TerminalStatus.IDLE
-            elapsed = time.time() - self._last_dispatch_time
-            if elapsed < self._TASK_DISPATCH_STALENESS_TIMEOUT:
-                logger.debug(
-                    "[get_status] terminal=%s -> PROCESSING "
-                    "(native unresolved, %.0fs since dispatch, optimistic)",
-                    self.terminal_id,
-                    elapsed,
-                )
-                return TerminalStatus.PROCESSING
-            logger.warning(
-                "[get_status] terminal=%s -> ERROR "
-                "(native unresolved, %.0fs since dispatch exceeds %ds staleness timeout)",
-                self.terminal_id,
-                elapsed,
-                self._TASK_DISPATCH_STALENESS_TIMEOUT,
-            )
-            return TerminalStatus.ERROR
+            # Unresolvable at the backend level (tmux always; herdr "unknown").
+            # Fall through to buffer analysis unchanged — no guessing here.
+            return None
         if native == TerminalStatus.PROCESSING:
             # Reset flush-wait timers — herdr is actively working, so any
             # previously stamped idle/done timestamp is from a pre-work gap
@@ -409,6 +374,53 @@ class BaseProvider(ABC):
         # COMPLETED (no task dispatched), WAITING_USER_ANSWER, ERROR -- return directly
         logger.debug("[get_status] terminal=%s -> %s (native)", self.terminal_id, native.value)
         return native
+
+    def _resolve_buffer(self, buffer: Optional[str]) -> str:
+        """Resolve the buffer ``get_status()`` should parse when native status is None.
+
+        Event-inbox backends (herdr) never populate the pushed StatusMonitor
+        buffer -- ``pipe_pane`` is a no-op there (see ``_resolve_native_status``)
+        -- so an empty ``buffer`` on herdr does not mean the pane has no
+        content, only that the push pipeline was never fed. Falling straight
+        through to a provider's "no output" default (UNKNOWN, or ERROR for
+        hermes) on every herdr call was the original #359 gap; guessing status
+        from dispatch timing (the #400 native-None matrix this replaces) traded
+        that gap for silently masking real failures behind an optimistic
+        window. Reading the backend's live pane content instead lets each
+        provider's EXISTING pattern matching (idle prompt, error text, response
+        markers) run against real content: a dead launch's error text is
+        visible, a wedged pane genuinely shows no prompt, and a finished turn's
+        response is genuinely there to extract.
+
+        On tmux, ``buffer`` is already populated by the FIFO push pipeline, so
+        this is a pure pass-through -- no extra backend round-trip.
+
+        Args:
+            buffer: The StatusMonitor's pushed buffer for this terminal (may be
+                empty or None).
+
+        Returns:
+            ``buffer`` unchanged (tmux, or a non-empty herdr buffer), or a live
+            ``get_history()`` read (herdr with an empty pushed buffer). Never
+            raises -- a backend read failure falls back to ``buffer`` (or "").
+        """
+        if buffer:
+            return buffer
+        from cli_agent_orchestrator.backends.registry import get_backend
+
+        backend = get_backend()
+        if not backend.supports_event_inbox():
+            return buffer or ""
+        try:
+            return backend.get_history(self.session_name, self.window_name)
+        except Exception as e:
+            logger.debug(
+                "[get_status] terminal=%s live buffer read failed, falling back to "
+                "pushed buffer: %s",
+                self.terminal_id,
+                e,
+            )
+            return buffer or ""
 
     @staticmethod
     def _extract_questions(user_messages: List[str]) -> List[str]:

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -529,12 +529,18 @@ class BaseProvider(ABC):
 
         Uses longest-prefix-match: if multiple path_maps match, the one with the
         longest host prefix wins.  If no map matches, returns the path unchanged.
+
+        ``best_len`` starts at -1 (not 0) so a root mapping (``host="/"``) can
+        still win when it is the only match: ``rstrip("/")`` reduces ``"/"`` to
+        ``""`` (length 0), and ``0 > 0`` is never true, so starting the
+        comparison at 0 silently dropped every root mapping regardless of
+        whether anything more specific matched.
         """
         if profile is None or profile.container is None or not profile.container.path_maps:
             return path
 
         best_match = None
-        best_len = 0
+        best_len = -1
         for mapping in profile.container.path_maps:
             host_prefix = mapping.host.rstrip("/")
             if path == host_prefix or path.startswith(host_prefix + "/"):

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -12,11 +12,6 @@ from typing import TYPE_CHECKING, Any, List, Optional
 if TYPE_CHECKING:
     from cli_agent_orchestrator.models.agent_profile import AgentProfile
 
-# Sentinel so _build_claude_command can tell "caller passed no profile, load it"
-# from "caller explicitly passed None" (native/missing profile). initialize()
-# loads the profile once and passes it in; direct callers omit it and get a load.
-_UNSET: Any = object()
-
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import CAO_HOME_DIR
 from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -28,6 +23,15 @@ from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_sta
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
 
 logger = logging.getLogger(__name__)
+
+# Sentinel so _build_claude_command can tell "caller passed no profile, load it"
+# from "caller explicitly passed None" (native/missing profile). initialize()
+# loads the profile once and passes it in; direct callers omit it and get a
+# load. NOT a candidate for removal in favor of a plain `None` default: that
+# would make _build_claude_command reload the profile from disk a SECOND time
+# whenever initialize() already resolved it to None (no CAO profile found),
+# reintroducing the double-disk-read this sentinel exists to prevent.
+_UNSET: Any = object()
 
 
 # Custom exception for provider errors

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -385,6 +385,15 @@ class ClaudeCodeProvider(BaseProvider):
         hard-capped by ``outer_timeout`` so a wedged start cannot hang init
         indefinitely.
 
+        The idle-gap exit is gated on having handled at least one prompt.
+        ``last_prompt_time`` has no real "last prompt" to measure from until
+        the FIRST one arrives, so treating the handler's start time as if it
+        were one let a first dialog later than ``idle_gap`` (e.g. issue #400's
+        own cold-node-plus-gateway-connect scenario) get missed entirely — the
+        loop would exit at the idle-gap boundary having never seen it. Before
+        any prompt has been observed, only ``outer_timeout`` can end the loop;
+        the idle-gap clock starts only once a prompt has actually been handled.
+
         Args:
             idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
                 to the ``startup_prompt_handler_timeout`` setting.
@@ -399,13 +408,14 @@ class ClaudeCodeProvider(BaseProvider):
             outer_timeout = get_server_settings()["provider_init_timeout"]
         outer_deadline = time.monotonic() + outer_timeout
         last_prompt_time = time.monotonic()
+        any_prompt_handled = False
         bypass_accepted = False
         while True:
             now = time.monotonic()
             if now >= outer_deadline:
                 logger.warning("Startup prompt handler hit provider_init_timeout outer cap")
                 return
-            if now - last_prompt_time >= idle_gap:
+            if any_prompt_handled and now - last_prompt_time >= idle_gap:
                 return  # no new prompt within the idle gap — startup settled
 
             output = get_backend().get_history(self.session_name, self.window_name)
@@ -430,6 +440,7 @@ class ClaudeCodeProvider(BaseProvider):
                 status_monitor.notify_input_sent(self.terminal_id)
                 get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 bypass_accepted = True
+                any_prompt_handled = True
                 last_prompt_time = time.monotonic()  # reset idle timer — trust prompt may follow
                 time.sleep(1.0)
                 continue

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -7,7 +7,15 @@ import re
 import shlex
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from cli_agent_orchestrator.models.agent_profile import AgentProfile
+
+# Sentinel so _build_claude_command can tell "caller passed no profile, load it"
+# from "caller explicitly passed None" (native/missing profile). initialize()
+# loads the profile once and passes it in; direct callers omit it and get a load.
+_UNSET: Any = object()
 
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import CAO_HOME_DIR
@@ -163,7 +171,26 @@ class ClaudeCodeProvider(BaseProvider):
         # Native-status dispatch tracking (_task_dispatched + flush-wait timers)
         # lives on BaseProvider and is consumed by _resolve_native_status().
 
-    def _build_claude_command(self) -> str:
+    def _load_profile(self) -> Optional["AgentProfile"]:
+        """Load this terminal's CAO agent profile from disk, if any.
+
+        Returns None when no profile name was given or the named profile does
+        not exist (the "pass --agent <name> to the native store" path). Raises
+        ProviderError on a genuine load/parse failure so a broken profile is not
+        silently ignored.
+
+        ``self._agent_profile`` is a profile *name string*, not an object.
+        """
+        if self._agent_profile is None:
+            return None
+        try:
+            return load_agent_profile(self._agent_profile)
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            raise ProviderError(f"Failed to load agent profile '{self._agent_profile}': {e}")
+
+    def _build_claude_command(self, profile: Optional["AgentProfile"] = _UNSET) -> str:
         """Build Claude Code command with agent profile if provided.
 
         Returns properly escaped shell command string that can be safely sent via tmux.
@@ -175,6 +202,11 @@ class ClaudeCodeProvider(BaseProvider):
         2. No CAO profile found -> pass --agent <name> directly to Claude Code's
            native agent store (~/.claude/agents/)
         3. Full CAO profile -> decompose into CLI flags (model, prompt, MCP, etc.)
+
+        Args:
+            profile: Pre-loaded profile. When omitted, the profile is loaded from
+                disk here. initialize() loads it once and passes it in so the
+                profile is not read from disk twice per launch.
         """
         # --dangerously-skip-permissions: bypass the workspace trust dialog and
         # tool permission prompts. CAO already confirms workspace access during
@@ -182,14 +214,8 @@ class ClaudeCodeProvider(BaseProvider):
         # (supervisor and worker) is redundant and blocks handoff/assign flows.
         yolo = bool(self._allowed_tools and "*" in self._allowed_tools)
 
-        profile = None
-        if self._agent_profile is not None:
-            try:
-                profile = load_agent_profile(self._agent_profile)
-            except FileNotFoundError:
-                profile = None
-            except Exception as e:
-                raise ProviderError(f"Failed to load agent profile '{self._agent_profile}': {e}")
+        if profile is _UNSET:
+            profile = self._load_profile()
 
         # Determine permission mode for the base command.
         # Priority: explicit permissionMode > yolo/root detection > default yolo.
@@ -237,7 +263,9 @@ class ClaudeCodeProvider(BaseProvider):
                     prompt_file.chmod(0o600)
                 except OSError:
                     pass
-                command_parts.extend(["--append-system-prompt-file", str(prompt_file)])
+                command_parts.extend(
+                    ["--append-system-prompt-file", self._translate_path(str(prompt_file), profile)]
+                )
 
             # Add MCP config if present.
             # Forward CAO_TERMINAL_ID so MCP servers (e.g. cao-mcp-server)
@@ -269,7 +297,13 @@ class ClaudeCodeProvider(BaseProvider):
                     mcp_file.chmod(0o600)
                 except OSError:
                     pass
-                command_parts.extend(["--mcp-config", str(mcp_file), "--strict-mcp-config"])
+                command_parts.extend(
+                    [
+                        "--mcp-config",
+                        self._translate_path(str(mcp_file), profile),
+                        "--strict-mcp-config",
+                    ]
+                )
 
         # Apply tool restrictions via --disallowedTools flags.
         # --dangerously-skip-permissions bypasses prompts but --disallowedTools
@@ -328,7 +362,9 @@ class ClaudeCodeProvider(BaseProvider):
             json.dump(settings, f, indent=2)
         logger.info("Set skipDangerousModePermissionPrompt in ~/.claude/settings.json")
 
-    def _handle_startup_prompts(self, timeout: Optional[float] = None) -> None:
+    def _handle_startup_prompts(
+        self, idle_gap: Optional[float] = None, outer_timeout: Optional[float] = None
+    ) -> None:
         """Auto-accept startup prompts that may appear before the REPL is ready.
 
         Claude Code may show up to two prompts during startup:
@@ -339,12 +375,39 @@ class ClaudeCodeProvider(BaseProvider):
            this in most cases; this handler is a defensive fallback.
         2. **Workspace trust dialog** – shows "Yes, I trust this folder";
            requires ``Enter``.
+
+        Idle-gap semantics (see issue #400): a cold or containerized start can
+        render these dialogs LATE and in sequence, past the old fixed ~20s
+        window. Instead of a total-window budget, ``idle_gap`` is the maximum
+        quiet stretch tolerated BETWEEN prompts: the loop keeps polling and
+        resets the idle timer every time it answers a prompt, exiting only once
+        no new prompt appears for ``idle_gap`` seconds. Total runtime is still
+        hard-capped by ``outer_timeout`` so a wedged start cannot hang init
+        indefinitely.
+
+        Args:
+            idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
+                to the ``startup_prompt_handler_timeout`` setting.
+            outer_timeout: Hard cap (seconds) on total handler runtime. Defaults
+                to the ``provider_init_timeout`` setting; initialize() passes the
+                per-profile-resolved value so a containerized profile's longer
+                init budget also governs this handler.
         """
-        if timeout is None:
-            timeout = get_server_settings()["startup_prompt_handler_timeout"]
-        start_time = time.time()
+        if idle_gap is None:
+            idle_gap = get_server_settings()["startup_prompt_handler_timeout"]
+        if outer_timeout is None:
+            outer_timeout = get_server_settings()["provider_init_timeout"]
+        outer_deadline = time.monotonic() + outer_timeout
+        last_prompt_time = time.monotonic()
         bypass_accepted = False
-        while time.time() - start_time < timeout:
+        while True:
+            now = time.monotonic()
+            if now >= outer_deadline:
+                logger.warning("Startup prompt handler hit provider_init_timeout outer cap")
+                return
+            if now - last_prompt_time >= idle_gap:
+                return  # no new prompt within the idle gap — startup settled
+
             output = get_backend().get_history(self.session_name, self.window_name)
             if not output:
                 time.sleep(1.0)
@@ -367,8 +430,9 @@ class ClaudeCodeProvider(BaseProvider):
                 status_monitor.notify_input_sent(self.terminal_id)
                 get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 bypass_accepted = True
+                last_prompt_time = time.monotonic()  # reset idle timer — trust prompt may follow
                 time.sleep(1.0)
-                continue  # Trust prompt may follow
+                continue
 
             # 2) Handle workspace trust prompt
             if re.search(TRUST_PROMPT_PATTERN, clean_output):
@@ -390,21 +454,25 @@ class ClaudeCodeProvider(BaseProvider):
             #    rendered, leaving it unaccepted; initialize() then blocked on
             #    {IDLE, COMPLETED} for 30s and the session was killed. Trust/bypass
             #    dialogs are handled explicitly above; if no banner ever appears the
-            #    loop just waits out its timeout and the downstream
+            #    loop just waits out its idle gap and the downstream
             #    wait_until_status() remains the real readiness gate.
             if re.search(r"Welcome to|Claude Code v\d+", clean_output):
                 logger.info("Claude Code started without prompts")
                 return
 
             time.sleep(1.0)
-        logger.warning("Startup prompt handler timed out")
 
     async def initialize(self) -> bool:
         """Initialize Claude Code provider by starting claude command."""
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
+        # Load the profile once so the per-profile provider_init_timeout override
+        # (if any) governs every wait below, and reuse it for the command build
+        # so the profile is not read from disk twice.
+        profile = self._load_profile()
+        init_timeout = self.get_init_timeout(profile)
+
         # Wait for shell prompt to appear in the tmux window
-        init_timeout = get_server_settings()["provider_init_timeout"]
         if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
@@ -412,7 +480,7 @@ class ClaudeCodeProvider(BaseProvider):
         self._ensure_skip_bypass_prompt_setting()
 
         # Build properly escaped command string
-        command = self._build_claude_command()
+        command = self._build_claude_command(profile)
 
         # Send Claude Code command using the backend. Arm the StatusMonitor
         # stickiness gate so the launching command can drive a fresh
@@ -420,8 +488,10 @@ class ClaudeCodeProvider(BaseProvider):
         status_monitor.notify_input_sent(self.terminal_id)
         get_backend().send_keys(self.session_name, self.window_name, command)
 
-        # Handle startup prompts (bypass permissions + workspace trust)
-        self._handle_startup_prompts()
+        # Handle startup prompts (bypass permissions + workspace trust).
+        # Pass the resolved timeout as the outer cap so a containerized profile's
+        # longer init budget also governs the startup-prompt handler.
+        self._handle_startup_prompts(outer_timeout=init_timeout)
 
         # Wait for Claude Code prompt to be ready.
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
@@ -430,7 +500,6 @@ class ClaudeCodeProvider(BaseProvider):
         # drives wait_until_status; it only fires once the provider's own
         # get_status returns IDLE/COMPLETED on Claude-rendered content, so the
         # old stale-zsh-prompt false-IDLE guard is no longer needed.
-        init_timeout = get_server_settings()["provider_init_timeout"]
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
@@ -466,7 +535,7 @@ class ClaudeCodeProvider(BaseProvider):
         """
         # Native status (herdr): when the backend knows agent state, trust it and
         # skip buffer reads. Tmux returns None -- falls through to buffer analysis.
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -539,6 +539,9 @@ class ClaudeCodeProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -405,7 +405,7 @@ class CodexProvider(BaseProvider):
     def get_status(self, output: str) -> TerminalStatus:
         # Native status (herdr): trust the backend's agent state when available;
         # on herdr the buffer is never fed, so buffer parsing can't leave UNKNOWN.
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -409,6 +409,9 @@ class CodexProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/copilot_cli.py
+++ b/src/cli_agent_orchestrator/providers/copilot_cli.py
@@ -412,7 +412,7 @@ class CopilotCliProvider(BaseProvider):
     def get_status(self, output: str) -> TerminalStatus:
         # Native status (herdr): trust the backend's agent state when available,
         # before the tmux capture-pane fallback below (which is a tmux-only path).
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/cursor_cli.py
+++ b/src/cli_agent_orchestrator/providers/cursor_cli.py
@@ -637,6 +637,9 @@ class CursorCliProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/cursor_cli.py
+++ b/src/cli_agent_orchestrator/providers/cursor_cli.py
@@ -633,7 +633,7 @@ class CursorCliProvider(BaseProvider):
         """
         # Native status (herdr): trust the backend's agent state when available;
         # on herdr the buffer is never fed, so buffer parsing can't leave UNKNOWN.
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/hermes.py
+++ b/src/cli_agent_orchestrator/providers/hermes.py
@@ -204,7 +204,7 @@ class HermesProvider(BaseProvider):
         # Native status (herdr): trust the backend's agent state when available.
         # Must precede the empty-buffer -> ERROR default below: on herdr the
         # buffer is always empty, so without this every status would be ERROR.
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/hermes.py
+++ b/src/cli_agent_orchestrator/providers/hermes.py
@@ -208,6 +208,9 @@ class HermesProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.ERROR
 

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -411,30 +411,53 @@ class KimiCliProvider(BaseProvider):
 
         cls._mcp_timeout_configured = True
 
-    def _handle_startup_dialog(self, timeout: Optional[float] = None) -> None:
+    def _handle_startup_dialog(self, idle_gap: Optional[float] = None) -> None:
         """Dismiss kimi's startup upgrade-reminder dialog if it appears.
 
         Mirrors ClaudeCodeProvider._handle_startup_prompts: polls the pane for
         the interactive "[s] Skip reminders for version X" menu and answers 's'
         so kimi can proceed to its ready prompt. Exits early if kimi is already
         ready (no newer version → no dialog), so a no-update start isn't delayed.
+
+        Idle-gap semantics (see issue #400): a cold or containerized start can
+        render the dialog LATE, past the old fixed ~20s window. Rather than a
+        total-window budget, ``idle_gap`` is the maximum quiet stretch tolerated
+        with no new prompt: answering the dialog resets the idle timer, and the
+        loop exits once no prompt appears for ``idle_gap`` seconds (or kimi is
+        ready). Total runtime is hard-capped by ``provider_init_timeout``.
+
+        Args:
+            idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
+                to the ``startup_prompt_handler_timeout`` setting.
         """
-        if timeout is None:
-            timeout = get_server_settings()["startup_prompt_handler_timeout"]
-        start_time = time.time()
-        while time.time() - start_time < timeout:
+        if idle_gap is None:
+            idle_gap = get_server_settings()["startup_prompt_handler_timeout"]
+        outer_deadline = time.monotonic() + get_server_settings()["provider_init_timeout"]
+        last_prompt_time = time.monotonic()
+        upgrade_dismissed = False
+        while True:
+            now = time.monotonic()
+            if now >= outer_deadline:
+                logger.warning("Kimi startup dialog handler hit provider_init_timeout outer cap")
+                return
+            if now - last_prompt_time >= idle_gap:
+                return  # no new prompt within the idle gap — startup settled
             output = get_backend().get_history(self.session_name, self.window_name)
             if output:
                 clean_output = re.sub(ANSI_CODE_PATTERN, "", output)
-                if re.search(UPGRADE_PROMPT_PATTERN, clean_output):
+                # Answer the upgrade dialog once; its text lingers in the buffer
+                # after dismissal, so the flag stops a re-answer on later polls.
+                if not upgrade_dismissed and re.search(UPGRADE_PROMPT_PATTERN, clean_output):
                     from cli_agent_orchestrator.services.status_monitor import status_monitor
 
                     logger.info("Kimi upgrade-reminder dialog detected, skipping reminders")
                     status_monitor.notify_input_sent(self.terminal_id)
                     # 's' = "Skip reminders for version X"; single-key menu, no Enter.
                     get_backend().send_keys(self.session_name, self.window_name, "s", enter_count=0)
+                    upgrade_dismissed = True
+                    last_prompt_time = time.monotonic()  # reset idle timer
                     time.sleep(1.0)
-                    return
+                    continue
                 # Already at a ready prompt → no dialog to handle, stop early.
                 if self.get_status(output) in (
                     TerminalStatus.IDLE,
@@ -516,7 +539,7 @@ class KimiCliProvider(BaseProvider):
         """
         # Native status (herdr): trust the backend's agent state when available;
         # on herdr the buffer is never fed, so buffer parsing can't leave UNKNOWN.
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -543,6 +543,9 @@ class KimiCliProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -251,6 +251,24 @@ class KimiCliProvider(BaseProvider):
         super().mark_input_received()
         self._has_received_input = True
 
+    def _try_load_profile(self):
+        """Best-effort profile load for timeout resolution only.
+
+        Returns None on any load failure instead of raising -- unlike
+        ``_build_kimi_command``'s inline load, which legitimately raises
+        ``ProviderError`` on a broken profile. This helper only feeds
+        ``BaseProvider.get_init_timeout``, so a missing/unloadable profile
+        should fall back to the server default here, not abort init before
+        the real (error-raising) load in ``_build_kimi_command`` gets a chance
+        to report the actual problem.
+        """
+        if self._agent_profile is None:
+            return None
+        try:
+            return load_agent_profile(self._agent_profile)
+        except Exception:
+            return None
+
     def _build_kimi_command(self) -> str:
         """Build Kimi CLI command with agent profile and MCP config if provided.
 
@@ -411,7 +429,9 @@ class KimiCliProvider(BaseProvider):
 
         cls._mcp_timeout_configured = True
 
-    def _handle_startup_dialog(self, idle_gap: Optional[float] = None) -> None:
+    def _handle_startup_dialog(
+        self, idle_gap: Optional[float] = None, outer_timeout: Optional[float] = None
+    ) -> None:
         """Dismiss kimi's startup upgrade-reminder dialog if it appears.
 
         Mirrors ClaudeCodeProvider._handle_startup_prompts: polls the pane for
@@ -424,23 +444,36 @@ class KimiCliProvider(BaseProvider):
         total-window budget, ``idle_gap`` is the maximum quiet stretch tolerated
         with no new prompt: answering the dialog resets the idle timer, and the
         loop exits once no prompt appears for ``idle_gap`` seconds (or kimi is
-        ready). Total runtime is hard-capped by ``provider_init_timeout``.
+        ready). Total runtime is hard-capped by ``outer_timeout``.
+
+        The idle-gap exit only starts counting once the first dialog has been
+        handled -- until then, a first dialog arriving later than ``idle_gap``
+        (the scenario issue #400 itself reports) would otherwise be missed: the
+        loop would exit at the idle-gap boundary having never seen it. Before
+        any dialog is observed, only ``outer_timeout`` can end the loop.
 
         Args:
             idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
                 to the ``startup_prompt_handler_timeout`` setting.
+            outer_timeout: Hard cap (seconds) on total handler runtime. Defaults
+                to the ``provider_init_timeout`` setting; initialize() passes the
+                per-profile-resolved value so a containerized profile's longer
+                init budget also governs this handler (mirrors ClaudeCodeProvider).
         """
         if idle_gap is None:
             idle_gap = get_server_settings()["startup_prompt_handler_timeout"]
-        outer_deadline = time.monotonic() + get_server_settings()["provider_init_timeout"]
+        if outer_timeout is None:
+            outer_timeout = get_server_settings()["provider_init_timeout"]
+        outer_deadline = time.monotonic() + outer_timeout
         last_prompt_time = time.monotonic()
+        any_prompt_handled = False
         upgrade_dismissed = False
         while True:
             now = time.monotonic()
             if now >= outer_deadline:
                 logger.warning("Kimi startup dialog handler hit provider_init_timeout outer cap")
                 return
-            if now - last_prompt_time >= idle_gap:
+            if any_prompt_handled and now - last_prompt_time >= idle_gap:
                 return  # no new prompt within the idle gap — startup settled
             output = get_backend().get_history(self.session_name, self.window_name)
             if output:
@@ -455,6 +488,7 @@ class KimiCliProvider(BaseProvider):
                     # 's' = "Skip reminders for version X"; single-key menu, no Enter.
                     get_backend().send_keys(self.session_name, self.window_name, "s", enter_count=0)
                     upgrade_dismissed = True
+                    any_prompt_handled = True
                     last_prompt_time = time.monotonic()  # reset idle timer
                     time.sleep(1.0)
                     continue
@@ -480,8 +514,23 @@ class KimiCliProvider(BaseProvider):
         Raises:
             TimeoutError: If shell or Kimi CLI doesn't start within timeout
         """
+        # Resolve the per-profile provider_init_timeout override (if any) so it
+        # governs the startup-dialog handler's outer cap too, mirroring
+        # ClaudeCodeProvider. Best-effort: a missing/unloadable profile falls
+        # back to the server default here; _build_kimi_command below still
+        # raises its own ProviderError on a genuine load failure.
+        init_timeout = self.get_init_timeout(self._try_load_profile())
+        # The readiness wait (dialog handler + wait_until_status) keeps its
+        # existing 120s floor above the server's provider_init_timeout default
+        # (60s) -- first-run setup / concurrent launches routinely exceed 60s.
+        # A profile override raises this further for containerized launches.
+        # Both waits MUST share this value: before this fix the dialog handler
+        # capped at the (shorter) server default while wait_until_status used
+        # a hardcoded 120s, so a dialog appearing after 60s but before 120s
+        # was never dismissed.
+        ready_timeout = max(120.0, init_timeout)
+
         # Wait for shell prompt to appear in the tmux window
-        init_timeout = get_server_settings()["provider_init_timeout"]
         if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
@@ -493,20 +542,18 @@ class KimiCliProvider(BaseProvider):
 
         # Dismiss the startup upgrade-reminder dialog before waiting for ready:
         # unanswered it blocks kimi from reaching its prompt (init would time out).
-        self._handle_startup_dialog()
+        self._handle_startup_dialog(outer_timeout=ready_timeout)
 
         # Wait for Kimi CLI to reach IDLE or COMPLETED state (prompt visible).
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
         # message that get_status() interprets as a completed response.
-        # Longer timeout (120s) to account for first-run setup and when
-        # multiple Kimi instances are starting concurrently (e.g. assign flow).
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=120.0,
+            timeout=ready_timeout,
             polling_interval=1.0,
         ):
-            raise TimeoutError("Kimi CLI initialization timed out after 120 seconds")
+            raise TimeoutError(f"Kimi CLI initialization timed out after {ready_timeout} seconds")
 
         self._initialized = True
         return True

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -370,6 +370,9 @@ class KiroCliProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -366,7 +366,7 @@ class KiroCliProvider(BaseProvider):
         BaseProvider helper consults the backend and disambiguates herdr's
         ambiguous "idle" via _task_dispatched (set by mark_input_received).
         """
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -199,6 +199,9 @@ class OpenCodeCliProvider(BaseProvider):
         if native is not None:
             return native
 
+        # herdr never pushes a buffer (pipe_pane is a no-op there); read live
+        # pane content instead of falling through to "no output" on every call.
+        output = self._resolve_buffer(output)
         if not output:
             return TerminalStatus.UNKNOWN
 

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -195,7 +195,7 @@ class OpenCodeCliProvider(BaseProvider):
         """
         # Native status (herdr): trust the backend's agent state when available;
         # on herdr the buffer is never fed, so buffer parsing can't leave UNKNOWN.
-        native = self._resolve_native_status()
+        native = self._resolve_native_status(output)
         if native is not None:
             return native
 

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -189,9 +189,14 @@ def get_server_settings() -> Dict[str, Any]:
     Returns a dict with the following keys (defaults shown):
       - mcp_request_timeout (30): Seconds to wait for MCP HTTP calls
       - event_bus_max_queue_size (1024): Max events buffered per subscriber
-      - provider_init_timeout (60): Seconds to wait for a CLI agent to reach IDLE
-      - startup_prompt_handler_timeout (20): Seconds to handle startup prompts
-        (e.g., workspace trust dialogs) before giving up
+      - provider_init_timeout (60): Seconds to wait for a CLI agent to reach IDLE.
+        Also the hard outer cap on total time the startup-prompt handler may run.
+      - startup_prompt_handler_timeout (20): Idle gap, in seconds, between
+        consecutive startup prompts (e.g. workspace trust / bypass dialogs). The
+        handler keeps polling and resets this timer every time it answers a
+        prompt; it stops once no new prompt appears for this many seconds (so a
+        dialog a cold/containerized start renders late is still handled). Total
+        time is bounded by provider_init_timeout.
 
     Values can be set via CAO_* environment variables or in
     ~/.aws/cli-agent-orchestrator/settings.json under the "server" key:

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -934,16 +934,29 @@ class TestGetNativeStatus:
         assert result == TerminalStatus.IDLE
 
     @patch("subprocess.run")
-    def test_unknown_returns_error(self, mock_run, backend):
+    def test_unknown_returns_none(self, mock_run, backend):
+        """herdr 'unknown' -> None (not ERROR): a wrapped exec launch hides the
+        agent CLI, so herdr never registers it and reports 'unknown' for a
+        healthy pane. None lets the caller resolve status another way."""
         self._setup_fresh_resolution(backend)
         mock_run.side_effect = self._make_resolution_side_effects(
             _completed(self._make_pane_get_response("unknown"))
         )
 
-        from cli_agent_orchestrator.models.terminal import TerminalStatus
+        result = backend.get_native_status("s", "w")
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_unrecognized_status_returns_none(self, mock_run, backend):
+        """Any agent_status herdr may add later that CAO does not map -> None,
+        same as 'unknown' (never leaks through as a bogus status)."""
+        self._setup_fresh_resolution(backend)
+        mock_run.side_effect = self._make_resolution_side_effects(
+            _completed(self._make_pane_get_response("some-future-state"))
+        )
 
         result = backend.get_native_status("s", "w")
-        assert result == TerminalStatus.ERROR
+        assert result is None
 
     @patch("subprocess.run")
     def test_command_failure_returns_none(self, mock_run, backend):

--- a/test/providers/test_antigravity_cli_unit.py
+++ b/test/providers/test_antigravity_cli_unit.py
@@ -71,8 +71,8 @@ def test_status_idle_vs_completed_split_on_turns():
 
 
 def test_status_empty_is_unknown():
-    assert make_provider().get_status("") == TerminalStatus.UNKNOWN
-    assert make_provider().get_status(None) == TerminalStatus.UNKNOWN
+    assert make_provider().get_status("") == TerminalStatus.IDLE
+    assert make_provider().get_status(None) == TerminalStatus.IDLE
 
 
 def test_status_processing_takes_priority_over_idle_footer():

--- a/test/providers/test_antigravity_cli_unit.py
+++ b/test/providers/test_antigravity_cli_unit.py
@@ -71,8 +71,11 @@ def test_status_idle_vs_completed_split_on_turns():
 
 
 def test_status_empty_is_unknown():
-    assert make_provider().get_status("") == TerminalStatus.IDLE
-    assert make_provider().get_status(None) == TerminalStatus.IDLE
+    # native=None always falls through (no dispatch-timing guess); on tmux the
+    # live-read fallback is a pass-through, so an empty buffer hits agy's own
+    # no-output default (UNKNOWN) directly.
+    assert make_provider().get_status("") == TerminalStatus.UNKNOWN
+    assert make_provider().get_status(None) == TerminalStatus.UNKNOWN
 
 
 def test_status_processing_takes_priority_over_idle_footer():

--- a/test/providers/test_base_provider.py
+++ b/test/providers/test_base_provider.py
@@ -126,6 +126,22 @@ class TestTranslatePath:
         profile = _profile(("/host", "/guest"))
         assert self.provider._translate_path("/hostile/x.txt", profile) == "/hostile/x.txt"
 
+    def test_root_mapping_alone_is_applied(self):
+        """A host="/" mapping must not silently no-op (nit fix, PR #428 review).
+
+        rstrip("/") reduces "/" to "" (length 0); the prior best_len=0 seed
+        made `len("") > 0` always false, so a root mapping never won even when
+        it was the only entry -- the guest translation was silently dropped.
+        """
+        profile = _profile(("/", "/guest"))
+        assert self.provider._translate_path("/host/x.txt", profile) == "/guest/host/x.txt"
+
+    def test_root_mapping_loses_to_more_specific_prefix(self):
+        """A root mapping still only wins when nothing more specific matches."""
+        profile = _profile(("/", "/guest"), ("/host", "/deep"))
+        assert self.provider._translate_path("/host/x.txt", profile) == "/deep/x.txt"
+        assert self.provider._translate_path("/other/x.txt", profile) == "/guest/other/x.txt"
+
 
 class TestResolveNativeStatus:
     """Tests for BaseProvider._resolve_native_status.

--- a/test/providers/test_base_provider.py
+++ b/test/providers/test_base_provider.py
@@ -1,6 +1,5 @@
 """Tests for base provider."""
 
-import time
 from unittest.mock import patch
 
 import pytest
@@ -128,100 +127,119 @@ class TestTranslatePath:
         assert self.provider._translate_path("/hostile/x.txt", profile) == "/hostile/x.txt"
 
 
-# Absolute path to base.time so staleness tests can pin time.time() deterministically.
-_BASE_TIME = "cli_agent_orchestrator.providers.base.time.time"
-
-
 class TestResolveNativeStatus:
-    """Tests for BaseProvider._resolve_native_status when the backend reports None.
+    """Tests for BaseProvider._resolve_native_status.
 
-    Covers the native-None resolution matrix (see the method docstring). The
-    backend's get_native_status() returns None both on tmux (buffer populated)
-    and on the herdr 'unknown' agent_status (empty buffer); this method
-    disambiguates via ``buffer`` and dispatch state:
+    ``get_native_status()`` returns None whenever the backend cannot resolve a
+    real agent state -- always on tmux, and on herdr for the "unknown"
+    agent_status (a wrapped exec launch hides the agent CLI). Both cases must
+    return None unconditionally: no guessing from dispatch state. A prior
+    version of this method inferred IDLE/PROCESSING/ERROR from
+    ``_task_dispatched`` timing when native was unresolvable and the buffer was
+    empty; that traded fail-fast init detection for optimistic guessing (a dead
+    herdr launch reported false-success IDLE, and a genuinely wedged wrapped
+    pane could never reach a real COMPLETED). This test class guards the
+    restored invariant: native unresolvable always falls through to buffer
+    analysis (via ``_resolve_buffer``, tested separately below), regardless of
+    dispatch state or buffer emptiness. No provider overrides
+    ``_resolve_native_status``, so ConcreteProvider exercises the real shared
+    implementation.
+    """
 
-    | buffer      | _task_dispatched     | Result                  |
-    |-------------|----------------------|-------------------------|
-    | non-empty   | *                    | None (fall to buffer)   |
-    | empty       | False                | IDLE                    |
-    | empty       | True, fresh (<120s)  | PROCESSING (optimistic) |
-    | empty       | True, stale (>=120s) | ERROR (+ warning log)   |
+    def _provider(self):
+        return ConcreteProvider("term-123", "session-1", "window-0")
 
-    Called directly (not via get_status) because row 1 — non-empty buffer
-    returning None — is only observable at this method's boundary; through
-    get_status() it continues into provider buffer parsing. No provider
-    overrides _resolve_native_status, so ConcreteProvider exercises the real
-    shared implementation.
+    @pytest.mark.parametrize(
+        "buffer, dispatched",
+        [("", False), ("", True), (None, False), (None, True), ("some content", False)],
+        ids=[
+            "empty_not_dispatched",
+            "empty_dispatched",
+            "none_not_dispatched",
+            "none_dispatched",
+            "nonempty_buffer",
+        ],
+    )
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_always_falls_through(self, mock_backend, buffer, dispatched):
+        """native=None -> always None, regardless of buffer content or dispatch state.
+
+        No guessing: the caller must fall through to buffer analysis on real
+        pane content in every case -- this is the fail-fast/real-COMPLETED fix.
+        """
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        provider._task_dispatched = dispatched
+        assert provider._resolve_native_status(buffer) is None
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_default_buffer_arg_falls_through(self, mock_backend):
+        """buffer defaults to None when omitted -- still falls through, not a guess."""
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        assert provider._resolve_native_status() is None
+
+
+class TestResolveBuffer:
+    """Tests for BaseProvider._resolve_buffer -- the herdr live-read fallback.
+
+    On tmux the pushed StatusMonitor buffer is always populated by the FIFO
+    pipeline, so this is a pass-through. On herdr, ``pipe_pane`` is a no-op and
+    the pushed buffer is always empty; an empty pushed buffer there means "the
+    push pipeline was never fed", not "the pane has no content" -- so this
+    reads the backend's live pane content instead, letting the provider's own
+    pattern matching run against real output rather than nothing.
     """
 
     def _provider(self):
         return ConcreteProvider("term-123", "session-1", "window-0")
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_empty_buffer_not_dispatched_returns_idle(self, mock_backend):
-        """Row: empty buffer, no task dispatched -> IDLE (unblocks init)."""
-        mock_backend.get_native_status.return_value = None
+    def test_nonempty_buffer_passthrough(self, mock_backend):
+        """A non-empty buffer is returned unchanged -- no backend read at all."""
         provider = self._provider()
-        assert provider._task_dispatched is False  # precondition
-        assert provider._resolve_native_status("") == TerminalStatus.IDLE
+        assert provider._resolve_buffer("some content") == "some content"
+        mock_backend.get_history.assert_not_called()
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_empty_buffer_none_arg_not_dispatched_returns_idle(self, mock_backend):
-        """A None buffer is treated like an empty buffer (herdr passes no buffer)."""
-        mock_backend.get_native_status.return_value = None
+    def test_empty_buffer_tmux_passthrough(self, mock_backend):
+        """tmux (supports_event_inbox=False): empty buffer stays empty, no live read."""
+        mock_backend.supports_event_inbox.return_value = False
         provider = self._provider()
-        assert provider._resolve_native_status(None) == TerminalStatus.IDLE
+        assert provider._resolve_buffer("") == ""
+        mock_backend.get_history.assert_not_called()
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_empty_buffer_dispatched_fresh_returns_processing(self, mock_backend):
-        """Row: empty buffer, dispatched, 119s elapsed (<120s) -> PROCESSING.
-
-        Boundary value: just inside the freshness window.
-        """
-        mock_backend.get_native_status.return_value = None
+    def test_none_buffer_tmux_returns_empty_string(self, mock_backend):
+        """tmux: a None buffer resolves to "" (never leaks None to callers)."""
+        mock_backend.supports_event_inbox.return_value = False
         provider = self._provider()
-        provider._task_dispatched = True
-        provider._last_dispatch_time = 1000.0
-        with patch(_BASE_TIME, return_value=1000.0 + 119.0):
-            assert provider._resolve_native_status("") == TerminalStatus.PROCESSING
+        assert provider._resolve_buffer(None) == ""
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_dispatched_at_staleness_boundary_returns_error(self, mock_backend):
-        """Boundary value: elapsed == 120s is NOT < timeout, so -> ERROR (not PROCESSING)."""
-        mock_backend.get_native_status.return_value = None
+    def test_empty_buffer_herdr_reads_live_history(self, mock_backend):
+        """herdr (supports_event_inbox=True): empty pushed buffer -> live get_history() read."""
+        mock_backend.supports_event_inbox.return_value = True
+        mock_backend.get_history.return_value = "live pane content"
         provider = self._provider()
-        provider._task_dispatched = True
-        provider._last_dispatch_time = 1000.0
-        with patch(_BASE_TIME, return_value=1000.0 + 120.0):
-            assert provider._resolve_native_status("") == TerminalStatus.ERROR
+        assert provider._resolve_buffer("") == "live pane content"
+        mock_backend.get_history.assert_called_once_with("session-1", "window-0")
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_empty_buffer_dispatched_stale_returns_error(self, mock_backend, caplog):
-        """Row: empty buffer, dispatched, 121s elapsed (>120s) -> ERROR + warning log."""
-        import logging
-
-        mock_backend.get_native_status.return_value = None
+    def test_none_buffer_herdr_reads_live_history(self, mock_backend):
+        """herdr: a None pushed buffer also triggers the live read."""
+        mock_backend.supports_event_inbox.return_value = True
+        mock_backend.get_history.return_value = "live pane content"
         provider = self._provider()
-        provider._task_dispatched = True
-        provider._last_dispatch_time = 1000.0
-        with patch(_BASE_TIME, return_value=1000.0 + 121.0):
-            with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.providers.base"):
-                result = provider._resolve_native_status("")
-        assert result == TerminalStatus.ERROR
-        assert any(
-            "staleness timeout" in r.message and r.levelno == logging.WARNING
-            for r in caplog.records
-        ), "stale native-None resolution must log a WARNING"
+        assert provider._resolve_buffer(None) == "live pane content"
 
-    @pytest.mark.parametrize("dispatched", [False, True], ids=["not_dispatched", "dispatched"])
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_nonempty_buffer_falls_through(self, mock_backend, dispatched):
-        """Row: non-empty buffer -> None regardless of dispatch state (defer to buffer path)."""
-        mock_backend.get_native_status.return_value = None
+    def test_herdr_live_read_failure_falls_back_to_empty(self, mock_backend):
+        """A live read failure (backend hiccup) falls back to the pushed buffer, not a raise."""
+        mock_backend.supports_event_inbox.return_value = True
+        mock_backend.get_history.side_effect = RuntimeError("herdr socket closed")
         provider = self._provider()
-        provider._task_dispatched = dispatched
-        provider._last_dispatch_time = time.time()
-        assert provider._resolve_native_status("some content") is None
+        assert provider._resolve_buffer("") == ""
 
 
 # Where get_init_timeout reads the server default from.

--- a/test/providers/test_base_provider.py
+++ b/test/providers/test_base_provider.py
@@ -1,7 +1,15 @@
 """Tests for base provider."""
 
+import time
+from unittest.mock import patch
+
 import pytest
 
+from cli_agent_orchestrator.models.agent_profile import (
+    AgentProfile,
+    ContainerConfig,
+    ContainerPathMap,
+)
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 
@@ -66,3 +74,176 @@ class TestBaseProvider:
         assert provider.extract_last_message_from_script("test") == "extracted message"
         assert provider.exit_cli() == "/exit"
         provider.cleanup()  # Should not raise
+
+
+def _profile(*pairs: tuple[str, str]) -> AgentProfile:
+    """Build a profile whose container declares the given host->guest maps."""
+    return AgentProfile(
+        name="a",
+        description="d",
+        container=ContainerConfig(path_maps=[ContainerPathMap(host=h, guest=g) for h, g in pairs]),
+    )
+
+
+class TestTranslatePath:
+    """Tests for BaseProvider._translate_path."""
+
+    def setup_method(self):
+        self.provider = ConcreteProvider("term-123", "session-1", "window-0")
+
+    def test_no_profile_returns_unchanged(self):
+        assert self.provider._translate_path("/host/x.txt") == "/host/x.txt"
+
+    def test_no_container_returns_unchanged(self):
+        profile = AgentProfile(name="a", description="d")
+        assert self.provider._translate_path("/host/x.txt", profile) == "/host/x.txt"
+
+    def test_empty_path_maps_returns_unchanged(self):
+        profile = AgentProfile(name="a", description="d", container=ContainerConfig())
+        assert self.provider._translate_path("/host/x.txt", profile) == "/host/x.txt"
+
+    def test_no_matching_prefix_returns_unchanged(self):
+        profile = _profile(("/host", "/guest"))
+        assert self.provider._translate_path("/other/x.txt", profile) == "/other/x.txt"
+
+    def test_simple_prefix_substitution(self):
+        profile = _profile(("/host", "/guest"))
+        assert self.provider._translate_path("/host/x.txt", profile) == "/guest/x.txt"
+
+    def test_longest_prefix_wins(self):
+        profile = _profile(("/host", "/guest"), ("/host/sub", "/deep"))
+        assert self.provider._translate_path("/host/sub/x.txt", profile) == "/deep/x.txt"
+
+    def test_exact_host_match(self):
+        profile = _profile(("/host", "/guest"))
+        assert self.provider._translate_path("/host", profile) == "/guest"
+
+    def test_trailing_slashes_normalized(self):
+        profile = _profile(("/host/", "/guest/"))
+        assert self.provider._translate_path("/host/x.txt", profile) == "/guest/x.txt"
+
+    def test_prefix_boundary_not_substring(self):
+        """A host prefix must match a path segment, not a bare substring."""
+        profile = _profile(("/host", "/guest"))
+        assert self.provider._translate_path("/hostile/x.txt", profile) == "/hostile/x.txt"
+
+
+# Absolute path to base.time so staleness tests can pin time.time() deterministically.
+_BASE_TIME = "cli_agent_orchestrator.providers.base.time.time"
+
+
+class TestResolveNativeStatus:
+    """Tests for BaseProvider._resolve_native_status when the backend reports None.
+
+    Covers the native-None resolution matrix (see the method docstring). The
+    backend's get_native_status() returns None both on tmux (buffer populated)
+    and on the herdr 'unknown' agent_status (empty buffer); this method
+    disambiguates via ``buffer`` and dispatch state:
+
+    | buffer      | _task_dispatched     | Result                  |
+    |-------------|----------------------|-------------------------|
+    | non-empty   | *                    | None (fall to buffer)   |
+    | empty       | False                | IDLE                    |
+    | empty       | True, fresh (<120s)  | PROCESSING (optimistic) |
+    | empty       | True, stale (>=120s) | ERROR (+ warning log)   |
+
+    Called directly (not via get_status) because row 1 — non-empty buffer
+    returning None — is only observable at this method's boundary; through
+    get_status() it continues into provider buffer parsing. No provider
+    overrides _resolve_native_status, so ConcreteProvider exercises the real
+    shared implementation.
+    """
+
+    def _provider(self):
+        return ConcreteProvider("term-123", "session-1", "window-0")
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_empty_buffer_not_dispatched_returns_idle(self, mock_backend):
+        """Row: empty buffer, no task dispatched -> IDLE (unblocks init)."""
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        assert provider._task_dispatched is False  # precondition
+        assert provider._resolve_native_status("") == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_empty_buffer_none_arg_not_dispatched_returns_idle(self, mock_backend):
+        """A None buffer is treated like an empty buffer (herdr passes no buffer)."""
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        assert provider._resolve_native_status(None) == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_empty_buffer_dispatched_fresh_returns_processing(self, mock_backend):
+        """Row: empty buffer, dispatched, 119s elapsed (<120s) -> PROCESSING.
+
+        Boundary value: just inside the freshness window.
+        """
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        provider._task_dispatched = True
+        provider._last_dispatch_time = 1000.0
+        with patch(_BASE_TIME, return_value=1000.0 + 119.0):
+            assert provider._resolve_native_status("") == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_dispatched_at_staleness_boundary_returns_error(self, mock_backend):
+        """Boundary value: elapsed == 120s is NOT < timeout, so -> ERROR (not PROCESSING)."""
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        provider._task_dispatched = True
+        provider._last_dispatch_time = 1000.0
+        with patch(_BASE_TIME, return_value=1000.0 + 120.0):
+            assert provider._resolve_native_status("") == TerminalStatus.ERROR
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_empty_buffer_dispatched_stale_returns_error(self, mock_backend, caplog):
+        """Row: empty buffer, dispatched, 121s elapsed (>120s) -> ERROR + warning log."""
+        import logging
+
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        provider._task_dispatched = True
+        provider._last_dispatch_time = 1000.0
+        with patch(_BASE_TIME, return_value=1000.0 + 121.0):
+            with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.providers.base"):
+                result = provider._resolve_native_status("")
+        assert result == TerminalStatus.ERROR
+        assert any(
+            "staleness timeout" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        ), "stale native-None resolution must log a WARNING"
+
+    @pytest.mark.parametrize("dispatched", [False, True], ids=["not_dispatched", "dispatched"])
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_nonempty_buffer_falls_through(self, mock_backend, dispatched):
+        """Row: non-empty buffer -> None regardless of dispatch state (defer to buffer path)."""
+        mock_backend.get_native_status.return_value = None
+        provider = self._provider()
+        provider._task_dispatched = dispatched
+        provider._last_dispatch_time = time.time()
+        assert provider._resolve_native_status("some content") is None
+
+
+# Where get_init_timeout reads the server default from.
+_SETTINGS_FN = "cli_agent_orchestrator.services.settings_service.get_server_settings"
+
+
+class TestGetInitTimeout:
+    """Tests for BaseProvider.get_init_timeout (per-profile init-timeout override)."""
+
+    def _provider(self):
+        return ConcreteProvider("term-123", "session-1", "window-0")
+
+    @patch(_SETTINGS_FN, return_value={"provider_init_timeout": 60})
+    def test_no_profile_uses_server_default(self, _):
+        assert self._provider().get_init_timeout() == 60
+
+    @patch(_SETTINGS_FN, return_value={"provider_init_timeout": 60})
+    def test_profile_without_override_uses_server_default(self, _):
+        profile = AgentProfile(name="a", description="d")
+        assert self._provider().get_init_timeout(profile) == 60
+
+    @patch(_SETTINGS_FN, return_value={"provider_init_timeout": 60})
+    def test_profile_override_wins(self, _):
+        profile = AgentProfile(name="a", description="d", provider_init_timeout=180)
+        assert self._provider().get_init_timeout(profile) == 180

--- a/test/providers/test_claude_code_coverage.py
+++ b/test/providers/test_claude_code_coverage.py
@@ -59,7 +59,7 @@ class TestHandleStartupPromptsBranches:
             "⚠ Bypass Permissions mode\n" "1. No, exit\n" "2. Yes, I accept\n"
         )
 
-        provider._handle_startup_prompts(timeout=1.0)
+        provider._handle_startup_prompts(idle_gap=1.0)
 
         # Down arrow sent via send_keys, Enter via send_special_key
         mock_backend.send_keys.assert_called_once()
@@ -93,7 +93,7 @@ class TestHandleStartupPromptsBranches:
         )
         mock_backend.get_history.side_effect = [echoed_launch_cmd, trust_frame]
 
-        provider._handle_startup_prompts(timeout=5.0)
+        provider._handle_startup_prompts(idle_gap=5.0)
 
         # Trust dialog accepted via Enter — proves we did not early-return on the
         # echoed "> memory_store" marker.
@@ -106,7 +106,7 @@ class TestHandleStartupPromptsBranches:
         """When welcome banner is visible, returns immediately."""
         mock_backend.get_history.return_value = "Welcome to Claude Code v2.5.0"
 
-        provider._handle_startup_prompts(timeout=1.0)
+        provider._handle_startup_prompts(idle_gap=1.0)
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_trust_prompt_detected(self, mock_backend, provider):
@@ -115,7 +115,7 @@ class TestHandleStartupPromptsBranches:
             "Do you trust the files in this folder?\n" "❯ Yes, I trust this folder"
         )
 
-        provider._handle_startup_prompts(timeout=1.0)
+        provider._handle_startup_prompts(idle_gap=1.0)
 
         mock_backend.send_special_key.assert_called_once_with(
             provider.session_name, provider.window_name, "Enter"

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -467,21 +467,21 @@ class TestClaudeCodeProviderStatusDetection:
         assert status != TerminalStatus.WAITING_USER_ANSWER
         assert status == TerminalStatus.COMPLETED
 
-    def test_get_status_empty_buffer_not_dispatched_returns_idle(self):
-        """Empty buffer + no task dispatched -> IDLE via native-None resolution.
+    def test_get_status_empty_buffer_returns_unknown(self):
+        """Empty buffer -> UNKNOWN (native=None always falls through to buffer analysis).
 
         The backend's get_native_status() returns None (tmux always; herdr
-        'unknown'); with an empty buffer and no dispatch the shared
-        _resolve_native_status() reports IDLE to unblock init rather than
-        falling through to buffer analysis (which would yield UNKNOWN). See the
-        native-None matrix in BaseProvider._resolve_native_status.
+        'unknown'); this always falls through to buffer analysis -- no
+        dispatch-timing guess. On tmux, BaseProvider._resolve_buffer() is a
+        pass-through, so the empty buffer hits Claude Code's own no-output
+        default (UNKNOWN) directly.
         """
         output = ""
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         status = provider.get_status(output)
 
-        assert status == TerminalStatus.IDLE
+        assert status == TerminalStatus.UNKNOWN
 
     def test_get_status_error_unrecognized(self):
         """Test UNKNOWN status with unrecognized output."""

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -8,6 +8,11 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
+from cli_agent_orchestrator.models.agent_profile import (
+    AgentProfile,
+    ContainerConfig,
+    ContainerPathMap,
+)
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider, ProviderError
 
@@ -127,6 +132,7 @@ class TestClaudeCodeProviderInitialization:
         mock_profile.system_prompt = "Test system prompt"
         mock_profile.mcpServers = None
         mock_profile.permissionMode = None
+        mock_profile.provider_init_timeout = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0", "test-agent")
@@ -223,6 +229,7 @@ class TestClaudeCodeProviderInitialization:
         mock_profile.system_prompt = None
         mock_profile.mcpServers = {"server1": {"command": "test", "args": ["--flag"]}}
         mock_profile.permissionMode = None
+        mock_profile.provider_init_timeout = None
         mock_load.return_value = mock_profile
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0", "test-agent")
@@ -460,14 +467,21 @@ class TestClaudeCodeProviderStatusDetection:
         assert status != TerminalStatus.WAITING_USER_ANSWER
         assert status == TerminalStatus.COMPLETED
 
-    def test_get_status_error_empty(self):
-        """Test UNKNOWN status with empty output."""
+    def test_get_status_empty_buffer_not_dispatched_returns_idle(self):
+        """Empty buffer + no task dispatched -> IDLE via native-None resolution.
+
+        The backend's get_native_status() returns None (tmux always; herdr
+        'unknown'); with an empty buffer and no dispatch the shared
+        _resolve_native_status() reports IDLE to unblock init rather than
+        falling through to buffer analysis (which would yield UNKNOWN). See the
+        native-None matrix in BaseProvider._resolve_native_status.
+        """
         output = ""
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         status = provider.get_status(output)
 
-        assert status == TerminalStatus.UNKNOWN
+        assert status == TerminalStatus.IDLE
 
     def test_get_status_error_unrecognized(self):
         """Test UNKNOWN status with unrecognized output."""
@@ -1219,6 +1233,73 @@ class TestClaudeCodeProviderMisc:
         assert server_env["CAO_TERMINAL_ID"] == "user-provided-id"
 
 
+class TestClaudeCodeProviderContainerPathTranslation:
+    """_build_claude_command must translate temp-file paths for container profiles.
+
+    Unit coverage of _translate_path itself lives in test_base_provider.py. These
+    tests cover the INTEGRATION point: that _build_claude_command routes the temp
+    prompt-file and MCP-config paths through _translate_path so the guest paths —
+    not the host paths — reach the emitted --append-system-prompt-file and
+    --mcp-config arguments.
+    """
+
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_temp_file_paths_translated_to_guest(self, mock_load, tmp_path):
+        """host CAO_HOME_DIR prefix -> guest path in both temp-file CLI args."""
+        # Map the (patched) CAO_HOME_DIR host prefix to a container guest path.
+        mock_load.return_value = AgentProfile(
+            name="test-agent",
+            description="d",
+            system_prompt="You are a container agent.",
+            mcpServers={"test-mcp": {"command": "echo", "args": []}},
+            container=ContainerConfig(
+                path_maps=[ContainerPathMap(host=str(tmp_path), guest="/app/config")]
+            ),
+        )
+
+        provider = ClaudeCodeProvider("test-container", "sess", "win", "test-agent")
+        with patch("cli_agent_orchestrator.providers.claude_code.CAO_HOME_DIR", tmp_path):
+            command = provider._build_claude_command()
+
+        args = shlex.split(command)
+        prompt_arg = args[args.index("--append-system-prompt-file") + 1]
+        mcp_arg = args[args.index("--mcp-config") + 1]
+
+        # Both args carry the translated guest path, not the host path.
+        assert prompt_arg == "/app/config/tmp/test-container.prompt"
+        assert mcp_arg == "/app/config/tmp/test-container.mcp.json"
+        # The host prefix must not leak into either arg (translation happened).
+        assert str(tmp_path) not in prompt_arg
+        assert str(tmp_path) not in mcp_arg
+
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_temp_file_paths_unchanged_without_container(self, mock_load, tmp_path):
+        """No container -> paths are the real host paths (translation is a no-op).
+
+        Guards against the assertions above passing for the wrong reason: the
+        guest prefix only appears when a container maps it.
+        """
+        mock_load.return_value = AgentProfile(
+            name="test-agent",
+            description="d",
+            system_prompt="You are a host agent.",
+            mcpServers={"test-mcp": {"command": "echo", "args": []}},
+        )
+
+        provider = ClaudeCodeProvider("test-host", "sess", "win", "test-agent")
+        with patch("cli_agent_orchestrator.providers.claude_code.CAO_HOME_DIR", tmp_path):
+            command = provider._build_claude_command()
+
+        args = shlex.split(command)
+        prompt_arg = args[args.index("--append-system-prompt-file") + 1]
+        mcp_arg = args[args.index("--mcp-config") + 1]
+
+        assert prompt_arg == str(tmp_path / "tmp" / "test-host.prompt")
+        assert mcp_arg == str(tmp_path / "tmp" / "test-host.mcp.json")
+        assert "/app/config" not in prompt_arg
+        assert "/app/config" not in mcp_arg
+
+
 class TestClaudeCodeProviderModelFlag:
     """Tests that profile.model is forwarded to Claude Code via --model."""
 
@@ -1372,7 +1453,7 @@ class TestClaudeCodeProviderStartupPrompts:
         )
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(timeout=2.0)
+        provider._handle_startup_prompts(idle_gap=2.0)
 
         mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
@@ -1382,20 +1463,33 @@ class TestClaudeCodeProviderStartupPrompts:
         mock_tmux.get_history.return_value = "Welcome to Claude Code v2.1.0"
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(timeout=2.0)
+        provider._handle_startup_prompts(idle_gap=2.0)
 
         mock_tmux.send_special_key.assert_not_called()
 
+    @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_handle_startup_prompts_timeout(self, mock_tmux, mock_time):
-        """Test startup prompt handler times out gracefully."""
+    def test_handle_startup_prompts_timeout(self, mock_tmux, mock_time, mock_settings):
+        """Handler gives up gracefully once the idle gap elapses with no prompt.
+
+        New idle-gap semantics (issue #400): the loop keeps polling and exits
+        only after ``idle_gap`` seconds pass with no new prompt (bounded by the
+        ``provider_init_timeout`` outer cap). Here only "Loading..." ever shows,
+        so once the idle gap elapses the handler returns having answered nothing.
+        """
+        mock_settings.return_value = {
+            "provider_init_timeout": 60,
+            "startup_prompt_handler_timeout": 20,
+        }
         mock_tmux.get_history.return_value = "Loading..."
-        mock_time.time.side_effect = [0.0, 0.0, 25.0]
+        # monotonic() calls: outer_deadline, last_prompt_time, iter-1 now (polls
+        # "Loading..."), iter-2 now (25s - 0s >= 20s idle gap -> return).
+        mock_time.monotonic.side_effect = [0.0, 0.0, 0.0, 25.0]
         mock_time.sleep = MagicMock()
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(timeout=20.0)
+        provider._handle_startup_prompts(idle_gap=20.0)
 
         mock_tmux.send_special_key.assert_not_called()
 
@@ -1408,7 +1502,7 @@ class TestClaudeCodeProviderStartupPrompts:
         ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(timeout=5.0)
+        provider._handle_startup_prompts(idle_gap=5.0)
 
         mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
@@ -1423,7 +1517,7 @@ class TestClaudeCodeProviderStartupPrompts:
         ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(timeout=5.0)
+        provider._handle_startup_prompts(idle_gap=5.0)
 
         # Verify Down arrow sent via send_keys and Enter via send_special_key
         mock_tmux.send_keys.assert_called_once()
@@ -1439,7 +1533,7 @@ class TestClaudeCodeProviderStartupPrompts:
         ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(timeout=5.0)
+        provider._handle_startup_prompts(idle_gap=5.0)
 
         # Bypass: send_keys (Down) + send_special_key (Enter)
         # Trust: send_special_key (Enter) — called twice total

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1471,21 +1471,23 @@ class TestClaudeCodeProviderStartupPrompts:
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_handle_startup_prompts_timeout(self, mock_tmux, mock_time, mock_settings):
-        """Handler gives up gracefully once the idle gap elapses with no prompt.
+        """Handler gives up gracefully at the outer cap when no prompt ever appears.
 
-        New idle-gap semantics (issue #400): the loop keeps polling and exits
-        only after ``idle_gap`` seconds pass with no new prompt (bounded by the
-        ``provider_init_timeout`` outer cap). Here only "Loading..." ever shows,
-        so once the idle gap elapses the handler returns having answered nothing.
+        should-fix-3: the idle-gap exit does not apply until a first prompt has
+        been handled, so with only "Loading..." ever showing, the loop runs
+        until the outer cap (provider_init_timeout=60) rather than the old
+        20s idle-gap boundary.
         """
         mock_settings.return_value = {
             "provider_init_timeout": 60,
             "startup_prompt_handler_timeout": 20,
         }
         mock_tmux.get_history.return_value = "Loading..."
-        # monotonic() calls: outer_deadline, last_prompt_time, iter-1 now (polls
-        # "Loading..."), iter-2 now (25s - 0s >= 20s idle gap -> return).
-        mock_time.monotonic.side_effect = [0.0, 0.0, 0.0, 25.0]
+        # monotonic() calls: outer_deadline, last_prompt_time, iter-1 now (no
+        # prompt handled yet -> idle-gap check skipped, polls "Loading..."),
+        # iter-2 now (still no prompt -> idle-gap check skipped), iter-3 now
+        # (61s >= 60s outer cap -> return).
+        mock_time.monotonic.side_effect = [0.0, 0.0, 0.0, 25.0, 61.0]
         mock_time.sleep = MagicMock()
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -750,7 +750,7 @@ class TestCodexProviderStatusDetection:
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status("")
 
-        assert status == TerminalStatus.UNKNOWN
+        assert status == TerminalStatus.IDLE
 
     def test_get_status_processing_when_old_prompt_present(self):
         # If the captured history contains an earlier prompt but the *latest* output is processing,

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -747,10 +747,13 @@ class TestCodexProviderStatusDetection:
         assert status == TerminalStatus.ERROR
 
     def test_get_status_empty_output(self):
+        # native=None always falls through (no dispatch-timing guess); on tmux
+        # the live-read fallback is a pass-through, so an empty buffer hits
+        # Codex's own no-output default directly.
         provider = CodexProvider("test1234", "test-session", "window-0")
         status = provider.get_status("")
 
-        assert status == TerminalStatus.IDLE
+        assert status == TerminalStatus.UNKNOWN
 
     def test_get_status_processing_when_old_prompt_present(self):
         # If the captured history contains an earlier prompt but the *latest* output is processing,

--- a/test/providers/test_container_wrapped.py
+++ b/test/providers/test_container_wrapped.py
@@ -8,8 +8,10 @@ COMBINE on a real provider (ClaudeCodeProvider) through its public surface —
 startup-prompt handler — in the container-wrapped scenario a wrapped
 ``podman``/``docker exec`` launch produces:
 
-  Task 1: herdr "unknown" agent_status surfaces as native None, and an
-          unresolved native status is aged out to ERROR past a staleness cap.
+  Task 1: herdr "unknown" agent_status surfaces as native None, which always
+          falls through to a LIVE buffer read (BaseProvider._resolve_buffer)
+          rather than a dispatch-timing guess -- restoring fail-fast ERROR
+          detection and a real COMPLETED path for wrapped agents.
   Task 2: host->guest path translation of the temp prompt/MCP files reaches the
           emitted CLI command.
   Task 3: idle-gap startup-prompt handling keeps polling for late dialogs under
@@ -20,7 +22,6 @@ startup-prompt handler — in the container-wrapped scenario a wrapped
 All backends and subprocesses are mocked — no Docker/Podman/tmux required.
 """
 
-import logging
 import shlex
 from unittest.mock import MagicMock, patch
 
@@ -103,46 +104,84 @@ def test_build_command_with_container_profile(mock_load, tmp_path):
 
 
 @patch(_BACKEND)
-def test_status_during_init_native_none(mock_backend):
-    """Tasks 1: dispatched + native None + empty buffer + fresh -> PROCESSING.
+def test_status_during_init_native_none_reads_live_buffer(mock_backend):
+    """Task 1: dispatched + native None -> live get_history() read, not a clock guess.
 
-    A wrapped exec hides the agent CLI from herdr, so get_native_status() is None
-    and the StatusMonitor buffer is empty. Within the staleness window the shared
-    resolver optimistically reports PROCESSING rather than stalling init.
+    A wrapped exec hides the agent CLI from herdr, so get_native_status() is
+    None. The shared resolver no longer infers PROCESSING from elapsed dispatch
+    time; it falls through to BaseProvider._resolve_buffer(), which reads the
+    backend's live pane content on herdr (supports_event_inbox=True). Claude
+    Code's own buffer-parsing then sees a real spinner line and reports
+    PROCESSING because the agent is genuinely still working, not because a
+    timer says so.
     """
     mock_backend.get_native_status.return_value = None
+    mock_backend.supports_event_inbox.return_value = True
+    mock_backend.get_history.return_value = "✻ Orbiting…"
 
     provider = ClaudeCodeProvider("t1", "sess", "win")
     provider.mark_input_received()  # real dispatch hook: sets _task_dispatched=True
     assert provider._task_dispatched is True
-    provider._last_dispatch_time = 1000.0  # pin for a deterministic elapsed
 
-    with patch(_BASE_TIME, return_value=1060.0):  # 60s elapsed, inside the 120s window
-        assert provider.get_status("") == TerminalStatus.PROCESSING
+    assert provider.get_status("") == TerminalStatus.PROCESSING
 
 
 @patch(_BACKEND)
-def test_status_staleness_timeout(mock_backend, caplog):
-    """Task 1: dispatched + native None + empty buffer past the staleness cap -> ERROR.
+def test_status_wedged_pane_reports_unknown_not_error_from_a_clock(mock_backend):
+    """Task 1: a genuinely idle-content-free wedged pane must not become ERROR by clock alone.
 
-    Boundary value: elapsed == 120s is NOT < the 120s timeout, so the optimistic
-    PROCESSING window has closed and the wedged agent is reported ERROR with a
-    WARNING log.
+    Regresses must-fix 2: the removed staleness cap flipped ANY unresolved
+    native status to ERROR purely from elapsed wall-clock time since dispatch,
+    even for a pane that never showed error text -- which meant a long-running
+    but healthy turn on a wrapped agent could never reach COMPLETED and would
+    hard-fail. With native=None now always falling through, a pane with no
+    recognizable content reports Claude Code's own empty-buffer default
+    (UNKNOWN) regardless of how long ago dispatch happened -- it does NOT
+    become ERROR just because a lot of time passed.
     """
     mock_backend.get_native_status.return_value = None
+    mock_backend.supports_event_inbox.return_value = True
+    mock_backend.get_history.return_value = ""  # pane alive, but no content yet
 
     provider = ClaudeCodeProvider("t1", "sess", "win")
     provider.mark_input_received()
     provider._last_dispatch_time = 1000.0
 
-    with patch(_BASE_TIME, return_value=1000.0 + 120.0):
-        with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.providers.base"):
-            result = provider.get_status("")
+    with patch(_BASE_TIME, return_value=1000.0 + 300.0):  # would have been "stale" pre-fix
+        result = provider.get_status("")
 
-    assert result == TerminalStatus.ERROR
-    assert any(
-        "staleness timeout" in r.message and r.levelno == logging.WARNING for r in caplog.records
-    ), "a stale unresolved native status must log a WARNING"
+    assert result == TerminalStatus.UNKNOWN
+
+
+@patch(_BACKEND)
+def test_status_dead_launch_reports_unknown_not_false_idle(mock_backend):
+    """Task 1: fail-fast is restored -- a dead launch no longer reports false-success IDLE.
+
+    Pre-#400, herdr 'unknown' mapped straight to ERROR, so wait_until_status()
+    kept polling a dead pane until a real TimeoutError. #400 regressed this: a
+    dead launch (no task ever dispatched, so _task_dispatched=False) reported
+    optimistic IDLE immediately -- init "succeeded" and pasted the task into a
+    dead pane. This test proves the rework restores fail-fast: the live read
+    sees plain shell output with no Claude Code prompt/response markers at
+    all, so Claude Code's own buffer parsing reports UNKNOWN. UNKNOWN is not in
+    {IDLE, COMPLETED}, so init's wait_until_status keeps polling toward a real
+    TimeoutError instead of falsely declaring success.
+    """
+    mock_backend.get_native_status.return_value = None
+    mock_backend.supports_event_inbox.return_value = True
+    # A dead/exited launch: the shell prompt is back, no Claude Code TUI ever
+    # rendered (no ❯/>, no ⏺/●, no separator) -- genuinely unrecognizable.
+    mock_backend.get_history.return_value = "bash: claude: command not found\n$ "
+
+    provider = ClaudeCodeProvider("t1", "sess", "win")
+    # No task dispatched -- this is the pre-dispatch init-wait scenario, where
+    # the #400 regression's guess (IDLE) was most damaging (false init success).
+    assert provider._task_dispatched is False
+
+    result = provider.get_status("")
+
+    assert result == TerminalStatus.UNKNOWN
+    assert result not in (TerminalStatus.IDLE, TerminalStatus.COMPLETED)
 
 
 @patch("cli_agent_orchestrator.providers.claude_code.time")

--- a/test/providers/test_container_wrapped.py
+++ b/test/providers/test_container_wrapped.py
@@ -162,8 +162,8 @@ def test_idle_timeout_prompt_handler(mock_backend, mock_time):
     """
     mock_time.sleep = MagicMock()
     mock_time.monotonic.side_effect = [
-        0.0,   # outer_deadline = 0 + 180 (per-profile init timeout)
-        0.0,   # last_prompt_time = 0
+        0.0,  # outer_deadline = 0 + 180 (per-profile init timeout)
+        0.0,  # last_prompt_time = 0
         18.0,  # iter1: gap 18<20 and 18<180 -> bypass handled, timer reset
         18.0,  # last_prompt_time reset to 18
         35.0,  # iter2: gap 35-18=17<20 and 35<180 -> trust handled -> return

--- a/test/providers/test_container_wrapped.py
+++ b/test/providers/test_container_wrapped.py
@@ -1,0 +1,225 @@
+"""Integration tests for the container-wrapped provider features (Tasks 1-4).
+
+The per-method unit tests live elsewhere (test_base_provider.py,
+test_provider_init_timeout.py, test_startup_prompt_idle_gap.py,
+test_claude_code_unit.py). These tests instead exercise the four features as they
+COMBINE on a real provider (ClaudeCodeProvider) through its public surface —
+``get_status()``, ``_build_claude_command()``, ``initialize()`` and the
+startup-prompt handler — in the container-wrapped scenario a wrapped
+``podman``/``docker exec`` launch produces:
+
+  Task 1: herdr "unknown" agent_status surfaces as native None, and an
+          unresolved native status is aged out to ERROR past a staleness cap.
+  Task 2: host->guest path translation of the temp prompt/MCP files reaches the
+          emitted CLI command.
+  Task 3: idle-gap startup-prompt handling keeps polling for late dialogs under
+          a hard outer cap.
+  Task 4: a per-profile ``provider_init_timeout`` override governs every init wait
+          and the startup-prompt handler's outer cap.
+
+All backends and subprocesses are mocked — no Docker/Podman/tmux required.
+"""
+
+import logging
+import shlex
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.models.agent_profile import (
+    AgentProfile,
+    ContainerConfig,
+    ContainerPathMap,
+)
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
+
+# time.time() lives in base.py; pin it here to make the staleness window deterministic.
+_BASE_TIME = "cli_agent_orchestrator.providers.base.time.time"
+# The backend singleton every provider resolves via backends.registry.get_backend().
+_BACKEND = "cli_agent_orchestrator.backends.registry._backend"
+
+
+def test_path_translation_unit():
+    """Task 2: _translate_path picks the longest matching host prefix and otherwise
+    passes the path through unchanged.
+
+    One profile carries two overlapping maps so a single call exercises all three
+    behaviors the container path layer relies on.
+    """
+    provider = ClaudeCodeProvider("t1", "sess", "win")
+    profile = AgentProfile(
+        name="c",
+        description="d",
+        container=ContainerConfig(
+            path_maps=[
+                ContainerPathMap(host="/host/work", guest="/guest/work"),
+                ContainerPathMap(host="/host/work/sub", guest="/deep"),
+            ]
+        ),
+    )
+
+    # Longest-prefix-wins: /host/work/sub is longer than /host/work, so it governs.
+    assert provider._translate_path("/host/work/sub/file.txt", profile) == "/deep/file.txt"
+    # A path under only the shorter prefix maps via that shorter prefix.
+    assert provider._translate_path("/host/work/other.txt", profile) == "/guest/work/other.txt"
+    # No mapping matches -> passthrough (unmapped host paths are never rewritten).
+    assert provider._translate_path("/unmapped/x.txt", profile) == "/unmapped/x.txt"
+
+
+@patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+def test_build_command_with_container_profile(mock_load, tmp_path):
+    """Task 2: with a ContainerConfig, the built command carries GUEST paths.
+
+    The temp prompt-file and MCP-config paths (rooted at CAO_HOME_DIR) must be
+    translated to the container's guest paths in the emitted
+    --append-system-prompt-file and --mcp-config arguments — the containerized
+    CLI cannot see the host paths.
+    """
+    mock_load.return_value = AgentProfile(
+        name="test-agent",
+        description="d",
+        system_prompt="You are a container agent.",
+        mcpServers={"test-mcp": {"command": "echo", "args": []}},
+        container=ContainerConfig(
+            path_maps=[ContainerPathMap(host=str(tmp_path), guest="/app/config")]
+        ),
+    )
+
+    provider = ClaudeCodeProvider("test-container", "sess", "win", "test-agent")
+    # tmp_path is the host prefix; files are written under it and auto-cleaned by pytest.
+    with patch("cli_agent_orchestrator.providers.claude_code.CAO_HOME_DIR", tmp_path):
+        command = provider._build_claude_command()
+
+    args = shlex.split(command)
+    prompt_arg = args[args.index("--append-system-prompt-file") + 1]
+    mcp_arg = args[args.index("--mcp-config") + 1]
+
+    assert prompt_arg == "/app/config/tmp/test-container.prompt"
+    assert mcp_arg == "/app/config/tmp/test-container.mcp.json"
+    # The host prefix must not leak into either arg — translation actually happened.
+    assert str(tmp_path) not in prompt_arg
+    assert str(tmp_path) not in mcp_arg
+
+
+@patch(_BACKEND)
+def test_status_during_init_native_none(mock_backend):
+    """Tasks 1: dispatched + native None + empty buffer + fresh -> PROCESSING.
+
+    A wrapped exec hides the agent CLI from herdr, so get_native_status() is None
+    and the StatusMonitor buffer is empty. Within the staleness window the shared
+    resolver optimistically reports PROCESSING rather than stalling init.
+    """
+    mock_backend.get_native_status.return_value = None
+
+    provider = ClaudeCodeProvider("t1", "sess", "win")
+    provider.mark_input_received()  # real dispatch hook: sets _task_dispatched=True
+    assert provider._task_dispatched is True
+    provider._last_dispatch_time = 1000.0  # pin for a deterministic elapsed
+
+    with patch(_BASE_TIME, return_value=1060.0):  # 60s elapsed, inside the 120s window
+        assert provider.get_status("") == TerminalStatus.PROCESSING
+
+
+@patch(_BACKEND)
+def test_status_staleness_timeout(mock_backend, caplog):
+    """Task 1: dispatched + native None + empty buffer past the staleness cap -> ERROR.
+
+    Boundary value: elapsed == 120s is NOT < the 120s timeout, so the optimistic
+    PROCESSING window has closed and the wedged agent is reported ERROR with a
+    WARNING log.
+    """
+    mock_backend.get_native_status.return_value = None
+
+    provider = ClaudeCodeProvider("t1", "sess", "win")
+    provider.mark_input_received()
+    provider._last_dispatch_time = 1000.0
+
+    with patch(_BASE_TIME, return_value=1000.0 + 120.0):
+        with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.providers.base"):
+            result = provider.get_status("")
+
+    assert result == TerminalStatus.ERROR
+    assert any(
+        "staleness timeout" in r.message and r.levelno == logging.WARNING for r in caplog.records
+    ), "a stale unresolved native status must log a WARNING"
+
+
+@patch("cli_agent_orchestrator.providers.claude_code.time")
+@patch(_BACKEND)
+def test_idle_timeout_prompt_handler(mock_backend, mock_time):
+    """Tasks 3 + 4: the idle gap keeps polling for a LATE dialog inside the outer cap.
+
+    A cold containerized start renders dialogs late and in sequence. The bypass
+    prompt at t=18s resets the idle timer; the trust prompt at t=35s is within the
+    20s idle gap of that reset (35-18=17<20) AND within the per-profile 180s outer
+    cap, so it is still handled. Under a fixed 20s-from-start window the loop would
+    have exited at t=20s and never answered the trust prompt.
+
+    idle_gap/outer_timeout are passed explicitly — the exact values initialize()
+    forwards from the per-profile provider_init_timeout — so no settings mock is
+    needed and the Task 3<->Task 4 wiring is what is under test.
+    """
+    mock_time.sleep = MagicMock()
+    mock_time.monotonic.side_effect = [
+        0.0,   # outer_deadline = 0 + 180 (per-profile init timeout)
+        0.0,   # last_prompt_time = 0
+        18.0,  # iter1: gap 18<20 and 18<180 -> bypass handled, timer reset
+        18.0,  # last_prompt_time reset to 18
+        35.0,  # iter2: gap 35-18=17<20 and 35<180 -> trust handled -> return
+    ]
+    mock_backend.get_history.side_effect = [
+        "WARNING: Bypass Permissions\n1. No\n2. Yes, I accept\n",
+        "Yes, I trust this folder",
+    ]
+
+    provider = ClaudeCodeProvider("t1", "sess", "win")
+    provider._handle_startup_prompts(idle_gap=20.0, outer_timeout=180.0)
+
+    # Bypass: Down arrow (send_keys) + Enter (send_special_key). Trust: Enter.
+    assert mock_backend.send_keys.call_count == 1
+    assert mock_backend.send_special_key.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
+@patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
+@patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+@patch("cli_agent_orchestrator.providers.claude_code.wait_for_shell")
+@patch("cli_agent_orchestrator.providers.claude_code.wait_until_status")
+@patch(_BACKEND)
+async def test_wrapped_provider_lifecycle(
+    mock_backend, mock_wait_status, mock_wait_shell, mock_load, mock_build, mock_ensure
+):
+    """End-to-end: launch -> prompts handled -> PROCESSING -> IDLE (all mocked).
+
+    Container-on-tmux: the wrapped CLI is invisible to native status, so
+    get_native_status() is always None and status comes from the buffer. The
+    container profile also carries a 180s provider_init_timeout that must flow to
+    every init wait.
+    """
+    mock_load.return_value = AgentProfile(name="c", description="d", provider_init_timeout=180)
+    mock_wait_shell.return_value = True
+    mock_wait_status.return_value = True
+    # A workspace-trust dialog is showing at startup (handled by the prompt handler).
+    mock_backend.get_history.return_value = "Yes, I trust this folder"
+    # Wrapped exec -> native status is always unresolved; status is buffer-driven.
+    mock_backend.get_native_status.return_value = None
+
+    provider = ClaudeCodeProvider("test-container-life", "sess", "win", "c")
+
+    # 1) Launch succeeds and the per-profile 180s cap flows to every init wait.
+    result = await provider.initialize()
+    assert result is True
+    assert provider._initialized is True
+    assert mock_wait_shell.call_args.kwargs["timeout"] == 180
+    assert mock_wait_status.call_args.kwargs["timeout"] == 180
+
+    # 2) The startup trust dialog was answered with Enter during initialize().
+    mock_backend.send_special_key.assert_called_with("sess", "win", "Enter")
+
+    # 3) Working turn: a live spinner in the buffer -> PROCESSING (native None -> buffer path).
+    assert provider.get_status("✻ Orbiting…") == TerminalStatus.PROCESSING
+
+    # 4) Turn finished: the ready prompt -> IDLE.
+    assert provider.get_status("❯ ") == TerminalStatus.IDLE

--- a/test/providers/test_cursor_cli_unit.py
+++ b/test/providers/test_cursor_cli_unit.py
@@ -282,12 +282,15 @@ class TestGetStatus:
         assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
 
     def test_empty_output_returns_unknown(self):
+        # native=None always falls through (no dispatch-timing guess); on tmux
+        # the live-read fallback is a pass-through, so an empty buffer hits
+        # Cursor's own no-output default directly.
         provider = make_provider()
-        assert provider.get_status("") == TerminalStatus.IDLE
+        assert provider.get_status("") == TerminalStatus.UNKNOWN
 
     def test_none_output_returns_unknown(self):
         provider = make_provider()
-        assert provider.get_status(None) == TerminalStatus.IDLE
+        assert provider.get_status(None) == TerminalStatus.UNKNOWN
 
     def test_unrecognizable_output_returns_unknown(self):
         provider = make_provider()

--- a/test/providers/test_cursor_cli_unit.py
+++ b/test/providers/test_cursor_cli_unit.py
@@ -283,11 +283,11 @@ class TestGetStatus:
 
     def test_empty_output_returns_unknown(self):
         provider = make_provider()
-        assert provider.get_status("") == TerminalStatus.UNKNOWN
+        assert provider.get_status("") == TerminalStatus.IDLE
 
     def test_none_output_returns_unknown(self):
         provider = make_provider()
-        assert provider.get_status(None) == TerminalStatus.UNKNOWN
+        assert provider.get_status(None) == TerminalStatus.IDLE
 
     def test_unrecognizable_output_returns_unknown(self):
         provider = make_provider()

--- a/test/providers/test_hermes_provider_unit.py
+++ b/test/providers/test_hermes_provider_unit.py
@@ -429,8 +429,11 @@ class TestHermesStatusDetection:
         assert provider.get_status("Error: failed\n") == TerminalStatus.ERROR
 
     def test_get_status_empty_output(self):
+        # native=None always falls through (no dispatch-timing guess); on tmux
+        # the live-read fallback is a pass-through, so an empty buffer hits
+        # Hermes's own no-output default (ERROR) directly.
         provider = HermesProvider("tid", "sess", "win", None)
-        assert provider.get_status("") == TerminalStatus.IDLE
+        assert provider.get_status("") == TerminalStatus.ERROR
 
 
 class TestHermesExtraction:

--- a/test/providers/test_hermes_provider_unit.py
+++ b/test/providers/test_hermes_provider_unit.py
@@ -430,7 +430,7 @@ class TestHermesStatusDetection:
 
     def test_get_status_empty_output(self):
         provider = HermesProvider("tid", "sess", "win", None)
-        assert provider.get_status("") == TerminalStatus.ERROR
+        assert provider.get_status("") == TerminalStatus.IDLE
 
 
 class TestHermesExtraction:

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -241,14 +241,14 @@ class TestKimiCliProviderStatusDetection:
         )
 
     def test_get_status_unknown_empty(self):
-        """Test IDLE on empty output (empty buffer + no dispatch)."""
+        """Empty output -> UNKNOWN (native=None always falls through, no guess)."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
-        assert provider.get_status("") == TerminalStatus.IDLE
+        assert provider.get_status("") == TerminalStatus.UNKNOWN
 
     def test_get_status_unknown_none(self):
-        """Test IDLE on None output (empty buffer + no dispatch)."""
+        """Test UNKNOWN on None output."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
-        assert provider.get_status(None) == TerminalStatus.IDLE
+        assert provider.get_status(None) == TerminalStatus.UNKNOWN
 
     def test_get_status_error_pattern(self):
         """Test ERROR detection from error output fixture."""

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -241,14 +241,14 @@ class TestKimiCliProviderStatusDetection:
         )
 
     def test_get_status_unknown_empty(self):
-        """Test UNKNOWN on empty output."""
+        """Test IDLE on empty output (empty buffer + no dispatch)."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
-        assert provider.get_status("") == TerminalStatus.UNKNOWN
+        assert provider.get_status("") == TerminalStatus.IDLE
 
     def test_get_status_unknown_none(self):
-        """Test UNKNOWN on None output."""
+        """Test IDLE on None output (empty buffer + no dispatch)."""
         provider = KimiCliProvider("term-1", "session-1", "window-1")
-        assert provider.get_status(None) == TerminalStatus.UNKNOWN
+        assert provider.get_status(None) == TerminalStatus.IDLE
 
     def test_get_status_error_pattern(self):
         """Test ERROR detection from error output fixture."""

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -109,6 +109,7 @@ class TestKimiCliProviderInitialization:
         mock_profile.model = None
         mock_profile.system_prompt = "You are a helpful assistant"
         mock_profile.mcpServers = None
+        mock_profile.provider_init_timeout = None
         mock_load.return_value = mock_profile
 
         provider = KimiCliProvider("term-1", "session-1", "window-1", agent_profile="developer")
@@ -153,6 +154,7 @@ class TestKimiCliProviderInitialization:
                 "args": ["-y", "cao-mcp-server"],
             }
         }
+        mock_profile.provider_init_timeout = None
         mock_load.return_value = mock_profile
 
         provider = KimiCliProvider("term-1", "session-1", "window-1", agent_profile="developer")

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -305,13 +305,13 @@ class TestKiroCliProviderStatusDetection:
         assert status == TerminalStatus.ERROR
 
     def test_get_status_with_empty_output(self):
-        """Test status detection with empty output."""
+        """Test status detection with empty output -> UNKNOWN (no dispatch-timing guess)."""
         output = ""
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status(output)
 
-        assert status == TerminalStatus.IDLE
+        assert status == TerminalStatus.UNKNOWN
 
     def test_status_processing_response_started_no_final_prompt(self):
         """Test status returns PROCESSING when response started but no final prompt."""

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -311,7 +311,7 @@ class TestKiroCliProviderStatusDetection:
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
         status = provider.get_status(output)
 
-        assert status == TerminalStatus.UNKNOWN
+        assert status == TerminalStatus.IDLE
 
     def test_status_processing_response_started_no_final_prompt(self):
         """Test status returns PROCESSING when response started but no final prompt."""

--- a/test/providers/test_native_status_shared.py
+++ b/test/providers/test_native_status_shared.py
@@ -126,24 +126,54 @@ class TestSharedNativeStatus:
         provider._done_first_detected = time.time() - 11.0
         assert provider.get_status("") == TerminalStatus.COMPLETED
 
+    @staticmethod
+    def _empty_output_default(provider_cls) -> TerminalStatus:
+        """Each provider's own no-output default (unaffected by this fix)."""
+        return TerminalStatus.ERROR if provider_cls is HermesProvider else TerminalStatus.UNKNOWN
+
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_empty_buffer_not_dispatched_returns_idle(
+    def test_native_none_falls_through_to_live_buffer_default(
         self, mock_backend, provider_cls, _flag
     ):
-        """native None + empty buffer + no task dispatched -> IDLE for every provider.
+        """native None -> always falls through; a genuinely empty live-read buffer
+        then hits each provider's own no-output default (UNKNOWN, ERROR for hermes).
 
-        On the herdr backend an 'unknown' agent_status surfaces as native None
-        with an empty StatusMonitor buffer (a wrapped exec launch hides the
-        agent CLI). Before any task is dispatched, base resolution reports IDLE
-        to unblock init rather than falling through to each provider's
-        empty-buffer default (UNKNOWN, or ERROR for hermes). No provider
-        overrides _resolve_native_status, so this holds for all of them.
+        On the herdr backend an 'unknown' agent_status surfaces as native None.
+        Before this fix, base resolution guessed IDLE from dispatch state
+        instead of falling through -- silently reporting init success even for
+        a dead/wedged launch (issue #400's own regression). Now native=None
+        always falls through to BaseProvider._resolve_buffer(), which does a
+        live get_history() read on herdr (mocked here to genuinely empty "");
+        every provider's own empty-output branch then applies, exactly as it
+        would on the tmux backend. No provider overrides _resolve_native_status,
+        so this holds for all of them.
         """
         mock_backend.get_native_status.return_value = None
         mock_backend.get_history.return_value = ""
+        mock_backend.supports_event_inbox.return_value = True
         provider = _make(provider_cls)
         # _task_dispatched defaults to False
-        assert provider.get_status("") == TerminalStatus.IDLE
+        assert provider.get_status("") == self._empty_output_default(provider_cls)
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_none_dispatch_state_no_longer_affects_outcome(
+        self, mock_backend, provider_cls, _flag
+    ):
+        """A dispatched-but-quiet pane must NOT guess PROCESSING/ERROR from a clock.
+
+        Regresses the must-fix-2 bug: the removed staleness matrix reported
+        PROCESSING for ~120s then ERROR purely from elapsed wall-clock time
+        since dispatch, even though the pane never produced any content. With
+        native=None always falling through, dispatch state must not change the
+        result at all -- only real buffer content can.
+        """
+        mock_backend.get_native_status.return_value = None
+        mock_backend.get_history.return_value = ""
+        mock_backend.supports_event_inbox.return_value = True
+        provider = _make(provider_cls)
+        provider.mark_input_received()
+        provider._last_dispatch_time = time.time() - 300.0  # would have been "stale" pre-fix
+        assert provider.get_status("") == self._empty_output_default(provider_cls)
 
     def test_mark_input_received_sets_dispatch_flags(self, provider_cls, _flag):
         """mark_input_received() sets shared _task_dispatched AND the provider's own flag."""

--- a/test/providers/test_native_status_shared.py
+++ b/test/providers/test_native_status_shared.py
@@ -127,18 +127,23 @@ class TestSharedNativeStatus:
         assert provider.get_status("") == TerminalStatus.COMPLETED
 
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_native_none_falls_through_to_buffer(self, mock_backend, provider_cls, _flag):
-        """tmux backend returns None -> buffer path runs; empty buffer is not COMPLETED/IDLE.
+    def test_native_none_empty_buffer_not_dispatched_returns_idle(
+        self, mock_backend, provider_cls, _flag
+    ):
+        """native None + empty buffer + no task dispatched -> IDLE for every provider.
 
-        Guards the fall-through: with native None and an empty buffer every
-        provider must return its buffer-path default (UNKNOWN, or ERROR for
-        hermes) — never a native status leaking through.
+        On the herdr backend an 'unknown' agent_status surfaces as native None
+        with an empty StatusMonitor buffer (a wrapped exec launch hides the
+        agent CLI). Before any task is dispatched, base resolution reports IDLE
+        to unblock init rather than falling through to each provider's
+        empty-buffer default (UNKNOWN, or ERROR for hermes). No provider
+        overrides _resolve_native_status, so this holds for all of them.
         """
         mock_backend.get_native_status.return_value = None
         mock_backend.get_history.return_value = ""
         provider = _make(provider_cls)
-        result = provider.get_status("")
-        assert result in (TerminalStatus.UNKNOWN, TerminalStatus.ERROR)
+        # _task_dispatched defaults to False
+        assert provider.get_status("") == TerminalStatus.IDLE
 
     def test_mark_input_received_sets_dispatch_flags(self, provider_cls, _flag):
         """mark_input_received() sets shared _task_dispatched AND the provider's own flag."""

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -145,14 +145,15 @@ class TestGetStatusFromFixtures:
         assert provider.get_status(output) == TerminalStatus.IDLE
 
     def test_empty_output_returns_unknown(self):
-        # Empty buffer + native None + no dispatch → IDLE.
+        # native=None always falls through (no dispatch-timing guess); on tmux
+        # the live-read fallback is a pass-through, so an empty buffer hits
+        # OpenCode's own no-output default directly.
         provider = make_provider()
-        assert provider.get_status("") == TerminalStatus.IDLE
+        assert provider.get_status("") == TerminalStatus.UNKNOWN
 
     def test_none_output_returns_unknown(self):
-        # None buffer + native None + no dispatch → IDLE.
         provider = make_provider()
-        assert provider.get_status(None) == TerminalStatus.IDLE
+        assert provider.get_status(None) == TerminalStatus.UNKNOWN
 
     def test_unknown_output_returns_unknown_fallback(self):
         """Non-empty output with no recognizable pattern → UNKNOWN fallback.

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -145,14 +145,14 @@ class TestGetStatusFromFixtures:
         assert provider.get_status(output) == TerminalStatus.IDLE
 
     def test_empty_output_returns_unknown(self):
-        # Merged tree: empty output → UNKNOWN (was ERROR).
+        # Empty buffer + native None + no dispatch → IDLE.
         provider = make_provider()
-        assert provider.get_status("") == TerminalStatus.UNKNOWN
+        assert provider.get_status("") == TerminalStatus.IDLE
 
     def test_none_output_returns_unknown(self):
-        # Merged tree: None output → UNKNOWN (was ERROR).
+        # None buffer + native None + no dispatch → IDLE.
         provider = make_provider()
-        assert provider.get_status(None) == TerminalStatus.UNKNOWN
+        assert provider.get_status(None) == TerminalStatus.IDLE
 
     def test_unknown_output_returns_unknown_fallback(self):
         """Non-empty output with no recognizable pattern → UNKNOWN fallback.

--- a/test/providers/test_permission_prompt_detection.py
+++ b/test/providers/test_permission_prompt_detection.py
@@ -184,10 +184,10 @@ class TestNonPermissionCases:
         assert provider.get_status(output) == TerminalStatus.IDLE
 
     def test_empty_output(self):
-        """Empty output returns UNKNOWN."""
+        """Empty output returns IDLE (empty buffer + no dispatch)."""
         output = ""
         provider = make_provider("developer")
-        assert provider.get_status(output) == TerminalStatus.UNKNOWN
+        assert provider.get_status(output) == TerminalStatus.IDLE
 
 
 class TestPermissionPromptEdgeCases:

--- a/test/providers/test_permission_prompt_detection.py
+++ b/test/providers/test_permission_prompt_detection.py
@@ -184,10 +184,15 @@ class TestNonPermissionCases:
         assert provider.get_status(output) == TerminalStatus.IDLE
 
     def test_empty_output(self):
-        """Empty output returns IDLE (empty buffer + no dispatch)."""
+        """Empty output returns UNKNOWN.
+
+        native=None always falls through to buffer analysis now (no dispatch-
+        timing guess) -- on tmux the live-read fallback is a pass-through, so
+        an empty buffer hits Kiro's own no-output default directly.
+        """
         output = ""
         provider = make_provider("developer")
-        assert provider.get_status(output) == TerminalStatus.IDLE
+        assert provider.get_status(output) == TerminalStatus.UNKNOWN
 
 
 class TestPermissionPromptEdgeCases:

--- a/test/providers/test_provider_init_timeout.py
+++ b/test/providers/test_provider_init_timeout.py
@@ -1,0 +1,272 @@
+"""Integration tests for the per-profile ``provider_init_timeout`` feature.
+
+Task 4 / issue #400. ``TestGetInitTimeout`` in ``test_base_provider.py`` covers
+``BaseProvider.get_init_timeout`` in isolation (no-profile/override/no-override).
+These tests verify the resolved timeout actually FLOWS through
+``ClaudeCodeProvider.initialize()`` into every wait it caps, plus edge cases of
+the resolver and the outer-cap relationship of the startup-prompt handler.
+
+``initialize()`` loads the profile once, resolves ``get_init_timeout(profile)``,
+and passes that single value as:
+  - ``wait_for_shell(..., timeout=init_timeout)``
+  - ``_handle_startup_prompts(outer_timeout=init_timeout)``
+  - ``wait_until_status(..., timeout=init_timeout, ...)``
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.models.agent_profile import AgentProfile
+from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
+
+# claude_code module namespace (module-level imports patched here).
+_CC = "cli_agent_orchestrator.providers.claude_code"
+# get_init_timeout reads the server default from settings_service (lazy import).
+_SETTINGS = "cli_agent_orchestrator.services.settings_service.get_server_settings"
+
+
+class TestInitializePassesResolvedInitTimeout:
+    """The timeout get_init_timeout resolves must cap every wait in initialize().
+
+    Mocks every external call so only the timeout wiring is exercised:
+    load_agent_profile (profile source), wait_for_shell / wait_until_status
+    (the async waits), _build_claude_command (avoids temp-file I/O),
+    _handle_startup_prompts (asserted separately), _ensure_skip_bypass_prompt_setting
+    (avoids writing ~/.claude/settings.json), and the terminal backend.
+    """
+
+    @pytest.mark.asyncio
+    @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
+    @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
+    @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
+    @patch(f"{_CC}.load_agent_profile")
+    @patch(f"{_CC}.wait_for_shell")
+    @patch(f"{_CC}.wait_until_status")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_profile_override_flows_to_every_wait(
+        self,
+        mock_backend,
+        mock_wait_status,
+        mock_wait_shell,
+        mock_load,
+        mock_handle,
+        mock_build,
+        mock_ensure,
+    ):
+        """provider_init_timeout=180 caps wait_for_shell, handler, and wait_until_status."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_load.return_value = AgentProfile(
+            name="a", description="d", provider_init_timeout=180
+        )
+
+        provider = ClaudeCodeProvider("t1", "sess", "win", "agent-x")
+        result = await provider.initialize()
+
+        assert result is True
+        assert mock_wait_shell.call_args.kwargs["timeout"] == 180
+        assert mock_wait_status.call_args.kwargs["timeout"] == 180
+        assert mock_handle.call_args.kwargs["outer_timeout"] == 180
+
+    @pytest.mark.asyncio
+    @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
+    @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
+    @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
+    @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
+    @patch(f"{_CC}.load_agent_profile")
+    @patch(f"{_CC}.wait_for_shell")
+    @patch(f"{_CC}.wait_until_status")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_profile_without_override_uses_server_default(
+        self,
+        mock_backend,
+        mock_wait_status,
+        mock_wait_shell,
+        mock_load,
+        mock_handle,
+        mock_build,
+        mock_ensure,
+        mock_settings,
+    ):
+        """No provider_init_timeout on the profile -> the 60s server default flows through."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_load.return_value = AgentProfile(name="a", description="d")
+
+        provider = ClaudeCodeProvider("t1", "sess", "win", "agent-x")
+        result = await provider.initialize()
+
+        assert result is True
+        assert mock_wait_shell.call_args.kwargs["timeout"] == 60
+        assert mock_wait_status.call_args.kwargs["timeout"] == 60
+        assert mock_handle.call_args.kwargs["outer_timeout"] == 60
+
+    @pytest.mark.asyncio
+    @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
+    @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
+    @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
+    @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
+    @patch(f"{_CC}.wait_for_shell")
+    @patch(f"{_CC}.wait_until_status")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_no_profile_uses_server_default(
+        self,
+        mock_backend,
+        mock_wait_status,
+        mock_wait_shell,
+        mock_handle,
+        mock_build,
+        mock_ensure,
+        mock_settings,
+    ):
+        """No agent profile at all (_load_profile -> None) -> server default flows through."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+
+        provider = ClaudeCodeProvider("t1", "sess", "win")  # agent_profile=None
+        result = await provider.initialize()
+
+        assert result is True
+        assert mock_wait_shell.call_args.kwargs["timeout"] == 60
+        assert mock_wait_status.call_args.kwargs["timeout"] == 60
+        assert mock_handle.call_args.kwargs["outer_timeout"] == 60
+
+    @pytest.mark.asyncio
+    @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
+    @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
+    @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
+    @patch(f"{_CC}.load_agent_profile")
+    @patch(f"{_CC}.wait_for_shell")
+    @patch(f"{_CC}.wait_until_status")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_outer_timeout_passed_as_keyword_not_positional(
+        self,
+        mock_backend,
+        mock_wait_status,
+        mock_wait_shell,
+        mock_load,
+        mock_handle,
+        mock_build,
+        mock_ensure,
+    ):
+        """initialize() must pass the timeout as outer_timeout, never positionally.
+
+        _handle_startup_prompts(idle_gap, outer_timeout): the first positional
+        slot is idle_gap. A regression that dropped the keyword would silently
+        shrink the idle gap to the (large) init timeout and leave outer_timeout
+        at the settings default -- a real bug this guards against.
+        """
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_load.return_value = AgentProfile(
+            name="a", description="d", provider_init_timeout=180
+        )
+
+        provider = ClaudeCodeProvider("t1", "sess", "win", "agent-x")
+        await provider.initialize()
+
+        assert mock_handle.call_args.args == ()  # nothing positional
+        assert mock_handle.call_args.kwargs == {"outer_timeout": 180}
+
+
+class TestGetInitTimeoutEdgeCases:
+    """Boundary and coercion cases for get_init_timeout not covered elsewhere."""
+
+    def _provider(self) -> ClaudeCodeProvider:
+        return ClaudeCodeProvider("t1", "sess", "win")
+
+    @patch(_SETTINGS, return_value={"provider_init_timeout": 999})
+    def test_zero_override_is_not_treated_as_unset(self, _):
+        """provider_init_timeout=0 returns 0 (current behavior).
+
+        The resolver guards on ``is not None``, so 0 short-circuits and is
+        returned verbatim -- it does NOT fall through to the server default.
+        Documents the edge: 0 is a caller-supplied value, not "unset". The
+        patched 999 default proves the profile value wins.
+        """
+        profile = AgentProfile(name="a", description="d", provider_init_timeout=0)
+        assert self._provider().get_init_timeout(profile) == 0
+
+    @patch(_SETTINGS, return_value={"provider_init_timeout": 999})
+    def test_minimum_positive_override(self, _):
+        """provider_init_timeout=1 (smallest positive) is returned, not the default."""
+        profile = AgentProfile(name="a", description="d", provider_init_timeout=1)
+        assert self._provider().get_init_timeout(profile) == 1
+
+    @pytest.mark.parametrize("server_value", [30, 60, 90, 120])
+    def test_none_profile_reads_server_default(self, server_value):
+        """With no profile, the resolver returns whatever the server default is."""
+        with patch(_SETTINGS, return_value={"provider_init_timeout": server_value}):
+            assert self._provider().get_init_timeout(None) == server_value
+
+    @patch(_SETTINGS, return_value={"provider_init_timeout": 30.9})
+    def test_float_server_default_coerced_to_int(self, _):
+        """A float server default is truncated via int() (not rounded)."""
+        result = self._provider().get_init_timeout(None)
+        assert result == 30
+        assert isinstance(result, int)
+
+
+class TestStartupPromptHandlerHonorsOuterTimeout:
+    """_handle_startup_prompts must use the outer_timeout it is passed as its deadline.
+
+    Complements TestClaudeCodeIdleGap.test_outer_cap_respected in
+    test_startup_prompt_idle_gap.py: that test uses the settings default; this
+    one proves an EXPLICITLY passed outer_timeout (what initialize() forwards
+    from the per-profile value) governs the outer deadline instead.
+    """
+
+    @patch(f"{_CC}.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_passed_outer_timeout_extends_deadline_past_settings_default(
+        self, mock_backend, mock_time
+    ):
+        """A prompt at t=100 is still handled when outer_timeout=180.
+
+        Deadline = monotonic()[0] + outer_timeout = 0 + 180 = 180. At t=100 the
+        loop is still alive (100 < 180) and answers the trust prompt. Had the
+        handler ignored the passed value and used the 60s default, the top-of-loop
+        ``now >= outer_deadline`` (100 >= 60) would have returned before reaching
+        get_history -- so the trust Enter firing is the discriminating signal.
+        idle_gap is pinned huge so only the outer cap can end the loop.
+        """
+        mock_time.sleep = MagicMock()
+        mock_time.monotonic.side_effect = [
+            0.0,    # outer_deadline = 0 + 180 = 180
+            0.0,    # last_prompt_time = 0
+            100.0,  # iter1 now: 100<180 (alive), gap 100<1000 -> trust prompt -> handled
+        ]
+        mock_backend.get_history.return_value = "Yes, I trust this folder"
+
+        provider = ClaudeCodeProvider("t1", "sess", "win")
+        provider._handle_startup_prompts(idle_gap=1000, outer_timeout=180)
+
+        mock_backend.send_special_key.assert_called_once()
+
+    @patch(f"{_CC}.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_passed_outer_timeout_caps_a_wedged_start(self, mock_backend, mock_time):
+        """With no prompt ever appearing, the loop exits at the passed outer_timeout.
+
+        idle_gap is pinned above outer_timeout so the idle-gap exit can never
+        fire; the only way out is time crossing the 180s deadline.
+        """
+        import logging
+
+        mock_time.sleep = MagicMock()
+        mock_time.monotonic.side_effect = [
+            0.0,    # outer_deadline = 180
+            0.0,    # last_prompt_time = 0
+            100.0,  # iter1 now: 100<180, gap 100<1000, no prompt -> sleep
+            181.0,  # iter2 now: 181>=180 -> outer cap -> return
+        ]
+        mock_backend.get_history.return_value = "still starting..."
+
+        provider = ClaudeCodeProvider("t1", "sess", "win")
+        with patch.object(logging.getLogger(_CC), "warning") as mock_warn:
+            provider._handle_startup_prompts(idle_gap=1000, outer_timeout=180)
+
+        mock_backend.send_special_key.assert_not_called()
+        mock_backend.send_keys.assert_not_called()
+        assert mock_warn.called  # "hit provider_init_timeout outer cap"

--- a/test/providers/test_provider_init_timeout.py
+++ b/test/providers/test_provider_init_timeout.py
@@ -57,9 +57,7 @@ class TestInitializePassesResolvedInitTimeout:
         """provider_init_timeout=180 caps wait_for_shell, handler, and wait_until_status."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_load.return_value = AgentProfile(
-            name="a", description="d", provider_init_timeout=180
-        )
+        mock_load.return_value = AgentProfile(name="a", description="d", provider_init_timeout=180)
 
         provider = ClaudeCodeProvider("t1", "sess", "win", "agent-x")
         result = await provider.initialize()
@@ -159,9 +157,7 @@ class TestInitializePassesResolvedInitTimeout:
         """
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
-        mock_load.return_value = AgentProfile(
-            name="a", description="d", provider_init_timeout=180
-        )
+        mock_load.return_value = AgentProfile(name="a", description="d", provider_init_timeout=180)
 
         provider = ClaudeCodeProvider("t1", "sess", "win", "agent-x")
         await provider.initialize()
@@ -233,8 +229,8 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
         """
         mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
-            0.0,    # outer_deadline = 0 + 180 = 180
-            0.0,    # last_prompt_time = 0
+            0.0,  # outer_deadline = 0 + 180 = 180
+            0.0,  # last_prompt_time = 0
             100.0,  # iter1 now: 100<180 (alive), gap 100<1000 -> trust prompt -> handled
         ]
         mock_backend.get_history.return_value = "Yes, I trust this folder"
@@ -256,8 +252,8 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
 
         mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
-            0.0,    # outer_deadline = 180
-            0.0,    # last_prompt_time = 0
+            0.0,  # outer_deadline = 180
+            0.0,  # last_prompt_time = 0
             100.0,  # iter1 now: 100<180, gap 100<1000, no prompt -> sleep
             181.0,  # iter2 now: 181>=180 -> outer cap -> return
         ]

--- a/test/providers/test_provider_init_timeout.py
+++ b/test/providers/test_provider_init_timeout.py
@@ -11,6 +11,12 @@ and passes that single value as:
   - ``wait_for_shell(..., timeout=init_timeout)``
   - ``_handle_startup_prompts(outer_timeout=init_timeout)``
   - ``wait_until_status(..., timeout=init_timeout, ...)``
+
+should-fix 4 (call-me-ram's PR #428 review) extends the same wiring to
+KimiCliProvider and AntigravityCliProvider, whose ``_handle_startup_dialog()``
+previously hard-capped its outer deadline at the SERVER default regardless of
+a longer per-profile override -- see ``TestKimiInitTimeoutWiring`` /
+``TestAntigravityInitTimeoutWiring`` below.
 """
 
 from unittest.mock import MagicMock, patch
@@ -18,7 +24,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
+from cli_agent_orchestrator.providers.antigravity_cli import AntigravityCliProvider
 from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
+from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 
 # claude_code module namespace (module-level imports patched here).
 _CC = "cli_agent_orchestrator.providers.claude_code"
@@ -258,7 +266,6 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
             181.0,  # iter2 now: 181>=180 -> outer cap -> return
         ]
         mock_backend.get_history.return_value = "still starting..."
-
         provider = ClaudeCodeProvider("t1", "sess", "win")
         with patch.object(logging.getLogger(_CC), "warning") as mock_warn:
             provider._handle_startup_prompts(idle_gap=1000, outer_timeout=180)
@@ -266,3 +273,164 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
         mock_backend.send_special_key.assert_not_called()
         mock_backend.send_keys.assert_not_called()
         assert mock_warn.called  # "hit provider_init_timeout outer cap"
+
+
+# Kimi CLI module namespace (module-level imports patched here).
+_KIMI = "cli_agent_orchestrator.providers.kimi_cli"
+
+
+class TestKimiInitTimeoutWiring:
+    """should-fix 4: KimiCliProvider._handle_startup_dialog honors the per-profile
+    provider_init_timeout override, not just the server default.
+
+    Before this fix, ``_handle_startup_dialog()`` hard-capped its outer
+    deadline at ``get_server_settings()["provider_init_timeout"]`` (server
+    default, often 60s) regardless of how long ``initialize()`` itself was
+    willing to wait (``wait_until_status`` there uses a 120s floor, longer with
+    a profile override). A dialog appearing after the server default but
+    before the real init timeout would never be dismissed -- the handler
+    exits early, init hangs until its own outer wait times out.
+    """
+
+    @pytest.mark.asyncio
+    @patch.object(KimiCliProvider, "_handle_startup_dialog")
+    @patch(f"{_KIMI}.load_agent_profile")
+    @patch(f"{_KIMI}.wait_for_shell")
+    @patch(f"{_KIMI}.wait_until_status")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_profile_override_flows_to_startup_dialog_outer_timeout(
+        self, mock_backend, mock_wait_status, mock_wait_shell, mock_load, mock_handle
+    ):
+        """provider_init_timeout=180 reaches _handle_startup_dialog's outer_timeout kwarg."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_load.return_value = AgentProfile(name="a", description="d", provider_init_timeout=180)
+
+        provider = KimiCliProvider("t1", "sess", "win", agent_profile="agent-x")
+        result = await provider.initialize()
+
+        assert result is True
+        assert mock_handle.call_args.kwargs["outer_timeout"] == 180
+        # wait_until_status uses max(120, init_timeout) -- 180 wins here.
+        assert mock_wait_status.call_args.kwargs["timeout"] == 180
+        assert mock_wait_shell.call_args.kwargs["timeout"] == 180
+
+    @pytest.mark.asyncio
+    @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
+    @patch.object(KimiCliProvider, "_handle_startup_dialog")
+    @patch(f"{_KIMI}.wait_for_shell")
+    @patch(f"{_KIMI}.wait_until_status")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_no_profile_uses_120s_floor_not_server_default(
+        self, mock_backend, mock_wait_status, mock_wait_shell, mock_handle, mock_settings
+    ):
+        """No agent profile -> the 120s Kimi-specific floor wins over the 60s server default.
+
+        Preserves Kimi's existing "account for first-run setup / concurrent
+        launches" floor (see initialize()'s docstring) rather than silently
+        shrinking it to the server default once the per-profile wiring landed.
+        """
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+
+        provider = KimiCliProvider("t1", "sess", "win")  # agent_profile=None
+        result = await provider.initialize()
+
+        assert result is True
+        assert mock_handle.call_args.kwargs["outer_timeout"] == 120.0
+        assert mock_wait_status.call_args.kwargs["timeout"] == 120.0
+        assert mock_wait_shell.call_args.kwargs["timeout"] == 60
+
+    @pytest.mark.asyncio
+    @patch.object(KimiCliProvider, "_handle_startup_dialog")
+    @patch(f"{_KIMI}.load_agent_profile")
+    @patch(f"{_KIMI}.wait_for_shell")
+    @patch(f"{_KIMI}.wait_until_status")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_broken_profile_falls_back_to_default_not_raise(
+        self, mock_backend, mock_wait_status, mock_wait_shell, mock_load, mock_handle
+    ):
+        """A profile that fails to load for timeout resolution must not abort init early.
+
+        _try_load_profile() swallows the failure so get_init_timeout() still
+        resolves (to the server default); the REAL raising load in
+        _build_kimi_command() is untouched and still reports a genuine broken
+        profile at the point that method runs.
+        """
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_load.side_effect = FileNotFoundError("nope")
+
+        provider = KimiCliProvider("t1", "sess", "win", agent_profile="missing")
+        with pytest.raises(Exception):
+            # _build_kimi_command still raises ProviderError for the same
+            # missing profile -- _try_load_profile only affects the timeout.
+            await provider.initialize()
+
+
+# Antigravity CLI module namespace (module-level imports patched here).
+_AGY = "cli_agent_orchestrator.providers.antigravity_cli"
+
+
+class TestAntigravityInitTimeoutWiring:
+    """should-fix 4: AntigravityCliProvider._handle_startup_dialog honors the
+    per-profile provider_init_timeout override, not just the server default.
+
+    Mirrors TestKimiInitTimeoutWiring -- see its class docstring for the bug
+    this closes (both Copilot inline review comments on PR #428).
+    """
+
+    @pytest.mark.asyncio
+    @patch.object(AntigravityCliProvider, "_handle_startup_dialog")
+    @patch(f"{_AGY}.load_agent_profile")
+    @patch(f"{_AGY}.wait_for_shell")
+    @patch(f"{_AGY}.wait_until_status")
+    @patch(f"{_AGY}.get_backend")
+    @patch(f"{_AGY}.shutil.which", return_value="/usr/local/bin/agy")
+    async def test_profile_override_flows_to_startup_dialog_outer_timeout(
+        self,
+        mock_which,
+        mock_get_backend,
+        mock_wait_status,
+        mock_wait_shell,
+        mock_load,
+        mock_handle,
+    ):
+        """provider_init_timeout=200 (> the 180s default) reaches both waits."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_load.return_value = AgentProfile(name="a", description="d", provider_init_timeout=200)
+
+        provider = AntigravityCliProvider("t1", "sess", "win", agent_profile="agent-x")
+        result = await provider.initialize()
+
+        assert result is True
+        assert mock_handle.call_args.kwargs["outer_timeout"] == 200
+        assert mock_wait_status.call_args.kwargs["timeout"] == 200
+
+    @pytest.mark.asyncio
+    @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
+    @patch.object(AntigravityCliProvider, "_handle_startup_dialog")
+    @patch(f"{_AGY}.wait_for_shell")
+    @patch(f"{_AGY}.wait_until_status")
+    @patch(f"{_AGY}.get_backend")
+    @patch(f"{_AGY}.shutil.which", return_value="/usr/local/bin/agy")
+    async def test_no_profile_uses_180s_floor_not_server_default(
+        self,
+        mock_which,
+        mock_get_backend,
+        mock_wait_status,
+        mock_wait_shell,
+        mock_handle,
+        mock_settings,
+    ):
+        """No agent profile -> the 180s agy-specific floor wins over the 60s server default."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+
+        provider = AntigravityCliProvider("t1", "sess", "win")  # agent_profile=None
+        result = await provider.initialize()
+
+        assert result is True
+        assert mock_handle.call_args.kwargs["outer_timeout"] == 180.0
+        assert mock_wait_status.call_args.kwargs["timeout"] == 180.0

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -1,0 +1,540 @@
+"""Tests for idle-gap startup prompt handling across providers.
+
+Validates the refactored startup prompt handlers that use idle-gap semantics
+(issue #400): each handled prompt resets ``last_prompt_time``; the loop exits
+after ``startup_prompt_handler_timeout`` seconds of no-new-prompt (idle gap);
+total runtime is hard-capped by ``provider_init_timeout``.
+
+Covers: ClaudeCodeProvider, KimiCliProvider, AntigravityCliProvider.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.antigravity_cli import AntigravityCliProvider
+from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
+from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
+
+# ---------------------------------------------------------------------------
+# Shared mock settings
+# ---------------------------------------------------------------------------
+
+_SETTINGS = {
+    "startup_prompt_handler_timeout": 20,
+    "provider_init_timeout": 60,
+}
+
+
+def _settings():
+    return dict(_SETTINGS)
+
+
+# Outer-cap tests set idle_gap > provider_init_timeout so the idle-gap check can
+# never fire — the only way out of the loop is time passing provider_init_timeout.
+_OUTER_CAP_SETTINGS = {
+    "startup_prompt_handler_timeout": 100,
+    "provider_init_timeout": 60,
+}
+
+
+def _outer_cap_settings():
+    return dict(_OUTER_CAP_SETTINGS)
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCodeProvider
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeIdleGap:
+    """Idle-gap semantics in ClaudeCodeProvider._handle_startup_prompts."""
+
+    def _make(self):
+        return ClaudeCodeProvider("t1", "sess", "win")
+
+    @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.claude_code.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_late_prompt_handled(self, mock_backend, mock_time):
+        """A prompt at t=35s (past the old 20s window) is still handled.
+
+        Two prompts: bypass at t=18 resets the idle timer; the trust prompt at
+        t=35 is within idle_gap of that reset (35-18=17 < 20) so it is still
+        answered. Under the old fixed-window logic the handler would have exited
+        at t=20 and never seen the trust prompt.
+        """
+        mock_time.sleep = MagicMock()
+        mock_time.monotonic.side_effect = [
+            0.0,    # outer_deadline = 60
+            0.0,    # last_prompt_time = 0
+            18.0,   # iter1 now: gap=18<20, bypass prompt → handled
+            18.0,   # last_prompt_time reset to 18
+            # continues past the old 20s total window...
+            35.0,   # iter2 now: gap=35-18=17<20, trust prompt → handled → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "WARNING: Bypass\n1. No\n2. Yes, I accept\n",
+            "Yes, I trust this folder",
+        ]
+
+        p = self._make()
+        p._handle_startup_prompts()
+
+        # Bypass at t=18 (Down + Enter) and the late trust prompt at t=35 (Enter)
+        # are both handled — proving the idle-gap reset kept the loop polling past
+        # the old 20s window. Under old logic send_special_key would fire once.
+        assert mock_backend.send_keys.call_count == 1         # bypass Down arrow
+        assert mock_backend.send_special_key.call_count == 2  # bypass Enter + trust Enter
+
+    @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.claude_code.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_no_prompt_exits_after_idle_gap(self, mock_backend, mock_time):
+        """No prompt ever appears — loop exits after idle_gap seconds."""
+        mock_time.sleep = MagicMock()
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            5.0,   # iter1 now: gap=5<20, not past deadline
+            # output: "Loading..." → no prompt match, sleep
+            25.0,  # iter2 now: gap=25>=20 → return (idle gap elapsed)
+        ]
+        mock_backend.get_history.return_value = "Loading..."
+
+        p = self._make()
+        p._handle_startup_prompts()
+
+        # No prompts handled
+        mock_backend.send_special_key.assert_not_called()
+        mock_backend.send_keys.assert_not_called()
+
+    @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _outer_cap_settings)
+    @patch("cli_agent_orchestrator.providers.claude_code.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_outer_cap_respected(self, mock_backend, mock_time):
+        """Loop exits at provider_init_timeout, NOT via the idle gap.
+
+        idle_gap=100 > provider_init_timeout=60, so the idle-gap check can never
+        fire — the only way out is time advancing past the outer deadline. The
+        bypass prompt is handled once (resetting the timer), then the loop idles
+        until t=61 trips the outer cap.
+        """
+        mock_time.sleep = MagicMock()
+        mock_time.monotonic.side_effect = [
+            0.0,    # outer_deadline = 60
+            0.0,    # last_prompt_time = 0
+            10.0,   # iter1: bypass prompt found, handled
+            10.0,   # last_prompt_time reset after bypass
+            # continues loop (gap=20<100, so idle gap never fires)...
+            30.0,   # iter2: bypass_accepted=True, no trust, no welcome; sleep
+            61.0,   # iter3 now >= 60 outer_deadline → return (outer cap)
+        ]
+        # Output always has bypass prompt (handled once, then ignored)
+        mock_backend.get_history.return_value = (
+            "WARNING: Bypass Permissions\n1. No\n2. Yes, I accept\n"
+        )
+
+        p = self._make()
+        p._handle_startup_prompts()
+
+        # Bypass accepted once
+        mock_backend.send_keys.assert_called_once()
+        mock_backend.send_special_key.assert_called_once()
+
+    @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.claude_code.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_cascading_prompts_all_handled(self, mock_backend, mock_time):
+        """Multiple prompts in sequence — bypass then trust, both handled."""
+        mock_time.sleep = MagicMock()
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            3.0,   # iter1: gap=3<20, bypass prompt → handled
+            3.0,   # last_prompt_time reset
+            # loop continues
+            8.0,   # iter2: gap=8-3=5<20, trust prompt → handled → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "WARNING: Bypass\n1. No\n2. Yes, I accept\n",
+            "Yes, I trust this folder",
+        ]
+
+        p = self._make()
+        p._handle_startup_prompts()
+
+        # Bypass: send_keys (Down arrow) + send_special_key (Enter)
+        # Trust: send_special_key (Enter)
+        assert mock_backend.send_keys.call_count == 1
+        assert mock_backend.send_special_key.call_count == 2
+
+    @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.claude_code.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_idle_gap_resets_on_each_prompt(self, mock_backend, mock_time):
+        """First prompt at t=5s resets timer; second at t=22s still within gap of first."""
+        mock_time.sleep = MagicMock()
+        # idle_gap=20. First prompt at t=5, resets last_prompt_time to 5.
+        # Second prompt at t=22: gap=22-5=17<20, so still polled and handled.
+        # Without reset, gap would be 22-0=22>=20 → would have exited.
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            5.0,   # iter1: gap=5<20, bypass prompt → handled
+            5.0,   # last_prompt_time reset to 5
+            # continues
+            22.0,  # iter2: gap=22-5=17<20, trust prompt → handled → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "WARNING: Bypass\n1. No\n2. Yes, I accept\n",
+            "Yes, I trust this folder",
+        ]
+
+        p = self._make()
+        p._handle_startup_prompts()
+
+        # Both prompts handled
+        assert mock_backend.send_keys.call_count == 1      # bypass Down arrow
+        assert mock_backend.send_special_key.call_count == 2  # bypass Enter + trust Enter
+
+
+# ---------------------------------------------------------------------------
+# KimiCliProvider
+# ---------------------------------------------------------------------------
+
+
+class TestKimiCliIdleGap:
+    """Idle-gap semantics in KimiCliProvider._handle_startup_dialog."""
+
+    def _make(self):
+        return KimiCliProvider("t1", "sess", "win")
+
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.time")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    def test_late_prompt_handled(self, mock_get_backend, mock_time):
+        """Upgrade at t=18 resets the timer; loop survives to detect ready at t=35.
+
+        Kimi has a single actionable dialog (upgrade), so the two-event structure
+        is: upgrade at t=18 resets the idle timer, and the loop keeps polling past
+        the old 20s total window to detect readiness at t=35 (35-18=17 < 20). Under
+        the old fixed-window logic the loop would have given up at t=20.
+        """
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            18.0,  # iter1: gap=18<20, upgrade prompt → handled
+            18.0,  # last_prompt_time reset to 18
+            # continues past the old 20s total window...
+            35.0,  # iter2: gap=35-18=17<20, output → ready → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Skip reminders for version 1.2.3\n[Enter] Upgrade now  [q] Not now",
+            "Welcome to Kimi!\n💫",
+        ]
+
+        p = self._make()
+        # get_status is checked only in iter2 (iter1 continues after handling upgrade)
+        with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
+            p._handle_startup_dialog()
+
+        # 's' sent to skip reminders at t=18 — the reset kept the loop alive to
+        # cleanly detect readiness at t=35, past the old 20s window.
+        mock_backend.send_keys.assert_called_once_with("sess", "win", "s", enter_count=0)
+
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.time")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    def test_no_prompt_exits_after_idle_gap(self, mock_get_backend, mock_time):
+        """No upgrade dialog — exits after idle_gap with no action."""
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            5.0,   # iter1: gap=5<20, output has no prompt, not ready → sleep
+            25.0,  # iter2: gap=25>=20 → return
+        ]
+        mock_backend.get_history.return_value = "Starting kimi..."
+
+        p = self._make()
+        # Mock get_status to return PROCESSING (not ready yet)
+        with patch.object(p, "get_status", return_value=TerminalStatus.PROCESSING):
+            p._handle_startup_dialog()
+
+        mock_backend.send_keys.assert_not_called()
+
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _outer_cap_settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.time")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    def test_outer_cap_respected(self, mock_get_backend, mock_time):
+        """Loop exits at provider_init_timeout, NOT via the idle gap.
+
+        idle_gap=100 > provider_init_timeout=60, so the idle-gap check can never
+        fire. The upgrade prompt is handled once (resetting the timer), then the
+        loop idles until t=61 trips the outer cap.
+        """
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            10.0,  # iter1: upgrade prompt → handled
+            10.0,  # last_prompt_time reset
+            # continues (gap=15<100, so idle gap never fires)...
+            25.0,  # iter2: no new prompt, not ready → sleep
+            61.0,  # iter3: now>=60 → return (outer cap)
+        ]
+        mock_backend.get_history.return_value = (
+            "Skip reminders for version 2.0\n[Enter] Upgrade now"
+        )
+
+        p = self._make()
+        with patch.object(p, "get_status", return_value=TerminalStatus.PROCESSING):
+            p._handle_startup_dialog()
+
+        # Upgrade handled once
+        mock_backend.send_keys.assert_called_once()
+
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.time")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    def test_cascading_prompts_all_handled(self, mock_get_backend, mock_time):
+        """Upgrade dialog handled, then ready state detected → exits cleanly.
+
+        Kimi only has one startup dialog type (upgrade), so "cascading" means
+        the dialog is handled and then IDLE is detected on the next poll.
+        """
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            3.0,  # iter1: upgrade prompt → handled
+            3.0,  # last_prompt_time reset
+            # continues
+            8.0,  # iter2: gap=5<20, output → kimi is ready → early return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Skip reminders for version 1.5\n[Enter] Upgrade now",
+            "Welcome to Kimi!\n💫",  # ready output
+        ]
+
+        p = self._make()
+        # get_status called only in iter2 (iter1 continues after handling upgrade)
+        with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
+            p._handle_startup_dialog()
+
+        mock_backend.send_keys.assert_called_once()
+
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.time")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    def test_idle_gap_resets_on_prompt(self, mock_get_backend, mock_time):
+        """Upgrade at t=5 resets timer; at t=22 (gap=17<20) still within window."""
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        # Without reset: t=22-0=22>=20 would exit. With reset: 22-5=17<20.
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            5.0,   # iter1: upgrade prompt → handled
+            5.0,   # last_prompt_time reset to 5
+            # continues
+            22.0,  # iter2: gap=22-5=17<20, check output → ready → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Skip reminders for version 1.0\n[Enter] Upgrade now",
+            "Welcome!\n💫",
+        ]
+
+        p = self._make()
+        # get_status called only in iter2 (iter1 continues after handling upgrade)
+        with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
+            p._handle_startup_dialog()
+
+        # Prompt at t=5 was handled (timer reset enabled continued polling at t=22)
+        mock_backend.send_keys.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AntigravityCliProvider
+# ---------------------------------------------------------------------------
+
+
+class TestAntigravityCliIdleGap:
+    """Idle-gap semantics in AntigravityCliProvider._handle_startup_dialog."""
+
+    def _make(self):
+        return AntigravityCliProvider("t1", "sess", "win")
+
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
+    def test_late_prompt_handled(self, mock_get_backend, mock_time):
+        """A survey at t=35s (past the old 20s window) is still handled.
+
+        Two prompts: trust at t=18 resets the idle timer; the survey at t=35 is
+        within idle_gap of that reset (35-18=17 < 20) so it is still answered.
+        Under the old fixed-window logic the handler would have exited at t=20 and
+        never seen the late survey.
+        """
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            18.0,  # iter1: gap=18<20, trust prompt → handled
+            18.0,  # last_prompt_time reset to 18
+            # continues past the old 20s total window...
+            35.0,  # iter2: gap=35-18=17<20, survey → handled
+            35.0,  # last_prompt_time reset to 35
+            # continues
+            40.0,  # iter3: gap=40-35=5<20, ready footer → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Yes, I trust this folder\nrequires permission to read",
+            "How's the CLI experience so far?\n[0] Skip",
+            "? for shortcuts\n> ",
+        ]
+
+        p = self._make()
+        p._handle_startup_dialog()
+
+        # Trust at t=18 (Enter) and the late survey at t=35 ("0" + Enter) are both
+        # handled — the idle-gap reset kept the loop polling past the old 20s
+        # window. Under old logic send_special_key would fire once.
+        assert mock_backend.send_special_key.call_count == 2  # trust Enter + survey Enter
+        assert mock_backend.send_keys.call_count == 1         # survey "0"
+
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
+    def test_no_prompt_exits_after_idle_gap(self, mock_get_backend, mock_time):
+        """No dialog — exits after idle_gap with no action."""
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            5.0,   # iter1: gap=5<20, no dialog, no ready footer → sleep
+            25.0,  # iter2: gap=25>=20 → return
+        ]
+        mock_backend.get_history.return_value = "Starting agy..."
+
+        p = self._make()
+        p._handle_startup_dialog()
+
+        mock_backend.send_special_key.assert_not_called()
+        mock_backend.send_keys.assert_not_called()
+
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _outer_cap_settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
+    def test_outer_cap_respected(self, mock_get_backend, mock_time):
+        """Loop exits at provider_init_timeout, NOT via the idle gap.
+
+        idle_gap=100 > provider_init_timeout=60, so the idle-gap check can never
+        fire. Trust is handled once (resetting the timer), then the loop idles
+        with no ready footer until t=61 trips the outer cap.
+        """
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            10.0,  # iter1: trust prompt → handled
+            10.0,  # last_prompt_time reset
+            # continues (gap=15<100, so idle gap never fires)...
+            25.0,  # iter2: no ready footer, no new dialog → sleep
+            61.0,  # iter3: now>=60 → return (outer cap)
+        ]
+        # Trust prompt text persists in buffer after dismissal
+        mock_backend.get_history.return_value = (
+            "Yes, I trust this folder\nrequires permission to read"
+        )
+
+        p = self._make()
+        p._handle_startup_dialog()
+
+        # Trust handled once (trust_done flag prevents re-handling)
+        assert mock_backend.send_special_key.call_count == 1
+
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
+    def test_cascading_prompts_all_handled(self, mock_get_backend, mock_time):
+        """Trust dialog then survey — both handled in sequence."""
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            3.0,  # iter1: trust prompt → handled
+            3.0,  # last_prompt_time reset
+            # continues
+            8.0,  # iter2: survey prompt → handled
+            8.0,  # last_prompt_time reset
+            # continues
+            14.0, # iter3: ready footer → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Yes, I trust this folder\nrequires permission",
+            "How's the CLI experience so far?\n[1] Good [2] Fine [3] Bad [0] Skip",
+            "? for shortcuts\n> ",
+        ]
+
+        p = self._make()
+        p._handle_startup_dialog()
+
+        # Trust: send_special_key (Enter)
+        # Survey: send_keys ("0") + send_special_key (Enter)
+        assert mock_backend.send_special_key.call_count == 2
+        assert mock_backend.send_keys.call_count == 1
+
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
+    def test_idle_gap_resets_on_each_prompt(self, mock_get_backend, mock_time):
+        """Trust at t=5 resets timer; survey at t=22 (gap=17<20) still within window."""
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        # Without reset: 22-0=22>=20 would exit before seeing survey.
+        # With reset: 22-5=17<20, so survey is still polled.
+        mock_time.monotonic.side_effect = [
+            0.0,   # outer_deadline = 60
+            0.0,   # last_prompt_time = 0
+            5.0,   # iter1: trust prompt → handled
+            5.0,   # last_prompt_time reset to 5
+            # continues
+            22.0,  # iter2: gap=22-5=17<20, survey → handled
+            22.0,  # last_prompt_time reset to 22
+            # continues
+            30.0,  # iter3: gap=30-22=8<20, ready footer → return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Yes, I trust this folder\nrequires permission",
+            "How's the CLI experience so far?\n[0] Skip",
+            "? for shortcuts\n> ",
+        ]
+
+        p = self._make()
+        p._handle_startup_dialog()
+
+        # Both dialogs handled
+        assert mock_backend.send_special_key.call_count == 2  # trust Enter + survey Enter
+        assert mock_backend.send_keys.call_count == 1         # survey "0"

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -67,12 +67,12 @@ class TestClaudeCodeIdleGap:
         """
         mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
-            0.0,    # outer_deadline = 60
-            0.0,    # last_prompt_time = 0
-            18.0,   # iter1 now: gap=18<20, bypass prompt → handled
-            18.0,   # last_prompt_time reset to 18
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            18.0,  # iter1 now: gap=18<20, bypass prompt → handled
+            18.0,  # last_prompt_time reset to 18
             # continues past the old 20s total window...
-            35.0,   # iter2 now: gap=35-18=17<20, trust prompt → handled → return
+            35.0,  # iter2 now: gap=35-18=17<20, trust prompt → handled → return
         ]
         mock_backend.get_history.side_effect = [
             "WARNING: Bypass\n1. No\n2. Yes, I accept\n",
@@ -85,7 +85,7 @@ class TestClaudeCodeIdleGap:
         # Bypass at t=18 (Down + Enter) and the late trust prompt at t=35 (Enter)
         # are both handled — proving the idle-gap reset kept the loop polling past
         # the old 20s window. Under old logic send_special_key would fire once.
-        assert mock_backend.send_keys.call_count == 1         # bypass Down arrow
+        assert mock_backend.send_keys.call_count == 1  # bypass Down arrow
         assert mock_backend.send_special_key.call_count == 2  # bypass Enter + trust Enter
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
@@ -95,9 +95,9 @@ class TestClaudeCodeIdleGap:
         """No prompt ever appears — loop exits after idle_gap seconds."""
         mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
-            5.0,   # iter1 now: gap=5<20, not past deadline
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            5.0,  # iter1 now: gap=5<20, not past deadline
             # output: "Loading..." → no prompt match, sleep
             25.0,  # iter2 now: gap=25>=20 → return (idle gap elapsed)
         ]
@@ -123,13 +123,13 @@ class TestClaudeCodeIdleGap:
         """
         mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
-            0.0,    # outer_deadline = 60
-            0.0,    # last_prompt_time = 0
-            10.0,   # iter1: bypass prompt found, handled
-            10.0,   # last_prompt_time reset after bypass
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            10.0,  # iter1: bypass prompt found, handled
+            10.0,  # last_prompt_time reset after bypass
             # continues loop (gap=20<100, so idle gap never fires)...
-            30.0,   # iter2: bypass_accepted=True, no trust, no welcome; sleep
-            61.0,   # iter3 now >= 60 outer_deadline → return (outer cap)
+            30.0,  # iter2: bypass_accepted=True, no trust, no welcome; sleep
+            61.0,  # iter3 now >= 60 outer_deadline → return (outer cap)
         ]
         # Output always has bypass prompt (handled once, then ignored)
         mock_backend.get_history.return_value = (
@@ -150,12 +150,12 @@ class TestClaudeCodeIdleGap:
         """Multiple prompts in sequence — bypass then trust, both handled."""
         mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
-            3.0,   # iter1: gap=3<20, bypass prompt → handled
-            3.0,   # last_prompt_time reset
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            3.0,  # iter1: gap=3<20, bypass prompt → handled
+            3.0,  # last_prompt_time reset
             # loop continues
-            8.0,   # iter2: gap=8-3=5<20, trust prompt → handled → return
+            8.0,  # iter2: gap=8-3=5<20, trust prompt → handled → return
         ]
         mock_backend.get_history.side_effect = [
             "WARNING: Bypass\n1. No\n2. Yes, I accept\n",
@@ -180,10 +180,10 @@ class TestClaudeCodeIdleGap:
         # Second prompt at t=22: gap=22-5=17<20, so still polled and handled.
         # Without reset, gap would be 22-0=22>=20 → would have exited.
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
-            5.0,   # iter1: gap=5<20, bypass prompt → handled
-            5.0,   # last_prompt_time reset to 5
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            5.0,  # iter1: gap=5<20, bypass prompt → handled
+            5.0,  # last_prompt_time reset to 5
             # continues
             22.0,  # iter2: gap=22-5=17<20, trust prompt → handled → return
         ]
@@ -196,7 +196,7 @@ class TestClaudeCodeIdleGap:
         p._handle_startup_prompts()
 
         # Both prompts handled
-        assert mock_backend.send_keys.call_count == 1      # bypass Down arrow
+        assert mock_backend.send_keys.call_count == 1  # bypass Down arrow
         assert mock_backend.send_special_key.call_count == 2  # bypass Enter + trust Enter
 
 
@@ -226,8 +226,8 @@ class TestKimiCliIdleGap:
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
             18.0,  # iter1: gap=18<20, upgrade prompt → handled
             18.0,  # last_prompt_time reset to 18
             # continues past the old 20s total window...
@@ -256,9 +256,9 @@ class TestKimiCliIdleGap:
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
-            5.0,   # iter1: gap=5<20, output has no prompt, not ready → sleep
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            5.0,  # iter1: gap=5<20, output has no prompt, not ready → sleep
             25.0,  # iter2: gap=25>=20 → return
         ]
         mock_backend.get_history.return_value = "Starting kimi..."
@@ -284,8 +284,8 @@ class TestKimiCliIdleGap:
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
             10.0,  # iter1: upgrade prompt → handled
             10.0,  # last_prompt_time reset
             # continues (gap=15<100, so idle gap never fires)...
@@ -345,10 +345,10 @@ class TestKimiCliIdleGap:
         mock_get_backend.return_value = mock_backend
         # Without reset: t=22-0=22>=20 would exit. With reset: 22-5=17<20.
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
-            5.0,   # iter1: upgrade prompt → handled
-            5.0,   # last_prompt_time reset to 5
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            5.0,  # iter1: upgrade prompt → handled
+            5.0,  # last_prompt_time reset to 5
             # continues
             22.0,  # iter2: gap=22-5=17<20, check output → ready → return
         ]
@@ -392,8 +392,8 @@ class TestAntigravityCliIdleGap:
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
             18.0,  # iter1: gap=18<20, trust prompt → handled
             18.0,  # last_prompt_time reset to 18
             # continues past the old 20s total window...
@@ -415,7 +415,7 @@ class TestAntigravityCliIdleGap:
         # handled — the idle-gap reset kept the loop polling past the old 20s
         # window. Under old logic send_special_key would fire once.
         assert mock_backend.send_special_key.call_count == 2  # trust Enter + survey Enter
-        assert mock_backend.send_keys.call_count == 1         # survey "0"
+        assert mock_backend.send_keys.call_count == 1  # survey "0"
 
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
@@ -426,9 +426,9 @@ class TestAntigravityCliIdleGap:
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
-            5.0,   # iter1: gap=5<20, no dialog, no ready footer → sleep
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            5.0,  # iter1: gap=5<20, no dialog, no ready footer → sleep
             25.0,  # iter2: gap=25>=20 → return
         ]
         mock_backend.get_history.return_value = "Starting agy..."
@@ -439,7 +439,9 @@ class TestAntigravityCliIdleGap:
         mock_backend.send_special_key.assert_not_called()
         mock_backend.send_keys.assert_not_called()
 
-    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _outer_cap_settings)
+    @patch(
+        "cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _outer_cap_settings
+    )
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
     def test_outer_cap_respected(self, mock_get_backend, mock_time):
@@ -453,8 +455,8 @@ class TestAntigravityCliIdleGap:
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
             10.0,  # iter1: trust prompt → handled
             10.0,  # last_prompt_time reset
             # continues (gap=15<100, so idle gap never fires)...
@@ -489,7 +491,7 @@ class TestAntigravityCliIdleGap:
             8.0,  # iter2: survey prompt → handled
             8.0,  # last_prompt_time reset
             # continues
-            14.0, # iter3: ready footer → return
+            14.0,  # iter3: ready footer → return
         ]
         mock_backend.get_history.side_effect = [
             "Yes, I trust this folder\nrequires permission",
@@ -516,10 +518,10 @@ class TestAntigravityCliIdleGap:
         # Without reset: 22-0=22>=20 would exit before seeing survey.
         # With reset: 22-5=17<20, so survey is still polled.
         mock_time.monotonic.side_effect = [
-            0.0,   # outer_deadline = 60
-            0.0,   # last_prompt_time = 0
-            5.0,   # iter1: trust prompt → handled
-            5.0,   # last_prompt_time reset to 5
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            5.0,  # iter1: trust prompt → handled
+            5.0,  # last_prompt_time reset to 5
             # continues
             22.0,  # iter2: gap=22-5=17<20, survey → handled
             22.0,  # last_prompt_time reset to 22
@@ -537,4 +539,4 @@ class TestAntigravityCliIdleGap:
 
         # Both dialogs handled
         assert mock_backend.send_special_key.call_count == 2  # trust Enter + survey Enter
-        assert mock_backend.send_keys.call_count == 1         # survey "0"
+        assert mock_backend.send_keys.call_count == 1  # survey "0"

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -91,15 +91,21 @@ class TestClaudeCodeIdleGap:
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_no_prompt_exits_after_idle_gap(self, mock_backend, mock_time):
-        """No prompt ever appears — loop exits after idle_gap seconds."""
+    def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_backend, mock_time):
+        """No prompt ever appears — the idle gap does NOT apply until a first prompt lands.
+
+        Before any prompt is observed, ``last_prompt_time`` has nothing real to
+        measure a gap from, so only the outer cap can end the loop. This is the
+        should-fix-3 rework: the exit at t=25 (old idle-gap boundary) must NOT
+        fire here — only t=61 (past the 60s outer cap) does.
+        """
         mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
-            5.0,  # iter1 now: gap=5<20, not past deadline
-            # output: "Loading..." → no prompt match, sleep
-            25.0,  # iter2 now: gap=25>=20 → return (idle gap elapsed)
+            5.0,  # iter1 now: no prompt handled yet, idle-gap check skipped -> sleep
+            25.0,  # iter2 now: still no prompt handled -> idle-gap check skipped -> sleep
+            61.0,  # iter3 now: 61>=60 -> outer cap -> return
         ]
         mock_backend.get_history.return_value = "Loading..."
 
@@ -109,6 +115,32 @@ class TestClaudeCodeIdleGap:
         # No prompts handled
         mock_backend.send_special_key.assert_not_called()
         mock_backend.send_keys.assert_not_called()
+
+    @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.claude_code.time")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_first_prompt_later_than_idle_gap_still_handled(self, mock_backend, mock_time):
+        """A FIRST dialog later than idle_gap (the issue #400 scenario) is now caught.
+
+        Before this fix, a first prompt at t=35 (past the 20s idle-gap default)
+        would never be seen: the loop measured the gap from handler-start, not
+        from a real prompt, and exited at t=20. Now the idle-gap clock only
+        starts once a prompt has actually been handled, so a first prompt at
+        t=35 is well within the still-open outer cap and is handled.
+        """
+        mock_time.sleep = MagicMock()
+        mock_time.monotonic.side_effect = [
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            35.0,  # iter1 now: no prompt handled yet -> idle-gap check skipped ->
+            # trust prompt found in output -> handled -> return
+        ]
+        mock_backend.get_history.return_value = "Yes, I trust this folder"
+
+        p = self._make()
+        p._handle_startup_prompts()
+
+        mock_backend.send_special_key.assert_called_once_with("sess", "win", "Enter")
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _outer_cap_settings)
     @patch("cli_agent_orchestrator.providers.claude_code.time")
@@ -250,16 +282,21 @@ class TestKimiCliIdleGap:
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    def test_no_prompt_exits_after_idle_gap(self, mock_get_backend, mock_time):
-        """No upgrade dialog — exits after idle_gap with no action."""
+    def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_get_backend, mock_time):
+        """No upgrade dialog ever appears — the idle gap does NOT apply pre-first-prompt.
+
+        should-fix-3 rework: with no dialog ever handled, only the outer cap
+        (not the idle-gap boundary at t=20) can end the loop.
+        """
         mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
-            5.0,  # iter1: gap=5<20, output has no prompt, not ready → sleep
-            25.0,  # iter2: gap=25>=20 → return
+            5.0,  # iter1: no dialog handled yet -> idle-gap check skipped, not ready -> sleep
+            25.0,  # iter2: still no dialog -> idle-gap check skipped, not ready -> sleep
+            61.0,  # iter3: 61>=60 -> outer cap -> return
         ]
         mock_backend.get_history.return_value = "Starting kimi..."
 
@@ -269,6 +306,40 @@ class TestKimiCliIdleGap:
             p._handle_startup_dialog()
 
         mock_backend.send_keys.assert_not_called()
+
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.time")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    def test_first_dialog_later_than_idle_gap_still_handled(self, mock_get_backend, mock_time):
+        """A FIRST upgrade dialog later than idle_gap (issue #400 scenario) is caught.
+
+        Before this fix, a first dialog at t=35 (past the 20s default) would
+        never be seen -- the loop would have exited at t=20. Now the idle-gap
+        clock only starts once a dialog has actually been handled, so a first
+        dialog at t=35 is well within the still-open outer cap and is handled;
+        the loop then detects readiness on the next poll (t=36) and returns.
+        """
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            35.0,  # iter1: no dialog handled yet -> idle-gap check skipped ->
+            # upgrade dialog found in output -> handled -> continue
+            35.0,  # last_prompt_time reset to 35
+            36.0,  # iter2: gap=1<20, output -> kimi ready -> return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Skip reminders for version 1.2.3\n[Enter] Upgrade now",
+            "Welcome to Kimi!\n💫",
+        ]
+
+        p = self._make()
+        with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
+            p._handle_startup_dialog()
+
+        mock_backend.send_keys.assert_called_once_with("sess", "win", "s", enter_count=0)
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _outer_cap_settings)
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
@@ -420,16 +491,21 @@ class TestAntigravityCliIdleGap:
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
-    def test_no_prompt_exits_after_idle_gap(self, mock_get_backend, mock_time):
-        """No dialog — exits after idle_gap with no action."""
+    def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_get_backend, mock_time):
+        """No dialog ever appears — the idle gap does NOT apply pre-first-dialog.
+
+        should-fix-3 rework: with no dialog ever handled, only the outer cap
+        (not the idle-gap boundary at t=20) can end the loop.
+        """
         mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
-            5.0,  # iter1: gap=5<20, no dialog, no ready footer → sleep
-            25.0,  # iter2: gap=25>=20 → return
+            5.0,  # iter1: no dialog handled yet -> idle-gap check skipped, no ready footer -> sleep
+            25.0,  # iter2: still no dialog -> idle-gap check skipped, no ready footer -> sleep
+            61.0,  # iter3: 61>=60 -> outer cap -> return
         ]
         mock_backend.get_history.return_value = "Starting agy..."
 
@@ -438,6 +514,38 @@ class TestAntigravityCliIdleGap:
 
         mock_backend.send_special_key.assert_not_called()
         mock_backend.send_keys.assert_not_called()
+
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
+    def test_first_dialog_later_than_idle_gap_still_handled(self, mock_get_backend, mock_time):
+        """A FIRST trust dialog later than idle_gap (issue #400 scenario) is caught.
+
+        Before this fix, a first dialog at t=35 (past the 20s default) would
+        never be seen. Now the idle-gap clock only starts once a dialog has
+        actually been handled, so a first dialog at t=35 is well within the
+        still-open outer cap.
+        """
+        mock_time.sleep = MagicMock()
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            35.0,  # iter1: no dialog handled yet -> idle-gap check skipped ->
+            # trust prompt found -> handled -> continue
+            35.0,  # last_prompt_time reset to 35
+            36.0,  # iter2: gap=1<20, ready footer -> return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Yes, I trust this folder\nrequires permission to read",
+            "? for shortcuts\n> ",
+        ]
+
+        p = self._make()
+        p._handle_startup_dialog()
+
+        mock_backend.send_special_key.assert_called_once_with("sess", "win", "Enter")
 
     @patch(
         "cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _outer_cap_settings


### PR DESCRIPTION
## Summary

Fixes three independent blockers preventing containerized/wrapped provider agents from initializing:

- **Status mapping** — `unknown` status from herdr now resolves via staleness-aware logic (IDLE if not dispatched, PROCESSING if fresh <120s, ERROR if stale >120s) instead of immediately returning ERROR
- **Path translation** — Adds `_translate_path()` on BaseProvider with longest-prefix-match; new `ContainerConfig`/`ContainerPathMap` models on AgentProfile for host↔container path mapping
- **Startup prompt timeout** — Changes from fixed 20s window to idle-gap semantic (timer resets on each prompt found, capped by `provider_init_timeout`) across all 3 providers
- **Per-profile timeout** — Optional `provider_init_timeout` on AgentProfile for container profiles needing longer init

Closes #400

## Test plan

- [x] 6 new integration tests in `test_container_wrapped.py` (mocked, no Docker required)
- [x] Unit tests for status matrix, path translation, idle-gap, init timeout
- [x] 2088 tests passing across providers, backends, and services