### PR TITLE
fix(install): honor frontmatter provider with flag > frontmatter > default precedence (fixes #414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- honor profile frontmatter `provider:` during install (flag > frontmatter > default) (#414)
+
 ## [2.3.0] - 2026-07-12
 
 ### Added

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -397,10 +397,14 @@ class InstallAgentProfileRequest(BaseModel):
 
     ``env_vars`` travels in the JSON body rather than as a query parameter so
     that any secrets callers inject are not written to HTTP access logs.
+
+    ``provider`` may be omitted (None): the install service then honours the
+    profile's frontmatter ``provider:`` key, falling back to the default
+    provider — the same flag > frontmatter > default precedence as the CLI.
     """
 
     source: str
-    provider: str = DEFAULT_PROVIDER
+    provider: Optional[str] = None
     env_vars: Optional[Dict[str, str]] = None
 
 

--- a/src/cli_agent_orchestrator/cli/commands/install.py
+++ b/src/cli_agent_orchestrator/cli/commands/install.py
@@ -64,8 +64,11 @@ def _copy_local_profile_to_store(agent_source: str) -> Optional[str]:
 @click.option(
     "--provider",
     type=click.Choice(PROVIDERS),
-    default=DEFAULT_PROVIDER,
-    help=f"Provider to use (default: {DEFAULT_PROVIDER})",
+    default=None,
+    help=(
+        "Provider to use. Precedence: this flag > the profile's frontmatter "
+        f"'provider:' key > default ({DEFAULT_PROVIDER})."
+    ),
 )
 @click.option(
     "--env",
@@ -77,7 +80,7 @@ def _copy_local_profile_to_store(agent_source: str) -> Optional[str]:
         "Repeatable: --env KEY=VALUE. Example: --env API_TOKEN=my-secret-token."
     ),
 )
-def install(agent_source: str, provider: str, env_vars: tuple[str, ...]) -> None:
+def install(agent_source: str, provider: Optional[str], env_vars: tuple[str, ...]) -> None:
     """
     Install an agent from local store, built-in store, URL, or file path.
 
@@ -138,4 +141,8 @@ def install(agent_source: str, provider: str, env_vars: tuple[str, ...]) -> None
     if result.context_file:
         click.echo(f"✓ Context file: {result.context_file}")
     if result.agent_file:
-        click.echo(f"✓ {provider} agent: {result.agent_file}")
+        # The service resolves flag > frontmatter > default; result.provider
+        # carries the winner (older mocks may omit it, hence the fallback).
+        click.echo(
+            f"✓ {result.provider or provider or DEFAULT_PROVIDER} agent: {result.agent_file}"
+        )

--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -6,7 +6,7 @@ import requests  # type: ignore[import-untyped]
 from fastmcp import FastMCP
 from pydantic import Field
 
-from cli_agent_orchestrator.constants import API_BASE_URL, DEFAULT_PROVIDER
+from cli_agent_orchestrator.constants import API_BASE_URL
 from cli_agent_orchestrator.ops_mcp_server.models import (
     InstallResult,
     LaunchResult,
@@ -194,9 +194,14 @@ async def get_profile_details(
 async def install_profile(
     source: Annotated[str, Field(description="Agent name or https:// URL to install")],
     provider: Annotated[
-        str,
-        Field(description="Target provider for the installed profile"),
-    ] = DEFAULT_PROVIDER,
+        Optional[str],
+        Field(
+            description=(
+                "Target provider for the installed profile. Omit to honour the "
+                "profile's frontmatter provider, falling back to the default."
+            )
+        ),
+    ] = None,
     env_vars: Annotated[
         Optional[Dict[str, str]],
         Field(description="Optional environment variables to inject before install"),
@@ -224,13 +229,16 @@ async def install_profile(
 
     Args:
         source: Agent name or https:// URL from an allow-listed host
-        provider: Target provider (default: kiro_cli)
+        provider: Target provider. Precedence: explicit value > the profile's
+            frontmatter ``provider:`` key > the server default (kiro_cli)
         env_vars: Optional env vars written to the managed .env before install
 
     Returns:
         InstallResult with success status, file paths, and unresolved env vars
     """
-    body: Dict[str, Any] = {"source": source, "provider": provider}
+    body: Dict[str, Any] = {"source": source}
+    if provider is not None:
+        body["provider"] = provider
     if env_vars:
         body["env_vars"] = env_vars
 

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -1,5 +1,6 @@
 """Service helpers for installing agent profiles."""
 
+import logging
 import os
 import re
 from pathlib import Path
@@ -13,6 +14,7 @@ from pydantic import BaseModel
 from cli_agent_orchestrator.constants import (
     AGENT_CONTEXT_DIR,
     COPILOT_AGENTS_DIR,
+    DEFAULT_PROVIDER,
     KIRO_AGENTS_DIR,
     LOCAL_AGENT_STORE_DIR,
     OPENCODE_AGENTS_DIR,
@@ -40,6 +42,8 @@ from cli_agent_orchestrator.utils.opencode_permissions import cao_tools_to_openc
 from cli_agent_orchestrator.utils.skill_injection import compose_agent_prompt
 from cli_agent_orchestrator.utils.tool_mapping import resolve_allowed_tools
 
+logger = logging.getLogger(__name__)
+
 
 class InstallResult(BaseModel):
     """Structured result for agent profile installation."""
@@ -51,6 +55,7 @@ class InstallResult(BaseModel):
     agent_file: Optional[str] = None
     unresolved_vars: Optional[List[str]] = None
     source_kind: Optional[Literal["url", "file", "name"]] = None
+    provider: Optional[str] = None
 
 
 # Profile names are used as filesystem path segments under LOCAL_AGENT_STORE_DIR
@@ -232,10 +237,15 @@ def _build_provider_config(
 
 def install_agent(
     source: str,
-    provider: str,
+    provider: Optional[str] = None,
     env_vars: Optional[Dict[str, str]] = None,
 ) -> InstallResult:
     """Install an agent profile for the requested provider.
+
+    ``provider`` resolution follows the same precedence as launch/handoff
+    (see ``resolve_provider``): an explicit argument wins, then the profile's
+    frontmatter ``provider:`` key, then ``DEFAULT_PROVIDER``. Pass ``None``
+    to defer to the profile.
 
     ``source`` must be either an https:// URL on the allowlist or a bare
     profile name matching ``_PROFILE_NAME_RE``. Local ``.md`` file paths
@@ -247,7 +257,10 @@ def install_agent(
     """
     try:
         valid_providers = [provider_type.value for provider_type in ProviderType]
-        if provider not in valid_providers:
+        # An explicit provider is validated up front so bad input fails fast
+        # BEFORE any URL download or env-file mutation. Frontmatter providers
+        # are validated after the profile is parsed (below).
+        if provider is not None and provider not in valid_providers:
             return InstallResult(
                 success=False,
                 message=(
@@ -283,6 +296,25 @@ def install_agent(
         raw_content = _read_agent_profile_source(agent_name)
         resolved_content = resolve_env_vars(raw_content)
         profile = parse_agent_profile_text(resolved_content, agent_name)
+
+        # No explicit provider — honour the profile's frontmatter ``provider:``
+        # key, mirroring resolve_provider() on the launch/handoff paths. Bogus
+        # frontmatter values warn and fall back to the default; built-in store
+        # profiles carry no frontmatter provider and keep the default.
+        if provider is None:
+            if profile.provider and profile.provider in valid_providers:
+                provider = profile.provider
+            else:
+                if profile.provider:
+                    logger.warning(
+                        "Agent profile '%s' has invalid provider '%s'. "
+                        "Valid providers: %s. Falling back to '%s'.",
+                        profile.name,
+                        profile.provider,
+                        valid_providers,
+                        DEFAULT_PROVIDER,
+                    )
+                provider = DEFAULT_PROVIDER
 
         # Resolve the bundled cao-mcp-server console script to a PATH-independent
         # invocation before materializing provider configs. The
@@ -411,6 +443,7 @@ def install_agent(
             agent_file=str(agent_file) if agent_file else None,
             unresolved_vars=unresolved_vars or None,
             source_kind=source_kind,
+            provider=provider,
         )
 
     except requests.RequestException as exc:

--- a/test/api/test_api_profiles.py
+++ b/test/api/test_api_profiles.py
@@ -106,6 +106,34 @@ class TestInstallAgentProfileEndpoint:
             },
         )
 
+    def test_omitted_provider_forwards_none_for_frontmatter_resolution(self, client) -> None:
+        """Requests without a provider should forward None so the service
+        resolves the profile's frontmatter provider (flag > frontmatter >
+        default precedence, GH #414) — identically to the CLI."""
+        service_result = InstallResult(
+            success=True,
+            message="Agent 'developer' installed successfully",
+            agent_name="developer",
+            provider="claude_code",
+        )
+
+        with patch(
+            "cli_agent_orchestrator.api.main.install_agent",
+            return_value=service_result,
+        ) as mock_install:
+            response = client.post(
+                "/agents/profiles/install",
+                json={"source": "developer"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["provider"] == "claude_code"
+        mock_install.assert_called_once_with(
+            source="developer",
+            provider=None,
+            env_vars=None,
+        )
+
     def test_returns_400_for_invalid_source(self, client) -> None:
         """Structured service failures should be surfaced as 400s."""
         with patch(

--- a/test/cli/commands/test_install.py
+++ b/test/cli/commands/test_install.py
@@ -70,6 +70,41 @@ class TestInstallCommand:
             {"API_TOKEN": "secret-token"},
         )
 
+    def test_install_without_provider_flag_passes_none_and_echoes_resolved_provider(
+        self, runner: CliRunner
+    ) -> None:
+        """Omitting --provider should pass None so the service resolves frontmatter.
+
+        The final summary line must echo the provider the service actually
+        resolved (flag > frontmatter > default), not the CLI default.
+        """
+        service_result = InstallResult(
+            success=True,
+            message="Agent 'developer' installed successfully",
+            agent_name="developer",
+            context_file="/tmp/agent-context/developer.md",
+            agent_file="/tmp/copilot/developer.agent.md",
+            source_kind="name",
+            provider="copilot_cli",
+        )
+
+        with patch(
+            "cli_agent_orchestrator.cli.commands.install.install_agent",
+            return_value=service_result,
+        ) as mock_install:
+            result = runner.invoke(install, ["developer"])
+
+        assert result.exit_code == 0
+        assert "copilot_cli agent: /tmp/copilot/developer.agent.md" in result.output
+        mock_install.assert_called_once_with("developer", None, None)
+
+    def test_install_help_documents_provider_precedence(self, runner: CliRunner) -> None:
+        """--provider help text should document flag > frontmatter > default."""
+        result = runner.invoke(install, ["--help"])
+
+        assert result.exit_code == 0
+        assert "frontmatter" in result.output
+
     def test_install_url_source_prints_download_confirmation(self, runner: CliRunner) -> None:
         """URL installs should print a download confirmation line."""
         service_result = InstallResult(

--- a/test/ops_mcp_server/test_server.py
+++ b/test/ops_mcp_server/test_server.py
@@ -184,6 +184,31 @@ class TestProfileTools:
             json={"source": "https://example.com/remote.md", "provider": "kiro_cli"},
         )
 
+    async def test_install_profile_omits_provider_when_not_explicit(self) -> None:
+        """Omitted provider should be left out of the body so the install API
+        resolves the profile's frontmatter provider (GH #414)."""
+        payload: InstallPayload = {
+            "success": True,
+            "message": "Agent 'developer' installed successfully",
+            "agent_name": "developer",
+            "context_file": "/tmp/developer.md",
+            "agent_file": None,
+            "unresolved_vars": None,
+        }
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(json_data=payload),
+        ) as mock_request:
+            result = await install_profile("developer")
+
+        assert result == InstallResult(**payload)
+        mock_request.assert_called_once_with(
+            "post",
+            "http://127.0.0.1:9889/agents/profiles/install",
+            params=None,
+            json={"source": "developer"},
+        )
+
     async def test_install_profile_forwards_env_vars(self) -> None:
         """Env var maps should be forwarded to the API install endpoint."""
         payload = {

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -1,6 +1,7 @@
 """Tests for the install service."""
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -8,18 +9,21 @@ import frontmatter
 import pytest
 import requests  # type: ignore[import-untyped]
 
+from cli_agent_orchestrator.constants import DEFAULT_PROVIDER
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.services.install_service import InstallResult, install_agent
 from cli_agent_orchestrator.utils.skill_injection import refresh_agent_md_prompt
 
 
-def _profile_text(*, name: str, include_prompt: bool = True) -> str:
+def _profile_text(*, name: str, include_prompt: bool = True, provider: str | None = None) -> str:
     """Build a profile fixture with env placeholders in prompt and MCP config."""
     prompt_lines = "Fallback prompt\n" if include_prompt else ""
+    provider_line = f"provider: {provider}\n" if provider else ""
     return (
         "---\n"
         f"name: {name}\n"
         "description: Test agent\n"
+        f"{provider_line}"
         "role: developer\n"
         "mcpServers:\n"
         "  service:\n"
@@ -387,6 +391,107 @@ class TestInstallAgent:
         assert result.success is False
         assert "Failed to install agent" in result.message
         assert "Unexpected error" in result.message
+
+
+class TestInstallProviderResolution:
+    """Tests for provider precedence: explicit flag > frontmatter > default (GH #414)."""
+
+    def test_explicit_provider_wins_over_frontmatter(self, install_paths: dict[str, Path]) -> None:
+        """An explicit provider argument should override the profile's frontmatter."""
+        local_profile = install_paths["local_store_dir"] / "fm-agent.md"
+        local_profile.write_text(
+            _profile_text(name="fm-agent", provider="claude_code"), encoding="utf-8"
+        )
+
+        result = install_agent("fm-agent", "kiro_cli")
+
+        assert result.success is True
+        assert result.provider == "kiro_cli"
+        assert (install_paths["kiro_dir"] / "fm-agent.json").exists()
+
+    def test_frontmatter_provider_used_when_flag_absent(
+        self, install_paths: dict[str, Path]
+    ) -> None:
+        """Without an explicit provider, the profile's frontmatter provider wins."""
+        local_profile = install_paths["local_store_dir"] / "fm-agent.md"
+        local_profile.write_text(
+            _profile_text(name="fm-agent", provider="claude_code"), encoding="utf-8"
+        )
+
+        result = install_agent("fm-agent")
+
+        assert result.success is True
+        assert result.provider == "claude_code"
+        # claude_code installs write a context file only — no kiro config,
+        # which is exactly what the pre-fix behaviour would have produced.
+        assert result.agent_file is None
+        assert not (install_paths["kiro_dir"] / "fm-agent.json").exists()
+
+    def test_default_provider_used_when_flag_and_frontmatter_absent(
+        self, install_paths: dict[str, Path]
+    ) -> None:
+        """No flag and no frontmatter provider should fall back to DEFAULT_PROVIDER."""
+        local_profile = install_paths["local_store_dir"] / "plain-agent.md"
+        local_profile.write_text(_profile_text(name="plain-agent"), encoding="utf-8")
+
+        result = install_agent("plain-agent")
+
+        assert result.success is True
+        assert result.provider == DEFAULT_PROVIDER
+        assert (install_paths["kiro_dir"] / "plain-agent.json").exists()
+
+    def test_invalid_frontmatter_provider_warns_and_falls_back(
+        self, install_paths: dict[str, Path], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A bogus frontmatter provider should log a warning and use the default."""
+        local_profile = install_paths["local_store_dir"] / "bogus-agent.md"
+        local_profile.write_text(
+            _profile_text(name="bogus-agent", provider="bogus_provider"), encoding="utf-8"
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="cli_agent_orchestrator.services.install_service"
+        ):
+            result = install_agent("bogus-agent")
+
+        assert result.success is True
+        assert result.provider == DEFAULT_PROVIDER
+        assert (install_paths["kiro_dir"] / "bogus-agent.json").exists()
+        assert "invalid provider 'bogus_provider'" in caplog.text
+
+    def test_explicit_invalid_provider_fails_before_download(
+        self, install_paths: dict[str, Path]
+    ) -> None:
+        """An explicit bad provider must fail fast BEFORE any URL download."""
+        with patch("cli_agent_orchestrator.services.install_service.requests.get") as mock_get:
+            result = install_agent(
+                "https://raw.githubusercontent.com/org/repo/main/agent.md",
+                "bad_provider",
+            )
+
+        assert result.success is False
+        assert result.message.startswith("Invalid provider 'bad_provider'.")
+        mock_get.assert_not_called()
+
+    def test_builtin_profile_without_frontmatter_provider_uses_default(
+        self, install_paths: dict[str, Path], tmp_path: Path
+    ) -> None:
+        """Built-in store profiles carry no frontmatter provider — bare installs keep the default."""
+        built_in_dir = tmp_path / "builtin-agent-store"
+        built_in_dir.mkdir()
+        (built_in_dir / "developer.md").write_text(
+            _profile_text(name="developer"), encoding="utf-8"
+        )
+
+        with patch(
+            "cli_agent_orchestrator.utils.agent_profiles.resources.files",
+            return_value=built_in_dir,
+        ):
+            result = install_agent("developer")
+
+        assert result.success is True
+        assert result.provider == DEFAULT_PROVIDER
+        assert (install_paths["kiro_dir"] / "developer.json").exists()
 
 
 class TestInstallAgentHardening:


### PR DESCRIPTION
## Summary
`cao install` now resolves the target provider with the same precedence the launch/assign/handoff paths already use: explicit `--provider` flag > profile frontmatter `provider:` > `DEFAULT_PROVIDER`. Fixes #414. Thanks @chaogebaba for the report and for validating the precedence approach.

## Root cause
The Click `--provider` option defaulted to `DEFAULT_PROVIDER` (kiro_cli) and `install_service.install_agent` branched on that argument alone, so a profile declaring `provider: codex` installed silently as a kiro_cli agent (exit 0, no warning). Install was the only entry point ignoring frontmatter — launch/assign/handoff/API resolve it via `resolve_provider()`.

## Fix
- CLI `--provider` defaults to `None`; help text documents the precedence; the install summary echoes the provider the service actually resolved.
- `install_agent` accepts `provider=None`; an explicit bad provider still fails fast **before** any URL download or env-file mutation; a bogus frontmatter provider logs a warning (same wording as `resolve_provider`) and falls back to the default. `InstallResult` gains a `provider` field with the resolved winner (so the CLI summary can't print `None`; backward-compatible, Optional).
- `InstallAgentProfileRequest.provider` and the ops-MCP `install_profile` tool default to `None` (provider omitted from the request body when not explicit, same pattern as `_launch_session_impl`), so all three entry points behave identically. Built-in store profiles carry no frontmatter provider and keep today's default-provider behavior.

## Tests
- flag wins over frontmatter; frontmatter wins when the flag is absent; both absent → `DEFAULT_PROVIDER`
- invalid frontmatter provider → warning logged + default used
- explicit invalid `--provider` → fail-fast before download (existing behavior preserved)
- built-in profile without frontmatter provider keeps the default
- API and ops-MCP entry points forward `None` for identical frontmatter resolution
- Full suite: 4021 passed; the one failure (`test_settings_service.py::TestGetServerSettings`) reproduces on a clean `upstream/main` checkout and is unrelated. `black`/`isort` clean.

Fixes #414