### PR TITLE
fix(security): make Jinja2 autoescape safety net real + regression test (#429 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Security
+
+- enable Jinja2 autoescape in the agent-profile scaffolding `Environment` (`agent_scaffold.py`). Jinja2 defaults to `autoescape=False`, which AppSec scanners flag as an XSS risk (ACAT `Jinja2AutoescapeDisabled`). A custom selector strips a trailing `.j2` before delegating to `select_autoescape(enabled_extensions=("html","htm","xml"))`, so a future `template.html.j2` / `template.xml.j2` is treated as HTML/XML and escaped, while the current `template.md.j2` markdown/bash output stays byte-identical (regression test added) (#429)
+
 ## [2.3.0] - 2026-07-12
 
 ### Added
@@ -85,8 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
-
-- security: enable Jinja2 autoescape in the agent-profile scaffolding `Environment` (`agent_scaffold.py`). Jinja2 defaults to `autoescape=False`, which AppSec scanners flag as an XSS risk. Uses `select_autoescape(enabled_extensions=("html","htm","xml"))` so HTML/XML templates would be escaped while the current markdown/bash `.md.j2` output stays byte-identical
 
 - stop TestPyPI squats breaking the release smoke test (#270)
 

--- a/src/cli_agent_orchestrator/services/agent_scaffold.py
+++ b/src/cli_agent_orchestrator/services/agent_scaffold.py
@@ -16,6 +16,29 @@ from jsonschema import Draft202012Validator
 # Templates live under src/cli_agent_orchestrator/templates/
 _TEMPLATES_ROOT = Path(__file__).resolve().parent.parent / "templates"
 
+# Base Jinja2 autoescape selector: escape only HTML/XML template extensions.
+_autoescape_selector = select_autoescape(
+    enabled_extensions=("html", "htm", "xml"),
+    default_for_string=False,
+)
+
+
+def _autoescape_for_template(template_name: Optional[str]) -> bool:
+    """Autoescape selector that understands the ``*.<ext>.j2`` naming convention.
+
+    CAO scaffold templates are named ``template.<ext>.j2`` (e.g.
+    ``template.md.j2``). Jinja2's stock ``select_autoescape`` matches on the
+    *final* filename suffix, which is always ``.j2`` here, so it would never
+    enable escaping for a future ``template.html.j2`` / ``template.xml.j2``.
+    Strip a single trailing ``.j2`` before delegating so an HTML/XML template
+    is treated as HTML/XML and its output is escaped (XSS-safe). The existing
+    ``template.md.j2`` still resolves to ``md`` (not in the enabled set), so
+    markdown/bash output stays byte-identical.
+    """
+    if template_name and template_name.endswith(".j2"):
+        template_name = template_name[: -len(".j2")]
+    return _autoescape_selector(template_name)
+
 
 def _check_containment(path: Path, root: Path) -> None:
     """Raise FileNotFoundError if resolved path escapes root."""
@@ -122,19 +145,17 @@ def render_template(template_name: str, config: dict) -> str:
         )
 
     # Templates use {{ config.x }} for values and bash ${VAR} passes through
-    # unchanged (not Jinja2 syntax). Autoescape is enabled via
-    # select_autoescape so it is never off by default (Jinja2's own default is
+    # unchanged (not Jinja2 syntax). Autoescape is enabled via a custom
+    # selector so it is never off by default (Jinja2's own default is
     # autoescape=False, flagged by security scanners as an XSS risk). The
-    # scaffold renders markdown/bash profile files, not HTML, so escaping only
-    # engages for HTML/XML template extensions — should such a template ever be
-    # added, its output is escaped; the current .md.j2 output is byte-identical.
+    # scaffold renders markdown/bash profile files, so escaping does not engage
+    # for the current template.md.j2 (byte-identical output). The selector
+    # strips a trailing .j2 before matching, so a future template.html.j2 /
+    # template.xml.j2 would be treated as HTML/XML and escaped (XSS-safe).
     env = Environment(
         loader=FileSystemLoader(str(template_dir)),
         keep_trailing_newline=True,
-        autoescape=select_autoescape(
-            enabled_extensions=("html", "htm", "xml"),
-            default_for_string=False,
-        ),
+        autoescape=_autoescape_for_template,
     )
     template = env.get_template("template.md.j2")
 

--- a/test/services/test_agent_scaffold.py
+++ b/test/services/test_agent_scaffold.py
@@ -195,3 +195,52 @@ class TestRenderTemplate:
     def test_invalid_config_raises(self):
         with pytest.raises(ValueError, match="validation failed"):
             render_template("aws/stepfunction", {"profile": "x"})
+
+
+class TestAutoescapeBehavior:
+    """Locks in the Jinja2 autoescape configuration (PR #429 follow-up).
+
+    The scaffold enables autoescape via a custom selector so it is never
+    silently off (Jinja2's default), but the current ``*.md.j2`` templates must
+    stay byte-identical — escaping HTML entities into a bash heredoc / JSON
+    body would functionally corrupt the generated agent. These tests assert
+    both halves of that contract explicitly, since the other render tests only
+    use benign values with no escapable characters.
+    """
+
+    # Contains every character HTML autoescape would rewrite: & < > " '
+    _SPECIAL = "<tag> & \"dquote\" 'squote' >payload<"
+    # markupsafe/Jinja2 HTML entities that MUST NOT appear in markdown output.
+    _HTML_ENTITIES = ["&amp;", "&lt;", "&gt;", "&#34;", "&quot;", "&#39;"]
+
+    def test_markdown_output_is_not_escaped(self):
+        config = {
+            "profile": "my-profile",
+            "region": "us-east-1",
+            "queue_url": "https://sqs.us-east-1.amazonaws.com/123/MyQueue",
+            "message_body": self._SPECIAL,
+            "message_group_id": "",
+        }
+        result = render_template("aws/sqs-send", config)
+
+        # The raw value is embedded verbatim (twice: the "Message Body" line
+        # and the heredoc), proving autoescape did not engage for .md.j2.
+        assert self._SPECIAL in result
+        for entity in self._HTML_ENTITIES:
+            assert entity not in result, f"unexpected HTML escaping: {entity}"
+
+    def test_selector_engages_for_html_and_xml_templates(self):
+        """The advertised safety net is real: a future ``template.html.j2`` /
+        ``template.xml.j2`` would be escaped despite the trailing ``.j2``."""
+        from cli_agent_orchestrator.services.agent_scaffold import (
+            _autoescape_for_template,
+        )
+
+        # Escaping engages for HTML/XML under the *.ext.j2 naming convention.
+        assert _autoescape_for_template("template.html.j2") is True
+        assert _autoescape_for_template("template.htm.j2") is True
+        assert _autoescape_for_template("template.xml.j2") is True
+        # ... and stays off for markdown and unknown inputs (byte-identical).
+        assert _autoescape_for_template("template.md.j2") is False
+        assert _autoescape_for_template("template.md") is False
+        assert _autoescape_for_template(None) is False


### PR DESCRIPTION
## What

Follow-up to the merged PR #429 (Jinja2 autoescape in agent-profile scaffolding), addressing @call-me-ram's review — which was missed before #429 merged. It resolves all three points he raised (two also flagged by Copilot).

## Review points addressed

**1. The advertised "future HTML/XML template is escaped" safety net was false.**
Under the repo's `*.ext.j2` naming convention, `select_autoescape` matches the *final* suffix — always `.j2` — so escaping would never engage for a `template.html.j2` / `template.xml.j2`. Verified: `template.html.j2 → False`, only bare `template.html → True`. Since "future HTML is protected" was half the justification of a security-labeled PR, this made it **true**: a small custom autoescape callable strips a trailing `.j2` before delegating to `select_autoescape`.

```
template.md.j2   -> False   (byte-identical, unchanged)
template.html.j2 -> True    (now escaped)
template.xml.j2  -> True    (now escaped)
None             -> False
```

The inline comment is aligned with the actual behavior.

**2. No regression test locked in the byte-identical claim.**
Added `TestAutoescapeBehavior`:
- renders `aws/sqs-send` with a `message_body` containing `< > & " '`, asserts the raw string appears and that no HTML entities (`&amp;`, `&lt;`, `&gt;`, `&#34;`, `&quot;`, `&#39;`) are emitted — locking in the byte-identical guarantee (matters because the value is embedded in a bash heredoc / JSON).
- asserts the selector engages for `*.html.j2` / `*.htm.j2` / `*.xml.j2` and stays off for `*.md.j2` / `None` — locking in point 1.

**3. Nit: CHANGELOG entry landed in the released `2.3.0` `### Fixed` block.**
Moved it into a new `[Unreleased]` `### Security` section and corrected the wording to describe the `.j2`-stripping behavior.

## Testing

- `test/services/test_agent_scaffold.py` — 20 passed (18 existing + 2 new).
- `test/cli/test_profile_cmd.py`, `test/api/test_api_profiles.py` — scaffold/render paths pass. (Two unrelated `TestAgentsListCommand` failures are environmental — a sandbox `Permission denied` on `~/.aws/.../settings.json` — and reproduce identically on clean `main`.)
- `black` / `isort` clean.

## Risk / impact

Behavior-preserving for all existing `*.md.j2` templates (byte-identical output, now enforced by a test). No new dependencies.

cc @call-me-ram — thanks for the catch; sorry I missed the review before #429 landed.
