### PR TITLE
feat(skills): add cao-contributing skill (dev loop + CI gate map + PR discipline)

### DIFF
--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -42,6 +42,7 @@ SHIPPED_SKILLS: List[str] = [
     "workflow-author",
     "cao-plugin",
     "cao-provider",
+    "cao-contributing",
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -46,6 +46,7 @@ SHIPPED_SKILLS: List[str] = [
     "cao-workflow",
     "cao-plugin",
     "cao-provider",
+    "cao-contributing",
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/skills/cao-contributing/SKILL.md
+++ b/skills/cao-contributing/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: cao-contributing
+description: Contribute changes to the CAO (CLI Agent Orchestrator) codebase — the local
+  dev loop, the CI gate map, and the pre-PR checklist. Use when the user says "open a PR",
+  "why did CI fail", "run the checks before I push", "the mypy/Code Quality job is red",
+  "add a test and verify coverage", or when making any code change intended to land on a
+  branch/PR. Covers uv-based build/test/lint, the ci.yml jobs and their pass/fail
+  semantics, and the golden rules that stop a green-locally / red-in-CI surprise. Not for
+  authoring agent skills (cao-skill-creator), building providers/plugins/MCP-apps, or
+  operating running sessions.
+---
+
+# Contributing to CAO
+
+How to make a change to the **cli-agent-orchestrator** codebase and get it through CI
+cleanly. Read this before pushing a branch or opening a PR. The canonical human docs are
+[`DEVELOPMENT.md`](../../DEVELOPMENT.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md), and
+[`AGENTS.md`](../../AGENTS.md) — this skill is the operational checklist that mirrors what
+CI actually enforces.
+
+## Golden rules (read these first)
+
+1. **`uv` is mandatory.** Run everything through it: `uv sync --all-extras --dev`,
+   `uv run pytest …`, `uv run mypy src/`, `uv run cao …`. There is no bare
+   `pip`/`python` workflow.
+2. **Verify the *actual* CI run after every push — never declare "done" on local tests
+   alone.** Poll it: `gh run list --branch <branch> --workflow CI` then
+   `gh run view <id>` / `gh run view <id> --log-failed`.
+3. **When a required check fails unexpectedly, diff EVERYTHING your commit changed —
+   including CI/workflow/config files** (`.github/workflows/*.yml`, `pyproject.toml`,
+   `mypy.ini`) — before concluding the cause is pre-existing or external. The signal is
+   often in your own diff (`git diff <base>..HEAD -- .github/`). A displaced one-line
+   workflow key (see the mypy note below) can turn a tolerated warning into a hard failure.
+4. **Never mark a task complete while a required CI gate is red.** A red gate means *not
+   done*; investigate, don't rationalize.
+5. **Match the repo, don't reshape it.** Don't bundle unrelated fixes (e.g. repo-wide type
+   errors) into a feature PR, and don't tighten a CI policy as a side effect of an
+   unrelated change.
+
+## Local dev loop
+
+```bash
+uv sync --all-extras --dev          # install (mirrors what CI does)
+uv run pytest test/path/to/test_x.py   # run targeted tests while iterating
+uv run black src/ test/             # format (CI checks --check)
+uv run isort src/ test/             # import order (CI checks --check-only)
+uv run mypy src/                    # type check (see the mypy note below)
+```
+
+Write tests **RED-first**: add a test that reproduces the bug/behavior and fails, then
+implement until it passes. New features and bug fixes ship with tests; patch coverage is
+expected to stay at 100% for changed lines.
+
+## The CI gate map (`.github/workflows/ci.yml`)
+
+Know which jobs are **blocking** vs **tolerated** so you can tell a real failure from noise.
+
+| Job | Runs | Blocking? |
+|-----|------|-----------|
+| **Unit Tests** (3.10 / 3.11 / 3.12) | `uv run pytest` (`--cov=src`, `-m 'not e2e'`) | **Yes** |
+| **Code Quality** | black `--check`, isort `--check-only`, then `uv run mypy src/` | black/isort **yes**; **mypy is non-blocking** (`continue-on-error: true`) |
+| **AG-UI demo (shift-left recording)** | boots a `CAO_AGUI_ENABLED` server, drives the viewer, asserts components render / off-list refused | **Yes** |
+| **CAO MCP Apps** + **E2E (Playwright)** | MCP Apps build/coverage + browser E2E | **Yes** |
+| **Web UI Build**, **Security Scan** | frontend build, Trivy | **Yes** |
+
+> **mypy is intentionally non-blocking.** The repo has **known, pre-existing, repo-wide
+> mypy errors** (historically in `services/agent_scaffold.py`, `cli/commands/profile.py`,
+> `services/memory_service.py` / `api/main.py` `MemoryArchiveBackend` call-arg, and a
+> `jsonschema` stub). CI tolerates them via `continue-on-error: true` on the mypy step.
+> Therefore:
+> - **Do not** make mypy blocking, and **do not** bundle those unrelated type-fixes into a
+>   feature PR (they belong in a dedicated cleanup PR).
+> - **Your change must add zero *new* mypy errors** — check the delta, not the raw count.
+> - **When you insert a new job/step near the `lint` job, keep `continue-on-error: true`
+>   attached to the mypy step.** A mis-insertion once displaced that line onto the next
+>   job's step, silently turning mypy into a hard gate and failing the build for
+>   unrelated, pre-existing errors.
+
+## Testing gotchas
+
+- **The full `uv run pytest test/` is flaky locally** — it needs a running server, tmux,
+  and real CLI binaries, and can hit a flaky OTel/gRPC abort. Run **targeted test files**
+  while iterating and **trust CI** (the Unit Tests job) for the full suite; get
+  authoritative missing-coverage lines from that job's `term-missing` output ∩ your diff.
+- **FastAPI `TestClient` must use `base_url="http://localhost"`** — the Host-header /
+  DNS-rebinding guard returns `400` otherwise.
+- **Provider status detection is screen-scraping** — provider tests are fixture-driven
+  state machines; when a CLI tool changes its TUI, update the regexes **and** add a fixture.
+- **The AG-UI demo recorder** (`examples/agui-eventsource-viewer/tools/`) needs a Chromium
+  `headless_shell` matching the pinned `@playwright/test` version (`npm run
+  playwright:install`) plus `ffmpeg`; it boots its own `CAO_AGUI_ENABLED` server with
+  `CAO_CORS_ORIGINS=http://localhost:8123`. It gates in CI, so you don't have to run it
+  locally to land a change.
+
+## Pre-PR checklist
+
+1. `uv run black src/ test/ && uv run isort src/ test/` (or `--check` to verify).
+2. `uv run mypy src/` — confirm **no *new* errors** vs the base (pre-existing ones are OK).
+3. `uv run pytest <targeted files>` green; add/keep tests for changed behavior.
+4. If you touched `skills/`, run `python scripts/sync_skills.py` so the packaged mirror
+   stays in lockstep (`test/test_skill_packaging_parity.py` enforces it).
+5. **Commits:** only when asked; sign if the repo expects it; keep the subject concise and
+   Conventional-Commits style; never force-push to `main`.
+6. **Open the PR, then watch its CI run to completion** and fix any red gate before calling
+   it done (rule #2 and #4). Use `gh pr create` / `gh pr checks`.
+
+## Not what you want?
+
+- Authoring a *new agent skill* (SKILL.md, frontmatter, evals) → use **cao-skill-creator**.
+- Building a provider / plugin / MCP-apps view → **cao-provider** / **cao-plugin** /
+  **cao-mcp-apps**.
+- Launching or steering running agent sessions → **cao-session-management**.

--- a/skills/cao-contributing/SKILL.md
+++ b/skills/cao-contributing/SKILL.md
@@ -15,14 +15,17 @@ description: Contribute changes to the CAO (CLI Agent Orchestrator) codebase —
 How to make a change to the **cli-agent-orchestrator** codebase and get it through CI
 cleanly. Read this before pushing a branch or opening a PR. The canonical human docs are
 [`DEVELOPMENT.md`](../../DEVELOPMENT.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md), and
-[`AGENTS.md`](../../AGENTS.md) — this skill is the operational checklist that mirrors what
+[`CODEBASE.md`](../../CODEBASE.md) — this skill is the operational checklist that mirrors what
 CI actually enforces.
 
 ## Golden rules (read these first)
 
-1. **`uv` is mandatory.** Run everything through it: `uv sync --all-extras --dev`,
-   `uv run pytest …`, `uv run mypy src/`, `uv run cao …`. There is no bare
-   `pip`/`python` workflow.
+1. **Run Python tooling through `uv`.** `uv sync --all-extras --dev`, `uv run pytest …`,
+   `uv run mypy src/`, `uv run cao …`. There is no bare `pip` workflow, and the venv CI
+   builds is the one `uv` manages. Repo scripts are documented in their own text as plain
+   `python scripts/<name>.py` (for example `scripts/sync_skills.py`, whose fix-up message
+   and `test_skill_packaging_parity.py` both quote that form) — run them as
+   `uv run python scripts/<name>.py`, which satisfies both.
 2. **Verify the *actual* CI run after every push — never declare "done" on local tests
    alone.** Poll it: `gh run list --branch <branch> --workflow CI` then
    `gh run view <id>` / `gh run view <id> --log-failed`.
@@ -53,15 +56,29 @@ expected to stay at 100% for changed lines.
 
 ## The CI gate map (`.github/workflows/ci.yml`)
 
-Know which jobs are **blocking** vs **tolerated** so you can tell a real failure from noise.
+Know which jobs are **blocking** vs **tolerated** so you can tell a real failure from
+noise. `test/test_cao_contributing_skill_accuracy.py` fails if this table drifts from
+`ci.yml`, so trust it — and if you rename a job, update it here.
 
 | Job | Runs | Blocking? |
 |-----|------|-----------|
-| **Unit Tests** (3.10 / 3.11 / 3.12) | `uv run pytest` (`--cov=src`, `-m 'not e2e'`) | **Yes** |
+| **Unit Tests** (3.10 / 3.11 / 3.12) | `uv run pytest test/ -m "not e2e" --cov=src/cli_agent_orchestrator --cov-report=term-missing` | **Yes** |
+| ↳ step: **Validate Markdown links** | `uv run python scripts/validate_markdown_links.py` — every relative link in every tracked `.md`, including `skills/` | **Yes** |
 | **Code Quality** | black `--check`, isort `--check-only`, then `uv run mypy src/` | black/isort **yes**; **mypy is non-blocking** (`continue-on-error: true`) |
-| **AG-UI demo (shift-left recording)** | boots a `CAO_AGUI_ENABLED` server, drives the viewer, asserts components render / off-list refused | **Yes** |
-| **CAO MCP Apps** + **E2E (Playwright)** | MCP Apps build/coverage + browser E2E | **Yes** |
-| **Web UI Build**, **Security Scan** | frontend build, Trivy | **Yes** |
+| **AG-UI demo (shift-left recording)** | boots a `CAO_AGUI_ENABLED` server, drives the viewer, records a GIF artifact | **Yes** |
+| **AG-UI construct demos (shift-left recordings)** | same pattern for the L2 construct library | **Yes** |
+| **AG-UI stock-client live (AC3)** | drives a real third-party AG-UI client against the surface | **Yes** |
+| **CAO MCP Apps** | MCP Apps build + backend coverage ratchet floor | **Yes** |
+| **CAO MCP Apps E2E (Playwright)** | browser E2E over the `ui://cao/*` views | **Yes** |
+| **Rust TUI** (Linux x86_64 / macOS arm64) | `cargo test` for the `tui/` crate | **Yes** |
+| **Web UI Build** | frontend build | **Yes** |
+| **AI-DLC Portfolio Example** | example project builds | **Yes** |
+| **Security Scan** | Trivy | **Yes** |
+
+> **The `-m "not e2e"` on the CI command overrides your local `addopts`.** CI deselects
+> *only* `e2e`, so **integration tests run in CI**. If your local config also deselects
+> `integration`, your local run is a strict subset of CI's and can be green while CI is
+> red. Compare deselected counts, not just pass counts.
 
 > **mypy is intentionally non-blocking.** The repo has **known, pre-existing, repo-wide
 > mypy errors** (historically in `services/agent_scaffold.py`, `cli/commands/profile.py`,
@@ -82,26 +99,43 @@ Know which jobs are **blocking** vs **tolerated** so you can tell a real failure
   and real CLI binaries, and can hit a flaky OTel/gRPC abort. Run **targeted test files**
   while iterating and **trust CI** (the Unit Tests job) for the full suite; get
   authoritative missing-coverage lines from that job's `term-missing` output ∩ your diff.
+- **A test that touches CAO's own state can pass only on your machine.** If a code path
+  reaches the real database, config dir, or a live session, it will be green on a
+  developer box that has an initialised CAO install and red on a clean runner with
+  `sqlite3.OperationalError: no such table: terminals`. Mock the store/DB seam explicitly;
+  when a test exercises a service function, check what that function calls *today* — a
+  rebase can introduce a new unmocked DB write into a path your test already covered.
+  Verify by running with an isolated `HOME`:
+  ```bash
+  TMPH=$(mktemp -d); HOME="$TMPH" uv run pytest test/path/to/test_x.py; rm -rf "$TMPH"
+  ```
+- **Local green and CI green are different claims, in both directions.** A local suite can
+  hide real failures (see above) *and* invent ones CI never sees (macOS-only, missing
+  optional binaries). When they disagree, CI is authoritative — read the job log rather
+  than reasoning from the local result.
 - **FastAPI `TestClient` must use `base_url="http://localhost"`** — the Host-header /
   DNS-rebinding guard returns `400` otherwise.
 - **Provider status detection is screen-scraping** — provider tests are fixture-driven
   state machines; when a CLI tool changes its TUI, update the regexes **and** add a fixture.
-- **The AG-UI demo recorder** (`examples/agui-eventsource-viewer/tools/`) needs a Chromium
-  `headless_shell` matching the pinned `@playwright/test` version (`npm run
-  playwright:install`) plus `ffmpeg`; it boots its own `CAO_AGUI_ENABLED` server with
-  `CAO_CORS_ORIGINS=http://localhost:8123`. It gates in CI, so you don't have to run it
-  locally to land a change.
+- **The AG-UI demo recorder** (`examples/ag-ui/ag-ui-eventsource-viewer/tools`) needs a
+  Chromium `headless_shell` matching the pinned `@playwright/test` version (`npm run
+  playwright:install`) plus `ffmpeg`, and boots its own `CAO_AGUI_ENABLED` server. It gates
+  in CI, so you don't have to run it locally to land a change. The construct-demo recorder
+  is the sibling at `examples/ag-ui/ag-ui-construct-demos/tools`.
 
 ## Pre-PR checklist
 
 1. `uv run black src/ test/ && uv run isort src/ test/` (or `--check` to verify).
 2. `uv run mypy src/` — confirm **no *new* errors** vs the base (pre-existing ones are OK).
 3. `uv run pytest <targeted files>` green; add/keep tests for changed behavior.
-4. If you touched `skills/`, run `python scripts/sync_skills.py` so the packaged mirror
+4. If you touched **any** `.md`, run `uv run python scripts/validate_markdown_links.py` —
+   a dead relative link fails the Unit Tests job, and `skills/` is in scope. CAO has no
+   root `AGENTS.md`; the contributor map is `CODEBASE.md`.
+5. If you touched `skills/`, run `uv run python scripts/sync_skills.py` so the packaged mirror
    stays in lockstep (`test/test_skill_packaging_parity.py` enforces it).
-5. **Commits:** only when asked; sign if the repo expects it; keep the subject concise and
+6. **Commits:** only when asked; sign if the repo expects it; keep the subject concise and
    Conventional-Commits style; never force-push to `main`.
-6. **Open the PR, then watch its CI run to completion** and fix any red gate before calling
+7. **Open the PR, then watch its CI run to completion** and fix any red gate before calling
    it done (rule #2 and #4). Use `gh pr create` / `gh pr checks`.
 
 ## Not what you want?

--- a/src/cli_agent_orchestrator/skills/cao-contributing/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-contributing/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: cao-contributing
+description: Contribute changes to the CAO (CLI Agent Orchestrator) codebase — the local
+  dev loop, the CI gate map, and the pre-PR checklist. Use when the user says "open a PR",
+  "why did CI fail", "run the checks before I push", "the mypy/Code Quality job is red",
+  "add a test and verify coverage", or when making any code change intended to land on a
+  branch/PR. Covers uv-based build/test/lint, the ci.yml jobs and their pass/fail
+  semantics, and the golden rules that stop a green-locally / red-in-CI surprise. Not for
+  authoring agent skills (cao-skill-creator), building providers/plugins/MCP-apps, or
+  operating running sessions.
+---
+
+# Contributing to CAO
+
+How to make a change to the **cli-agent-orchestrator** codebase and get it through CI
+cleanly. Read this before pushing a branch or opening a PR. The canonical human docs are
+[`DEVELOPMENT.md`](../../DEVELOPMENT.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md), and
+[`AGENTS.md`](../../AGENTS.md) — this skill is the operational checklist that mirrors what
+CI actually enforces.
+
+## Golden rules (read these first)
+
+1. **`uv` is mandatory.** Run everything through it: `uv sync --all-extras --dev`,
+   `uv run pytest …`, `uv run mypy src/`, `uv run cao …`. There is no bare
+   `pip`/`python` workflow.
+2. **Verify the *actual* CI run after every push — never declare "done" on local tests
+   alone.** Poll it: `gh run list --branch <branch> --workflow CI` then
+   `gh run view <id>` / `gh run view <id> --log-failed`.
+3. **When a required check fails unexpectedly, diff EVERYTHING your commit changed —
+   including CI/workflow/config files** (`.github/workflows/*.yml`, `pyproject.toml`,
+   `mypy.ini`) — before concluding the cause is pre-existing or external. The signal is
+   often in your own diff (`git diff <base>..HEAD -- .github/`). A displaced one-line
+   workflow key (see the mypy note below) can turn a tolerated warning into a hard failure.
+4. **Never mark a task complete while a required CI gate is red.** A red gate means *not
+   done*; investigate, don't rationalize.
+5. **Match the repo, don't reshape it.** Don't bundle unrelated fixes (e.g. repo-wide type
+   errors) into a feature PR, and don't tighten a CI policy as a side effect of an
+   unrelated change.
+
+## Local dev loop
+
+```bash
+uv sync --all-extras --dev          # install (mirrors what CI does)
+uv run pytest test/path/to/test_x.py   # run targeted tests while iterating
+uv run black src/ test/             # format (CI checks --check)
+uv run isort src/ test/             # import order (CI checks --check-only)
+uv run mypy src/                    # type check (see the mypy note below)
+```
+
+Write tests **RED-first**: add a test that reproduces the bug/behavior and fails, then
+implement until it passes. New features and bug fixes ship with tests; patch coverage is
+expected to stay at 100% for changed lines.
+
+## The CI gate map (`.github/workflows/ci.yml`)
+
+Know which jobs are **blocking** vs **tolerated** so you can tell a real failure from noise.
+
+| Job | Runs | Blocking? |
+|-----|------|-----------|
+| **Unit Tests** (3.10 / 3.11 / 3.12) | `uv run pytest` (`--cov=src`, `-m 'not e2e'`) | **Yes** |
+| **Code Quality** | black `--check`, isort `--check-only`, then `uv run mypy src/` | black/isort **yes**; **mypy is non-blocking** (`continue-on-error: true`) |
+| **AG-UI demo (shift-left recording)** | boots a `CAO_AGUI_ENABLED` server, drives the viewer, asserts components render / off-list refused | **Yes** |
+| **CAO MCP Apps** + **E2E (Playwright)** | MCP Apps build/coverage + browser E2E | **Yes** |
+| **Web UI Build**, **Security Scan** | frontend build, Trivy | **Yes** |
+
+> **mypy is intentionally non-blocking.** The repo has **known, pre-existing, repo-wide
+> mypy errors** (historically in `services/agent_scaffold.py`, `cli/commands/profile.py`,
+> `services/memory_service.py` / `api/main.py` `MemoryArchiveBackend` call-arg, and a
+> `jsonschema` stub). CI tolerates them via `continue-on-error: true` on the mypy step.
+> Therefore:
+> - **Do not** make mypy blocking, and **do not** bundle those unrelated type-fixes into a
+>   feature PR (they belong in a dedicated cleanup PR).
+> - **Your change must add zero *new* mypy errors** — check the delta, not the raw count.
+> - **When you insert a new job/step near the `lint` job, keep `continue-on-error: true`
+>   attached to the mypy step.** A mis-insertion once displaced that line onto the next
+>   job's step, silently turning mypy into a hard gate and failing the build for
+>   unrelated, pre-existing errors.
+
+## Testing gotchas
+
+- **The full `uv run pytest test/` is flaky locally** — it needs a running server, tmux,
+  and real CLI binaries, and can hit a flaky OTel/gRPC abort. Run **targeted test files**
+  while iterating and **trust CI** (the Unit Tests job) for the full suite; get
+  authoritative missing-coverage lines from that job's `term-missing` output ∩ your diff.
+- **FastAPI `TestClient` must use `base_url="http://localhost"`** — the Host-header /
+  DNS-rebinding guard returns `400` otherwise.
+- **Provider status detection is screen-scraping** — provider tests are fixture-driven
+  state machines; when a CLI tool changes its TUI, update the regexes **and** add a fixture.
+- **The AG-UI demo recorder** (`examples/agui-eventsource-viewer/tools/`) needs a Chromium
+  `headless_shell` matching the pinned `@playwright/test` version (`npm run
+  playwright:install`) plus `ffmpeg`; it boots its own `CAO_AGUI_ENABLED` server with
+  `CAO_CORS_ORIGINS=http://localhost:8123`. It gates in CI, so you don't have to run it
+  locally to land a change.
+
+## Pre-PR checklist
+
+1. `uv run black src/ test/ && uv run isort src/ test/` (or `--check` to verify).
+2. `uv run mypy src/` — confirm **no *new* errors** vs the base (pre-existing ones are OK).
+3. `uv run pytest <targeted files>` green; add/keep tests for changed behavior.
+4. If you touched `skills/`, run `python scripts/sync_skills.py` so the packaged mirror
+   stays in lockstep (`test/test_skill_packaging_parity.py` enforces it).
+5. **Commits:** only when asked; sign if the repo expects it; keep the subject concise and
+   Conventional-Commits style; never force-push to `main`.
+6. **Open the PR, then watch its CI run to completion** and fix any red gate before calling
+   it done (rule #2 and #4). Use `gh pr create` / `gh pr checks`.
+
+## Not what you want?
+
+- Authoring a *new agent skill* (SKILL.md, frontmatter, evals) → use **cao-skill-creator**.
+- Building a provider / plugin / MCP-apps view → **cao-provider** / **cao-plugin** /
+  **cao-mcp-apps**.
+- Launching or steering running agent sessions → **cao-session-management**.

--- a/src/cli_agent_orchestrator/skills/cao-contributing/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-contributing/SKILL.md
@@ -15,14 +15,17 @@ description: Contribute changes to the CAO (CLI Agent Orchestrator) codebase —
 How to make a change to the **cli-agent-orchestrator** codebase and get it through CI
 cleanly. Read this before pushing a branch or opening a PR. The canonical human docs are
 [`DEVELOPMENT.md`](../../DEVELOPMENT.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md), and
-[`AGENTS.md`](../../AGENTS.md) — this skill is the operational checklist that mirrors what
+[`CODEBASE.md`](../../CODEBASE.md) — this skill is the operational checklist that mirrors what
 CI actually enforces.
 
 ## Golden rules (read these first)
 
-1. **`uv` is mandatory.** Run everything through it: `uv sync --all-extras --dev`,
-   `uv run pytest …`, `uv run mypy src/`, `uv run cao …`. There is no bare
-   `pip`/`python` workflow.
+1. **Run Python tooling through `uv`.** `uv sync --all-extras --dev`, `uv run pytest …`,
+   `uv run mypy src/`, `uv run cao …`. There is no bare `pip` workflow, and the venv CI
+   builds is the one `uv` manages. Repo scripts are documented in their own text as plain
+   `python scripts/<name>.py` (for example `scripts/sync_skills.py`, whose fix-up message
+   and `test_skill_packaging_parity.py` both quote that form) — run them as
+   `uv run python scripts/<name>.py`, which satisfies both.
 2. **Verify the *actual* CI run after every push — never declare "done" on local tests
    alone.** Poll it: `gh run list --branch <branch> --workflow CI` then
    `gh run view <id>` / `gh run view <id> --log-failed`.
@@ -53,15 +56,29 @@ expected to stay at 100% for changed lines.
 
 ## The CI gate map (`.github/workflows/ci.yml`)
 
-Know which jobs are **blocking** vs **tolerated** so you can tell a real failure from noise.
+Know which jobs are **blocking** vs **tolerated** so you can tell a real failure from
+noise. `test/test_cao_contributing_skill_accuracy.py` fails if this table drifts from
+`ci.yml`, so trust it — and if you rename a job, update it here.
 
 | Job | Runs | Blocking? |
 |-----|------|-----------|
-| **Unit Tests** (3.10 / 3.11 / 3.12) | `uv run pytest` (`--cov=src`, `-m 'not e2e'`) | **Yes** |
+| **Unit Tests** (3.10 / 3.11 / 3.12) | `uv run pytest test/ -m "not e2e" --cov=src/cli_agent_orchestrator --cov-report=term-missing` | **Yes** |
+| ↳ step: **Validate Markdown links** | `uv run python scripts/validate_markdown_links.py` — every relative link in every tracked `.md`, including `skills/` | **Yes** |
 | **Code Quality** | black `--check`, isort `--check-only`, then `uv run mypy src/` | black/isort **yes**; **mypy is non-blocking** (`continue-on-error: true`) |
-| **AG-UI demo (shift-left recording)** | boots a `CAO_AGUI_ENABLED` server, drives the viewer, asserts components render / off-list refused | **Yes** |
-| **CAO MCP Apps** + **E2E (Playwright)** | MCP Apps build/coverage + browser E2E | **Yes** |
-| **Web UI Build**, **Security Scan** | frontend build, Trivy | **Yes** |
+| **AG-UI demo (shift-left recording)** | boots a `CAO_AGUI_ENABLED` server, drives the viewer, records a GIF artifact | **Yes** |
+| **AG-UI construct demos (shift-left recordings)** | same pattern for the L2 construct library | **Yes** |
+| **AG-UI stock-client live (AC3)** | drives a real third-party AG-UI client against the surface | **Yes** |
+| **CAO MCP Apps** | MCP Apps build + backend coverage ratchet floor | **Yes** |
+| **CAO MCP Apps E2E (Playwright)** | browser E2E over the `ui://cao/*` views | **Yes** |
+| **Rust TUI** (Linux x86_64 / macOS arm64) | `cargo test` for the `tui/` crate | **Yes** |
+| **Web UI Build** | frontend build | **Yes** |
+| **AI-DLC Portfolio Example** | example project builds | **Yes** |
+| **Security Scan** | Trivy | **Yes** |
+
+> **The `-m "not e2e"` on the CI command overrides your local `addopts`.** CI deselects
+> *only* `e2e`, so **integration tests run in CI**. If your local config also deselects
+> `integration`, your local run is a strict subset of CI's and can be green while CI is
+> red. Compare deselected counts, not just pass counts.
 
 > **mypy is intentionally non-blocking.** The repo has **known, pre-existing, repo-wide
 > mypy errors** (historically in `services/agent_scaffold.py`, `cli/commands/profile.py`,
@@ -82,26 +99,43 @@ Know which jobs are **blocking** vs **tolerated** so you can tell a real failure
   and real CLI binaries, and can hit a flaky OTel/gRPC abort. Run **targeted test files**
   while iterating and **trust CI** (the Unit Tests job) for the full suite; get
   authoritative missing-coverage lines from that job's `term-missing` output ∩ your diff.
+- **A test that touches CAO's own state can pass only on your machine.** If a code path
+  reaches the real database, config dir, or a live session, it will be green on a
+  developer box that has an initialised CAO install and red on a clean runner with
+  `sqlite3.OperationalError: no such table: terminals`. Mock the store/DB seam explicitly;
+  when a test exercises a service function, check what that function calls *today* — a
+  rebase can introduce a new unmocked DB write into a path your test already covered.
+  Verify by running with an isolated `HOME`:
+  ```bash
+  TMPH=$(mktemp -d); HOME="$TMPH" uv run pytest test/path/to/test_x.py; rm -rf "$TMPH"
+  ```
+- **Local green and CI green are different claims, in both directions.** A local suite can
+  hide real failures (see above) *and* invent ones CI never sees (macOS-only, missing
+  optional binaries). When they disagree, CI is authoritative — read the job log rather
+  than reasoning from the local result.
 - **FastAPI `TestClient` must use `base_url="http://localhost"`** — the Host-header /
   DNS-rebinding guard returns `400` otherwise.
 - **Provider status detection is screen-scraping** — provider tests are fixture-driven
   state machines; when a CLI tool changes its TUI, update the regexes **and** add a fixture.
-- **The AG-UI demo recorder** (`examples/agui-eventsource-viewer/tools/`) needs a Chromium
-  `headless_shell` matching the pinned `@playwright/test` version (`npm run
-  playwright:install`) plus `ffmpeg`; it boots its own `CAO_AGUI_ENABLED` server with
-  `CAO_CORS_ORIGINS=http://localhost:8123`. It gates in CI, so you don't have to run it
-  locally to land a change.
+- **The AG-UI demo recorder** (`examples/ag-ui/ag-ui-eventsource-viewer/tools`) needs a
+  Chromium `headless_shell` matching the pinned `@playwright/test` version (`npm run
+  playwright:install`) plus `ffmpeg`, and boots its own `CAO_AGUI_ENABLED` server. It gates
+  in CI, so you don't have to run it locally to land a change. The construct-demo recorder
+  is the sibling at `examples/ag-ui/ag-ui-construct-demos/tools`.
 
 ## Pre-PR checklist
 
 1. `uv run black src/ test/ && uv run isort src/ test/` (or `--check` to verify).
 2. `uv run mypy src/` — confirm **no *new* errors** vs the base (pre-existing ones are OK).
 3. `uv run pytest <targeted files>` green; add/keep tests for changed behavior.
-4. If you touched `skills/`, run `python scripts/sync_skills.py` so the packaged mirror
+4. If you touched **any** `.md`, run `uv run python scripts/validate_markdown_links.py` —
+   a dead relative link fails the Unit Tests job, and `skills/` is in scope. CAO has no
+   root `AGENTS.md`; the contributor map is `CODEBASE.md`.
+5. If you touched `skills/`, run `uv run python scripts/sync_skills.py` so the packaged mirror
    stays in lockstep (`test/test_skill_packaging_parity.py` enforces it).
-5. **Commits:** only when asked; sign if the repo expects it; keep the subject concise and
+6. **Commits:** only when asked; sign if the repo expects it; keep the subject concise and
    Conventional-Commits style; never force-push to `main`.
-6. **Open the PR, then watch its CI run to completion** and fix any red gate before calling
+7. **Open the PR, then watch its CI run to completion** and fix any red gate before calling
    it done (rule #2 and #4). Use `gh pr create` / `gh pr checks`.
 
 ## Not what you want?

--- a/test/test_cao_contributing_skill_accuracy.py
+++ b/test/test_cao_contributing_skill_accuracy.py
@@ -1,0 +1,133 @@
+"""The ``cao-contributing`` skill documents CI. This pins it to the real CI.
+
+A skill that describes the CI gate map in prose drifts the moment a job is
+renamed, added, or has its command changed -- and a stale skill is worse than no
+skill, because an agent will act on it confidently. That is not hypothetical:
+review on #448 caught three factual drifts (a wrong ``--cov`` target, a moved
+recorder path, and a gate map missing six jobs) that accumulated in the 46 days
+the PR sat open.
+
+These tests read ``.github/workflows/ci.yml`` and fail if the skill no longer
+matches it, so the next rename is caught by CI rather than by a reviewer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SKILL = REPO_ROOT / "skills" / "cao-contributing" / "SKILL.md"
+PACKAGED_SKILL = (
+    REPO_ROOT / "src" / "cli_agent_orchestrator" / "skills" / "cao-contributing" / "SKILL.md"
+)
+
+# Jobs deliberately left out of the skill's gate map, with the reason. Anything
+# not listed here MUST appear in the map -- that is what makes the test a gate
+# rather than a suggestion.
+INTENTIONALLY_UNDOCUMENTED: dict[str, str] = {
+    "Dependency Review": "advisory-only, PR-scoped; no local equivalent to run",
+}
+
+
+def _ci_job_names() -> set[str]:
+    spec = yaml.safe_load(CI_WORKFLOW.read_text())
+    names: set[str] = set()
+    for job_id, job in (spec.get("jobs") or {}).items():
+        name = (job or {}).get("name") or job_id
+        # Strip matrix interpolation: "Rust TUI (${{ matrix.label }})" -> "Rust TUI"
+        name = re.sub(r"\s*\(\$\{\{.*?\}\}\)", "", name).strip()
+        names.add(name)
+    return names
+
+
+def _skill_text() -> str:
+    return SKILL.read_text()
+
+
+class TestTheGateMapMatchesCi:
+    def test_every_ci_job_is_documented(self):
+        documented = _skill_text()
+        missing = sorted(
+            name
+            for name in _ci_job_names()
+            if name not in INTENTIONALLY_UNDOCUMENTED and name not in documented
+        )
+        assert not missing, (
+            "These CI jobs are not mentioned in the cao-contributing gate map: "
+            f"{missing}. Add them to the table in {SKILL.relative_to(REPO_ROOT)}, or "
+            "record why they are omitted in INTENTIONALLY_UNDOCUMENTED."
+        )
+
+    def test_no_phantom_jobs_are_documented(self):
+        """The skill must not promise a job that CI does not run."""
+        real = _ci_job_names()
+        # Only the FIRST column of a table row names a job -- later columns hold
+        # the blocking verdict, which is also bolded.
+        claimed = {
+            m.strip() for m in re.findall(r"^\|\s*\*\*(.+?)\*\*", _skill_text(), re.MULTILINE)
+        }
+        phantom = sorted(
+            c for c in claimed if not any(c.startswith(r) or r.startswith(c) for r in real)
+        )
+        assert not phantom, f"The skill documents jobs that no longer exist in ci.yml: {phantom}"
+
+
+class TestQuotedCommandsAreReal:
+    def test_the_coverage_target_matches_ci(self):
+        ci = CI_WORKFLOW.read_text()
+        match = re.search(r"--cov=(\S+)", ci)
+        assert match, "ci.yml no longer passes --cov; update this test."
+        target = match.group(1)
+        # Compare exact tokens. A substring check would pass "--cov=src" against a
+        # skill saying "--cov=src/cli_agent_orchestrator", which is the very drift
+        # this test exists to catch.
+        quoted = set(re.findall(r"--cov=([^\s`|)]+)", _skill_text()))
+        assert target in quoted, (
+            f"ci.yml runs coverage as --cov={target}, but the skill quotes {quoted or '{}'}. "
+            "A wrong coverage target sends contributors looking at the wrong report."
+        )
+
+    def test_the_marker_expression_matches_ci(self):
+        ci = CI_WORKFLOW.read_text()
+        match = re.search(r'-m\s+"([^"]+)"', ci)
+        assert match, "ci.yml no longer passes -m; update this test."
+        assert match.group(1) in _skill_text(), (
+            f'ci.yml deselects with -m "{match.group(1)}"; the skill must quote it '
+            "verbatim, because it overrides any local addopts."
+        )
+
+
+class TestReferencedPathsExist:
+    @pytest.mark.parametrize("quoted", re.findall(r"`(examples/[^`]+?)`", SKILL.read_text()))
+    def test_every_referenced_example_path_exists(self, quoted: str):
+        path = REPO_ROOT / quoted.rstrip("/")
+        assert path.exists(), (
+            f"The skill references {quoted}, which does not exist. "
+            "Paths in a skill are instructions an agent will follow literally."
+        )
+
+
+class TestMypyToleranceClaim:
+    def test_mypy_is_still_non_blocking(self):
+        """The skill tells contributors not to 'fix' red mypy. Verify that holds."""
+        spec = yaml.safe_load(CI_WORKFLOW.read_text())
+        steps = spec["jobs"]["lint"]["steps"]
+        mypy_steps = [s for s in steps if "mypy" in str(s.get("run", ""))]
+        assert mypy_steps, "The lint job no longer runs mypy; update the skill."
+        assert all(s.get("continue-on-error") is True for s in mypy_steps), (
+            "mypy is now BLOCKING in CI. The skill's guidance to ignore pre-existing "
+            "mypy errors is actively harmful until it is rewritten."
+        )
+
+
+class TestPackagedMirrorStaysInLockstep:
+    def test_the_two_copies_are_identical(self):
+        assert PACKAGED_SKILL.read_text() == SKILL.read_text(), (
+            "skills/ and the packaged mirror have diverged. "
+            "Run `uv run python scripts/sync_skills.py`."
+        )


### PR DESCRIPTION
## Summary

Adds a new shipped agent skill, **`cao-contributing`**, that teaches an agent (or a human
skimming it) how to make a change to the CAO codebase and get it through CI cleanly.

Every skill CAO currently ships teaches how to **build/operate CAO** (providers, plugins,
MCP apps, sessions, orchestration, memory, workflows, `agui-author`). None covers
**contributing *to* the codebase** — the dev loop, CI gate semantics, and PR discipline.
That gap recently produced a green-locally / red-in-CI surprise, so this encodes the
lesson as a reusable skill.

## What it covers

- **uv-based local dev loop** + RED-first testing expectation / 100% patch coverage.
- **CI gate map** (`.github/workflows/ci.yml`): which jobs are **blocking** vs **tolerated**
  — notably that the **mypy step is non-blocking** (`continue-on-error: true`) because of
  known pre-existing repo-wide type errors. So contributors must add **zero *new*** mypy
  errors and must **preserve that line when inserting a CI job near the `lint` job** (a
  mis-insertion once displaced it and turned mypy into a hard gate).
- **Golden rules:** verify the *actual* CI run after every push; diff everything the commit
  changed (including workflow/config files) before blaming pre-existing causes; never mark
  done with a required gate red; don't bundle unrelated fixes.
- **Testing gotchas:** flaky full `pytest` (run targeted + trust CI), `TestClient
  base_url="http://localhost"`, fixture-driven provider state machines, the AG-UI demo
  recorder prerequisites.
- A **pre-PR checklist** and the `scripts/sync_skills.py` packaging reminder.

## Wiring

- Canonical source: `skills/cao-contributing/SKILL.md`.
- Registered in `SHIPPED_SKILLS` and mirrored into `src/cli_agent_orchestrator/skills/`
  via `scripts/sync_skills.py`.
- `test/test_skill_packaging_parity.py` gates parity + validation (green locally).

## Scope

Standalone, additive, and independent of PR #436 (the AG-UI work) — no overlapping files.
Cross-references existing skills (`cao-skill-creator`, `cao-provider`, `cao-plugin`,
`cao-mcp-apps`, `cao-session-management`) for "not what you want?" routing.

## Testing

`uv run pytest test/test_skill_packaging_parity.py` → 57 passed, 8 skipped.

Co-authored-by: Kiro Agent
