### PR TITLE
fix(build): stop bump_version clobbering mypy python_version (main reads 2.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ profile = "black"
 line_length = 100
 
 [tool.mypy]
-python_version = "2.3.0"
+python_version = "3.10"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -29,7 +29,11 @@ def bump(part: str, version: str) -> str:
 
 def update_pyproject(new_version: str) -> None:
     content = PYPROJECT.read_text()
-    content = re.sub(r'version = "[^"]+"', f'version = "{new_version}"', content)
+    # Anchor to the start of a line so only the [project] ``version`` key is
+    # rewritten. An unanchored ``version = "..."`` also matches the tail of
+    # ``python_version = "..."`` under [tool.mypy], which previously clobbered
+    # the mypy target with the package version on every release.
+    content = re.sub(r'(?m)^version = "[^"]+"', f'version = "{new_version}"', content, count=1)
     PYPROJECT.write_text(content)
 
 


### PR DESCRIPTION
## Problem

`[tool.mypy].python_version` on `main` is `"2.3.0"` — the package version, not a Python target. `scripts/bump_version.py` rewrites it on every release because `update_pyproject` uses an **unanchored** regex:

```python
re.sub(r'version = "[^"]+"', f'version = "{new_version}"', content)
```

`version = "..."` also matches the tail of `python_version = "..."` under `[tool.mypy]`, so each bump clobbers the mypy target. This means mypy is not type-checking against the supported floor (`requires-python = ">=3.10"`, Black `py310`).

## Fix

- Anchor the substitution to the start of a line and cap it to the first match, so only the `[project]` version is rewritten:
  ```python
  re.sub(r'(?m)^version = "[^"]+"', f'version = "{new_version}"', content, count=1)
  ```
- Repair the current value to `python_version = "3.10"`.

## Verification

Simulated a bump against the real `pyproject.toml`: the `[project]` version updates while `python_version` stays `"3.10"` (previously it was overwritten). Two-line change; no runtime code touched.

Co-authored-by: Kiro Agent <244629292+kiro-agent@users.noreply.github.com>


---

**Context / Refs #386** — surfaced while rebasing the AG-UI workstream (#386) onto latest `main`; a valid `[tool.mypy].python_version` is a prerequisite for the type-check gate to be meaningful on the feature PR (#436). This fix is independent and can merge on its own.
