### PR TITLE
feat(terminal): group/metadata fields + list_siblings discovery tool (#432)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -97,9 +97,21 @@ See [Skills](skills.md) for discovery, installation, and catalog behavior.
 - `GET /terminals/{terminal_id}/siblings` lists other terminals sharing a
   leading prefix of `terminal_id`'s own `group`, optionally narrowed by
   `depth`; a caller can never see a wider scope than its own group, and a
-  terminal with no `group` set finds no siblings. Sibling `metadata` is
+  terminal with no `group` set finds no siblings. Session-scoped by default
+  — results are also filtered to the caller's own tmux session unless the
+  explicit `cross_session=true` opt-in is passed. Sibling `metadata` is
   agent-authored, untrusted content — same trust domain as an inbound
-  `send_message` body.
+  `send_message` body. The `list_siblings`/`update_metadata` MCP tools also
+  require the `discovery` entry in `allowedTools` — a separate opt-in from
+  orchestration tools, not bundled into `@cao-mcp-server` — see
+  [Tool Restrictions](tool-restrictions.md) and
+  [Discovery Tool Coexistence](discovery-tool-coexistence.md).
+
+**`group` is an organizational label, not a security boundary.** On a
+default install with auth disabled, a worker already has local shell access
+to this API, so `group`/`discovery`/session-scoping provide no tenant
+isolation or access-control guarantee even used together — do not build a
+security boundary on top of them.
 
 Terminal identifiers used in these routes are eight-character hexadecimal
 strings. See [Control Planes](control-planes.md) for operator-facing choices.

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,6 +85,21 @@ See [Skills](skills.md) for discovery, installation, and catalog behavior.
   commits — commit and merge/push results before the terminal is deleted if
   they need to be kept. See the MCP `handoff`/`assign` tool descriptions for
   the full behavior.
+- `POST /sessions` accepts optional `group`/`metadata` at creation, opting a
+  session's initial terminal into peer discovery (a mid-session worker uses
+  `PATCH /terminals/{terminal_id}/group`/`metadata` instead — see below).
+  `group` is an ordered, general-to-specific array (e.g.
+  `["tenant_1", "project_5"]`); `metadata` is a free-form JSON object the
+  running agent updates via the `update_metadata` MCP tool. Both PATCH
+  endpoints are whole-value replace, not merge, last-write-wins under
+  concurrent calls, and reject an omitted field with `422` (an explicit
+  `null`/`[]`/`{}` clears the value; omitting it does not).
+- `GET /terminals/{terminal_id}/siblings` lists other terminals sharing a
+  leading prefix of `terminal_id`'s own `group`, optionally narrowed by
+  `depth`; a caller can never see a wider scope than its own group, and a
+  terminal with no `group` set finds no siblings. Sibling `metadata` is
+  agent-authored, untrusted content — same trust domain as an inbound
+  `send_message` body.
 
 Terminal identifiers used in these routes are eight-character hexadecimal
 strings. See [Control Planes](control-planes.md) for operator-facing choices.

--- a/docs/discovery-tool-coexistence.md
+++ b/docs/discovery-tool-coexistence.md
@@ -1,0 +1,58 @@
+# Discovery Tool Coexistence (first-pass write-up)
+
+**Status: first-pass draft**, written per tedswinyar's request on [issue #432](https://github.com/awslabs/cli-agent-orchestrator/issues/432) (comment, 2026-07-18T00:29:56Z). This documents where things landed between klabulan and tedswinyar on the two design questions tedswinyar raised; it has not yet been reviewed by @anilkmr-a2z, @call-me-ram, or @gutosantos82, who were explicitly asked for objections or alternatives before #433 revises in this direction. Treat this as the starting point for that review, not a settled contract.
+
+## The two topologies
+
+CAO now has two distinct ways for agents to reach each other:
+
+1. **Supervisor hierarchy** — `handoff`, `assign`, `send_message`. Structural: a worker's `caller_id` records who spawned it, and `send_message` uses that (or an explicit `receiver_id`/assign callback) to route replies. This is the shape CAO's `role`/`allowedTools` system, and the built-in `supervisor`/`developer`/`reviewer` roles, were designed around.
+2. **Flat peer layer** — `group`, `list_siblings`, `update_metadata` (issue #432). Non-hierarchical: any terminal with a `group` set can discover and message any OTHER terminal sharing a leading prefix of that group, with no supervisor in the loop.
+
+These are genuinely different capabilities with different risk profiles. A profile that should be able to orchestrate workers (topology 1) is not automatically a profile that should be able to see and message arbitrary peers (topology 2), and vice versa. That's the premise behind keeping them separately grantable.
+
+## The opt-in marker
+
+`list_siblings` and `update_metadata` require a new CAO tool-vocabulary token, `discovery`, in the calling terminal's resolved `allowedTools` (or `*`/unrestricted). This is **layered under**, not instead of, the existing `@cao-mcp-server` MCP-server-level gate:
+
+- `@cao-mcp-server` still controls whether the `cao-mcp-server` MCP process is wired into the provider's launch command at all (via the profile's own `mcpServers` frontmatter block). Without it, none of `cao-mcp-server`'s tools — including `list_siblings`/`update_metadata` — are reachable, same as today.
+- `discovery` is a second, independent check specifically for the two discovery tools, evaluated when they're called (see "Enforcement mechanism" below). A profile can have `@cao-mcp-server` without `discovery` (orchestration, no peer discovery — this is every existing built-in role's default) or, in principle, `discovery` without the rest of orchestration if some future profile shape wanted that.
+
+None of the built-in roles (`supervisor`, `developer`, `reviewer`) grant `discovery` by default. A profile author adds `"discovery"` to `allowedTools` explicitly:
+
+```yaml
+---
+name: my_peer_aware_worker
+role: developer
+allowedTools: ["@builtin", "fs_*", "execute_bash", "web_fetch", "@cao-mcp-server", "discovery"]
+---
+```
+
+## Enforcement mechanism
+
+CAO's existing tool-restriction system has two enforcement paths:
+
+- **Native, hard blocking** for provider built-in tools (`execute_bash`, `fs_read`, etc.) — `get_disallowed_tools` maps a CAO vocabulary token to concrete provider-native tool names (`Bash`, `Read`, ...) and passes them to the provider's own `--disallowedTools`-style flag. The tool is genuinely unavailable to the model.
+- **No existing per-MCP-tool mechanism.** `cao-mcp-server` is one shared FastMCP process; every profile that wires it in gets the same static tool list (`handoff`, `assign`, `send_message`, `list_siblings`, `update_metadata`, `load_skill`, `answer_user_prompt`, ...). There is currently no per-caller filtering of which of *that* server's tools a given connection sees.
+
+Building genuine hard-blocking for `discovery` specifically — hiding `list_siblings`/`update_metadata` from the model entirely for a profile that lacks the marker — would need either splitting discovery into its own MCP server (a second `mcpServers` entry a profile opts into, mirroring how `@cao-mcp-server` itself works) or teaching `get_disallowed_tools` about individual MCP tool names (e.g. Claude Code's `mcp__cao-mcp-server__list_siblings` naming) on providers that support disallowing them. Both are real options for a follow-up; neither is done in this first pass.
+
+What's implemented instead: a **runtime authorization check inside the tool handler** (`_require_discovery_marker` in `mcp_server/server.py`). Both tools are still visible in the MCP tool list regardless of the marker, but calling either without it returns a structured `{"success": False, "error": "..."}` naming the missing `discovery` requirement, rather than performing the discovery/write. This is soft in the sense that the tool is still *offered*; it is hard in the sense that the call cannot succeed without the marker — the model cannot argue its way past it. The check fails closed: if the caller's own `allowed_tools` can't be resolved (network error, unexpected response shape), discovery is denied, not granted.
+
+This mirrors CAO's own precedent for capability enforcement that a provider can't do natively (see `SOFT_ENFORCEMENT_PROVIDERS` for kimi_cli/codex/antigravity_cli, which rely on a prompt-level security constraint rather than provider-native blocking) — a documented, deliberate trade-off, not an oversight, made explicit here so it can be revisited alongside those.
+
+## `group` is organizational, not a security boundary
+
+Independent of the marker discussion: `group`-prefix matching, `discovery`, and session-scoping (below) are all **organizational**, not isolation guarantees. On a default CAO install (auth disabled, localhost trust model), a worker already has local shell access to the CAO API — nothing about `group` or `discovery` changes that. A consumer building a real multi-tenant boundary on top of `group` would be building on an assumption CAO does not provide. See docs/api.md and docs/tool-restrictions.md, where this is now stated explicitly.
+
+## Session scoping (the second design question)
+
+Not strictly a "coexistence" question, but resolved in the same discussion and worth summarizing here since it shapes the same feature surface: `list_siblings` is session-scoped by default (an implicit, non-bypassable filter on the caller's own `tmux_session`, layered on top of the group-prefix match), with server-wide/cross-session discovery available only via an explicit `cross_session=true` opt-in. This closes the failure mode where two unrelated CAO sessions reusing the same `group` prefix (naming collision, copy-pasted template, coincidentally-shared tenant/project id) would otherwise silently discover each other — see the issue #432 comment thread for the incident history that motivated treating this as a hard default rather than a documented caveat.
+
+## Open questions for the wider maintainer review
+
+- Is `discovery` the right vocabulary-token name, and is layering it under `@cao-mcp-server` (rather than a fully separate MCP server) the right shape long-term, or should Phase 2 move to a second `mcpServers` entry for real hard-blocking?
+- Should `discovery` ever be part of a built-in role's defaults (e.g. a future `peer` role), or should it always require an explicit profile-level opt-in as implemented here?
+- Is a runtime-checked soft gate acceptable as the permanent mechanism, or is native per-MCP-tool blocking (where a provider supports it) worth building before this ships broadly?
+
+This write-up implements the two changes klabulan and tedswinyar converged on in the issue #432 thread. It has not been reviewed or agreed to by the other three tagged maintainers — their objections or alternatives are still open, and this document (and the code implementing it) should be read as a proposal for that review, not a final decision.

--- a/docs/tool-restrictions.md
+++ b/docs/tool-restrictions.md
@@ -109,9 +109,18 @@ No `role` is needed — `allowedTools` is the full specification of what tools t
 | `web_fetch` | Fetch URLs / search the web | `WebFetch`, `WebSearch` | (not mapped) |
 | `@builtin` | Provider built-in capabilities | (internal) | (internal) |
 | `@cao-mcp-server` | CAO orchestration tools | `handoff`, `assign`, `send_message`, plus Hermes prompt answers via `answer_user_prompt` | Same |
+| `discovery` | Sibling discovery/metadata (`list_siblings`, `update_metadata`) | Same | Same |
 | `*` | Everything (unrestricted) | All tools | All tools |
 
 CAO translates these to each provider's native tool names automatically. You write one vocabulary; it works across supported providers.
+
+#### `discovery` is a separate opt-in, not part of `@cao-mcp-server`
+
+`discovery` gates `list_siblings`/`update_metadata` independently of `@cao-mcp-server`. A profile with `@cao-mcp-server` (handoff/assign/send_message) does **not** automatically get sibling discovery, and vice versa — none of the built-in roles (`supervisor`, `developer`, `reviewer`) include `discovery`; add it explicitly if a profile needs peer-to-peer discovery.
+
+This is deliberate (see the design discussion on [issue #432](https://github.com/awslabs/cli-agent-orchestrator/issues/432)): the supervisor/worker hierarchy `handoff`/`assign`/`send_message` are built around, and the flat peer layer `group`/`list_siblings`/`update_metadata` introduce, are two different communication topologies. A profile should be able to keep one without the other. See [Discovery Tool Coexistence](discovery-tool-coexistence.md) for the full rationale, the enforcement mechanism, and open follow-ups.
+
+**`group` is an organizational label, not a security boundary.** On a default install with auth disabled, a worker already has local shell access, so `discovery`/`group`/session-scoping provide no isolation guarantee even when used together — see [docs/api.md](api.md) and the coexistence write-up linked above.
 
 ### 3. `--yolo` — The Escape Hatch
 

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -263,20 +263,27 @@ def _validate_model_id(value: str) -> None:
 class UpdateGroupBody(BaseModel):
     """Request body for ``PATCH /terminals/{id}/group`` (#432).
 
-    A dedicated body (rather than a bare query param) so an empty-list
-    "clear the group" request is unambiguous from an omitted field.
+    ``group`` is required (no default) so an omitted field is rejected with
+    422 rather than silently treated the same as an explicit ``null`` —
+    clearing the group is always an explicit choice (``null`` or ``[]``),
+    never an accident of a partial/empty body (Copilot review, PR #433).
     """
 
-    group: Optional[List[str]] = None
+    group: Optional[List[str]]
 
 
 class UpdateMetadataBody(BaseModel):
     """Request body for ``PATCH /terminals/{id}/metadata`` (#432).
 
     Called by the running agent itself via the ``update_metadata`` MCP tool.
+
+    ``metadata`` is required (no default) for the same reason as
+    ``UpdateGroupBody.group`` above: an omitted field is rejected with 422
+    instead of being indistinguishable from an explicit clearing ``null``
+    (Copilot review, PR #433).
     """
 
-    metadata: Optional[Dict] = None
+    metadata: Optional[Dict]
 
 
 class RunStepRequest(BaseModel):
@@ -2304,11 +2311,13 @@ async def update_terminal_group_endpoint(
 
     Lets a consumer whose own grouping can change after a terminal already
     exists (e.g. harness-control folder/project reassignment,
-    harness-control#92) keep ``group`` from going stale. An empty/omitted
-    ``group`` clears it, opting the terminal back out of discovery.
+    harness-control#92) keep ``group`` from going stale. ``group`` is
+    required in the request body: an explicit ``null`` or ``[]`` clears it
+    (opting the terminal back out of discovery), while omitting the field
+    entirely is rejected with 422 rather than silently clearing it.
     """
     try:
-        updated = terminal_service.update_group(terminal_id, body.group)
+        updated = await asyncio.to_thread(terminal_service.update_group, terminal_id, body.group)
         if not updated:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail=f"Terminal '{terminal_id}' not found"
@@ -2336,7 +2345,9 @@ async def update_terminal_metadata_endpoint(
     (as well as by any other authorized API caller).
     """
     try:
-        updated = terminal_service.update_metadata(terminal_id, body.metadata)
+        updated = await asyncio.to_thread(
+            terminal_service.update_metadata, terminal_id, body.metadata
+        )
         if not updated:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail=f"Terminal '{terminal_id}' not found"
@@ -2387,7 +2398,7 @@ async def list_terminal_siblings(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
     try:
-        return terminal_service.list_siblings(terminal_id, depth=depth)
+        return await asyncio.to_thread(terminal_service.list_siblings, terminal_id, depth=depth)
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -223,9 +223,20 @@ class CreateSessionBody(CreateTerminalBody):
     Reuses the terminal-creation message payload and keeps operator-forwarded
     environment variables in the request body, preserving the existing
     ``{"env_vars": {...}}`` wire shape.
+
+    ``group``/``metadata`` are the #432 discovery fields (see
+    ``UpdateGroupBody``/``UpdateMetadataBody`` below for their dedicated PATCH
+    counterparts). They live here — rather than as separate top-level
+    ``Body(embed=True)`` params — so this endpoint keeps its single flat JSON
+    body wire shape (adding a second embedded body param would force FastAPI
+    to nest everything under a ``"body"`` key, breaking existing callers that
+    already POST ``{"env_vars": ..., "initial_message": ...}`` at the top
+    level, e.g. ``ops_mcp_server/server.py``'s ``_launch_session_impl``).
     """
 
     env_vars: Optional[Dict[str, str]] = None
+    group: Optional[List[str]] = None
+    metadata: Optional[Dict] = None
 
 
 def _validate_model_id(value: str) -> None:
@@ -247,6 +258,25 @@ def _validate_model_id(value: str) -> None:
         raise ValueError(f"model exceeds the {MODEL_ID_MAX_LEN}-char cap")
     if not re.fullmatch(MODEL_ID_RE, value):
         raise ValueError(f"model {value!r} is invalid (must match {MODEL_ID_RE!r})")
+
+
+class UpdateGroupBody(BaseModel):
+    """Request body for ``PATCH /terminals/{id}/group`` (#432).
+
+    A dedicated body (rather than a bare query param) so an empty-list
+    "clear the group" request is unambiguous from an omitted field.
+    """
+
+    group: Optional[List[str]] = None
+
+
+class UpdateMetadataBody(BaseModel):
+    """Request body for ``PATCH /terminals/{id}/metadata`` (#432).
+
+    Called by the running agent itself via the ``update_metadata`` MCP tool.
+    """
+
+    metadata: Optional[Dict] = None
 
 
 class RunStepRequest(BaseModel):
@@ -1935,6 +1965,11 @@ async def create_session(
 
     ``model`` is an optional per-launch override. It uses the same validation
     and provider handoff as the existing terminal-creation endpoint.
+
+    ``body.group``/``body.metadata`` are the #432 discovery fields, set on
+    the initial terminal at creation time (``group`` is also updatable later
+    via ``PATCH /terminals/{id}/group``, ``metadata`` via the
+    ``update_metadata`` MCP tool).
     """
     initial_message = body.initial_message if body else None
     initial_message_orchestration_type = None
@@ -1984,6 +2019,8 @@ async def create_session(
             initial_message=initial_message,
             initial_message_orchestration_type=initial_message_orchestration_type,
             model=model,
+            group=body.group if body else None,
+            metadata=body.metadata if body else None,
         )
 
         if memory_manager and str(memory_manager).lower() in ("true", "1", "yes"):
@@ -2254,6 +2291,107 @@ async def get_terminal(terminal_id: TerminalId) -> Terminal:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to get terminal: {str(e)}",
+        )
+
+
+@app.patch("/terminals/{terminal_id}/group", response_model=Terminal)
+async def update_terminal_group_endpoint(
+    terminal_id: TerminalId,
+    body: UpdateGroupBody,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Terminal:
+    """Replace a terminal's group array (#432).
+
+    Lets a consumer whose own grouping can change after a terminal already
+    exists (e.g. harness-control folder/project reassignment,
+    harness-control#92) keep ``group`` from going stale. An empty/omitted
+    ``group`` clears it, opting the terminal back out of discovery.
+    """
+    try:
+        updated = terminal_service.update_group(terminal_id, body.group)
+        if not updated:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"Terminal '{terminal_id}' not found"
+            )
+        terminal = await asyncio.to_thread(terminal_service.get_terminal, terminal_id)
+        return Terminal(**terminal)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update terminal group: {str(e)}",
+        )
+
+
+@app.patch("/terminals/{terminal_id}/metadata", response_model=Terminal)
+async def update_terminal_metadata_endpoint(
+    terminal_id: TerminalId,
+    body: UpdateMetadataBody,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Terminal:
+    """Replace a terminal's free-form metadata dict (#432).
+
+    Called by the running agent itself via the ``update_metadata`` MCP tool
+    (as well as by any other authorized API caller).
+    """
+    try:
+        updated = terminal_service.update_metadata(terminal_id, body.metadata)
+        if not updated:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"Terminal '{terminal_id}' not found"
+            )
+        terminal = await asyncio.to_thread(terminal_service.get_terminal, terminal_id)
+        return Terminal(**terminal)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update terminal metadata: {str(e)}",
+        )
+
+
+@app.get("/terminals/{terminal_id}/siblings")
+async def list_terminal_siblings(
+    terminal_id: TerminalId,
+    depth: Optional[int] = Query(
+        default=None,
+        ge=1,
+        description=(
+            "How many leading elements of this terminal's own group to match "
+            "against. Omit for the widest scope this terminal is allowed to "
+            "see (its full own group). Server clamps to at most len(own "
+            "group) — can never exceed it. depth=0 is rejected (422) rather "
+            "than silently reinterpreted as an unscoped, all-terminals query."
+        ),
+    ),
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
+) -> List[Dict]:
+    """List sibling terminals sharing a leading prefix of this terminal's own group (#432).
+
+    ``terminal_id`` in the URL IS the caller's resolved identity — the MCP
+    ``list_siblings`` tool passes its own ``CAO_TERMINAL_ID`` here, never a
+    client-supplied "who am I" claim (same mechanism ``send_message``/
+    ``handoff`` already use). This endpoint only ever compares against THAT
+    terminal's own persisted ``group``, so a caller can never request a scope
+    wider than its own group no matter what ``depth`` is passed. A terminal
+    with no ``group`` set finds no siblings — it participates in no
+    discovery — rather than erroring or matching everything.
+    """
+    try:
+        # 404 if the terminal itself doesn't exist, distinct from "exists but
+        # has no group" (empty list result, not an error — #432).
+        await asyncio.to_thread(terminal_service.get_terminal, terminal_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    try:
+        return terminal_service.list_siblings(terminal_id, depth=depth)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list siblings: {str(e)}",
         )
 
 

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -60,6 +60,9 @@ from cli_agent_orchestrator.constants import (
     SERVER_HOST,
     SERVER_PORT,
     SERVER_VERSION,
+    TERMINAL_GROUP_ELEMENT_MAX_LEN,
+    TERMINAL_GROUP_MAX_ELEMENTS,
+    TERMINAL_METADATA_MAX_BYTES,
     TERMINALS_RUN_STEP_ROUTE,
     TRUSTED_FORWARDER_IPS,
     WORKFLOW_ENV_ALLOWLIST,
@@ -217,6 +220,49 @@ class CreateTerminalBody(BaseModel):
     initial_message_orchestration_type: Optional[str] = None
 
 
+def _check_group_size(group: Optional[List[str]]) -> Optional[List[str]]:
+    """Enforce structural caps on ``group`` (call-me-ram, PR #433 review).
+
+    ``group`` is written by the terminal's own agent via the ``update_group``
+    MCP tool with no operator review in the loop; an uncapped array lets a
+    worker grow the ``terminals.group`` TEXT column arbitrarily. Raises
+    ``ValueError`` (surfaces as 422 at every call site below) rather than
+    silently truncating — an over-cap request should fail loudly, not have
+    part of the caller's intended group silently dropped.
+    """
+    if not group:
+        return group
+    if len(group) > TERMINAL_GROUP_MAX_ELEMENTS:
+        raise ValueError(f"group has {len(group)} elements (max {TERMINAL_GROUP_MAX_ELEMENTS})")
+    for element in group:
+        if len(element) > TERMINAL_GROUP_ELEMENT_MAX_LEN:
+            raise ValueError(
+                f"group element {element!r} is {len(element)} chars "
+                f"(max {TERMINAL_GROUP_ELEMENT_MAX_LEN})"
+            )
+    return group
+
+
+def _check_metadata_size(metadata: Optional[Dict]) -> Optional[Dict]:
+    """Enforce a max-encoded-bytes cap on ``metadata`` (call-me-ram, PR #433 review).
+
+    ``metadata`` is a free-form dict the running agent writes about itself via
+    the ``update_metadata`` MCP tool; an unbounded ``Dict[str, Any]`` lets a
+    worker grow the ``terminals.metadata`` TEXT column arbitrarily, amplified
+    into every sibling's ``list_siblings`` response. Measured on the same
+    ``json.dumps`` encoding actually persisted (``WORKFLOW_MAX_SPEC_BYTES``
+    precedent), not e.g. a naive ``len(str(metadata))``.
+    """
+    if not metadata:
+        return metadata
+    encoded_len = len(json.dumps(metadata).encode("utf-8"))
+    if encoded_len > TERMINAL_METADATA_MAX_BYTES:
+        raise ValueError(
+            f"metadata is {encoded_len} bytes encoded (max {TERMINAL_METADATA_MAX_BYTES})"
+        )
+    return metadata
+
+
 class CreateSessionBody(CreateTerminalBody):
     """Optional JSON body for POST /sessions.
 
@@ -237,6 +283,16 @@ class CreateSessionBody(CreateTerminalBody):
     env_vars: Optional[Dict[str, str]] = None
     group: Optional[List[str]] = None
     metadata: Optional[Dict] = None
+
+    @field_validator("group")
+    @classmethod
+    def validate_group(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        return _check_group_size(v)
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, v: Optional[Dict]) -> Optional[Dict]:
+        return _check_metadata_size(v)
 
 
 def _validate_model_id(value: str) -> None:
@@ -271,6 +327,11 @@ class UpdateGroupBody(BaseModel):
 
     group: Optional[List[str]]
 
+    @field_validator("group")
+    @classmethod
+    def validate_group(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        return _check_group_size(v)
+
 
 class UpdateMetadataBody(BaseModel):
     """Request body for ``PATCH /terminals/{id}/metadata`` (#432).
@@ -284,6 +345,11 @@ class UpdateMetadataBody(BaseModel):
     """
 
     metadata: Optional[Dict]
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, v: Optional[Dict]) -> Optional[Dict]:
+        return _check_metadata_size(v)
 
 
 class RunStepRequest(BaseModel):
@@ -1980,6 +2046,10 @@ async def create_session(
     """
     initial_message = body.initial_message if body else None
     initial_message_orchestration_type = None
+    # Structural caps on group/metadata (call-me-ram, PR #433 review) are
+    # enforced by CreateSessionBody's own field_validators above — invalid
+    # values fail Pydantic body parsing and FastAPI returns 422 automatically,
+    # before this function body ever runs.
     try:
         if session_name is not None:
             # terminal_service.create_terminal prepends SESSION_PREFIX
@@ -2342,7 +2412,10 @@ async def update_terminal_metadata_endpoint(
     """Replace a terminal's free-form metadata dict (#432).
 
     Called by the running agent itself via the ``update_metadata`` MCP tool
-    (as well as by any other authorized API caller).
+    (as well as by any other authorized API caller). Whole-dict replace, not
+    a merge -- concurrent calls are last-write-wins (tedswinyar, PR #433
+    review); an acceptable design for this field, but callers should re-send
+    the full intended dict rather than assuming a partial update accumulates.
     """
     try:
         updated = await asyncio.to_thread(
@@ -2389,6 +2462,12 @@ async def list_terminal_siblings(
     wider than its own group no matter what ``depth`` is passed. A terminal
     with no ``group`` set finds no siblings — it participates in no
     discovery — rather than erroring or matching everything.
+
+    Each result includes a ``status`` (tedswinyar, PR #433 review): a live,
+    point-in-time snapshot, not a guarantee. A handoff terminal can still
+    complete and delete itself between this call returning and a caller's
+    follow-up message to it, so callers should still expect sends to an
+    apparently-live sibling to occasionally fail.
     """
     try:
         # 404 if the terminal itself doesn't exist, distinct from "exists but

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -2450,6 +2450,17 @@ async def list_terminal_siblings(
             "than silently reinterpreted as an unscoped, all-terminals query."
         ),
     ),
+    cross_session: bool = Query(
+        default=False,
+        description=(
+            "Sibling discovery is session-scoped by default (issue #432 "
+            "design discussion, 2026-07-17/18): results are additionally "
+            "filtered to this terminal's own tmux session unless this is "
+            "explicitly set to true. Prevents two unrelated CAO sessions "
+            "that happen to reuse the same group prefix from silently "
+            "discovering each other."
+        ),
+    ),
     _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
 ) -> List[Dict]:
     """List sibling terminals sharing a leading prefix of this terminal's own group (#432).
@@ -2462,6 +2473,13 @@ async def list_terminal_siblings(
     wider than its own group no matter what ``depth`` is passed. A terminal
     with no ``group`` set finds no siblings — it participates in no
     discovery — rather than erroring or matching everything.
+
+    Session-scoped by default: results are also filtered to this terminal's
+    own ``tmux_session`` unless ``cross_session=true`` is explicitly passed
+    (issue #432 design discussion). ``group`` is an organizational label,
+    not a security boundary — on a default install with auth disabled, a
+    worker already has local shell access, so nothing here provides tenant
+    isolation even with session scoping applied; see docs/api.md.
 
     Each result includes a ``status`` (tedswinyar, PR #433 review): a live,
     point-in-time snapshot, not a guarantee. A handoff terminal can still
@@ -2477,7 +2495,9 @@ async def list_terminal_siblings(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
     try:
-        return await asyncio.to_thread(terminal_service.list_siblings, terminal_id, depth=depth)
+        return await asyncio.to_thread(
+            terminal_service.list_siblings, terminal_id, depth=depth, cross_session=cross_session
+        )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -954,8 +954,14 @@ def create_terminal(
             "shell_command": terminal.shell_command,
             "caller_id": terminal.caller_id,
             "engine": terminal.engine,
-            "group": group,
-            "metadata": metadata,
+            # Normalized the same way as what was actually stored (an empty
+            # container is stored as NULL, same as omitted) -- self-ROAST
+            # finding: echoing the raw `group`/`metadata` input here made
+            # create_terminal(group=[]) return {"group": []} while an
+            # immediately-following get_terminal_metadata() on the same row
+            # returns {"group": None}, an API-consistency gap.
+            "group": group if group else None,
+            "metadata": metadata if metadata else None,
         }
 
 

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -1040,14 +1040,44 @@ def list_siblings_by_group_prefix(caller_id: str, prefix: List[str]) -> List[Dic
     depth — this function does no clamping itself, it only matches. A
     candidate terminal with no group, or a group shorter than ``len(prefix)``,
     is excluded rather than compared partially or raising (#432).
+
+    ``group`` is stored JSON-encoded (see ``TerminalModel.group``), so the
+    query prefilters with a SQL ``LIKE`` prefix match on that encoding before
+    loading/decoding candidate rows in Python (Copilot review, PR #433) —
+    without it this scanned and JSON-decoded every grouped terminal on the
+    server regardless of how narrow ``prefix`` is. Because ``json.dumps``
+    closes each string element in a quote immediately, the encoded prefix
+    (full array minus its trailing ``]``) can't false-positive match a
+    longer sibling element that merely shares a text prefix (e.g. prefix
+    element ``"project_5"`` vs. a sibling group containing ``"project_50"``
+    — the sibling's extra ``0`` before its closing ``"`` breaks the SQL
+    match). The exact Python-level comparison below is kept regardless, as
+    the source of truth — the SQL match only narrows candidates (a prefilter
+    defect can only cause a false negative here, i.e. a missed perf win,
+    never a false positive / correctness or security regression).
+
+    This SQL-level match assumes the stored ``group`` was encoded with the
+    same ``json.dumps`` defaults used below (notably ``ensure_ascii=True``,
+    the default) — true today since ``update_terminal_group`` is the only
+    write path and uses plain ``json.dumps(group)``. If that write path ever
+    changes its encoding, this prefilter must change with it.
     """
     import json as _json
 
     depth = len(prefix)
+    # Encode the prefix array and drop its trailing ']' so this matches both
+    # a sibling group of the same length and a longer one that starts with
+    # it, e.g. prefix ["a", "b"] -> '["a", "b"' matches '["a", "b"]' and
+    # '["a", "b", "c"]'.
+    like_prefix = _json.dumps(prefix)[:-1]
     with SessionLocal() as db:
         rows = (
             db.query(TerminalModel)
-            .filter(TerminalModel.id != caller_id, TerminalModel.group.isnot(None))
+            .filter(
+                TerminalModel.id != caller_id,
+                TerminalModel.group.isnot(None),
+                TerminalModel.group.startswith(like_prefix, autoescape=True),
+            )
             .all()
         )
         siblings = []

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -1033,13 +1033,30 @@ def get_terminal_group(terminal_id: str) -> Optional[List[str]]:
         return cast(List[str], _json.loads(terminal.group))
 
 
-def list_siblings_by_group_prefix(caller_id: str, prefix: List[str]) -> List[Dict[str, Any]]:
+def list_siblings_by_group_prefix(
+    caller_id: str,
+    prefix: List[str],
+    caller_session: Optional[str] = None,
+    cross_session: bool = False,
+) -> List[Dict[str, Any]]:
     """Return ``{id, group, metadata}`` for every OTHER terminal sharing ``prefix``.
 
     ``prefix`` is the caller's own group truncated to the (already-clamped)
     depth — this function does no clamping itself, it only matches. A
     candidate terminal with no group, or a group shorter than ``len(prefix)``,
     is excluded rather than compared partially or raising (#432).
+
+    Session-scoped by default (issue #432 design discussion, tedswinyar +
+    klabulan, 2026-07-17/18): ``caller_session`` (the caller's own
+    ``tmux_session``) is an implicit, non-bypassable first filter ON TOP of
+    the group-prefix match, unless ``cross_session=True`` is explicitly
+    passed. Without this, two unrelated CAO sessions that happen to reuse
+    the same ``group`` prefix (a naming collision, a copy-pasted template,
+    two features that picked the same tenant/project id) would silently
+    discover each other -- the same class of "implicitly-scoped state that
+    turns out not to be" mistake cited in that discussion's incident
+    history. Cross-session discovery is a legitimate use case and stays
+    available, just opt-in rather than the unstated default.
 
     ``group`` is stored JSON-encoded (see ``TerminalModel.group``), so the
     query prefilters with a SQL ``LIKE`` prefix match on that encoding before
@@ -1079,15 +1096,14 @@ def list_siblings_by_group_prefix(caller_id: str, prefix: List[str]) -> List[Dic
     # '["a", "b", "c"]'.
     like_prefix = _json.dumps(prefix)[:-1]
     with SessionLocal() as db:
-        rows = (
-            db.query(TerminalModel)
-            .filter(
-                TerminalModel.id != caller_id,
-                TerminalModel.group.isnot(None),
-                TerminalModel.group.startswith(like_prefix, autoescape=True),
-            )
-            .all()
+        query = db.query(TerminalModel).filter(
+            TerminalModel.id != caller_id,
+            TerminalModel.group.isnot(None),
+            TerminalModel.group.startswith(like_prefix, autoescape=True),
         )
+        if not cross_session and caller_session is not None:
+            query = query.filter(TerminalModel.tmux_session == caller_session)
+        rows = query.all()
         siblings = []
         for row in rows:
             try:

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -1058,9 +1058,17 @@ def list_siblings_by_group_prefix(caller_id: str, prefix: List[str]) -> List[Dic
 
     This SQL-level match assumes the stored ``group`` was encoded with the
     same ``json.dumps`` defaults used below (notably ``ensure_ascii=True``,
-    the default) — true today since ``update_terminal_group`` is the only
-    write path and uses plain ``json.dumps(group)``. If that write path ever
-    changes its encoding, this prefilter must change with it.
+    the default) — true today of both write paths (``create_terminal`` and
+    ``update_terminal_group``), which both use plain ``json.dumps(group)``.
+    If either write path ever changes its encoding, this prefilter must
+    change with it.
+
+    A single row with corrupt ``group`` JSON (e.g. hand-edited DB, a future
+    write-path bug) is logged and excluded rather than raising and failing
+    discovery for every OTHER terminal in the same request (tedswinyar, PR
+    #433 review). Corrupt ``metadata`` JSON on an otherwise-matching sibling
+    is likewise logged and reported back as ``metadata=None`` -- the sibling
+    itself is still real and discoverable, only its metadata is unreadable.
     """
     import json as _json
 
@@ -1082,17 +1090,38 @@ def list_siblings_by_group_prefix(caller_id: str, prefix: List[str]) -> List[Dic
         )
         siblings = []
         for row in rows:
-            sibling_group = _json.loads(row.group)
+            try:
+                sibling_group = _json.loads(row.group)
+                if not isinstance(sibling_group, list):
+                    raise ValueError(f"decoded to {type(sibling_group).__name__}, expected list")
+            except (TypeError, ValueError) as e:
+                logger.warning(
+                    "list_siblings_by_group_prefix: skipping terminal %s -- "
+                    "corrupt group JSON (%s)",
+                    row.id,
+                    e,
+                )
+                continue
             if len(sibling_group) < depth:
                 continue
             if sibling_group[:depth] == prefix:
+                metadata = None
+                if row.metadata_json:
+                    try:
+                        metadata = _json.loads(row.metadata_json)
+                    except (TypeError, ValueError) as e:
+                        logger.warning(
+                            "list_siblings_by_group_prefix: terminal %s has "
+                            "corrupt metadata JSON (%s); returning it with "
+                            "metadata=None",
+                            row.id,
+                            e,
+                        )
                 siblings.append(
                     {
                         "id": row.id,
                         "group": sibling_group,
-                        "metadata": (
-                            _json.loads(row.metadata_json) if row.metadata_json else None
-                        ),
+                        "metadata": metadata,
                     }
                 )
         return siblings

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -43,6 +43,16 @@ class TerminalModel(Base):
     shell_command = Column(String, nullable=True)  # shell process name captured before kiro launch
     caller_id = Column(String, nullable=True)  # terminal that created this one (callback target)
     engine = Column(String, nullable=True)  # resolved Kiro engine; NULL for legacy/non-Kiro rows
+    # Ordered, general-to-specific array of strings (JSON-encoded), e.g.
+    # '["tenant_1", "project_5", "folder_12"]'. CAO only does ordered-prefix
+    # matching (list_siblings); consumers own what the levels mean (#432).
+    group = Column(Text, nullable=True)
+    # Free-form JSON (JSON-encoded dict), consumer-defined, no fixed schema.
+    # Python attribute is ``metadata_json`` (not ``metadata``) because
+    # SQLAlchemy's declarative Base reserves ``.metadata`` for the schema
+    # MetaData object on every mapped class; the DB column itself is still
+    # literally named "metadata" per #432's design.
+    metadata_json = Column("metadata", Text, nullable=True)
     last_active = Column(DateTime, default=datetime.now)
 
 
@@ -887,6 +897,16 @@ def _migrate_terminals_schema() -> None:
             conn.execute("ALTER TABLE terminals ADD COLUMN engine TEXT")
             conn.commit()
             logger.info("Migration: added engine column to terminals table")
+        if "group" not in columns:
+            # "group" is a SQL reserved word in some dialects but not SQLite;
+            # quoted defensively so this ALTER survives if that ever changes.
+            conn.execute('ALTER TABLE terminals ADD COLUMN "group" TEXT')
+            conn.commit()
+            logger.info("Migration: added group column to terminals table")
+        if "metadata" not in columns:
+            conn.execute('ALTER TABLE terminals ADD COLUMN "metadata" TEXT')
+            conn.commit()
+            logger.info("Migration: added metadata column to terminals table")
         conn.close()
     except Exception as e:
         logger.warning(f"Migration check for terminals schema failed: {e}")
@@ -902,6 +922,8 @@ def create_terminal(
     shell_command: Optional[str] = None,
     caller_id: Optional[str] = None,
     engine: Optional[str] = None,
+    group: Optional[List[str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Create terminal metadata record."""
     import json as _json
@@ -917,6 +939,8 @@ def create_terminal(
             shell_command=shell_command,
             caller_id=caller_id,
             engine=engine,
+            group=_json.dumps(group) if group else None,
+            metadata_json=_json.dumps(metadata) if metadata else None,
         )
         db.add(terminal)
         db.commit()
@@ -930,6 +954,8 @@ def create_terminal(
             "shell_command": terminal.shell_command,
             "caller_id": terminal.caller_id,
             "engine": terminal.engine,
+            "group": group,
+            "metadata": metadata,
         }
 
 
@@ -946,6 +972,8 @@ def get_terminal_metadata(terminal_id: str) -> Optional[Dict[str, Any]]:
             f"Retrieved terminal metadata for {terminal_id}: provider={terminal.provider}, session={terminal.tmux_session}"
         )
         allowed_tools = _json.loads(terminal.allowed_tools) if terminal.allowed_tools else None
+        group = _json.loads(terminal.group) if terminal.group else None
+        metadata = _json.loads(terminal.metadata_json) if terminal.metadata_json else None
         return {
             "id": terminal.id,
             "tmux_session": terminal.tmux_session,
@@ -956,8 +984,82 @@ def get_terminal_metadata(terminal_id: str) -> Optional[Dict[str, Any]]:
             "shell_command": terminal.shell_command,
             "caller_id": terminal.caller_id,
             "engine": terminal.engine or ("v2" if terminal.provider == "kiro_cli" else None),
+            "group": group,
+            "metadata": metadata,
             "last_active": terminal.last_active,
         }
+
+
+def update_terminal_group(terminal_id: str, group: Optional[List[str]]) -> bool:
+    """Replace a terminal's group array. ``None``/``[]`` clears it (opts out of discovery)."""
+    import json as _json
+
+    with SessionLocal() as db:
+        terminal = db.query(TerminalModel).filter(TerminalModel.id == terminal_id).first()
+        if not terminal:
+            return False
+        terminal.group = _json.dumps(group) if group else None
+        db.commit()
+        return True
+
+
+def update_terminal_metadata(terminal_id: str, metadata: Optional[Dict[str, Any]]) -> bool:
+    """Replace a terminal's free-form metadata dict. ``None``/``{}`` clears it."""
+    import json as _json
+
+    with SessionLocal() as db:
+        terminal = db.query(TerminalModel).filter(TerminalModel.id == terminal_id).first()
+        if not terminal:
+            return False
+        terminal.metadata_json = _json.dumps(metadata) if metadata else None
+        db.commit()
+        return True
+
+
+def get_terminal_group(terminal_id: str) -> Optional[List[str]]:
+    """Return a terminal's own group array, or None if unset or the terminal doesn't exist."""
+    import json as _json
+
+    with SessionLocal() as db:
+        terminal = db.query(TerminalModel).filter(TerminalModel.id == terminal_id).first()
+        if not terminal or not terminal.group:
+            return None
+        return cast(List[str], _json.loads(terminal.group))
+
+
+def list_siblings_by_group_prefix(caller_id: str, prefix: List[str]) -> List[Dict[str, Any]]:
+    """Return ``{id, group, metadata}`` for every OTHER terminal sharing ``prefix``.
+
+    ``prefix`` is the caller's own group truncated to the (already-clamped)
+    depth — this function does no clamping itself, it only matches. A
+    candidate terminal with no group, or a group shorter than ``len(prefix)``,
+    is excluded rather than compared partially or raising (#432).
+    """
+    import json as _json
+
+    depth = len(prefix)
+    with SessionLocal() as db:
+        rows = (
+            db.query(TerminalModel)
+            .filter(TerminalModel.id != caller_id, TerminalModel.group.isnot(None))
+            .all()
+        )
+        siblings = []
+        for row in rows:
+            sibling_group = _json.loads(row.group)
+            if len(sibling_group) < depth:
+                continue
+            if sibling_group[:depth] == prefix:
+                siblings.append(
+                    {
+                        "id": row.id,
+                        "group": sibling_group,
+                        "metadata": (
+                            _json.loads(row.metadata_json) if row.metadata_json else None
+                        ),
+                    }
+                )
+        return siblings
 
 
 def list_terminals_by_session(tmux_session: str) -> List[Dict[str, Any]]:

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -594,7 +594,7 @@ MEMORY_ARCHIVE_MAX_GZIP_RATIO = 100  # reject > 100x expansion
 # Built-in role defaults. A role is a named bundle of allowedTools.
 # Users can define custom roles in settings.json under "roles".
 # CAO vocabulary: execute_bash, fs_read, fs_write, fs_list, fs_*, web_fetch,
-# @builtin, @cao-mcp-server.
+# @builtin, @cao-mcp-server, discovery.
 # web_fetch is granted only to developer: supervisor/reviewer are intentionally
 # kept off the network (no WebFetch/WebSearch), shrinking their exfiltration surface.
 ROLE_TOOL_DEFAULTS = {
@@ -602,6 +602,18 @@ ROLE_TOOL_DEFAULTS = {
     "reviewer": ["@builtin", "fs_read", "fs_list", "@cao-mcp-server"],
     "developer": ["@builtin", "fs_*", "execute_bash", "web_fetch", "@cao-mcp-server"],
 }
+
+# Issue #432 design discussion (tedswinyar + klabulan, 2026-07-17/18): sibling
+# discovery (list_siblings/update_metadata) is a distinct capability from the
+# existing handoff/assign/send_message orchestration trio, and must be an
+# explicit, separate opt-in rather than bundled into @cao-mcp-server's
+# all-or-nothing MCP-server-level grant -- a profile should be able to keep
+# orchestration tools while declining peer-to-peer discovery. Deliberately
+# NOT in any built-in role's defaults above; a profile author adds it
+# explicitly (see docs/tool-restrictions.md and
+# docs/discovery-tool-coexistence.md for the full rationale and enforcement
+# mechanism).
+DISCOVERY_TOOL_MARKER = "discovery"
 
 # Security constraints prepended to system prompts for providers without
 # native tool restriction mechanisms (kimi_cli, codex).

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -804,3 +804,17 @@ WORKFLOW_SCRIPT_TERM_GRACE = 5.0  # SIGTERM->SIGKILL grace (BR-10/11, NFR-REL-1)
 WORKFLOW_SCRIPT_TIMEOUT = 8700.0
 WORKFLOW_SCRIPT_LOG_CAP = 256 * 1024  # per-stream tail cap, bytes (BR-24/25, Q7=A)
 WORKFLOW_SCRIPT_SCRATCH_DIR = CAO_HOME_DIR / "workflow-script-scratch"  # 0o700 (BR-30)
+
+# =============================================================================
+# Terminal group/metadata caps (#432 follow-up review, PR #433)
+# =============================================================================
+# ``group`` and (especially) ``metadata`` are written by the terminal's own
+# running agent via the ``update_metadata``/``update_group`` MCP tools, with
+# no operator review in the loop. Left unbounded, a worker could grow the
+# terminals.metadata/group TEXT columns arbitrarily, and that growth is
+# amplified into every sibling's ``list_siblings`` response (call-me-ram, PR
+# #433 review). Same shape as ``WORKFLOW_MAX_SPEC_BYTES``: a structural cap
+# enforced at the request boundary, fail-closed with 422.
+TERMINAL_METADATA_MAX_BYTES = 16 * 1024  # encoded (json.dumps) size cap
+TERMINAL_GROUP_MAX_ELEMENTS = 16
+TERMINAL_GROUP_ELEMENT_MAX_LEN = 128

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -1619,9 +1619,15 @@ async def list_siblings(
 
     Resolves your identity from your own CAO_TERMINAL_ID (never a value you
     pass in) and looks up your own persisted `group`. Returns the id, group,
-    and metadata of every OTHER terminal whose group shares the resolved
-    prefix. If you have no group set, you have no siblings — this is not an
-    error.
+    metadata, and status of every OTHER terminal whose group shares the
+    resolved prefix. If you have no group set, you have no siblings — this
+    is not an error.
+
+    `status` is a live snapshot at call time, not a guarantee -- a sibling
+    (especially a handoff terminal) can complete and delete itself between
+    this call and your next message to it, so expect send_message to a
+    discovered sibling to occasionally fail even when status looked healthy
+    here.
 
     Use this to find other agents working in the same project/folder/tenant,
     then message them with send_message using the returned id.
@@ -1634,15 +1640,20 @@ async def update_metadata(
     metadata: Dict[str, Any] = Field(
         description=(
             "Free-form JSON describing what this terminal is doing right "
-            "now. Replaces any existing metadata entirely (not merged). "
-            "Visible to sibling terminals via list_siblings."
+            "now. Replaces any existing metadata entirely (not merged) -- "
+            "concurrent calls are last-write-wins, so if you're updating "
+            "part of a larger metadata dict, re-send the whole thing each "
+            "time rather than assuming earlier fields still apply. Visible "
+            "to sibling terminals via list_siblings."
         )
     ),
 ) -> Dict[str, Any]:
     """Update your own terminal's metadata, visible to siblings via list_siblings.
 
     Use this so other agents in your group can see a short description of
-    what you're currently working on without messaging you directly.
+    what you're currently working on without messaging you directly. Whole-
+    dict replace, last-write-wins under concurrent calls -- not an
+    accumulating/merging store.
     """
     return _update_metadata_impl(metadata)
 

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -14,6 +14,7 @@ from pydantic import Field
 from cli_agent_orchestrator.constants import (
     API_BASE_URL,
     DEFAULT_PROVIDER,
+    DISCOVERY_TOOL_MARKER,
     WORKFLOW_EVENTS_CONNECT_TIMEOUT,
     WORKFLOW_EVENTS_MCP_MAX_EVENTS,
     WORKFLOW_EVENTS_MCP_MAX_SECONDS,
@@ -1556,16 +1557,72 @@ def _own_terminal_id_or_error(action: str) -> Union[str, Dict[str, Any]]:
     return own_terminal_id
 
 
-def _list_siblings_impl(depth: Optional[int]) -> Dict[str, Any]:
+def _require_discovery_marker(own_terminal_id: str, action: str) -> Optional[Dict[str, Any]]:
+    """Enforce the discovery opt-in marker (issue #432 design discussion).
+
+    Sibling discovery (list_siblings/update_metadata) is deliberately NOT
+    bundled into @cao-mcp-server's all-or-nothing MCP-server-level grant --
+    a profile must additionally list ``"discovery"`` in its own
+    ``allowedTools`` (or be unrestricted) to use these two tools, even if it
+    already has orchestration tools. See
+    docs/discovery-tool-coexistence.md for the full rationale and why this
+    is enforced here (a runtime check inside the tool handler) rather than
+    by hiding the tool from the model entirely -- cao-mcp-server is one
+    process shared by every profile that wires it in, with no existing
+    mechanism to filter which of its tools a given caller sees.
+
+    Returns an error dict if the marker is missing (call this and return its
+    result immediately when non-None), or ``None`` if the caller is
+    authorized.
+    """
+    try:
+        response = requests.get(
+            f"{API_BASE_URL}/terminals/{own_terminal_id}", timeout=_mcp_timeout()
+        )
+        response.raise_for_status()
+        allowed_tools = response.json().get("allowed_tools")
+    except Exception as e:
+        # Fail closed: an unresolvable allowed_tools lookup must not silently
+        # grant discovery -- same posture as _own_terminal_id_or_error above.
+        return {
+            "success": False,
+            "error": f"Failed to {action}: could not resolve this terminal's allowed_tools: {e}",
+        }
+    # None (no role/allowedTools resolved at all) and "*" both mean
+    # unrestricted, matching resolve_allowed_tools' own semantics elsewhere.
+    if (
+        allowed_tools is not None
+        and "*" not in allowed_tools
+        and (DISCOVERY_TOOL_MARKER not in allowed_tools)
+    ):
+        return {
+            "success": False,
+            "error": (
+                f"Failed to {action}: this agent profile is not granted the "
+                f"'{DISCOVERY_TOOL_MARKER}' tool. Add '{DISCOVERY_TOOL_MARKER}' to "
+                "allowedTools to use sibling discovery (list_siblings/"
+                "update_metadata) -- see docs/tool-restrictions.md."
+            ),
+        }
+    return None
+
+
+def _list_siblings_impl(depth: Optional[int], cross_session: bool = False) -> Dict[str, Any]:
     """Implementation of list_siblings logic."""
     own_terminal_id = _own_terminal_id_or_error("list siblings")
     if isinstance(own_terminal_id, dict):
         return own_terminal_id
 
+    denied = _require_discovery_marker(own_terminal_id, "list siblings")
+    if denied is not None:
+        return denied
+
     try:
         params: Dict[str, Any] = {}
         if depth is not None:
             params["depth"] = depth
+        if cross_session:
+            params["cross_session"] = "true"
         response = requests.get(
             f"{API_BASE_URL}/terminals/{own_terminal_id}/siblings",
             params=params,
@@ -1585,6 +1642,10 @@ def _update_metadata_impl(metadata: Dict[str, Any]) -> Dict[str, Any]:
     own_terminal_id = _own_terminal_id_or_error("update metadata")
     if isinstance(own_terminal_id, dict):
         return own_terminal_id
+
+    denied = _require_discovery_marker(own_terminal_id, "update metadata")
+    if denied is not None:
+        return denied
 
     try:
         response = requests.patch(
@@ -1614,14 +1675,35 @@ async def list_siblings(
             "all-terminals query."
         ),
     ),
+    cross_session: bool = Field(
+        default=False,
+        description=(
+            "Discovery is scoped to your own tmux session by default -- set "
+            "this to true to also see matching siblings in OTHER CAO "
+            "sessions. Explicit opt-in only; two unrelated sessions that "
+            "happen to reuse the same group prefix must not silently "
+            "discover each other."
+        ),
+    ),
 ) -> Dict[str, Any]:
     """Discover sibling terminals sharing a leading prefix of your own group.
+
+    Requires the 'discovery' tool to be granted in your agent profile's
+    allowedTools -- sibling discovery is a separate opt-in from the
+    handoff/assign/send_message orchestration trio, not bundled into
+    @cao-mcp-server (see docs/tool-restrictions.md).
 
     Resolves your identity from your own CAO_TERMINAL_ID (never a value you
     pass in) and looks up your own persisted `group`. Returns the id, group,
     metadata, and status of every OTHER terminal whose group shares the
-    resolved prefix. If you have no group set, you have no siblings — this
-    is not an error.
+    resolved prefix AND is in your own tmux session, unless
+    cross_session=true. If you have no group set, you have no siblings —
+    this is not an error.
+
+    `group` is an organizational label, not a security boundary -- on a
+    default install with auth disabled, a worker already has local shell
+    access, so nothing here provides tenant isolation even with session
+    scoping applied.
 
     `status` is a live snapshot at call time, not a guarantee -- a sibling
     (especially a handoff terminal) can complete and delete itself between
@@ -1632,7 +1714,7 @@ async def list_siblings(
     Use this to find other agents working in the same project/folder/tenant,
     then message them with send_message using the returned id.
     """
-    return _list_siblings_impl(depth)
+    return _list_siblings_impl(depth, cross_session)
 
 
 @mcp.tool()
@@ -1650,10 +1732,17 @@ async def update_metadata(
 ) -> Dict[str, Any]:
     """Update your own terminal's metadata, visible to siblings via list_siblings.
 
+    Requires the 'discovery' tool to be granted in your agent profile's
+    allowedTools -- sibling discovery is a separate opt-in from the
+    handoff/assign/send_message orchestration trio, not bundled into
+    @cao-mcp-server (see docs/tool-restrictions.md).
+
     Use this so other agents in your group can see a short description of
     what you're currently working on without messaging you directly. Whole-
     dict replace, last-write-wins under concurrent calls -- not an
-    accumulating/merging store.
+    accumulating/merging store. Metadata you publish here is visible to any
+    sibling that can discover you -- treat it as you would any other
+    inter-agent message, not as private state.
     """
     return _update_metadata_impl(metadata)
 

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -1539,6 +1539,114 @@ def delete_terminal(
         return {"success": False, "message": f"Failed to delete terminal: {str(e)}"}
 
 
+def _own_terminal_id_or_error(action: str) -> Union[str, Dict[str, Any]]:
+    """Resolve this MCP process's own terminal id, or an error dict.
+
+    The identity comes from this process's own environment — set by CAO when
+    the terminal was spawned, never a client-supplied argument the calling
+    model could set — the same trust mechanism ``send_message``/``handoff``
+    already rely on (#432).
+    """
+    own_terminal_id = os.environ.get("CAO_TERMINAL_ID")
+    if not own_terminal_id:
+        return {
+            "success": False,
+            "error": f"CAO_TERMINAL_ID not set - cannot {action} (must run within a CAO terminal)",
+        }
+    return own_terminal_id
+
+
+def _list_siblings_impl(depth: Optional[int]) -> Dict[str, Any]:
+    """Implementation of list_siblings logic."""
+    own_terminal_id = _own_terminal_id_or_error("list siblings")
+    if isinstance(own_terminal_id, dict):
+        return own_terminal_id
+
+    try:
+        params: Dict[str, Any] = {}
+        if depth is not None:
+            params["depth"] = depth
+        response = requests.get(
+            f"{API_BASE_URL}/terminals/{own_terminal_id}/siblings",
+            params=params,
+            timeout=_mcp_timeout(),
+        )
+        response.raise_for_status()
+        return {"success": True, "siblings": response.json()}
+    except requests.HTTPError as e:
+        detail = _extract_error_detail(e.response, str(e)) if e.response is not None else str(e)
+        return {"success": False, "error": f"Failed to list siblings: {detail}"}
+    except Exception as e:
+        return {"success": False, "error": f"Failed to list siblings: {str(e)}"}
+
+
+def _update_metadata_impl(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Implementation of update_metadata logic."""
+    own_terminal_id = _own_terminal_id_or_error("update metadata")
+    if isinstance(own_terminal_id, dict):
+        return own_terminal_id
+
+    try:
+        response = requests.patch(
+            f"{API_BASE_URL}/terminals/{own_terminal_id}/metadata",
+            json={"metadata": metadata},
+            timeout=_mcp_timeout(),
+        )
+        response.raise_for_status()
+        return {"success": True, "metadata": response.json().get("metadata")}
+    except requests.HTTPError as e:
+        detail = _extract_error_detail(e.response, str(e)) if e.response is not None else str(e)
+        return {"success": False, "error": f"Failed to update metadata: {detail}"}
+    except Exception as e:
+        return {"success": False, "error": f"Failed to update metadata: {str(e)}"}
+
+
+@mcp.tool()
+async def list_siblings(
+    depth: Optional[int] = Field(
+        default=None,
+        description=(
+            "How many leading elements of THIS terminal's own group to match "
+            "against. Omit for the widest scope you're allowed to see (your "
+            "full own group). The server clamps this to your own group's "
+            "length — you can never see a wider scope than your own group — "
+            "and rejects 0 outright rather than treating it as an unscoped, "
+            "all-terminals query."
+        ),
+    ),
+) -> Dict[str, Any]:
+    """Discover sibling terminals sharing a leading prefix of your own group.
+
+    Resolves your identity from your own CAO_TERMINAL_ID (never a value you
+    pass in) and looks up your own persisted `group`. Returns the id, group,
+    and metadata of every OTHER terminal whose group shares the resolved
+    prefix. If you have no group set, you have no siblings — this is not an
+    error.
+
+    Use this to find other agents working in the same project/folder/tenant,
+    then message them with send_message using the returned id.
+    """
+    return _list_siblings_impl(depth)
+
+
+@mcp.tool()
+async def update_metadata(
+    metadata: Dict[str, Any] = Field(
+        description=(
+            "Free-form JSON describing what this terminal is doing right "
+            "now. Replaces any existing metadata entirely (not merged). "
+            "Visible to sibling terminals via list_siblings."
+        )
+    ),
+) -> Dict[str, Any]:
+    """Update your own terminal's metadata, visible to siblings via list_siblings.
+
+    Use this so other agents in your group can see a short description of
+    what you're currently working on without messaging you directly.
+    """
+    return _update_metadata_impl(metadata)
+
+
 # =============================================================================
 # Profile Discovery Tools
 # =============================================================================

--- a/src/cli_agent_orchestrator/models/terminal.py
+++ b/src/cli_agent_orchestrator/models/terminal.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
@@ -39,6 +39,19 @@ class Terminal(BaseModel):
     engine: Optional[KiroEngine] = Field(None, description="Resolved Kiro engine")
     shell_command: Optional[str] = Field(
         None, description="Shell process name captured before kiro launch"
+    )
+    group: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Ordered, general-to-specific grouping array (e.g. "
+            '["tenant_1", "project_5", "folder_12"]). CAO does ordered-prefix '
+            "matching only; consumers own what the levels mean. None = this "
+            "terminal participates in no group-based discovery (see "
+            "list_siblings)."
+        ),
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        None, description="Free-form, consumer-defined JSON describing what this terminal is doing"
     )
     status: Optional[TerminalStatus] = Field(
         None, description="Current terminal status (live only)"

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -20,7 +20,7 @@ Session Lifecycle:
 """
 
 import logging
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import list_terminals_by_session
@@ -53,6 +53,8 @@ async def create_session(
     initial_message: str | None = None,
     initial_message_orchestration_type: OrchestrationType | None = None,
     model: str | None = None,
+    group: Optional[List[str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Terminal:
     """Create a new session by creating its initial terminal.
 
@@ -66,6 +68,11 @@ async def create_session(
     initialization behavior used by existing callers.
     On the deferred path, the ``post_create_session`` plugin event is dispatched
     before provider initialization and message delivery finish.
+
+    ``group``/``metadata`` are the #432 discovery fields, set on the initial
+    terminal at creation time (``group`` is also updatable later via
+    ``PATCH /terminals/{id}/group``, ``metadata`` via the ``update_metadata``
+    MCP tool).
     """
     if initial_message == "":
         raise ValueError("initial_message must not be empty")
@@ -91,6 +98,8 @@ async def create_session(
         initial_message=initial_message,
         initial_message_orchestration_type=initial_message_orchestration_type,
         model=model,
+        group=group,
+        metadata=metadata,
     )
     dispatch_plugin_event(
         registry,

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -34,7 +34,6 @@ from cli_agent_orchestrator.clients.database import (
 from cli_agent_orchestrator.clients.database import create_terminal as db_create_terminal
 from cli_agent_orchestrator.clients.database import delete_terminal as db_delete_terminal
 from cli_agent_orchestrator.clients.database import (
-    get_terminal_group,
     get_terminal_metadata,
     list_siblings_by_group_prefix,
     update_last_active,
@@ -1017,7 +1016,9 @@ def update_metadata(terminal_id: str, metadata: Optional[Dict[str, Any]]) -> boo
     return update_terminal_metadata(terminal_id, metadata)
 
 
-def list_siblings(caller_id: str, depth: Optional[int] = None) -> List[Dict[str, Any]]:
+def list_siblings(
+    caller_id: str, depth: Optional[int] = None, cross_session: bool = False
+) -> List[Dict[str, Any]]:
     """Resolve ``caller_id``'s own group and return matching sibling terminals.
 
     Depth is clamped server-side to ``[1, len(caller_group)]`` (#432): it can
@@ -1030,6 +1031,11 @@ def list_siblings(caller_id: str, depth: Optional[int] = None) -> List[Dict[str,
     A caller with no group set finds no siblings (participates in no
     discovery, per #432) rather than erroring.
 
+    Session-scoped by default (issue #432 design discussion): results are
+    additionally filtered to the caller's own ``tmux_session`` unless
+    ``cross_session=True`` is explicitly passed — see
+    ``list_siblings_by_group_prefix``'s own docstring for the full rationale.
+
     Returns:
         List of ``{id, group, metadata, status}`` dicts for every OTHER
         terminal whose group shares the resolved prefix. ``status`` is a
@@ -1041,14 +1047,18 @@ def list_siblings(caller_id: str, depth: Optional[int] = None) -> List[Dict[str,
         proactively, but callers should still expect sends to occasionally
         fail against a sibling that disappeared in that window.
     """
-    caller_group = get_terminal_group(caller_id)
+    caller_metadata = get_terminal_metadata(caller_id)
+    caller_group = caller_metadata.get("group") if caller_metadata else None
     if not caller_group:
         return []
+    caller_session = caller_metadata.get("tmux_session") if caller_metadata else None
     max_depth = len(caller_group)
     effective_depth = max_depth if depth is None else depth
     effective_depth = max(1, min(effective_depth, max_depth))
     prefix = caller_group[:effective_depth]
-    siblings = list_siblings_by_group_prefix(caller_id, prefix)
+    siblings = list_siblings_by_group_prefix(
+        caller_id, prefix, caller_session=caller_session, cross_session=cross_session
+    )
     for sibling in siblings:
         sibling["status"] = status_monitor.get_status(sibling["id"]).value
     return siblings

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -25,7 +25,7 @@ import threading
 import time
 from datetime import datetime
 from enum import Enum
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import (
@@ -34,8 +34,12 @@ from cli_agent_orchestrator.clients.database import (
 from cli_agent_orchestrator.clients.database import create_terminal as db_create_terminal
 from cli_agent_orchestrator.clients.database import delete_terminal as db_delete_terminal
 from cli_agent_orchestrator.clients.database import (
+    get_terminal_group,
     get_terminal_metadata,
+    list_siblings_by_group_prefix,
     update_last_active,
+    update_terminal_group,
+    update_terminal_metadata,
     update_terminal_shell_command,
 )
 from cli_agent_orchestrator.constants import (
@@ -173,6 +177,8 @@ async def create_terminal(
     kiro_capability_probe: Optional[Callable[[KiroEngine, set[str]], KiroCapabilities]] = None,
     model: Optional[str] = None,
     use_worktree: bool = False,
+    group: Optional[List[str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Terminal:
     """Create a new terminal with an initialized CLI agent.
 
@@ -217,6 +223,11 @@ async def create_terminal(
             branch there, and overrides ``working_directory`` to the new
             worktree path before the tmux session/window is created. Requires
             the resolved directory to actually be inside a git repository.
+        group: Ordered, general-to-specific grouping array for list_siblings
+            discovery (#432). None = this terminal opts out of discovery.
+        metadata: Free-form JSON describing what this terminal is doing.
+            Also updatable later by the running agent via the
+            ``update_metadata`` MCP tool.
 
     Returns:
         Terminal object with all metadata populated
@@ -406,6 +417,8 @@ async def create_terminal(
             allowed_tools,
             caller_id=caller_id,
             engine=resolved_engine.value if resolved_engine is not None else None,
+            group=group,
+            metadata=metadata,
         )
 
         # Step 4/5: Set up the FIFO event-driven output pipeline for pipe-pane
@@ -505,6 +518,8 @@ async def create_terminal(
             allowed_tools=allowed_tools,
             engine=resolved_engine,
             shell_command=shell_command,
+            group=group,
+            metadata=metadata,
             status=initial_status,
             last_active=datetime.now(),
         )
@@ -963,6 +978,8 @@ def get_terminal(terminal_id: str) -> Dict:
             "caller_id": metadata.get("caller_id"),
             "allowed_tools": metadata.get("allowed_tools"),
             "engine": metadata.get("engine"),
+            "group": metadata.get("group"),
+            "metadata": metadata.get("metadata"),
             "status": status,
             "last_active": metadata["last_active"],
         }
@@ -970,6 +987,56 @@ def get_terminal(terminal_id: str) -> Dict:
     except Exception as e:
         logger.error(f"Failed to get terminal {terminal_id}: {e}")
         raise
+
+
+def update_group(terminal_id: str, group: Optional[List[str]]) -> bool:
+    """Replace a terminal's group array.
+
+    Used by consumers whose own grouping can change after a terminal already
+    exists (e.g. harness-control folder/project reassignment) so ``group``
+    doesn't go stale (#432). ``None``/``[]`` opts the terminal back out of
+    discovery.
+
+    Returns:
+        False if the terminal does not exist, True otherwise.
+    """
+    return update_terminal_group(terminal_id, group)
+
+
+def update_metadata(terminal_id: str, metadata: Optional[Dict[str, Any]]) -> bool:
+    """Replace a terminal's free-form metadata dict.
+
+    Returns:
+        False if the terminal does not exist, True otherwise.
+    """
+    return update_terminal_metadata(terminal_id, metadata)
+
+
+def list_siblings(caller_id: str, depth: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Resolve ``caller_id``'s own group and return matching sibling terminals.
+
+    Depth is clamped server-side to ``[1, len(caller_group)]`` (#432): it can
+    never be widened past the caller's own group length, and an explicit 0 is
+    rejected by the API layer's query-param validation before this is ever
+    called (never silently reinterpreted as an unscoped, all-terminals
+    query). ``depth=None`` defaults to the caller's full own group length —
+    the widest scope the caller is allowed to see.
+
+    A caller with no group set finds no siblings (participates in no
+    discovery, per #432) rather than erroring.
+
+    Returns:
+        List of ``{id, group, metadata}`` dicts for every OTHER terminal
+        whose group shares the resolved prefix.
+    """
+    caller_group = get_terminal_group(caller_id)
+    if not caller_group:
+        return []
+    max_depth = len(caller_group)
+    effective_depth = max_depth if depth is None else depth
+    effective_depth = max(1, min(effective_depth, max_depth))
+    prefix = caller_group[:effective_depth]
+    return list_siblings_by_group_prefix(caller_id, prefix)
 
 
 def get_working_directory(terminal_id: str) -> Optional[str]:

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -1006,6 +1006,11 @@ def update_group(terminal_id: str, group: Optional[List[str]]) -> bool:
 def update_metadata(terminal_id: str, metadata: Optional[Dict[str, Any]]) -> bool:
     """Replace a terminal's free-form metadata dict.
 
+    Whole-dict replace, not a merge: concurrent calls are last-write-wins
+    (tedswinyar, PR #433 review). Acceptable for this field -- callers should
+    re-send the full intended dict each time rather than assuming a partial
+    update accumulates on top of a prior one.
+
     Returns:
         False if the terminal does not exist, True otherwise.
     """
@@ -1026,8 +1031,15 @@ def list_siblings(caller_id: str, depth: Optional[int] = None) -> List[Dict[str,
     discovery, per #432) rather than erroring.
 
     Returns:
-        List of ``{id, group, metadata}`` dicts for every OTHER terminal
-        whose group shares the resolved prefix.
+        List of ``{id, group, metadata, status}`` dicts for every OTHER
+        terminal whose group shares the resolved prefix. ``status`` is a
+        live, point-in-time snapshot (tedswinyar, PR #433 review): a handoff
+        terminal that has COMPLETED can still delete itself between this
+        call returning and a caller's follow-up ``send_message`` to it, so a
+        discovered sibling is never a guarantee it's still reachable --
+        ``status`` lets a caller skip an obviously-finished sibling
+        proactively, but callers should still expect sends to occasionally
+        fail against a sibling that disappeared in that window.
     """
     caller_group = get_terminal_group(caller_id)
     if not caller_group:
@@ -1036,7 +1048,10 @@ def list_siblings(caller_id: str, depth: Optional[int] = None) -> List[Dict[str,
     effective_depth = max_depth if depth is None else depth
     effective_depth = max(1, min(effective_depth, max_depth))
     prefix = caller_group[:effective_depth]
-    return list_siblings_by_group_prefix(caller_id, prefix)
+    siblings = list_siblings_by_group_prefix(caller_id, prefix)
+    for sibling in siblings:
+        sibling["status"] = status_monitor.get_status(sibling["id"]).value
+    return siblings
 
 
 def get_working_directory(terminal_id: str) -> Optional[str]:

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -296,6 +296,8 @@ class TestCreateSession:
             initial_message=None,
             initial_message_orchestration_type=None,
             model=None,
+            group=None,
+            metadata=None,
         )
 
     def test_create_session_passes_explicit_kiro_engine(self, client):

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -1319,3 +1319,210 @@ class TestCrossProviderResolution:
 
             assert response.status_code == 500
             assert "Failed to create terminal" in response.json()["detail"]
+
+
+def _terminal_dict(**overrides: Dict) -> Dict:
+    base = {
+        "id": "abcd1234",
+        "name": "test-window",
+        "provider": "kiro_cli",
+        "session_name": "test-session",
+        "agent_profile": "developer",
+        "caller_id": None,
+        "allowed_tools": None,
+        "shell_command": None,
+        "group": None,
+        "metadata": None,
+        "status": "idle",
+        "last_active": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCreateSessionWithGroupAndMetadata:
+    """#432: POST /sessions accepts group/metadata in the JSON body."""
+
+    def test_group_and_metadata_forwarded_to_session_service(self, client):
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            mock_svc.create_session = AsyncMock(
+                return_value=Terminal(**_terminal_dict(group=["tenant_1", "project_5"]))
+            )
+
+            response = client.post(
+                "/sessions",
+                params={"provider": "kiro_cli", "agent_profile": "developer"},
+                json={"group": ["tenant_1", "project_5"], "metadata": {"task": "bootstrap"}},
+            )
+
+            assert response.status_code == 201
+            assert response.json()["group"] == ["tenant_1", "project_5"]
+            call_kwargs = mock_svc.create_session.call_args.kwargs
+            assert call_kwargs["group"] == ["tenant_1", "project_5"]
+            assert call_kwargs["metadata"] == {"task": "bootstrap"}
+
+    def test_omitted_group_and_metadata_default_to_none(self, client):
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            mock_svc.create_session = AsyncMock(return_value=Terminal(**_terminal_dict()))
+
+            response = client.post(
+                "/sessions",
+                params={"provider": "kiro_cli", "agent_profile": "developer"},
+            )
+
+            assert response.status_code == 201
+            call_kwargs = mock_svc.create_session.call_args.kwargs
+            assert call_kwargs["group"] is None
+            assert call_kwargs["metadata"] is None
+
+
+class TestUpdateTerminalGroupEndpoint:
+    """#432: PATCH /terminals/{id}/group."""
+
+    def test_update_group_success(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(group=["tenant_1", "project_9"])
+
+            response = client.patch(
+                "/terminals/abcd1234/group", json={"group": ["tenant_1", "project_9"]}
+            )
+
+            assert response.status_code == 200
+            assert response.json()["group"] == ["tenant_1", "project_9"]
+            mock_svc.update_group.assert_called_once_with("abcd1234", ["tenant_1", "project_9"])
+
+    def test_update_group_clears_with_empty_list(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(group=None)
+
+            response = client.patch("/terminals/abcd1234/group", json={"group": []})
+
+            assert response.status_code == 200
+            mock_svc.update_group.assert_called_once_with("abcd1234", [])
+
+    def test_update_group_terminal_not_found(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.return_value = False
+
+            response = client.patch(
+                "/terminals/deadbeef/group", json={"group": ["tenant_1"]}
+            )
+
+            assert response.status_code == 404
+
+    def test_update_group_server_error(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.side_effect = Exception("db exploded")
+
+            response = client.patch(
+                "/terminals/abcd1234/group", json={"group": ["tenant_1"]}
+            )
+
+            assert response.status_code == 500
+            assert "Failed to update terminal group" in response.json()["detail"]
+
+
+class TestUpdateTerminalMetadataEndpoint:
+    """#432: PATCH /terminals/{id}/metadata (also called by the update_metadata MCP tool)."""
+
+    def test_update_metadata_success(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_metadata.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(metadata={"task": "writing tests"})
+
+            response = client.patch(
+                "/terminals/abcd1234/metadata", json={"metadata": {"task": "writing tests"}}
+            )
+
+            assert response.status_code == 200
+            assert response.json()["metadata"] == {"task": "writing tests"}
+            mock_svc.update_metadata.assert_called_once_with(
+                "abcd1234", {"task": "writing tests"}
+            )
+
+    def test_update_metadata_terminal_not_found(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_metadata.return_value = False
+
+            response = client.patch(
+                "/terminals/deadbeef/metadata", json={"metadata": {"task": "x"}}
+            )
+
+            assert response.status_code == 404
+
+
+class TestListSiblingsEndpoint:
+    """#432: GET /terminals/{id}/siblings.
+
+    ``terminal_id`` in the URL is the caller's own resolved identity (the MCP
+    ``list_siblings`` tool passes its own CAO_TERMINAL_ID here) -- this
+    endpoint only ever compares against that terminal's own persisted group.
+    """
+
+    def test_list_siblings_success(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.return_value = _terminal_dict(group=["tenant_1"])
+            mock_svc.list_siblings.return_value = [
+                {"id": "sib-1", "group": ["tenant_1"], "metadata": {"task": "x"}}
+            ]
+
+            response = client.get("/terminals/abcd1234/siblings")
+
+            assert response.status_code == 200
+            assert response.json() == [
+                {"id": "sib-1", "group": ["tenant_1"], "metadata": {"task": "x"}}
+            ]
+            mock_svc.list_siblings.assert_called_once_with("abcd1234", depth=None)
+
+    def test_list_siblings_passes_depth_through(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.return_value = _terminal_dict(group=["tenant_1", "project_5"])
+            mock_svc.list_siblings.return_value = []
+
+            response = client.get("/terminals/abcd1234/siblings", params={"depth": 2})
+
+            assert response.status_code == 200
+            mock_svc.list_siblings.assert_called_once_with("abcd1234", depth=2)
+
+    def test_list_siblings_depth_zero_rejected(self, client):
+        """#432: depth can never be 0 (an unscoped, all-terminals query) --
+        rejected at the API boundary rather than silently reinterpreted."""
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.return_value = _terminal_dict(group=["tenant_1"])
+
+            response = client.get("/terminals/abcd1234/siblings", params={"depth": 0})
+
+            assert response.status_code == 422
+            mock_svc.list_siblings.assert_not_called()
+
+    def test_list_siblings_negative_depth_rejected(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.return_value = _terminal_dict(group=["tenant_1"])
+
+            response = client.get("/terminals/abcd1234/siblings", params={"depth": -1})
+
+            assert response.status_code == 422
+            mock_svc.list_siblings.assert_not_called()
+
+    def test_list_siblings_terminal_not_found(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.side_effect = ValueError("Terminal 'deadbeef' not found")
+
+            response = client.get("/terminals/deadbeef/siblings")
+
+            assert response.status_code == 404
+            mock_svc.list_siblings.assert_not_called()
+
+    def test_list_siblings_no_group_returns_empty_not_error(self, client):
+        """A terminal that exists but has no group set finds no siblings --
+        this is a 200 with an empty list, not an error (#432)."""
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.return_value = _terminal_dict(group=None)
+            mock_svc.list_siblings.return_value = []
+
+            response = client.get("/terminals/abcd1234/siblings")
+
+            assert response.status_code == 200
+            assert response.json() == []

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -7,6 +7,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cli_agent_orchestrator.api.main import app
+from cli_agent_orchestrator.constants import (
+    TERMINAL_GROUP_ELEMENT_MAX_LEN,
+    TERMINAL_GROUP_MAX_ELEMENTS,
+    TERMINAL_METADATA_MAX_BYTES,
+)
 from cli_agent_orchestrator.models.terminal import Terminal
 
 
@@ -1569,3 +1574,119 @@ class TestListSiblingsEndpoint:
 
             assert response.status_code == 200
             assert response.json() == []
+
+
+class TestGroupSizeCap:
+    """call-me-ram, PR #433 review: group elements/count are agent-writable
+    (via update_group) and must be capped -- an uncapped array lets a worker
+    grow the terminals.group TEXT column arbitrarily, amplified into every
+    sibling's list_siblings response."""
+
+    def test_group_at_cap_accepted(self, client):
+        group = [f"g{i}" for i in range(TERMINAL_GROUP_MAX_ELEMENTS)]
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(group=group)
+
+            response = client.patch("/terminals/abcd1234/group", json={"group": group})
+
+            assert response.status_code == 200
+            mock_svc.update_group.assert_called_once_with("abcd1234", group)
+
+    def test_group_over_element_count_cap_rejected(self, client):
+        group = [f"g{i}" for i in range(TERMINAL_GROUP_MAX_ELEMENTS + 1)]
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            response = client.patch("/terminals/abcd1234/group", json={"group": group})
+
+            assert response.status_code == 422
+            mock_svc.update_group.assert_not_called()
+
+    def test_group_element_at_length_cap_accepted(self, client):
+        element = "x" * TERMINAL_GROUP_ELEMENT_MAX_LEN
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(group=[element])
+
+            response = client.patch("/terminals/abcd1234/group", json={"group": [element]})
+
+            assert response.status_code == 200
+
+    def test_group_element_over_length_cap_rejected(self, client):
+        element = "x" * (TERMINAL_GROUP_ELEMENT_MAX_LEN + 1)
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            response = client.patch("/terminals/abcd1234/group", json={"group": [element]})
+
+            assert response.status_code == 422
+            mock_svc.update_group.assert_not_called()
+
+    def test_empty_group_not_subject_to_caps(self, client):
+        """Clearing the group ([]/null) must never be rejected by the caps
+        meant for growth, not clearing."""
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(group=None)
+
+            response = client.patch("/terminals/abcd1234/group", json={"group": []})
+
+            assert response.status_code == 200
+
+    def test_create_session_group_over_cap_rejected_with_422(self, client):
+        group = [f"g{i}" for i in range(TERMINAL_GROUP_MAX_ELEMENTS + 1)]
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            response = client.post(
+                "/sessions",
+                params={"provider": "kiro_cli", "agent_profile": "developer"},
+                json={"group": group},
+            )
+
+            assert response.status_code == 422
+            mock_svc.create_session.assert_not_called()
+
+
+class TestMetadataSizeCap:
+    """call-me-ram, PR #433 review: metadata is a raw agent-writable
+    Dict[str, Any] (via update_metadata) and must be capped by encoded
+    bytes, following the WORKFLOW_MAX_SPEC_BYTES precedent."""
+
+    def test_metadata_at_byte_cap_accepted(self, client):
+        # Reserve room for the JSON envelope (quotes, braces, key) so the
+        # encoded dict lands at (not under) the cap.
+        padding = "x" * (TERMINAL_METADATA_MAX_BYTES - len('{"k": ""}'))
+        metadata = {"k": padding}
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_metadata.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(metadata=metadata)
+
+            response = client.patch("/terminals/abcd1234/metadata", json={"metadata": metadata})
+
+            assert response.status_code == 200
+
+    def test_metadata_over_byte_cap_rejected(self, client):
+        padding = "x" * TERMINAL_METADATA_MAX_BYTES
+        metadata = {"k": padding}
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            response = client.patch("/terminals/abcd1234/metadata", json={"metadata": metadata})
+
+            assert response.status_code == 422
+            mock_svc.update_metadata.assert_not_called()
+
+    def test_empty_metadata_not_subject_to_cap(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_metadata.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(metadata=None)
+
+            response = client.patch("/terminals/abcd1234/metadata", json={"metadata": {}})
+
+            assert response.status_code == 200
+
+    def test_create_session_metadata_over_cap_rejected_with_422(self, client):
+        metadata = {"k": "x" * TERMINAL_METADATA_MAX_BYTES}
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            response = client.post(
+                "/sessions",
+                params={"provider": "kiro_cli", "agent_profile": "developer"},
+                json={"metadata": metadata},
+            )
+
+            assert response.status_code == 422
+            mock_svc.create_session.assert_not_called()

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -1411,9 +1411,7 @@ class TestUpdateTerminalGroupEndpoint:
         with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
             mock_svc.update_group.return_value = False
 
-            response = client.patch(
-                "/terminals/deadbeef/group", json={"group": ["tenant_1"]}
-            )
+            response = client.patch("/terminals/deadbeef/group", json={"group": ["tenant_1"]})
 
             assert response.status_code == 404
 
@@ -1421,9 +1419,7 @@ class TestUpdateTerminalGroupEndpoint:
         with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
             mock_svc.update_group.side_effect = Exception("db exploded")
 
-            response = client.patch(
-                "/terminals/abcd1234/group", json={"group": ["tenant_1"]}
-            )
+            response = client.patch("/terminals/abcd1234/group", json={"group": ["tenant_1"]})
 
             assert response.status_code == 500
             assert "Failed to update terminal group" in response.json()["detail"]
@@ -1466,9 +1462,7 @@ class TestUpdateTerminalMetadataEndpoint:
 
             assert response.status_code == 200
             assert response.json()["metadata"] == {"task": "writing tests"}
-            mock_svc.update_metadata.assert_called_once_with(
-                "abcd1234", {"task": "writing tests"}
-            )
+            mock_svc.update_metadata.assert_called_once_with("abcd1234", {"task": "writing tests"})
 
     def test_update_metadata_terminal_not_found(self, client):
         with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
@@ -1522,7 +1516,9 @@ class TestListSiblingsEndpoint:
             assert response.json() == [
                 {"id": "sib-1", "group": ["tenant_1"], "metadata": {"task": "x"}}
             ]
-            mock_svc.list_siblings.assert_called_once_with("abcd1234", depth=None)
+            mock_svc.list_siblings.assert_called_once_with(
+                "abcd1234", depth=None, cross_session=False
+            )
 
     def test_list_siblings_passes_depth_through(self, client):
         with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
@@ -1532,7 +1528,31 @@ class TestListSiblingsEndpoint:
             response = client.get("/terminals/abcd1234/siblings", params={"depth": 2})
 
             assert response.status_code == 200
-            mock_svc.list_siblings.assert_called_once_with("abcd1234", depth=2)
+            mock_svc.list_siblings.assert_called_once_with("abcd1234", depth=2, cross_session=False)
+
+    def test_list_siblings_cross_session_defaults_to_false(self, client):
+        """Issue #432 design discussion: session-scoped by default."""
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.return_value = _terminal_dict(group=["tenant_1"])
+            mock_svc.list_siblings.return_value = []
+
+            client.get("/terminals/abcd1234/siblings")
+
+            mock_svc.list_siblings.assert_called_once_with(
+                "abcd1234", depth=None, cross_session=False
+            )
+
+    def test_list_siblings_cross_session_true_is_forwarded(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_terminal.return_value = _terminal_dict(group=["tenant_1"])
+            mock_svc.list_siblings.return_value = []
+
+            response = client.get("/terminals/abcd1234/siblings", params={"cross_session": "true"})
+
+            assert response.status_code == 200
+            mock_svc.list_siblings.assert_called_once_with(
+                "abcd1234", depth=None, cross_session=True
+            )
 
     def test_list_siblings_depth_zero_rejected(self, client):
         """#432: depth can never be 0 (an unscoped, all-terminals query) --

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -1423,6 +1423,29 @@ class TestUpdateTerminalGroupEndpoint:
             assert response.status_code == 500
             assert "Failed to update terminal group" in response.json()["detail"]
 
+    def test_update_group_omitted_field_rejected_not_treated_as_clear(self, client):
+        """Copilot review, PR #433: an omitted ``group`` field must be
+        rejected (422) rather than silently treated the same as an explicit
+        ``null`` (which clears the group) -- a partial/empty body must never
+        accidentally clear data."""
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            response = client.patch("/terminals/abcd1234/group", json={})
+
+            assert response.status_code == 422
+            mock_svc.update_group.assert_not_called()
+
+    def test_update_group_explicit_null_still_clears(self, client):
+        """The omitted-field fix must not break the pre-existing explicit-null
+        clearing path."""
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_group.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(group=None)
+
+            response = client.patch("/terminals/abcd1234/group", json={"group": None})
+
+            assert response.status_code == 200
+            mock_svc.update_group.assert_called_once_with("abcd1234", None)
+
 
 class TestUpdateTerminalMetadataEndpoint:
     """#432: PATCH /terminals/{id}/metadata (also called by the update_metadata MCP tool)."""
@@ -1451,6 +1474,26 @@ class TestUpdateTerminalMetadataEndpoint:
             )
 
             assert response.status_code == 404
+
+    def test_update_metadata_omitted_field_rejected_not_treated_as_clear(self, client):
+        """Copilot review, PR #433: same omitted-vs-null fix as ``group`` --
+        an omitted ``metadata`` field must be rejected (422), not silently
+        treated as an explicit clearing ``null``."""
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            response = client.patch("/terminals/abcd1234/metadata", json={})
+
+            assert response.status_code == 422
+            mock_svc.update_metadata.assert_not_called()
+
+    def test_update_metadata_explicit_null_still_clears(self, client):
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.update_metadata.return_value = True
+            mock_svc.get_terminal.return_value = _terminal_dict(metadata=None)
+
+            response = client.patch("/terminals/abcd1234/metadata", json={"metadata": None})
+
+            assert response.status_code == 200
+            mock_svc.update_metadata.assert_called_once_with("abcd1234", None)
 
 
 class TestListSiblingsEndpoint:

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -369,6 +369,27 @@ class TestGroupAndMetadata:
         assert added_terminal.metadata_json is None
 
     @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_create_terminal_explicit_empty_group_and_metadata_normalized_to_none(
+        self, mock_session_class
+    ):
+        """Self-ROAST finding: an explicit empty container (group=[], metadata={},
+        as opposed to omitted/None) is stored as NULL -- the return dict must echo
+        that same normalized None, not the raw [] / {} the caller passed in, or a
+        create_terminal() response would disagree with an immediately-following
+        get_terminal_metadata()/GET /terminals/{id} on the same row."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session_class.return_value = mock_session
+
+        result = create_terminal(
+            "test123", "cao-session", "window-0", "kiro_cli", "developer", group=[], metadata={}
+        )
+
+        assert result["group"] is None
+        assert result["metadata"] is None
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
     def test_get_terminal_metadata_decodes_group_and_metadata(self, mock_session_class):
         mock_session = MagicMock()
         mock_session.__enter__ = MagicMock(return_value=mock_session)
@@ -1130,6 +1151,67 @@ class TestTerminalsSchemaMigration:
             columns = [row[1] for row in conn.execute("PRAGMA table_info(terminals)")]
         assert columns.count("caller_id") == 1
         assert columns.count("allowed_tools") == 1
+
+    def test_group_and_metadata_columns_added_to_legacy_table(self, tmp_path, monkeypatch):
+        """#432: a pre-existing terminals table (predating group/metadata) gains both
+        columns, and existing rows get NULL rather than erroring."""
+        import sqlite3
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        db_file = tmp_path / "pre432.db"
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "CREATE TABLE terminals ("
+                "id TEXT PRIMARY KEY, tmux_session TEXT NOT NULL, "
+                "tmux_window TEXT NOT NULL, provider TEXT NOT NULL, "
+                "agent_profile TEXT, allowed_tools TEXT, shell_command TEXT, "
+                "caller_id TEXT, last_active TIMESTAMP)"
+            )
+            conn.execute(
+                "INSERT INTO terminals (id, tmux_session, tmux_window, provider) "
+                "VALUES ('abc12345', 'cao-s', 'w-0', 'kiro_cli')"
+            )
+            conn.commit()
+
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+
+        db_mod._migrate_terminals_schema()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(terminals)")}
+            rows = conn.execute("SELECT id, \"group\", \"metadata\" FROM terminals").fetchall()
+        assert {"group", "metadata"} <= columns
+        assert rows == [("abc12345", None, None)]
+
+    def test_group_and_metadata_migration_is_idempotent(self, tmp_path, monkeypatch):
+        """Running the migration twice must not fail or duplicate the new columns."""
+        import sqlite3
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        db_file = tmp_path / "pre432_twice.db"
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "CREATE TABLE terminals ("
+                "id TEXT PRIMARY KEY, tmux_session TEXT NOT NULL, "
+                "tmux_window TEXT NOT NULL, provider TEXT NOT NULL)"
+            )
+            conn.commit()
+
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+
+        db_mod._migrate_terminals_schema()
+        db_mod._migrate_terminals_schema()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            columns = [row[1] for row in conn.execute("PRAGMA table_info(terminals)")]
+        assert columns.count("group") == 1
+        assert columns.count("metadata") == 1
 
 
 class TestCallerIdRoundTrip:

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -791,6 +791,127 @@ class TestListSiblingsByGroupPrefix:
 
         assert [r["id"] for r in result] == ["exact"]
 
+    def test_corrupt_group_json_skipped_not_fatal_to_whole_query(self, test_db, caplog):
+        """tedswinyar, PR #433 review: a row with corrupt JSON in its group
+        column must be logged and skipped, not raise and fail discovery for
+        every OTHER terminal sharing the same prefix."""
+        import logging
+
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="corrupt",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    # Malformed JSON (unterminated array) but still matches the
+                    # SQL LIKE prefilter, so it reaches the Python decode step.
+                    group='["tenant_1", "project_5"',
+                ),
+                TerminalModel(
+                    id="good-1",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5", "folder_1"]',
+                ),
+                TerminalModel(
+                    id="good-2",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5", "folder_2"]',
+                ),
+            ],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.clients.database"):
+            with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+                result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert {r["id"] for r in result} == {"good-1", "good-2"}
+        assert any("corrupt" in record.getMessage() for record in caplog.records)
+
+    def test_corrupt_group_json_decoding_to_non_list_is_also_skipped(self, test_db, caplog):
+        """Well-formed JSON that decodes to something other than a list (e.g.
+        a stray object) is exactly as unusable for prefix matching as a
+        JSONDecodeError, so it must be treated the same way -- logged and
+        skipped, not crash on the ``sibling_group[:depth]`` slice below.
+
+        This can't happen through the real write path today (both writers
+        always encode a list), so it's reached here by making the decode
+        itself return a dict for the corrupted row -- the same defense
+        that would trigger against a hand-edited DB row.
+        """
+        import json as real_json
+        import logging
+
+        corrupted_group_text = '["tenant_1", "project_5", "onlyme"]'
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="not-a-list",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group=corrupted_group_text,
+                ),
+                TerminalModel(
+                    id="good-1",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                ),
+            ],
+        )
+
+        _orig_loads = real_json.loads
+
+        def fake_loads(text):
+            if text == corrupted_group_text:
+                return {"tenant_1": "project_5"}  # decodes fine, but not a list
+            return _orig_loads(text)
+
+        with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.clients.database"):
+            with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+                with patch("json.loads", side_effect=fake_loads):
+                    result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert [r["id"] for r in result] == ["good-1"]
+        assert any("corrupt" in record.getMessage() for record in caplog.records)
+
+    def test_corrupt_metadata_json_reports_sibling_with_metadata_none(self, test_db, caplog):
+        """A matching sibling with corrupt metadata JSON is still a REAL,
+        discoverable sibling -- only its metadata is unreadable, logged and
+        reported as None rather than dropping the whole sibling."""
+        import logging
+
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="corrupt-metadata",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                    metadata_json="{not valid json",
+                ),
+            ],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.clients.database"):
+            with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+                result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert len(result) == 1
+        assert result[0]["id"] == "corrupt-metadata"
+        assert result[0]["metadata"] is None
+        assert any("corrupt" in record.getMessage() for record in caplog.records)
+
     def test_group_element_with_like_special_characters_matches_literally(self, test_db):
         """Group elements containing SQL LIKE wildcards (``%``, ``_``) must
         be matched as literal text, not interpreted as wildcards, in the SQL
@@ -1316,6 +1437,115 @@ class TestTerminalsSchemaMigration:
 
         db_mod._migrate_terminals_schema()
         db_mod._migrate_terminals_schema()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            columns = [row[1] for row in conn.execute("PRAGMA table_info(terminals)")]
+        assert columns.count("group") == 1
+        assert columns.count("metadata") == 1
+
+    def test_real_production_upgrade_seeded_rows_survive_init_db(self, tmp_path, monkeypatch):
+        """tedswinyar, PR #433 review: every other migration test here starts
+        from an empty database and only checks the resulting schema. This is
+        the actual production-upgrade case -- a DB with SEVERAL pre-#432
+        terminal rows already in it (the shape right after #284's caller_id
+        migration, no group/metadata columns yet) -- exercised through the
+        real ``init_db()`` entry point (not the internal migration helper
+        directly) and read back through the real application read path
+        (``get_terminal_metadata``, not raw SQL), so this proves the whole
+        upgrade a running server actually performs, twice for idempotency.
+        """
+        import sqlite3
+
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from cli_agent_orchestrator.clients import database as db_mod
+
+        db_file = tmp_path / "prod_upgrade.db"
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "CREATE TABLE terminals ("
+                "id TEXT PRIMARY KEY, tmux_session TEXT NOT NULL, "
+                "tmux_window TEXT NOT NULL, provider TEXT NOT NULL, "
+                "agent_profile TEXT, allowed_tools TEXT, shell_command TEXT, "
+                "caller_id TEXT, last_active TIMESTAMP)"
+            )
+            conn.executemany(
+                "INSERT INTO terminals "
+                "(id, tmux_session, tmux_window, provider, agent_profile, "
+                "allowed_tools, shell_command, caller_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (
+                        "aaaa1111",
+                        "cao-sess-1",
+                        "developer-0",
+                        "kiro_cli",
+                        "developer",
+                        '["send_message", "handoff"]',
+                        "bash",
+                        None,
+                    ),
+                    (
+                        "bbbb2222",
+                        "cao-sess-1",
+                        "reviewer-0",
+                        "claude_code",
+                        "reviewer",
+                        None,
+                        None,
+                        "aaaa1111",
+                    ),
+                    (
+                        "cccc3333",
+                        "cao-sess-2",
+                        "developer-1",
+                        "codex",
+                        None,
+                        None,
+                        None,
+                        None,
+                    ),
+                ],
+            )
+            conn.commit()
+
+        # A real server binds `engine`/`SessionLocal` to DATABASE_FILE once at
+        # import time -- point BOTH at the seeded legacy file so init_db()'s
+        # create_all/migrations and the subsequent application-level reads
+        # all operate on the same DB (not the process's real one).
+        new_engine = create_engine(
+            f"sqlite:///{db_file}", connect_args={"check_same_thread": False}
+        )
+        monkeypatch.setattr(db_mod, "engine", new_engine)
+        monkeypatch.setattr(db_mod, "SessionLocal", sessionmaker(bind=new_engine))
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+
+        def assert_seeded_rows_intact():
+            aaaa = db_mod.get_terminal_metadata("aaaa1111")
+            bbbb = db_mod.get_terminal_metadata("bbbb2222")
+            cccc = db_mod.get_terminal_metadata("cccc3333")
+
+            for row in (aaaa, bbbb, cccc):
+                assert row is not None
+                assert row["group"] is None, "pre-migration rows must read group as NULL"
+                assert row["metadata"] is None, "pre-migration rows must read metadata as NULL"
+
+            # Original pre-migration data must survive untouched.
+            assert aaaa["tmux_session"] == "cao-sess-1"
+            assert aaaa["agent_profile"] == "developer"
+            assert aaaa["allowed_tools"] == ["send_message", "handoff"]
+            assert bbbb["caller_id"] == "aaaa1111"
+            assert cccc["provider"] == "codex"
+
+        db_mod.init_db()
+        assert_seeded_rows_intact()
+
+        # Idempotency: a second real init_db() call (e.g. server restart)
+        # must not fail or corrupt the already-migrated rows.
+        db_mod.init_db()
+        assert_seeded_rows_intact()
 
         with sqlite3.connect(str(db_file)) as conn:
             columns = [row[1] for row in conn.execute("PRAGMA table_info(terminals)")]

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -23,16 +23,20 @@ from cli_agent_orchestrator.clients.database import (
     get_flow,
     get_inbox_messages,
     get_pending_messages,
+    get_terminal_group,
     get_terminal_metadata,
     init_db,
     list_flows,
     list_pending_receiver_ids_by_provider,
     list_pending_receiver_ids_older_than,
+    list_siblings_by_group_prefix,
     list_terminals_by_session,
     update_flow_enabled,
     update_flow_run_times,
     update_last_active,
     update_message_status,
+    update_terminal_group,
+    update_terminal_metadata,
     update_terminal_shell_command,
 )
 from cli_agent_orchestrator.models.inbox import MessageStatus
@@ -78,6 +82,8 @@ class TestTerminalOperations:
         mock_terminal.provider = "kiro_cli"
         mock_terminal.agent_profile = "developer"
         mock_terminal.allowed_tools = None
+        mock_terminal.group = None
+        mock_terminal.metadata_json = None
         mock_terminal.last_active = datetime.now()
 
         mock_query = MagicMock()
@@ -89,6 +95,8 @@ class TestTerminalOperations:
 
         assert result is not None
         assert result["id"] == "test123"
+        assert result["group"] is None
+        assert result["metadata"] is None
 
     @patch("cli_agent_orchestrator.clients.database.SessionLocal")
     def test_get_terminal_metadata_not_found(self, mock_session_class):
@@ -316,6 +324,373 @@ class TestTerminalOperations:
         result = delete_terminals_by_session("cao-session")
 
         assert result == 2
+
+
+class TestGroupAndMetadata:
+    """Tests for the #432 group/metadata columns and their CRUD helpers."""
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_create_terminal_persists_group_and_metadata(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session_class.return_value = mock_session
+
+        result = create_terminal(
+            "test123",
+            "cao-session",
+            "window-0",
+            "kiro_cli",
+            "developer",
+            group=["tenant_1", "project_5"],
+            metadata={"task": "reviewing PR"},
+        )
+
+        assert result["group"] == ["tenant_1", "project_5"]
+        assert result["metadata"] == {"task": "reviewing PR"}
+        added_terminal = mock_session.add.call_args[0][0]
+        assert added_terminal.group == '["tenant_1", "project_5"]'
+        assert added_terminal.metadata_json == '{"task": "reviewing PR"}'
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_create_terminal_no_group_or_metadata_stores_null(self, mock_session_class):
+        """Omitting group/metadata must not write the literal string 'null'."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session_class.return_value = mock_session
+
+        result = create_terminal("test123", "cao-session", "window-0", "kiro_cli", "developer")
+
+        assert result["group"] is None
+        assert result["metadata"] is None
+        added_terminal = mock_session.add.call_args[0][0]
+        assert added_terminal.group is None
+        assert added_terminal.metadata_json is None
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_get_terminal_metadata_decodes_group_and_metadata(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_terminal = MagicMock()
+        mock_terminal.id = "test123"
+        mock_terminal.tmux_session = "cao-session"
+        mock_terminal.tmux_window = "window-0"
+        mock_terminal.provider = "kiro_cli"
+        mock_terminal.agent_profile = "developer"
+        mock_terminal.allowed_tools = None
+        mock_terminal.group = '["tenant_1", "project_5"]'
+        mock_terminal.metadata_json = '{"task": "reviewing PR"}'
+        mock_terminal.last_active = datetime.now()
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_terminal
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = get_terminal_metadata("test123")
+
+        assert result["group"] == ["tenant_1", "project_5"]
+        assert result["metadata"] == {"task": "reviewing PR"}
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_update_terminal_group(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_terminal = MagicMock()
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_terminal
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = update_terminal_group("test123", ["tenant_1", "project_9"])
+
+        assert result is True
+        assert mock_terminal.group == '["tenant_1", "project_9"]'
+        mock_session.commit.assert_called_once()
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_update_terminal_group_empty_list_clears(self, mock_session_class):
+        """An empty list clears the group column (opts back out of discovery)."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_terminal = MagicMock()
+        mock_terminal.group = '["stale"]'
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_terminal
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = update_terminal_group("test123", [])
+
+        assert result is True
+        assert mock_terminal.group is None
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_update_terminal_group_not_found(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = None
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = update_terminal_group("nonexistent", ["a"])
+
+        assert result is False
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_update_terminal_metadata(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_terminal = MagicMock()
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_terminal
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = update_terminal_metadata("test123", {"task": "writing tests"})
+
+        assert result is True
+        assert mock_terminal.metadata_json == '{"task": "writing tests"}'
+        mock_session.commit.assert_called_once()
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_update_terminal_metadata_not_found(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = None
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        result = update_terminal_metadata("nonexistent", {"task": "x"})
+
+        assert result is False
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_get_terminal_group_returns_decoded_list(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_terminal = MagicMock()
+        mock_terminal.group = '["tenant_1", "project_5"]'
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_terminal
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        assert get_terminal_group("test123") == ["tenant_1", "project_5"]
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_get_terminal_group_none_when_unset(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_terminal = MagicMock()
+        mock_terminal.group = None
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_terminal
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        assert get_terminal_group("test123") is None
+
+    @patch("cli_agent_orchestrator.clients.database.SessionLocal")
+    def test_get_terminal_group_none_when_terminal_missing(self, mock_session_class):
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = None
+        mock_session.query.return_value = mock_query
+        mock_session_class.return_value = mock_session
+
+        assert get_terminal_group("nonexistent") is None
+
+
+class TestListSiblingsByGroupPrefix:
+    """Real-DB regression tests for the #432 sibling-discovery prefix match.
+
+    Uses the in-memory-sqlite ``test_db`` fixture (not a mocked session) so
+    the actual JSON decode + prefix comparison across multiple rows is
+    exercised, not just the query-building calls.
+    """
+
+    def _seed(self, test_db, terminals):
+        with test_db() as seed:
+            seed.add_all(terminals)
+            seed.commit()
+
+    def test_matching_siblings_returned_with_group_and_metadata(self, test_db):
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="sib-1",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5", "folder_1"]',
+                    metadata_json='{"task": "reviewing"}',
+                ),
+                TerminalModel(
+                    id="sib-2",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5", "folder_2"]',
+                ),
+                TerminalModel(
+                    id="other-tenant",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_2", "project_5", "folder_1"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        ids = {r["id"] for r in result}
+        assert ids == {"sib-1", "sib-2"}
+        by_id = {r["id"]: r for r in result}
+        assert by_id["sib-1"]["group"] == ["tenant_1", "project_5", "folder_1"]
+        assert by_id["sib-1"]["metadata"] == {"task": "reviewing"}
+        assert by_id["sib-2"]["metadata"] is None
+
+    def test_caller_excluded_from_its_own_results(self, test_db):
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="caller-1",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                ),
+                TerminalModel(
+                    id="sib-1",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert {r["id"] for r in result} == {"sib-1"}
+
+    def test_shorter_sibling_group_excluded_not_partially_matched(self, test_db):
+        """A sibling whose group is shorter than the requested depth is
+        excluded rather than compared partially or raising an IndexError
+        (#432's own documented edge case)."""
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="shallow",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert result == []
+
+    def test_longer_sibling_group_matches_on_shared_prefix(self, test_db):
+        """A sibling with a LONGER group than the requested depth still
+        matches as long as its leading elements agree."""
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="deep",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5", "folder_9", "subtask_2"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert [r["id"] for r in result] == ["deep"]
+
+    def test_no_group_terminal_excluded_from_being_found(self, test_db):
+        """A terminal with no group set is never returned as a sibling to
+        anyone, regardless of what prefix is requested."""
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="no-group",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group=None,
+                ),
+                TerminalModel(
+                    id="has-group",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1"])
+
+        assert [r["id"] for r in result] == ["has-group"]
+
+    def test_no_matching_prefix_returns_empty(self, test_db):
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="unrelated",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_9", "project_1"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert result == []
 
 
 class TestInboxOperations:

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -713,6 +713,115 @@ class TestListSiblingsByGroupPrefix:
 
         assert result == []
 
+    def test_sql_prefilter_narrows_rows_before_python_decode(self, test_db):
+        """Copilot review, PR #433: prove the SQL query itself narrows the
+        candidate set, not just that the final (correct) results happen to
+        match -- i.e. this is no longer a full-table scan + Python filter.
+
+        ``json.loads`` is only ever called (inside the function) on
+        ``row.group`` for rows the DB query actually returned, so its call
+        count is a direct proxy for how many rows were pulled into Python
+        for decoding. 5 non-matching siblings (different top-level tenant)
+        plus 1 matching one are seeded -- a full scan would decode all 6; a
+        working SQL prefilter decodes only the 1 that can possibly match.
+        """
+        import json as real_json
+
+        non_matching = [
+            TerminalModel(
+                id=f"other-tenant-{i}",
+                tmux_session="s",
+                tmux_window="w",
+                provider="kiro_cli",
+                group=f'["tenant_{i}", "project_5"]',
+            )
+            for i in range(2, 7)
+        ]
+        self._seed(
+            test_db,
+            non_matching
+            + [
+                TerminalModel(
+                    id="sib-1",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5", "folder_1"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            with patch("json.loads", wraps=real_json.loads) as mock_loads:
+                result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert [r["id"] for r in result] == ["sib-1"]
+        # Only the 1 matching row should ever reach json.loads -- proof the
+        # other 5 were excluded at the SQL level, never loaded for decoding.
+        assert mock_loads.call_count == 1
+
+    def test_element_text_prefix_does_not_false_positive_match(self, test_db):
+        """A sibling group element that merely shares a *text* prefix with a
+        requested prefix element (e.g. "project_50" vs. requested
+        "project_5") must not match -- the SQL LIKE prefilter operates on
+        the JSON encoding, where each string element is quote-delimited, so
+        this can't false-positive."""
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="near-miss",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_50"]',
+                ),
+                TerminalModel(
+                    id="exact",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5", "folder_1"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1", "project_5"])
+
+        assert [r["id"] for r in result] == ["exact"]
+
+    def test_group_element_with_like_special_characters_matches_literally(self, test_db):
+        """Group elements containing SQL LIKE wildcards (``%``, ``_``) must
+        be matched as literal text, not interpreted as wildcards, in the SQL
+        prefilter (autoescape)."""
+        import json as real_json
+
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="literal-match",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group=real_json.dumps(["50%_off", "folder_1"]),
+                ),
+                TerminalModel(
+                    id="unrelated",
+                    tmux_session="s",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group=real_json.dumps(["completely_different", "folder_1"]),
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["50%_off"])
+
+        assert [r["id"] for r in result] == ["literal-match"]
+
 
 class TestInboxOperations:
     """Tests for inbox database operations."""

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -943,6 +943,103 @@ class TestListSiblingsByGroupPrefix:
 
         assert [r["id"] for r in result] == ["literal-match"]
 
+    def test_session_scoped_by_default_excludes_other_sessions(self, test_db):
+        """Issue #432 design discussion (tedswinyar + klabulan, 2026-07-17/18):
+        sibling discovery is session-scoped by default -- two terminals in
+        DIFFERENT tmux sessions that happen to share a group prefix (a
+        naming collision, a copy-pasted template, two features reusing the
+        same tenant/project id) must NOT discover each other unless
+        cross_session=True is explicitly passed."""
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="same-session-sibling",
+                    tmux_session="cao-session-a",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                ),
+                TerminalModel(
+                    id="other-session-sibling",
+                    tmux_session="cao-session-b",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix(
+                "caller-1", ["tenant_1", "project_5"], caller_session="cao-session-a"
+            )
+
+        assert [r["id"] for r in result] == ["same-session-sibling"]
+
+    def test_cross_session_true_includes_other_sessions(self, test_db):
+        """cross_session=True is the explicit opt-in that restores the
+        previous (pre-#432-discussion) server-wide behavior."""
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="same-session-sibling",
+                    tmux_session="cao-session-a",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                ),
+                TerminalModel(
+                    id="other-session-sibling",
+                    tmux_session="cao-session-b",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1", "project_5"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix(
+                "caller-1",
+                ["tenant_1", "project_5"],
+                caller_session="cao-session-a",
+                cross_session=True,
+            )
+
+        assert {r["id"] for r in result} == {"same-session-sibling", "other-session-sibling"}
+
+    def test_no_caller_session_provided_does_not_filter_by_session(self, test_db):
+        """Backward-compatible default: omitting caller_session entirely
+        (the pre-existing call shape every other test in this class uses)
+        applies no session filter at all, rather than matching only
+        terminals with a null/empty session."""
+        self._seed(
+            test_db,
+            [
+                TerminalModel(
+                    id="session-a-sibling",
+                    tmux_session="cao-session-a",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1"]',
+                ),
+                TerminalModel(
+                    id="session-b-sibling",
+                    tmux_session="cao-session-b",
+                    tmux_window="w",
+                    provider="kiro_cli",
+                    group='["tenant_1"]',
+                ),
+            ],
+        )
+
+        with patch("cli_agent_orchestrator.clients.database.SessionLocal", test_db):
+            result = list_siblings_by_group_prefix("caller-1", ["tenant_1"])
+
+        assert {r["id"] for r in result} == {"session-a-sibling", "session-b-sibling"}
+
 
 class TestInboxOperations:
     """Tests for inbox database operations."""
@@ -1412,7 +1509,7 @@ class TestTerminalsSchemaMigration:
 
         with sqlite3.connect(str(db_file)) as conn:
             columns = {row[1] for row in conn.execute("PRAGMA table_info(terminals)")}
-            rows = conn.execute("SELECT id, \"group\", \"metadata\" FROM terminals").fetchall()
+            rows = conn.execute('SELECT id, "group", "metadata" FROM terminals').fetchall()
         assert {"group", "metadata"} <= columns
         assert rows == [("abc12345", None, None)]
 

--- a/test/mcp_server/test_list_siblings_and_metadata.py
+++ b/test/mcp_server/test_list_siblings_and_metadata.py
@@ -1,0 +1,140 @@
+"""Tests for the #432 list_siblings and update_metadata MCP tools."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from cli_agent_orchestrator.mcp_server.server import (
+    _list_siblings_impl,
+    _mcp_timeout,
+    _update_metadata_impl,
+)
+
+
+class TestListSiblingsImpl:
+    """Tests for the _list_siblings_impl helper."""
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_resolves_own_identity_from_env_not_an_argument(self, mock_get):
+        """The tool takes no 'who am I' argument -- identity comes solely
+        from this process's own CAO_TERMINAL_ID env var (#432)."""
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = [{"id": "sib-1", "group": ["t1"], "metadata": None}]
+        mock_get.return_value = response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            result = _list_siblings_impl(None)
+
+        assert result == {
+            "success": True,
+            "siblings": [{"id": "sib-1", "group": ["t1"], "metadata": None}],
+        }
+        mock_get.assert_called_once_with(
+            "http://127.0.0.1:9889/terminals/caller-abc/siblings",
+            params={},
+            timeout=_mcp_timeout(),
+        )
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_depth_forwarded_when_provided(self, mock_get):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = []
+        mock_get.return_value = response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            _list_siblings_impl(2)
+
+        mock_get.assert_called_once_with(
+            "http://127.0.0.1:9889/terminals/caller-abc/siblings",
+            params={"depth": 2},
+            timeout=_mcp_timeout(),
+        )
+
+    def test_no_terminal_id_returns_error_without_network_call(self):
+        """Outside a CAO terminal (no CAO_TERMINAL_ID) the tool must fail
+        fast with a clear error, not attempt to call the API with no
+        identity to scope the query to."""
+        with patch("cli_agent_orchestrator.mcp_server.server.requests.get") as mock_get:
+            with patch.dict(os.environ, {}, clear=True):
+                result = _list_siblings_impl(None)
+
+            assert result["success"] is False
+            assert "CAO_TERMINAL_ID not set" in result["error"]
+            mock_get.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_depth_zero_rejection_surfaces_server_detail(self, mock_get):
+        """The server rejects depth=0 with a 422; the tool should surface
+        that detail rather than swallowing it."""
+        response = MagicMock()
+        response.json.return_value = {"detail": "depth must be >= 1"}
+        http_error = requests.HTTPError("422 Client Error")
+        http_error.response = response
+        response.raise_for_status.side_effect = http_error
+        mock_get.return_value = response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            result = _list_siblings_impl(0)
+
+        assert result["success"] is False
+        assert "depth must be >= 1" in result["error"]
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_connection_error_returns_structured_error(self, mock_get):
+        mock_get.side_effect = requests.ConnectionError("boom")
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            result = _list_siblings_impl(None)
+
+        assert result["success"] is False
+        assert "Failed to list siblings" in result["error"]
+
+
+class TestUpdateMetadataImpl:
+    """Tests for the _update_metadata_impl helper."""
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.patch")
+    def test_resolves_own_identity_and_replaces_metadata(self, mock_patch):
+        """The tool takes no target terminal id argument -- it can only ever
+        update ITS OWN metadata, resolved from CAO_TERMINAL_ID (#432)."""
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"metadata": {"task": "reviewing PR"}}
+        mock_patch.return_value = response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            result = _update_metadata_impl({"task": "reviewing PR"})
+
+        assert result == {"success": True, "metadata": {"task": "reviewing PR"}}
+        mock_patch.assert_called_once_with(
+            "http://127.0.0.1:9889/terminals/caller-abc/metadata",
+            json={"metadata": {"task": "reviewing PR"}},
+            timeout=_mcp_timeout(),
+        )
+
+    def test_no_terminal_id_returns_error_without_network_call(self):
+        with patch("cli_agent_orchestrator.mcp_server.server.requests.patch") as mock_patch:
+            with patch.dict(os.environ, {}, clear=True):
+                result = _update_metadata_impl({"task": "x"})
+
+            assert result["success"] is False
+            assert "CAO_TERMINAL_ID not set" in result["error"]
+            mock_patch.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.patch")
+    def test_http_error_surfaces_server_detail(self, mock_patch):
+        response = MagicMock()
+        response.json.return_value = {"detail": "Terminal 'caller-abc' not found"}
+        http_error = requests.HTTPError("404 Client Error")
+        http_error.response = response
+        response.raise_for_status.side_effect = http_error
+        mock_patch.return_value = response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            result = _update_metadata_impl({"task": "x"})
+
+        assert result["success"] is False
+        assert "Terminal 'caller-abc' not found" in result["error"]

--- a/test/mcp_server/test_list_siblings_and_metadata.py
+++ b/test/mcp_server/test_list_siblings_and_metadata.py
@@ -8,15 +8,27 @@ import requests
 from cli_agent_orchestrator.mcp_server.server import (
     _list_siblings_impl,
     _mcp_timeout,
+    _require_discovery_marker,
     _update_metadata_impl,
+)
+
+# Every test below that isn't specifically exercising the discovery-marker
+# gate itself (see TestRequireDiscoveryMarker /
+# TestDiscoveryMarkerEnforcementInImpls) patches it out to a permissive
+# no-op, so the pre-existing requests.get/patch assertions keep testing
+# exactly what they tested before that gate was added (#432 design
+# discussion, issue #432 comment thread, 2026-07-17/18).
+_PERMISSIVE_MARKER = patch(
+    "cli_agent_orchestrator.mcp_server.server._require_discovery_marker", return_value=None
 )
 
 
 class TestListSiblingsImpl:
     """Tests for the _list_siblings_impl helper."""
 
+    @_PERMISSIVE_MARKER
     @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
-    def test_resolves_own_identity_from_env_not_an_argument(self, mock_get):
+    def test_resolves_own_identity_from_env_not_an_argument(self, mock_get, mock_marker):
         """The tool takes no 'who am I' argument -- identity comes solely
         from this process's own CAO_TERMINAL_ID env var (#432)."""
         response = MagicMock()
@@ -37,8 +49,9 @@ class TestListSiblingsImpl:
             timeout=_mcp_timeout(),
         )
 
+    @_PERMISSIVE_MARKER
     @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
-    def test_depth_forwarded_when_provided(self, mock_get):
+    def test_depth_forwarded_when_provided(self, mock_get, mock_marker):
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = []
@@ -50,6 +63,43 @@ class TestListSiblingsImpl:
         mock_get.assert_called_once_with(
             "http://127.0.0.1:9889/terminals/caller-abc/siblings",
             params={"depth": 2},
+            timeout=_mcp_timeout(),
+        )
+
+    @_PERMISSIVE_MARKER
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_cross_session_true_forwarded_as_query_param(self, mock_get, mock_marker):
+        """cross_session=True (issue #432 design discussion) must reach the
+        REST endpoint as a query param -- the default (False) sends no
+        param at all, matching the depth-omitted shape above."""
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = []
+        mock_get.return_value = response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            _list_siblings_impl(None, cross_session=True)
+
+        mock_get.assert_called_once_with(
+            "http://127.0.0.1:9889/terminals/caller-abc/siblings",
+            params={"cross_session": "true"},
+            timeout=_mcp_timeout(),
+        )
+
+    @_PERMISSIVE_MARKER
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_cross_session_false_omits_the_param(self, mock_get, mock_marker):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = []
+        mock_get.return_value = response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            _list_siblings_impl(None, cross_session=False)
+
+        mock_get.assert_called_once_with(
+            "http://127.0.0.1:9889/terminals/caller-abc/siblings",
+            params={},
             timeout=_mcp_timeout(),
         )
 
@@ -65,8 +115,9 @@ class TestListSiblingsImpl:
             assert "CAO_TERMINAL_ID not set" in result["error"]
             mock_get.assert_not_called()
 
+    @_PERMISSIVE_MARKER
     @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
-    def test_depth_zero_rejection_surfaces_server_detail(self, mock_get):
+    def test_depth_zero_rejection_surfaces_server_detail(self, mock_get, mock_marker):
         """The server rejects depth=0 with a 422; the tool should surface
         that detail rather than swallowing it."""
         response = MagicMock()
@@ -82,8 +133,9 @@ class TestListSiblingsImpl:
         assert result["success"] is False
         assert "depth must be >= 1" in result["error"]
 
+    @_PERMISSIVE_MARKER
     @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
-    def test_connection_error_returns_structured_error(self, mock_get):
+    def test_connection_error_returns_structured_error(self, mock_get, mock_marker):
         mock_get.side_effect = requests.ConnectionError("boom")
 
         with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
@@ -96,8 +148,9 @@ class TestListSiblingsImpl:
 class TestUpdateMetadataImpl:
     """Tests for the _update_metadata_impl helper."""
 
+    @_PERMISSIVE_MARKER
     @patch("cli_agent_orchestrator.mcp_server.server.requests.patch")
-    def test_resolves_own_identity_and_replaces_metadata(self, mock_patch):
+    def test_resolves_own_identity_and_replaces_metadata(self, mock_patch, mock_marker):
         """The tool takes no target terminal id argument -- it can only ever
         update ITS OWN metadata, resolved from CAO_TERMINAL_ID (#432)."""
         response = MagicMock()
@@ -124,8 +177,9 @@ class TestUpdateMetadataImpl:
             assert "CAO_TERMINAL_ID not set" in result["error"]
             mock_patch.assert_not_called()
 
+    @_PERMISSIVE_MARKER
     @patch("cli_agent_orchestrator.mcp_server.server.requests.patch")
-    def test_http_error_surfaces_server_detail(self, mock_patch):
+    def test_http_error_surfaces_server_detail(self, mock_patch, mock_marker):
         response = MagicMock()
         response.json.return_value = {"detail": "Terminal 'caller-abc' not found"}
         http_error = requests.HTTPError("404 Client Error")
@@ -138,3 +192,103 @@ class TestUpdateMetadataImpl:
 
         assert result["success"] is False
         assert "Terminal 'caller-abc' not found" in result["error"]
+
+
+class TestRequireDiscoveryMarker:
+    """Tests for _require_discovery_marker, the opt-in gate for sibling
+    discovery tools (issue #432 design discussion, tedswinyar + klabulan,
+    2026-07-17/18: a separate opt-in marker rather than bundling discovery
+    into @cao-mcp-server's all-or-nothing grant)."""
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_granted_when_discovery_in_allowed_tools(self, mock_get):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"allowed_tools": ["@cao-mcp-server", "discovery"]}
+        mock_get.return_value = response
+
+        result = _require_discovery_marker("caller-abc", "list siblings")
+
+        assert result is None
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_denied_when_orchestration_granted_but_not_discovery(self, mock_get):
+        """The exact scenario the design discussion was about: a profile
+        with orchestration tools (@cao-mcp-server) but NOT discovery must be
+        denied -- discovery is not implied by having handoff/assign/
+        send_message."""
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"allowed_tools": ["@cao-mcp-server", "fs_read"]}
+        mock_get.return_value = response
+
+        result = _require_discovery_marker("caller-abc", "list siblings")
+
+        assert result is not None
+        assert result["success"] is False
+        assert "discovery" in result["error"]
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_granted_when_unrestricted_wildcard(self, mock_get):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"allowed_tools": ["*"]}
+        mock_get.return_value = response
+
+        assert _require_discovery_marker("caller-abc", "list siblings") is None
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_granted_when_allowed_tools_is_none(self, mock_get):
+        """allowed_tools=None (no role/allowedTools resolved at all) means
+        unrestricted, matching resolve_allowed_tools' own semantics
+        elsewhere in this codebase -- not a denial."""
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"allowed_tools": None}
+        mock_get.return_value = response
+
+        assert _require_discovery_marker("caller-abc", "list siblings") is None
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_fails_closed_on_lookup_error(self, mock_get):
+        """An unresolvable allowed_tools lookup (network error, non-200,
+        etc.) must deny rather than silently grant -- fail-closed, same
+        posture as _own_terminal_id_or_error."""
+        mock_get.side_effect = requests.ConnectionError("boom")
+
+        result = _require_discovery_marker("caller-abc", "list siblings")
+
+        assert result is not None
+        assert result["success"] is False
+
+
+class TestDiscoveryMarkerEnforcementInImpls:
+    """Confirms _list_siblings_impl/_update_metadata_impl actually call the
+    gate and short-circuit on denial, rather than the gate existing but
+    never being wired in."""
+
+    @patch("cli_agent_orchestrator.mcp_server.server._require_discovery_marker")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.get")
+    def test_list_siblings_denied_without_calling_siblings_endpoint(self, mock_get, mock_marker):
+        mock_marker.return_value = {"success": False, "error": "not granted 'discovery'"}
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            result = _list_siblings_impl(None)
+
+        assert result == {"success": False, "error": "not granted 'discovery'"}
+        # The marker check itself uses requests.get for /terminals/{id}; the
+        # siblings-list GET must never additionally fire once denied.
+        mock_get.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server._require_discovery_marker")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests.patch")
+    def test_update_metadata_denied_without_calling_metadata_endpoint(
+        self, mock_patch, mock_marker
+    ):
+        mock_marker.return_value = {"success": False, "error": "not granted 'discovery'"}
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "caller-abc"}):
+            result = _update_metadata_impl({"task": "x"})
+
+        assert result == {"success": False, "error": "not granted 'discovery'"}
+        mock_patch.assert_not_called()

--- a/test/services/test_terminal_service.py
+++ b/test/services/test_terminal_service.py
@@ -7,6 +7,7 @@ import pytest
 from cli_agent_orchestrator.services.terminal_service import (
     exit_terminal_cli,
     get_working_directory,
+    list_siblings,
     send_special_key,
 )
 
@@ -271,3 +272,100 @@ class TestExitTerminalCli:
         mock_pm.get_provider.return_value = None
         with pytest.raises(ValueError, match="Provider not found"):
             exit_terminal_cli("deadbeef")
+
+
+class TestListSiblingsDepthClamping:
+    """#432: list_siblings() must clamp depth to [1, len(caller_group)] and
+    never let a caller widen its own discovery scope.
+
+    ``get_terminal_group``/``list_siblings_by_group_prefix`` are mocked so
+    these tests isolate the clamping arithmetic itself (the actual prefix
+    match is covered by the real-DB tests in
+    test/clients/test_database.py::TestListSiblingsByGroupPrefix).
+    """
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_caller_with_no_group_returns_empty_without_querying(
+        self, mock_get_group, mock_list_prefix
+    ):
+        """A caller with no group participates in no discovery (#432) --
+        must short-circuit before ever calling the prefix-match query."""
+        mock_get_group.return_value = None
+
+        result = list_siblings("caller-1", depth=2)
+
+        assert result == []
+        mock_list_prefix.assert_not_called()
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_depth_none_defaults_to_full_own_group_length(self, mock_get_group, mock_list_prefix):
+        """Omitting depth means the widest scope the caller is allowed: its
+        own full group."""
+        mock_get_group.return_value = ["tenant_1", "project_5", "folder_9"]
+        mock_list_prefix.return_value = []
+
+        list_siblings("caller-1", depth=None)
+
+        mock_list_prefix.assert_called_once_with(
+            "caller-1", ["tenant_1", "project_5", "folder_9"]
+        )
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_depth_wider_than_own_group_is_clamped_down(self, mock_get_group, mock_list_prefix):
+        """depth can never exceed len(caller_group) -- a caller cannot widen
+        its own scope by asking for more than it has (#432)."""
+        mock_get_group.return_value = ["tenant_1", "project_5"]
+        mock_list_prefix.return_value = []
+
+        list_siblings("caller-1", depth=99)
+
+        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1", "project_5"])
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_depth_within_range_uses_exact_prefix(self, mock_get_group, mock_list_prefix):
+        mock_get_group.return_value = ["tenant_1", "project_5", "folder_9"]
+        mock_list_prefix.return_value = []
+
+        list_siblings("caller-1", depth=2)
+
+        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1", "project_5"])
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_depth_zero_is_clamped_up_to_one_defense_in_depth(
+        self, mock_get_group, mock_list_prefix
+    ):
+        """The API layer rejects depth=0 outright (422, see test_terminals.py).
+        This asserts the service layer ALSO never treats an explicit 0 as an
+        unscoped, all-terminals query if it's ever reached directly --
+        defense in depth, not a documented public entry point for 0."""
+        mock_get_group.return_value = ["tenant_1", "project_5"]
+        mock_list_prefix.return_value = []
+
+        list_siblings("caller-1", depth=0)
+
+        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1"])
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_negative_depth_is_clamped_up_to_one(self, mock_get_group, mock_list_prefix):
+        mock_get_group.return_value = ["tenant_1", "project_5"]
+        mock_list_prefix.return_value = []
+
+        list_siblings("caller-1", depth=-5)
+
+        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1"])
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_returns_prefix_match_results_unchanged(self, mock_get_group, mock_list_prefix):
+        mock_get_group.return_value = ["tenant_1"]
+        mock_list_prefix.return_value = [{"id": "sib-1", "group": ["tenant_1"], "metadata": None}]
+
+        result = list_siblings("caller-1", depth=1)
+
+        assert result == [{"id": "sib-1", "group": ["tenant_1"], "metadata": None}]

--- a/test/services/test_terminal_service.py
+++ b/test/services/test_terminal_service.py
@@ -360,12 +360,42 @@ class TestListSiblingsDepthClamping:
 
         mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1"])
 
+    @patch(f"{_TS}.status_monitor")
     @patch(f"{_TS}.list_siblings_by_group_prefix")
     @patch(f"{_TS}.get_terminal_group")
-    def test_returns_prefix_match_results_unchanged(self, mock_get_group, mock_list_prefix):
+    def test_returns_prefix_match_results_unchanged(
+        self, mock_get_group, mock_list_prefix, mock_status_monitor
+    ):
         mock_get_group.return_value = ["tenant_1"]
         mock_list_prefix.return_value = [{"id": "sib-1", "group": ["tenant_1"], "metadata": None}]
+        mock_status_monitor.get_status.return_value = MagicMock(value="idle")
 
         result = list_siblings("caller-1", depth=1)
 
-        assert result == [{"id": "sib-1", "group": ["tenant_1"], "metadata": None}]
+        assert result == [
+            {"id": "sib-1", "group": ["tenant_1"], "metadata": None, "status": "idle"}
+        ]
+
+    @patch(f"{_TS}.status_monitor")
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_group")
+    def test_status_is_a_live_snapshot_per_sibling(
+        self, mock_get_group, mock_list_prefix, mock_status_monitor
+    ):
+        """tedswinyar, PR #433 review: siblings include a live status snapshot
+        (point-in-time, not a delivery guarantee -- see the docstring) so a
+        discovering agent can skip an obviously-finished sibling. Each
+        sibling's status is looked up individually, not assumed uniform."""
+        mock_get_group.return_value = ["tenant_1"]
+        mock_list_prefix.return_value = [
+            {"id": "sib-1", "group": ["tenant_1"], "metadata": None},
+            {"id": "sib-2", "group": ["tenant_1"], "metadata": None},
+        ]
+        statuses = {"sib-1": MagicMock(value="completed"), "sib-2": MagicMock(value="idle")}
+        mock_status_monitor.get_status.side_effect = lambda terminal_id: statuses[terminal_id]
+
+        result = list_siblings("caller-1", depth=1)
+
+        assert [s["status"] for s in result] == ["completed", "idle"]
+        mock_status_monitor.get_status.assert_any_call("sib-1")
+        mock_status_monitor.get_status.assert_any_call("sib-2")

--- a/test/services/test_terminal_service.py
+++ b/test/services/test_terminal_service.py
@@ -278,20 +278,20 @@ class TestListSiblingsDepthClamping:
     """#432: list_siblings() must clamp depth to [1, len(caller_group)] and
     never let a caller widen its own discovery scope.
 
-    ``get_terminal_group``/``list_siblings_by_group_prefix`` are mocked so
+    ``get_terminal_metadata``/``list_siblings_by_group_prefix`` are mocked so
     these tests isolate the clamping arithmetic itself (the actual prefix
     match is covered by the real-DB tests in
     test/clients/test_database.py::TestListSiblingsByGroupPrefix).
     """
 
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
+    @patch(f"{_TS}.get_terminal_metadata")
     def test_caller_with_no_group_returns_empty_without_querying(
-        self, mock_get_group, mock_list_prefix
+        self, mock_get_metadata, mock_list_prefix
     ):
         """A caller with no group participates in no discovery (#432) --
         must short-circuit before ever calling the prefix-match query."""
-        mock_get_group.return_value = None
+        mock_get_metadata.return_value = {"group": None, "tmux_session": "cao-sess"}
 
         result = list_siblings("caller-1", depth=2)
 
@@ -299,74 +299,102 @@ class TestListSiblingsDepthClamping:
         mock_list_prefix.assert_not_called()
 
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
-    def test_depth_none_defaults_to_full_own_group_length(self, mock_get_group, mock_list_prefix):
+    @patch(f"{_TS}.get_terminal_metadata")
+    def test_depth_none_defaults_to_full_own_group_length(
+        self, mock_get_metadata, mock_list_prefix
+    ):
         """Omitting depth means the widest scope the caller is allowed: its
         own full group."""
-        mock_get_group.return_value = ["tenant_1", "project_5", "folder_9"]
+        mock_get_metadata.return_value = {
+            "group": ["tenant_1", "project_5", "folder_9"],
+            "tmux_session": "cao-sess",
+        }
         mock_list_prefix.return_value = []
 
         list_siblings("caller-1", depth=None)
 
         mock_list_prefix.assert_called_once_with(
-            "caller-1", ["tenant_1", "project_5", "folder_9"]
+            "caller-1",
+            ["tenant_1", "project_5", "folder_9"],
+            caller_session="cao-sess",
+            cross_session=False,
         )
 
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
-    def test_depth_wider_than_own_group_is_clamped_down(self, mock_get_group, mock_list_prefix):
+    @patch(f"{_TS}.get_terminal_metadata")
+    def test_depth_wider_than_own_group_is_clamped_down(self, mock_get_metadata, mock_list_prefix):
         """depth can never exceed len(caller_group) -- a caller cannot widen
         its own scope by asking for more than it has (#432)."""
-        mock_get_group.return_value = ["tenant_1", "project_5"]
+        mock_get_metadata.return_value = {
+            "group": ["tenant_1", "project_5"],
+            "tmux_session": "cao-sess",
+        }
         mock_list_prefix.return_value = []
 
         list_siblings("caller-1", depth=99)
 
-        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1", "project_5"])
+        mock_list_prefix.assert_called_once_with(
+            "caller-1", ["tenant_1", "project_5"], caller_session="cao-sess", cross_session=False
+        )
 
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
-    def test_depth_within_range_uses_exact_prefix(self, mock_get_group, mock_list_prefix):
-        mock_get_group.return_value = ["tenant_1", "project_5", "folder_9"]
+    @patch(f"{_TS}.get_terminal_metadata")
+    def test_depth_within_range_uses_exact_prefix(self, mock_get_metadata, mock_list_prefix):
+        mock_get_metadata.return_value = {
+            "group": ["tenant_1", "project_5", "folder_9"],
+            "tmux_session": "cao-sess",
+        }
         mock_list_prefix.return_value = []
 
         list_siblings("caller-1", depth=2)
 
-        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1", "project_5"])
+        mock_list_prefix.assert_called_once_with(
+            "caller-1", ["tenant_1", "project_5"], caller_session="cao-sess", cross_session=False
+        )
 
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
+    @patch(f"{_TS}.get_terminal_metadata")
     def test_depth_zero_is_clamped_up_to_one_defense_in_depth(
-        self, mock_get_group, mock_list_prefix
+        self, mock_get_metadata, mock_list_prefix
     ):
         """The API layer rejects depth=0 outright (422, see test_terminals.py).
         This asserts the service layer ALSO never treats an explicit 0 as an
         unscoped, all-terminals query if it's ever reached directly --
         defense in depth, not a documented public entry point for 0."""
-        mock_get_group.return_value = ["tenant_1", "project_5"]
+        mock_get_metadata.return_value = {
+            "group": ["tenant_1", "project_5"],
+            "tmux_session": "cao-sess",
+        }
         mock_list_prefix.return_value = []
 
         list_siblings("caller-1", depth=0)
 
-        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1"])
+        mock_list_prefix.assert_called_once_with(
+            "caller-1", ["tenant_1"], caller_session="cao-sess", cross_session=False
+        )
 
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
-    def test_negative_depth_is_clamped_up_to_one(self, mock_get_group, mock_list_prefix):
-        mock_get_group.return_value = ["tenant_1", "project_5"]
+    @patch(f"{_TS}.get_terminal_metadata")
+    def test_negative_depth_is_clamped_up_to_one(self, mock_get_metadata, mock_list_prefix):
+        mock_get_metadata.return_value = {
+            "group": ["tenant_1", "project_5"],
+            "tmux_session": "cao-sess",
+        }
         mock_list_prefix.return_value = []
 
         list_siblings("caller-1", depth=-5)
 
-        mock_list_prefix.assert_called_once_with("caller-1", ["tenant_1"])
+        mock_list_prefix.assert_called_once_with(
+            "caller-1", ["tenant_1"], caller_session="cao-sess", cross_session=False
+        )
 
     @patch(f"{_TS}.status_monitor")
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
+    @patch(f"{_TS}.get_terminal_metadata")
     def test_returns_prefix_match_results_unchanged(
-        self, mock_get_group, mock_list_prefix, mock_status_monitor
+        self, mock_get_metadata, mock_list_prefix, mock_status_monitor
     ):
-        mock_get_group.return_value = ["tenant_1"]
+        mock_get_metadata.return_value = {"group": ["tenant_1"], "tmux_session": "cao-sess"}
         mock_list_prefix.return_value = [{"id": "sib-1", "group": ["tenant_1"], "metadata": None}]
         mock_status_monitor.get_status.return_value = MagicMock(value="idle")
 
@@ -378,15 +406,15 @@ class TestListSiblingsDepthClamping:
 
     @patch(f"{_TS}.status_monitor")
     @patch(f"{_TS}.list_siblings_by_group_prefix")
-    @patch(f"{_TS}.get_terminal_group")
+    @patch(f"{_TS}.get_terminal_metadata")
     def test_status_is_a_live_snapshot_per_sibling(
-        self, mock_get_group, mock_list_prefix, mock_status_monitor
+        self, mock_get_metadata, mock_list_prefix, mock_status_monitor
     ):
         """tedswinyar, PR #433 review: siblings include a live status snapshot
         (point-in-time, not a delivery guarantee -- see the docstring) so a
         discovering agent can skip an obviously-finished sibling. Each
         sibling's status is looked up individually, not assumed uniform."""
-        mock_get_group.return_value = ["tenant_1"]
+        mock_get_metadata.return_value = {"group": ["tenant_1"], "tmux_session": "cao-sess"}
         mock_list_prefix.return_value = [
             {"id": "sib-1", "group": ["tenant_1"], "metadata": None},
             {"id": "sib-2", "group": ["tenant_1"], "metadata": None},
@@ -399,3 +427,30 @@ class TestListSiblingsDepthClamping:
         assert [s["status"] for s in result] == ["completed", "idle"]
         mock_status_monitor.get_status.assert_any_call("sib-1")
         mock_status_monitor.get_status.assert_any_call("sib-2")
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_metadata")
+    def test_cross_session_true_is_forwarded(self, mock_get_metadata, mock_list_prefix):
+        """cross_session=True is an explicit opt-in the caller must pass
+        through -- default is session-scoped (issue #432 design
+        discussion)."""
+        mock_get_metadata.return_value = {"group": ["tenant_1"], "tmux_session": "cao-sess"}
+        mock_list_prefix.return_value = []
+
+        list_siblings("caller-1", depth=1, cross_session=True)
+
+        mock_list_prefix.assert_called_once_with(
+            "caller-1", ["tenant_1"], caller_session="cao-sess", cross_session=True
+        )
+
+    @patch(f"{_TS}.list_siblings_by_group_prefix")
+    @patch(f"{_TS}.get_terminal_metadata")
+    def test_cross_session_defaults_to_false(self, mock_get_metadata, mock_list_prefix):
+        mock_get_metadata.return_value = {"group": ["tenant_1"], "tmux_session": "cao-sess"}
+        mock_list_prefix.return_value = []
+
+        list_siblings("caller-1", depth=1)
+
+        mock_list_prefix.assert_called_once_with(
+            "caller-1", ["tenant_1"], caller_session="cao-sess", cross_session=False
+        )

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -180,6 +180,8 @@ class TestCreateTerminal:
             ["fs_read"],
             caller_id=None,
             engine="v2",
+            group=None,
+            metadata=None,
         )
         assert mock_provider_manager.create_provider.call_args.args[5] == ["fs_read"]
 


### PR DESCRIPTION
## Summary

Implements the proposal from #432: `group`/`metadata` fields on terminals + `list_siblings`/`update_metadata` MCP tools, so an agent can discover and message sibling terminals without going through the supervisor-dispatched `handoff`/`assign` flow.

- `group`: nullable, ordered array of strings (general-to-specific). Set at `create_terminal`, updatable later via `PATCH /terminals/{id}/group`.
- `metadata`: nullable free-form JSON, settable at creation and updatable by the running agent itself via the `update_metadata` MCP tool.
- `list_siblings(depth?)`: resolves the caller's own identity from `CAO_TERMINAL_ID` (never a client-supplied value — same trust mechanism `send_message`/`handoff` already use), clamps `depth` server-side to `[1, len(caller_group)]` (0 rejected with 422, never silently reinterpreted as an unscoped all-terminals query, never widened past the caller's own group), returns `{id, group, metadata}` for every other terminal whose group shares the resolved prefix. A terminal with no `group` set participates in no discovery (neither finds nor is found) rather than erroring.

## Why this shape

Keeps CAO domain-agnostic — it never needs to understand what "project"/"folder"/"tenant" means, just ordered-array-prefix matching; consumers own the semantics. `group[0]` naturally becomes a hard multi-tenancy boundary for any consumer that sets it to a tenant id, since a caller can only ever compare against its OWN `group[0]`, never an arbitrarily-requested one — this falls out of the design rather than requiring CAO to understand tenancy.

## Testing

Full suite green. Added coverage for the security-relevant edge cases specifically: depth=0/negative rejection (422, both API-level and service-level), depth clamped to caller's own group length even when a larger value is requested, mismatched group-length siblings excluded correctly, no-group terminals excluded both directions, group persistence across the update endpoint, metadata persistence and MCP tool round-trip.

An independent adversarial self-review (separate pass from the implementation itself) found two minor gaps (empty-container normalization on the create-terminal response, a missing migration-path test) — both fixed, with a migration test added for existing terminal rows created before this change (no `group`/`metadata` columns).

## Validation on our own downstream (harness-control)

Validated end-to-end against a real, separate consumer of this API (`workain/harness-control`, a multi-agent session manager built on CAO): `create_session` now sets `group` from that product's own real workspace/project/folder hierarchy at terminal-creation time, and its folder-reassignment flow re-syncs `group` via the new `PATCH` endpoint so it doesn't go stale when a folder moves between projects. Confirmed live (real HTTP calls against a real running patched `cao-server`, not mocked): `group`/`metadata` persistence, bidirectional `list_siblings` discovery between two real terminals, `depth=0` rejection, and message delivery to a sibling found purely via discovery (no receiver_id known ahead of time).

One thing NOT yet verified live: an actual running agent process invoking `list_siblings`/`update_metadata` as MCP tool calls itself (as opposed to the REST endpoints being driven directly, which IS verified). Downstream host contention prevented a clean live agent run during this validation pass; flagging honestly rather than claiming more than was actually exercised. The MCP tool wiring itself follows the exact same pattern as the already-shipped `send_message`/`memory_store` tools in this same file, so the risk is judged low, but it's an open item, not a closed one.

Ref: #432.
