### PR TITLE
fix(claude_code): gate first paste on real input readiness (settle check)

### DIFF
--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -185,6 +185,22 @@ class BaseProvider(ABC):
         """
         return 0.3
 
+    async def wait_until_input_ready(self, timeout: float = 5.0) -> bool:
+        """Wait until the provider's input surface actually accepts keystrokes.
+
+        Called after ``initialize()``'s status wait reports IDLE/COMPLETED and
+        before the first paste is sent. For most CLIs the status wait is
+        sufficient and this default returns immediately. TUI providers whose
+        renderer drops keystrokes for a beat after the prompt first renders
+        (e.g. Claude Code's Ink input box) override this with a real readiness
+        check, so the first ``send_input`` does not race the widget.
+
+        Returns True when input is believed ready; False on timeout. Callers
+        treat False as "proceed anyway" (best effort) — the method must never
+        raise for a readiness miss.
+        """
+        return True
+
     @property
     def accepts_input_while_processing(self) -> bool:
         """Whether this provider buffers pasted input during PROCESSING for next-turn pickup.

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -1,5 +1,6 @@
 """Claude Code provider implementation."""
 
+import asyncio
 import json
 import logging
 import os
@@ -439,8 +440,55 @@ class ClaudeCodeProvider(BaseProvider):
         ):
             raise TimeoutError(f"Claude Code initialization timed out after {init_timeout}s")
 
+        # The status wait fires as soon as the input box RENDERS, but the Ink
+        # renderer drops keystrokes for a beat after that — "box rendered" is
+        # not "box accepting input". Gate on actual input readiness so the
+        # first paste does not race the widget (best effort: a False return
+        # proceeds anyway rather than failing init).
+        await self.wait_until_input_ready()
+
         self._initialized = True
         return True
+
+    async def wait_until_input_ready(self, timeout: float = 5.0) -> bool:
+        """Settle-check readiness gate for the Ink input box.
+
+        The new-TUI input box matching NEW_TUI_BOX_PATTERN appears one render
+        pass before the widget accepts keystrokes. Require the rendered pane
+        content to be STABLE across two consecutive captures ~0.5s apart (and
+        still showing the input box) before declaring input-ready. A changing
+        pane means Ink is still painting startup content (banner, tips, MCP
+        status), during which the first keystrokes get dropped.
+
+        Uses capture-pane (rendered screen) rather than the pipe-pane buffer:
+        stability of the RENDERED output is the actual readiness signal.
+        """
+        poll = 0.5
+        deadline = time.monotonic() + timeout
+        previous: Optional[str] = None
+        while time.monotonic() < deadline:
+            try:
+                current = get_backend().get_history(
+                    self.session_name, self.window_name, tail_lines=40
+                )
+            except Exception as exc:  # backend hiccup: don't fail init for the gate
+                logger.warning("input-ready settle check capture failed: %s", exc)
+                return False
+            if (
+                previous is not None
+                and current == previous
+                and NEW_TUI_BOX_PATTERN.search(strip_terminal_escapes(current))
+            ):
+                logger.debug("input-ready settle check passed for %s", self.terminal_id)
+                return True
+            previous = current
+            await asyncio.sleep(poll)
+        logger.warning(
+            "input-ready settle check timed out after %.1fs for %s; proceeding anyway",
+            timeout,
+            self.terminal_id,
+        )
+        return False
 
     def get_status(self, output: str) -> TerminalStatus:
         """Get Claude Code status.

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1870,3 +1870,62 @@ class TestBackgroundWaitReviewHardening:
             + "\n  ⏵⏵ bypass permissions on\n"
         )
         assert self._p().get_status(output) == TerminalStatus.COMPLETED
+
+
+class TestWaitUntilInputReady:
+    """Settle-check gate: 'box rendered' is not 'box accepting input'.
+
+    The gate requires the rendered pane to be stable across two consecutive
+    captures AND still showing the input box before the first paste is sent.
+    """
+
+    BOX = "─" * 40 + "\n> \n" + "─" * 40
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_ready_when_pane_stable_with_box(self, mock_tmux):
+        mock_tmux.get_history.side_effect = [self.BOX, self.BOX]
+        provider = ClaudeCodeProvider("t1", "sess", "win")
+        assert await provider.wait_until_input_ready(timeout=3.0) is True
+        assert mock_tmux.get_history.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_waits_out_still_painting_pane(self, mock_tmux):
+        # Startup content still changing between captures (banner, tips, MCP
+        # status lines) — exactly the window where Ink drops keystrokes. The
+        # gate must NOT pass until two identical box-bearing captures.
+        mock_tmux.get_history.side_effect = [
+            "Welcome to Claude Code",
+            "Welcome to Claude Code\ntips...",
+            self.BOX,
+            self.BOX,
+        ]
+        provider = ClaudeCodeProvider("t2", "sess", "win")
+        assert await provider.wait_until_input_ready(timeout=5.0) is True
+        assert mock_tmux.get_history.call_count == 4
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_stable_pane_without_box_does_not_pass(self, mock_tmux):
+        # A stable pane that never shows the input box (e.g. stuck on an
+        # error screen) must time out with False, not report ready.
+        mock_tmux.get_history.return_value = "some stable non-box content"
+        provider = ClaudeCodeProvider("t3", "sess", "win")
+        assert await provider.wait_until_input_ready(timeout=1.2) is False
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_capture_failure_returns_false_not_raise(self, mock_tmux):
+        # Backend hiccups must never fail initialization via the gate.
+        mock_tmux.get_history.side_effect = RuntimeError("pane gone")
+        provider = ClaudeCodeProvider("t4", "sess", "win")
+        assert await provider.wait_until_input_ready(timeout=2.0) is False
+
+    @pytest.mark.asyncio
+    async def test_base_provider_default_is_immediate_true(self):
+        # Non-TUI providers keep the old behavior: no extra gate.
+        from cli_agent_orchestrator.providers.base import BaseProvider
+
+        provider = ClaudeCodeProvider("t5", "sess", "win")
+        assert await BaseProvider.wait_until_input_ready(provider) is True


### PR DESCRIPTION
## What this addresses

`provider.initialize()` for Claude Code reports ready as soon as the new-TUI input box renders (`NEW_TUI_BOX_PATTERN` matches via the status pipeline). But "box rendered" is not "box accepting input": the Ink renderer can drop keystrokes for a beat after the box first appears, while startup content (banner, tips, MCP status) is still painting. When that happens, the very first `send_input` paste races the widget and is either dropped entirely or lands in the box without submitting — the agent then sits at an idle prompt and the orchestration stalls.

## Transparency on reproducibility

We diagnosed and reproduced this race in June on Claude Code 2.1.170–2.1.175 (dropped first paste on a meaningful fraction of launches; a synchronous send-side confirmation prototype confirmed the mechanism). **Re-validating against current Claude Code 2.1.206, the race no longer reproduces**: 8/8 control launches on unpatched main delivered the first paste cleanly, including under concurrent-launch + CPU-load stress. The current Ink boot appears more settled than the versions where we hit it.

So this PR is **hardening, not an urgent fix**: the failure mode is real and version-dependent, Claude's TUI changes frequently (this repo has absorbed several such changes — #327, #392), and the gate makes first-paste delivery robust to the next regression rather than waiting for it.

## The fix

- `BaseProvider.wait_until_input_ready()` — new hook, defaults to immediate `True`: zero behavior change for every other provider.
- `ClaudeCodeProvider` overrides it with a **settle check**: after the status wait fires, require the rendered pane (capture-pane) to be stable across two consecutive captures ~0.5s apart and still showing the input box, before the first paste. A changing pane means Ink is still painting — exactly the window where keystrokes get dropped.
- **Best-effort by design**: a timeout or capture failure logs a warning and returns `False`, and initialization proceeds — the gate can delay the first paste slightly but can never break a launch.
- Readiness is derived from observed render behavior, not tuned delays, so it should hold across TUI versions.

## Live validation (patched, Claude Code 2.1.206, real tmux + Bedrock)

- 11/11 single launches delivered the first paste; 4/4 under moderate stress (2 concurrent launches + CPU noise, 2 rounds).
- The gate engaged on every claude_code launch (17 settle-check passes, 0 timeouts) and added well under a second between status-ready and first paste; launch time was unaffected.

## Testing

- 5 unit tests: stable-pane-with-box passes; still-painting pane waits it out; stable pane without the box times out `False` (an error screen must not read as input-ready); capture failure returns `False` rather than raising; the `BaseProvider` default returns immediately.
- black / isort / mypy / full pytest suite green.
