### PR TITLE
fix(terminal): kill orphaned tmux window on init failure for new_session=False spawns

### DIFF
--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -187,6 +187,14 @@ async def create_terminal(
         TimeoutError: If provider initialization times out
     """
     session_created = False  # tracks whether THIS call created the tmux session
+    # harness-control#186: tracks whether THIS call created a new WINDOW in an
+    # already-existing session (the `new_session=False` branch below — what
+    # every MCP spawn/assign-into-existing-session call does). Independent of
+    # `session_created` above: on failure, the cleanup path already tears
+    # down the whole session (window included) when THIS call created a brand
+    # new one, but had no equivalent for a window added to a session that
+    # already existed — see the `except` block.
+    window_created = False
     try:
         # Step 1: Generate unique identifiers
         terminal_id = generate_terminal_id()
@@ -236,6 +244,7 @@ async def create_terminal(
                 working_directory,
                 extra_env=get_session_env(session_name),
             )
+            window_created = True  # only set after successful creation
 
         # Step 3: Load the profile once for allowed tool resolution before
         # provider initialization. The skill catalog is computed only for
@@ -429,6 +438,24 @@ async def create_terminal(
             # secrets don't linger in memory or bleed into a future reuse
             # of the same name.
             clear_session_env(session_name)
+        elif window_created and session_name and window_name:
+            # harness-control#186: a window added to an ALREADY-EXISTING session
+            # (new_session=False -- every MCP spawn/assign-into-existing-session
+            # call) has no session-level teardown to fall back on above, since
+            # `session_created` is False and the pre-existing session must stay
+            # up. Live-reproduced without this: a provider init timeout here
+            # (e.g. "Claude Code initialization timed out after 60s") rolls back
+            # the DB row and stops the FIFO/provider/status-monitor above, but
+            # the tmux WINDOW itself — the actual pane, still running whatever
+            # shell/process the provider left behind — was never torn down.
+            # Result: the caller (the spawning agent's MCP tool call) gets a
+            # hard error back, AND a permanently orphaned window is left behind:
+            # invisible to this terminal's own list/tree (the DB row is gone),
+            # never cleaned up, sitting there indefinitely.
+            try:
+                get_backend().kill_window(session_name, window_name)
+            except Exception:
+                pass  # Ignore cleanup errors
         raise
 
 

--- a/test/services/test_terminal_service_coverage.py
+++ b/test/services/test_terminal_service_coverage.py
@@ -98,9 +98,13 @@ class TestCreateTerminalCleanup:
         mock_fifo_manager,
         mock_status_monitor,
     ):
-        """When new_session=False, cleanup rolls back the DB terminal row but must
-        NOT kill the pre-existing session. The regression guard for "delete DB
-        row, don't kill session."."""
+        """When new_session=False, cleanup rolls back the DB terminal row and kills
+        the WINDOW it just created, but must NOT kill the pre-existing session
+        itself. The regression guard for "delete DB row, don't kill session" --
+        extended (harness-control#186) to also require the orphaned window itself
+        gets torn down: previously nothing did, and a provider init failure (e.g.
+        a Claude Code/Kiro CLI init timeout, live-reproduced) left a permanently
+        orphaned, unregistered tmux window behind on every such failure."""
         from cli_agent_orchestrator.services.terminal_service import create_terminal
 
         mock_tmux.session_exists.return_value = True
@@ -124,6 +128,111 @@ class TestCreateTerminalCleanup:
         mock_pm.cleanup_provider.assert_called_once()
         mock_db_delete.assert_called_once_with("tid1")
         mock_tmux.kill_session.assert_not_called()
+        mock_tmux.kill_window.assert_called_once_with("cao-existing", "w1")
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch(
+        "cli_agent_orchestrator.services.terminal_service.generate_window_name", return_value="w1"
+    )
+    @patch(
+        "cli_agent_orchestrator.services.terminal_service.generate_terminal_id",
+        return_value="tid1",
+    )
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_cleanup_does_not_kill_window_if_it_was_never_created(
+        self,
+        mock_load_profile,
+        mock_tid,
+        mock_wname,
+        mock_db_create,
+        mock_db_delete,
+        mock_pm,
+        mock_tmux,
+        mock_log_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        """harness-control#186 regression guard, other direction: if new_session=False
+        fails BEFORE the window is actually created (the target session doesn't
+        exist), there is no window to tear down -- kill_window must not be called
+        against a window that was never made."""
+        from cli_agent_orchestrator.services.terminal_service import create_terminal
+
+        mock_tmux.session_exists.return_value = False  # target session doesn't exist
+        mock_load_profile.return_value = AgentProfile(name="dev", description="Dev")
+
+        with pytest.raises(ValueError, match="not found"):
+            await create_terminal(
+                provider="kiro_cli",
+                agent_profile="dev",
+                session_name="cao-missing",
+                new_session=False,
+                allowed_tools=["*"],
+            )
+
+        mock_tmux.create_window.assert_not_called()
+        mock_tmux.kill_window.assert_not_called()
+        mock_tmux.kill_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch(
+        "cli_agent_orchestrator.services.terminal_service.generate_window_name", return_value="w1"
+    )
+    @patch(
+        "cli_agent_orchestrator.services.terminal_service.generate_terminal_id",
+        return_value="tid1",
+    )
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_cleanup_swallows_kill_window_errors(
+        self,
+        mock_load_profile,
+        mock_tid,
+        mock_wname,
+        mock_db_create,
+        mock_db_delete,
+        mock_pm,
+        mock_tmux,
+        mock_log_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        """A kill_window failure during cleanup must not mask the original error,
+        same "ignore cleanup errors" contract as every other cleanup step here."""
+        from cli_agent_orchestrator.services.terminal_service import create_terminal
+
+        mock_tmux.session_exists.return_value = True
+        mock_tmux.create_window.return_value = "w1"
+        mock_tmux.kill_window.side_effect = Exception("kill_window error")
+        mock_load_profile.return_value = AgentProfile(name="dev", description="Dev")
+
+        mock_provider = MagicMock()
+        mock_provider.initialize = AsyncMock(side_effect=Exception("original error"))
+        mock_pm.create_provider.return_value = mock_provider
+
+        with pytest.raises(Exception, match="original error"):
+            await create_terminal(
+                provider="kiro_cli",
+                agent_profile="dev",
+                session_name="cao-existing",
+                new_session=False,
+                allowed_tools=["*"],
+            )
+
+        mock_tmux.kill_window.assert_called_once_with("cao-existing", "w1")
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")


### PR DESCRIPTION
## Summary

`create_terminal()`'s failure-cleanup path rolls back the DB row and cleans up the FIFO
reader/status monitor/provider on any exception, and additionally kills the whole tmux **session**
when this call created a brand-new one (`session_created=True`). It had no equivalent for the other
branch (`new_session=False` -- adding a worker **window** to an already-existing session, exactly
what every MCP `spawn`/`assign`-into-existing-session call does): on failure there, the window
itself was never torn down.

## Repro

Live-reproduced twice against a real cao-server (downstream user's dev/test stand) via direct calls
to `POST /sessions/{name}/terminals` -- the same endpoint the MCP spawn/assign tools call
server-side:

```
{"detail":"Failed to create terminal: Claude Code initialization timed out after 60s"}
{"detail":"Failed to create terminal: Kiro CLI initialization timed out with TUI and `--legacy-ui`"}
```

Both times the DB terminal row was correctly rolled back (as designed), but the tmux window itself
(confirmed via `tmux list-windows`) was left running indefinitely -- invisible to the service's own
terminal list from that point on, never cleaned up. The caller (the spawning agent's own MCP tool
call) also gets a hard error back either way -- this orphaned-window leak is very likely contributing
to "silent glitches in the terminal" reports we've seen downstream when agents spawn sub-agents into
an existing session under load/contention.

## Fix

Track window creation (`window_created`, mirroring the existing `session_created` flag) and, in the
`new_session=False` branch specifically (where `session_created` is always `False`, so the existing
`kill_session` cleanup never applies), kill the window it just created -- same "ignore cleanup
errors" contract as every other step in this handler.

## Test plan

- 3 tests added/updated in `test/services/test_terminal_service_coverage.py`:
  - `test_cleanup_on_failure_does_not_kill_session_if_not_new`: extended to also assert
    `kill_window` IS now called (the actual regression this fixes)
  - `test_cleanup_does_not_kill_window_if_it_was_never_created`: failure before the window exists
    (target session missing) -> `kill_window` not called
  - `test_cleanup_swallows_kill_window_errors`: a `kill_window` failure doesn't mask the original
    error
- Rebased cleanly onto current `main` (`d7c1cd0`); full targeted suite green:
  `pytest test/services/test_terminal_service_coverage.py -q` -> 12 passed
- Validated end-to-end downstream: this exact fix is running live in a downstream deployment
  (`workain/harness-control`) serving real sessions, confirmed the orphaned-window leak no longer
  reproduces there.

Related: our other open PRs on this repo, #397 (pipe-pane liveness) and #433
(group/metadata/siblings) -- this fix is independent of both (different code path,
`terminal_service.py`'s failure-cleanup, not the FIFO reader or the group/metadata endpoints), no
overlap expected.