### PR TITLE
fix(security): enable Jinja2 autoescape in agent-profile scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- security: enable Jinja2 autoescape in the agent-profile scaffolding `Environment` (`agent_scaffold.py`). Jinja2 defaults to `autoescape=False`, which AppSec scanners flag as an XSS risk. Uses `select_autoescape(enabled_extensions=("html","htm","xml"))` so HTML/XML templates would be escaped while the current markdown/bash `.md.j2` output stays byte-identical
+
 - stop TestPyPI squats breaking the release smoke test (#270)
 
 - handle v0.136+ TUI footer and skip MCP tool-call markers … (#274)

--- a/src/cli_agent_orchestrator/services/agent_scaffold.py
+++ b/src/cli_agent_orchestrator/services/agent_scaffold.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from jsonschema import Draft202012Validator
 
 # Templates live under src/cli_agent_orchestrator/templates/
@@ -121,11 +121,20 @@ def render_template(template_name: str, config: dict) -> str:
             + "\n".join(f"  - {e}" for e in errors)
         )
 
-    # Render with Jinja2 defaults. Templates use {{ config.x }} for values
-    # and bash ${VAR} passes through unchanged (not Jinja2 syntax).
+    # Templates use {{ config.x }} for values and bash ${VAR} passes through
+    # unchanged (not Jinja2 syntax). Autoescape is enabled via
+    # select_autoescape so it is never off by default (Jinja2's own default is
+    # autoescape=False, flagged by security scanners as an XSS risk). The
+    # scaffold renders markdown/bash profile files, not HTML, so escaping only
+    # engages for HTML/XML template extensions — should such a template ever be
+    # added, its output is escaped; the current .md.j2 output is byte-identical.
     env = Environment(
         loader=FileSystemLoader(str(template_dir)),
         keep_trailing_newline=True,
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=False,
+        ),
     )
     template = env.get_template("template.md.j2")
 


### PR DESCRIPTION
## What

Enables Jinja2 autoescaping in the agent-profile scaffolding engine (`agent_scaffold.py`). The `Environment` was constructed without `autoescape`, and Jinja2 defaults to `autoescape=False` — flagged by AppSec tooling (ACAT
rule `Jinja2AutoescapeDisabled`) as an XSS risk.

  ## Change

  ```python
  env = Environment(
      loader=FileSystemLoader(str(template_dir)),
      keep_trailing_newline=True,
      autoescape=select_autoescape(
          enabled_extensions=("html", "htm", "xml"),
          default_for_string=False,
      ),
  )

  Autoescape is now explicitly enabled and can never be off by default.                                                                                                                                                                                                                            
  
  Why this configuration (and not autoescape=True)

  The scaffold renders markdown/bash profile files (template.md.j2), not HTML. select_autoescape engages escaping only for HTML/XML template extensions, so:

  - If an .html/.xml template is ever added, its output is escaped (XSS-safe).
  - The current .md.j2 output is byte-identical — no behavior change.

  Verified: config values containing <, >, &, " render exactly as before.

  Risk / impact
  
  - Behavior-preserving for all existing templates (byte-identical .md output).
  - No new dependencies (select_autoescape ships with Jinja2).

  Testing

  - test/services/test_agent_scaffold.py, test/cli/test_profile_cmd.py,  test/api/test_api_profiles.py — 60 passed.                                                                                                  
  - black / isort clean.

  Notes

  - Closes AppSec/ACAT finding Jinja2AutoescapeDisabled on agent_scaffold.py. The scanner should auto-resolve the ticket once this lands on main.
  - Unrelated to PR #415 (memory secret-gate) — different file and area.
