### PR TITLE
fix(claude_code): stop initialize() from blocking the shared event loop

### DIFF
--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -455,7 +455,7 @@ class ClaudeCodeProvider(BaseProvider):
             json.dump(settings, f, indent=2)
         logger.info("Set skipDangerousModePermissionPrompt in ~/.claude/settings.json")
 
-    def _handle_startup_prompts(
+    async def _handle_startup_prompts(
         self, idle_gap: Optional[float] = None, outer_timeout: Optional[float] = None
     ) -> None:
         """Auto-accept startup prompts that may appear before the REPL is ready.
@@ -487,6 +487,28 @@ class ClaudeCodeProvider(BaseProvider):
         any prompt has been observed, only ``outer_timeout`` can end the loop;
         the idle-gap clock starts only once a prompt has actually been handled.
 
+        harness-control#215: this method is awaited directly from initialize(),
+        which itself runs on cao-server's single asyncio event loop (uvicorn is
+        started with no ``workers=``, so there is exactly one). Every
+        tmux-backed call here (``get_history``/``send_keys``/``send_special_key``)
+        is a blocking subprocess exec, and every sleep used to be a plain
+        ``time.sleep`` — which blocks the WHOLE OS thread, not just this
+        coroutine. Under N concurrent ``POST /sessions`` calls, that froze
+        every other in-flight request (including other terminals' own
+        wait_for_shell/initialize/wait_until_status, and unrelated endpoints
+        like GET /health) for as long as this loop ran, turning N-way-concurrent
+        session creation into a fully serial queue whose wall-clock length
+        scaled with N — live-reproduced: 18 concurrent creates against this
+        exact method clustered at ~56.5s each (vs. ~18-35s at N=6-12, ~18s at
+        N=1), converging on CAO's own 60s provider_init_timeout purely from
+        this self-inflicted queueing, not from Claude Code itself being slow
+        (a plain, CAO-uninvolved `claude --remote-control` launch reached its
+        own equivalent trust-dialog prompt in low single-digit seconds under
+        the identical real host load). All blocking calls are now offloaded to
+        a worker thread via asyncio.to_thread and all sleeps are
+        asyncio.sleep, so this coroutine yields the event loop instead of
+        freezing it.
+
         Args:
             idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
                 to the ``startup_prompt_handler_timeout`` setting.
@@ -511,9 +533,11 @@ class ClaudeCodeProvider(BaseProvider):
             if any_prompt_handled and now - last_prompt_time >= idle_gap:
                 return  # no new prompt within the idle gap — startup settled
 
-            output = get_backend().get_history(self.session_name, self.window_name)
+            output = await asyncio.to_thread(
+                get_backend().get_history, self.session_name, self.window_name
+            )
             if not output:
-                time.sleep(1.0)
+                await asyncio.sleep(1.0)
                 continue
 
             clean_output = re.sub(ANSI_CODE_PATTERN, "", output)
@@ -526,16 +550,22 @@ class ClaudeCodeProvider(BaseProvider):
                 logger.info("Bypass permissions prompt detected, auto-accepting")
                 # Send Down arrow to move cursor to "Yes, I accept", then Enter.
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_keys(
-                    self.session_name, self.window_name, "\x1b[B", enter_count=0
+                await asyncio.to_thread(
+                    get_backend().send_keys,
+                    self.session_name,
+                    self.window_name,
+                    "\x1b[B",
+                    enter_count=0,
                 )
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 bypass_accepted = True
                 any_prompt_handled = True
                 last_prompt_time = time.monotonic()  # reset idle timer — trust prompt may follow
-                time.sleep(1.0)
+                await asyncio.sleep(1.0)
                 continue
 
             # 2) Handle workspace trust prompt
@@ -544,7 +574,9 @@ class ClaudeCodeProvider(BaseProvider):
 
                 logger.info("Workspace trust prompt detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 return
 
             # 3) Claude Code fully started — no prompts needed.
@@ -564,7 +596,7 @@ class ClaudeCodeProvider(BaseProvider):
                 logger.info("Claude Code started without prompts")
                 return
 
-            time.sleep(1.0)
+            await asyncio.sleep(1.0)
 
     async def initialize(self) -> bool:
         """Initialize Claude Code provider by starting claude command."""
@@ -589,13 +621,18 @@ class ClaudeCodeProvider(BaseProvider):
         # Send Claude Code command using the backend. Arm the StatusMonitor
         # stickiness gate so the launching command can drive a fresh
         # PROCESSING transition past any stale ready latch.
+        # harness-control#215: offloaded to a thread (see _handle_startup_prompts'
+        # own docstring) so this single subprocess exec can't add to the
+        # same event-loop-blocking pileup under concurrent session creation.
         status_monitor.notify_input_sent(self.terminal_id)
-        get_backend().send_keys(self.session_name, self.window_name, command)
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, command
+        )
 
         # Handle startup prompts (bypass permissions + workspace trust).
         # Pass the resolved timeout as the outer cap so a containerized profile's
         # longer init budget also governs the startup-prompt handler.
-        self._handle_startup_prompts(outer_timeout=init_timeout)
+        await self._handle_startup_prompts(outer_timeout=init_timeout)
 
         # Wait for Claude Code prompt to be ready.
         # Accept both IDLE and COMPLETED — some CLI versions show a startup

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -613,7 +613,11 @@ class ClaudeCodeProvider(BaseProvider):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Prevent bypass permissions dialog from appearing (settings-based fix).
-        self._ensure_skip_bypass_prompt_setting()
+        # harness-control#215 self-ROAST finding: this does blocking file I/O
+        # (~/.claude/settings.json read+write) directly on the event loop this
+        # coroutine runs on -- small in practice, but offloaded for the same
+        # reason as the calls below, so nothing in initialize() blocks the loop.
+        await asyncio.to_thread(self._ensure_skip_bypass_prompt_setting)
 
         # Build properly escaped command string
         command = self._build_claude_command(profile)

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import shlex
+import stat
 import threading
 import time
 from pathlib import Path
@@ -447,13 +448,17 @@ class ClaudeCodeProvider(BaseProvider):
 
         After the async conversion, N concurrent inits may run this
         read-modify-write in N threads. ``_SETTINGS_WRITE_LOCK`` serializes
-        our own threads; ``os.replace`` makes the write atomic so nothing
-        outside CAO ever sees a half-written file.
+        our own threads (in-process only: a second cao-server process, or
+        Claude Code itself, writing between our read and ``os.replace`` is
+        still a last-writer-wins lost update); ``os.replace`` only guarantees
+        no torn reads for anything outside CAO.
         """
         settings_path = Path.home() / ".claude" / "settings.json"
         with _SETTINGS_WRITE_LOCK:
             settings: dict = {}
+            existing_mode: Optional[int] = None
             if settings_path.exists():
+                existing_mode = stat.S_IMODE(os.stat(settings_path).st_mode)
                 try:
                     with open(settings_path) as f:
                         settings = json.load(f)
@@ -466,8 +471,14 @@ class ClaudeCodeProvider(BaseProvider):
             settings["skipDangerousModePermissionPrompt"] = True
             settings_path.parent.mkdir(parents=True, exist_ok=True)
             tmp_path = settings_path.with_suffix(".json.tmp")
+            # Preserve the existing file's mode (or default to 0600 for a
+            # freshly-created settings file, since it may carry `env`/
+            # `apiKeyHelper` secrets) -- the tmp file would otherwise pick up
+            # the process umask (typically 0644) and os.replace would make
+            # the target adopt that on every launch that toggles this flag.
             with open(tmp_path, "w") as f:
                 json.dump(settings, f, indent=2)
+            os.chmod(tmp_path, existing_mode if existing_mode is not None else 0o600)
             os.replace(tmp_path, settings_path)
         logger.info("Set skipDangerousModePermissionPrompt in ~/.claude/settings.json")
 

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -470,16 +470,26 @@ class ClaudeCodeProvider(BaseProvider):
 
             settings["skipDangerousModePermissionPrompt"] = True
             settings_path.parent.mkdir(parents=True, exist_ok=True)
-            tmp_path = settings_path.with_suffix(".json.tmp")
-            # Preserve the existing file's mode (or default to 0600 for a
-            # freshly-created settings file, since it may carry `env`/
-            # `apiKeyHelper` secrets) -- the tmp file would otherwise pick up
-            # the process umask (typically 0644) and os.replace would make
-            # the target adopt that on every launch that toggles this flag.
-            with open(tmp_path, "w") as f:
-                json.dump(settings, f, indent=2)
-            os.chmod(tmp_path, existing_mode if existing_mode is not None else 0o600)
-            os.replace(tmp_path, settings_path)
+            # PID-suffixed so a stale tmp file from a prior crashed process
+            # can never collide with -- or be clobbered by -- this write.
+            tmp_path = settings_path.with_suffix(f".json.tmp.{os.getpid()}")
+            try:
+                # Preserve the existing file's mode (or default to 0600 for a
+                # freshly-created settings file, since it may carry `env`/
+                # `apiKeyHelper` secrets) -- the tmp file would otherwise pick
+                # up the process umask (typically 0644) and os.replace would
+                # make the target adopt that on every launch that toggles
+                # this flag.
+                with open(tmp_path, "w") as f:
+                    json.dump(settings, f, indent=2)
+                os.chmod(tmp_path, existing_mode if existing_mode is not None else 0o600)
+                os.replace(tmp_path, settings_path)
+            except BaseException:
+                # An exception between tmp-file creation and the replace
+                # (e.g. a chmod/disk-full failure) would otherwise orphan
+                # the tmp file indefinitely.
+                tmp_path.unlink(missing_ok=True)
+                raise
         logger.info("Set skipDangerousModePermissionPrompt in ~/.claude/settings.json")
 
     async def _handle_startup_prompts(
@@ -514,27 +524,12 @@ class ClaudeCodeProvider(BaseProvider):
         any prompt has been observed, only ``outer_timeout`` can end the loop;
         the idle-gap clock starts only once a prompt has actually been handled.
 
-        harness-control#215: this method is awaited directly from initialize(),
-        which itself runs on cao-server's single asyncio event loop (uvicorn is
-        started with no ``workers=``, so there is exactly one). Every
-        tmux-backed call here (``get_history``/``send_keys``/``send_special_key``)
-        is a blocking subprocess exec, and every sleep used to be a plain
-        ``time.sleep`` — which blocks the WHOLE OS thread, not just this
-        coroutine. Under N concurrent ``POST /sessions`` calls, that froze
-        every other in-flight request (including other terminals' own
-        wait_for_shell/initialize/wait_until_status, and unrelated endpoints
-        like GET /health) for as long as this loop ran, turning N-way-concurrent
-        session creation into a fully serial queue whose wall-clock length
-        scaled with N — live-reproduced: 18 concurrent creates against this
-        exact method clustered at ~56.5s each (vs. ~18-35s at N=6-12, ~18s at
-        N=1), converging on CAO's own 60s provider_init_timeout purely from
-        this self-inflicted queueing, not from Claude Code itself being slow
-        (a plain, CAO-uninvolved `claude --remote-control` launch reached its
-        own equivalent trust-dialog prompt in low single-digit seconds under
-        the identical real host load). All blocking calls are now offloaded to
-        a worker thread via asyncio.to_thread and all sleeps are
-        asyncio.sleep, so this coroutine yields the event loop instead of
-        freezing it.
+        This method is awaited directly from initialize(), which runs on
+        cao-server's single asyncio event loop. Every tmux-backed call here
+        is offloaded via ``asyncio.to_thread`` and every sleep is
+        ``asyncio.sleep`` (see #451): a blocking ``time.sleep``/subprocess
+        exec here would freeze the WHOLE OS thread, serializing every other
+        in-flight request for as long as this loop ran.
 
         Args:
             idle_gap: Seconds of no-new-prompt quiet that ends the loop. Defaults
@@ -640,10 +635,12 @@ class ClaudeCodeProvider(BaseProvider):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Prevent bypass permissions dialog from appearing (settings-based fix).
-        # harness-control#215 self-ROAST finding: this does blocking file I/O
-        # (~/.claude/settings.json read+write) directly on the event loop this
-        # coroutine runs on -- small in practice, but offloaded for the same
-        # reason as the calls below, so nothing in initialize() blocks the loop.
+        # This does blocking file I/O (~/.claude/settings.json read+write)
+        # directly on the event loop this coroutine runs on -- small in
+        # practice, but offloaded for the same reason as the calls below (#451).
+        # Not exhaustive: wait_for_shell's own backend polling, _load_profile(),
+        # and _build_claude_command's temp-file I/O above/below are still
+        # loop-side -- tens of ms each, not the multi-second pileup #451 fixes.
         await asyncio.to_thread(self._ensure_skip_bypass_prompt_setting)
 
         # Build properly escaped command string
@@ -651,10 +648,10 @@ class ClaudeCodeProvider(BaseProvider):
 
         # Send Claude Code command using the backend. Arm the StatusMonitor
         # stickiness gate so the launching command can drive a fresh
-        # PROCESSING transition past any stale ready latch.
-        # harness-control#215: offloaded to a thread (see _handle_startup_prompts'
-        # own docstring) so this single subprocess exec can't add to the
-        # same event-loop-blocking pileup under concurrent session creation.
+        # PROCESSING transition past any stale ready latch. Offloaded to a
+        # thread (see _handle_startup_prompts' own docstring, #451) so this
+        # single subprocess exec can't add to the same event-loop-blocking
+        # pileup under concurrent session creation.
         status_monitor.notify_input_sent(self.terminal_id)
         await asyncio.to_thread(
             get_backend().send_keys, self.session_name, self.window_name, command

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import shlex
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional
@@ -25,6 +26,13 @@ from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_sta
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
 
 logger = logging.getLogger(__name__)
+
+# Serializes concurrent _ensure_skip_bypass_prompt_setting() read-modify-writes to
+# ~/.claude/settings.json -- after the async conversion, N concurrent inits can run this
+# in N threads (via asyncio.to_thread), and an unlocked read-modify-write can race: one
+# thread reads while another is mid-write, decodes a truncated file, falls back to {}, and
+# clobbers the user's global settings with just the one key.
+_SETTINGS_WRITE_LOCK = threading.Lock()
 
 # Sentinel so _build_claude_command can tell "caller passed no profile, load it"
 # from "caller explicitly passed None" (native/missing profile). initialize()
@@ -436,23 +444,31 @@ class ClaudeCodeProvider(BaseProvider):
         ``skipDangerousModePermissionPrompt: true`` is persisted in
         ``~/.claude/settings.json``.  CAO already uses the flag intentionally,
         so the confirmation is redundant and blocks initialization.
+
+        After the async conversion, N concurrent inits may run this
+        read-modify-write in N threads. ``_SETTINGS_WRITE_LOCK`` serializes
+        our own threads; ``os.replace`` makes the write atomic so nothing
+        outside CAO ever sees a half-written file.
         """
         settings_path = Path.home() / ".claude" / "settings.json"
-        settings: dict = {}
-        if settings_path.exists():
-            try:
-                with open(settings_path) as f:
-                    settings = json.load(f)
-            except (json.JSONDecodeError, OSError):
-                pass
+        with _SETTINGS_WRITE_LOCK:
+            settings: dict = {}
+            if settings_path.exists():
+                try:
+                    with open(settings_path) as f:
+                        settings = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    pass
 
-        if settings.get("skipDangerousModePermissionPrompt") is True:
-            return
+            if settings.get("skipDangerousModePermissionPrompt") is True:
+                return
 
-        settings["skipDangerousModePermissionPrompt"] = True
-        settings_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(settings_path, "w") as f:
-            json.dump(settings, f, indent=2)
+            settings["skipDangerousModePermissionPrompt"] = True
+            settings_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = settings_path.with_suffix(".json.tmp")
+            with open(tmp_path, "w") as f:
+                json.dump(settings, f, indent=2)
+            os.replace(tmp_path, settings_path)
         logger.info("Set skipDangerousModePermissionPrompt in ~/.claude/settings.json")
 
     async def _handle_startup_prompts(

--- a/test/providers/test_claude_code_coverage.py
+++ b/test/providers/test_claude_code_coverage.py
@@ -52,14 +52,15 @@ class TestBuildCommandMcpServerModelDump:
 class TestHandleStartupPromptsBranches:
     """Test _handle_startup_prompts branches."""
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_bypass_permissions_prompt(self, mock_backend, provider):
+    async def test_bypass_permissions_prompt(self, mock_backend, provider):
         """Detects bypass permissions prompt and sends Down arrow + Enter via backend."""
         mock_backend.get_history.return_value = (
             "⚠ Bypass Permissions mode\n" "1. No, exit\n" "2. Yes, I accept\n"
         )
 
-        provider._handle_startup_prompts(idle_gap=1.0)
+        await provider._handle_startup_prompts(idle_gap=1.0)
 
         # Down arrow sent via send_keys, Enter via send_special_key
         mock_backend.send_keys.assert_called_once()
@@ -67,9 +68,12 @@ class TestHandleStartupPromptsBranches:
             provider.session_name, provider.window_name, "Enter"
         )
 
-    @patch("cli_agent_orchestrator.providers.claude_code.time.sleep", lambda *a, **k: None)
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_echoed_prompt_does_not_short_circuit_trust(self, mock_backend, provider):
+    async def test_echoed_prompt_does_not_short_circuit_trust(
+        self, mock_backend, mock_sleep, provider
+    ):
         """Regression: the injected --append-system-prompt contains a line that
         starts with "> `memory_store`". The shell echoes the launch command into
         the capture buffer ~300ms before the workspace-trust dialog renders, so
@@ -93,7 +97,7 @@ class TestHandleStartupPromptsBranches:
         )
         mock_backend.get_history.side_effect = [echoed_launch_cmd, trust_frame]
 
-        provider._handle_startup_prompts(idle_gap=5.0)
+        await provider._handle_startup_prompts(idle_gap=5.0)
 
         # Trust dialog accepted via Enter — proves we did not early-return on the
         # echoed "> memory_store" marker.
@@ -101,21 +105,23 @@ class TestHandleStartupPromptsBranches:
             provider.session_name, provider.window_name, "Enter"
         )
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_welcome_banner_detected_early_return(self, mock_backend, provider):
+    async def test_welcome_banner_detected_early_return(self, mock_backend, provider):
         """When welcome banner is visible, returns immediately."""
         mock_backend.get_history.return_value = "Welcome to Claude Code v2.5.0"
 
-        provider._handle_startup_prompts(idle_gap=1.0)
+        await provider._handle_startup_prompts(idle_gap=1.0)
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_trust_prompt_detected(self, mock_backend, provider):
+    async def test_trust_prompt_detected(self, mock_backend, provider):
         """Trust prompt sends Enter to accept via backend send_special_key."""
         mock_backend.get_history.return_value = (
             "Do you trust the files in this folder?\n" "❯ Yes, I trust this folder"
         )
 
-        provider._handle_startup_prompts(idle_gap=1.0)
+        await provider._handle_startup_prompts(idle_gap=1.0)
 
         mock_backend.send_special_key.assert_called_once_with(
             provider.session_name, provider.window_name, "Enter"

--- a/test/providers/test_claude_code_coverage.py
+++ b/test/providers/test_claude_code_coverage.py
@@ -53,8 +53,9 @@ class TestHandleStartupPromptsBranches:
     """Test _handle_startup_prompts branches."""
 
     @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    async def test_bypass_permissions_prompt(self, mock_backend, provider):
+    async def test_bypass_permissions_prompt(self, mock_backend, mock_sleep, provider):
         """Detects bypass permissions prompt and sends Down arrow + Enter via backend."""
         mock_backend.get_history.return_value = (
             "⚠ Bypass Permissions mode\n" "1. No, exit\n" "2. Yes, I accept\n"
@@ -106,16 +107,18 @@ class TestHandleStartupPromptsBranches:
         )
 
     @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    async def test_welcome_banner_detected_early_return(self, mock_backend, provider):
+    async def test_welcome_banner_detected_early_return(self, mock_backend, mock_sleep, provider):
         """When welcome banner is visible, returns immediately."""
         mock_backend.get_history.return_value = "Welcome to Claude Code v2.5.0"
 
         await provider._handle_startup_prompts(idle_gap=1.0)
 
     @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    async def test_trust_prompt_detected(self, mock_backend, provider):
+    async def test_trust_prompt_detected(self, mock_backend, mock_sleep, provider):
         """Trust prompt sends Enter to accept via backend send_special_key."""
         mock_backend.get_history.return_value = (
             "Do you trust the files in this folder?\n" "❯ Yes, I trust this folder"

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1,7 +1,10 @@
 """Unit tests for Claude Code provider."""
 
 import json
+import os
 import shlex
+import stat
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
@@ -1944,6 +1947,100 @@ class TestClaudeCodeProviderSettings:
 
         result = json.loads(settings_file.read_text())
         assert result["skipDangerousModePermissionPrompt"] is True
+
+    def test_ensure_skip_bypass_prompt_preserves_file_mode(self, tmp_path):
+        """Regression test (review finding on PR #451): the atomic
+        tmp-file + os.replace write must not downgrade an existing
+        settings.json's permissions to the process umask."""
+        settings_file = tmp_path / ".claude" / "settings.json"
+        settings_file.parent.mkdir(parents=True)
+        settings_file.write_text(json.dumps({"permissions": {"allow": []}}))
+        settings_file.chmod(0o600)
+
+        with patch("cli_agent_orchestrator.providers.claude_code.Path") as mock_path_cls:
+            mock_home = MagicMock()
+            mock_path_cls.home.return_value = mock_home
+            mock_home.__truediv__ = MagicMock(
+                return_value=MagicMock(__truediv__=MagicMock(return_value=settings_file))
+            )
+
+            ClaudeCodeProvider._ensure_skip_bypass_prompt_setting()
+
+        assert stat.S_IMODE(settings_file.stat().st_mode) == 0o600
+
+    def test_ensure_skip_bypass_prompt_new_file_defaults_to_0600(self, tmp_path):
+        """A freshly-created settings.json (no prior file to inherit a mode
+        from) should default to 0600, not the process umask -- it may carry
+        `env`/`apiKeyHelper` secrets."""
+        settings_file = tmp_path / ".claude" / "settings.json"
+
+        with patch("cli_agent_orchestrator.providers.claude_code.Path") as mock_path_cls:
+            mock_home = MagicMock()
+            mock_path_cls.home.return_value = mock_home
+            mock_home.__truediv__ = MagicMock(
+                return_value=MagicMock(__truediv__=MagicMock(return_value=settings_file))
+            )
+
+            ClaudeCodeProvider._ensure_skip_bypass_prompt_setting()
+
+        assert stat.S_IMODE(settings_file.stat().st_mode) == 0o600
+
+    def test_ensure_skip_bypass_prompt_concurrent_writes_preserve_keys(self, tmp_path):
+        """Regression test (review finding on PR #451): N concurrent
+        initializers must not race the settings.json read-modify-write and
+        drop pre-existing keys. Pre-lock, a thread reading mid-write would
+        JSON-decode-fail, fall back to {}, and clobber every other key."""
+        settings_file = tmp_path / ".claude" / "settings.json"
+        settings_file.parent.mkdir(parents=True)
+        seed = {f"key{i}": f"value{i}" for i in range(6)}
+        settings_file.write_text(json.dumps(seed))
+
+        with patch("cli_agent_orchestrator.providers.claude_code.Path") as mock_path_cls:
+            mock_home = MagicMock()
+            mock_path_cls.home.return_value = mock_home
+            mock_home.__truediv__ = MagicMock(
+                return_value=MagicMock(__truediv__=MagicMock(return_value=settings_file))
+            )
+
+            threads = [
+                threading.Thread(target=ClaudeCodeProvider._ensure_skip_bypass_prompt_setting)
+                for _ in range(32)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        result = json.loads(settings_file.read_text())
+        for key, value in seed.items():
+            assert result[key] == value
+        assert result["skipDangerousModePermissionPrompt"] is True
+        assert not settings_file.with_suffix(".json.tmp").exists()
+
+    def test_ensure_skip_bypass_prompt_uses_atomic_replace(self, tmp_path):
+        """Pin the atomic-write mechanics: os.replace must be the mechanism
+        that lands the tmp file onto settings.json (contrast
+        test_skill_injection.py:158, which pins its own atomic write the
+        same way)."""
+        settings_file = tmp_path / ".claude" / "settings.json"
+
+        with (
+            patch("cli_agent_orchestrator.providers.claude_code.Path") as mock_path_cls,
+            patch(
+                "cli_agent_orchestrator.providers.claude_code.os.replace", wraps=os.replace
+            ) as mock_replace,
+        ):
+            mock_home = MagicMock()
+            mock_path_cls.home.return_value = mock_home
+            mock_home.__truediv__ = MagicMock(
+                return_value=MagicMock(__truediv__=MagicMock(return_value=settings_file))
+            )
+
+            ClaudeCodeProvider._ensure_skip_bypass_prompt_setting()
+
+        mock_replace.assert_called_once()
+        tmp_arg = mock_replace.call_args[0][0]
+        assert str(tmp_arg).endswith(".json.tmp")
 
 
 class TestClaudeCodeMcpCallNotCompleted:

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import shlex
 import stat
 import threading
@@ -2015,7 +2016,7 @@ class TestClaudeCodeProviderSettings:
         for key, value in seed.items():
             assert result[key] == value
         assert result["skipDangerousModePermissionPrompt"] is True
-        assert not settings_file.with_suffix(".json.tmp").exists()
+        assert list(settings_file.parent.glob("*.json.tmp.*")) == []
 
     def test_ensure_skip_bypass_prompt_uses_atomic_replace(self, tmp_path):
         """Pin the atomic-write mechanics: os.replace must be the mechanism
@@ -2040,7 +2041,9 @@ class TestClaudeCodeProviderSettings:
 
         mock_replace.assert_called_once()
         tmp_arg = mock_replace.call_args[0][0]
-        assert str(tmp_arg).endswith(".json.tmp")
+        # PID-suffixed (e.g. "settings.json.tmp.12345") so a stale tmp file
+        # from a prior crashed process can never collide with this write.
+        assert re.search(r"\.json\.tmp\.\d+$", str(tmp_arg))
 
 
 class TestClaudeCodeMcpCallNotCompleted:

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1727,38 +1727,48 @@ class TestClaudeCodeProviderYoloRootRegression:
 class TestClaudeCodeProviderStartupPrompts:
     """Tests for Claude Code startup prompt handling (trust + bypass)."""
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_handle_startup_prompts_detected_and_accepted(self, mock_tmux):
+    async def test_handle_startup_prompts_detected_and_accepted(self, mock_tmux):
         """Test that trust prompt is detected and auto-accepted."""
         mock_tmux.get_history.return_value = (
             "\x1b[1m❯\x1b[0m 1. Yes, I trust this folder\n  2. No, don't trust\n"
         )
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(idle_gap=2.0)
+        await provider._handle_startup_prompts(idle_gap=2.0)
 
         mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_handle_startup_prompts_not_needed(self, mock_tmux):
+    async def test_handle_startup_prompts_not_needed(self, mock_tmux):
         """Test early return when Claude Code starts without prompts."""
         mock_tmux.get_history.return_value = "Welcome to Claude Code v2.1.0"
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(idle_gap=2.0)
+        await provider._handle_startup_prompts(idle_gap=2.0)
 
         mock_tmux.send_special_key.assert_not_called()
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings")
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_handle_startup_prompts_timeout(self, mock_tmux, mock_time, mock_settings):
+    async def test_handle_startup_prompts_timeout(
+        self, mock_tmux, mock_time, mock_sleep, mock_settings
+    ):
         """Handler gives up gracefully at the outer cap when no prompt ever appears.
 
         should-fix-3: the idle-gap exit does not apply until a first prompt has
         been handled, so with only "Loading..." ever showing, the loop runs
         until the outer cap (provider_init_timeout=60) rather than the old
-        20s idle-gap boundary.
+        20s idle-gap boundary. harness-control#215: the loop's own sleep is
+        now asyncio.sleep (mocked here to keep the test instant), and the
+        blocking get_history call is offloaded via asyncio.to_thread — both
+        transparent to this test since it mocks the backend/time layer, not
+        asyncio.to_thread itself.
         """
         mock_settings.return_value = {
             "provider_init_timeout": 60,
@@ -1770,15 +1780,15 @@ class TestClaudeCodeProviderStartupPrompts:
         # iter-2 now (still no prompt -> idle-gap check skipped), iter-3 now
         # (61s >= 60s outer cap -> return).
         mock_time.monotonic.side_effect = [0.0, 0.0, 0.0, 25.0, 61.0]
-        mock_time.sleep = MagicMock()
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(idle_gap=20.0)
+        await provider._handle_startup_prompts(idle_gap=20.0)
 
         mock_tmux.send_special_key.assert_not_called()
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_handle_startup_prompts_empty_output_then_detected(self, mock_tmux):
+    async def test_handle_startup_prompts_empty_output_then_detected(self, mock_tmux):
         """Test trust prompt detection after initially empty output."""
         mock_tmux.get_history.side_effect = [
             "",
@@ -1786,12 +1796,13 @@ class TestClaudeCodeProviderStartupPrompts:
         ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(idle_gap=5.0)
+        await provider._handle_startup_prompts(idle_gap=5.0)
 
         mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_handle_bypass_prompt_detected_and_accepted(self, mock_tmux):
+    async def test_handle_bypass_prompt_detected_and_accepted(self, mock_tmux):
         """Test that bypass permissions prompt is detected and auto-accepted."""
         # First poll: bypass prompt; second poll: welcome banner (after dismissal)
         mock_tmux.get_history.side_effect = [
@@ -1801,14 +1812,15 @@ class TestClaudeCodeProviderStartupPrompts:
         ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(idle_gap=5.0)
+        await provider._handle_startup_prompts(idle_gap=5.0)
 
         # Verify Down arrow sent via send_keys and Enter via send_special_key
         mock_tmux.send_keys.assert_called_once()
         mock_tmux.send_special_key.assert_called_once_with("test-session", "window-0", "Enter")
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_handle_bypass_then_trust_prompt(self, mock_tmux):
+    async def test_handle_bypass_then_trust_prompt(self, mock_tmux):
         """Test that bypass prompt is handled, then trust prompt follows."""
         # Poll 1: bypass prompt; Poll 2: trust prompt (after bypass dismissed)
         mock_tmux.get_history.side_effect = [
@@ -1817,7 +1829,7 @@ class TestClaudeCodeProviderStartupPrompts:
         ]
 
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
-        provider._handle_startup_prompts(idle_gap=5.0)
+        await provider._handle_startup_prompts(idle_gap=5.0)
 
         # Bypass: send_keys (Down) + send_special_key (Enter)
         # Trust: send_special_key (Enter) — called twice total

--- a/test/providers/test_container_wrapped.py
+++ b/test/providers/test_container_wrapped.py
@@ -23,7 +23,7 @@ All backends and subprocesses are mocked — no Docker/Podman/tmux required.
 """
 
 import shlex
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/test/providers/test_container_wrapped.py
+++ b/test/providers/test_container_wrapped.py
@@ -184,9 +184,11 @@ def test_status_dead_launch_reports_unknown_not_false_idle(mock_backend):
     assert result not in (TerminalStatus.IDLE, TerminalStatus.COMPLETED)
 
 
+@pytest.mark.asyncio
+@patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
 @patch("cli_agent_orchestrator.providers.claude_code.time")
 @patch(_BACKEND)
-def test_idle_timeout_prompt_handler(mock_backend, mock_time):
+async def test_idle_timeout_prompt_handler(mock_backend, mock_time, mock_sleep):
     """Tasks 3 + 4: the idle gap keeps polling for a LATE dialog inside the outer cap.
 
     A cold containerized start renders dialogs late and in sequence. The bypass
@@ -199,7 +201,6 @@ def test_idle_timeout_prompt_handler(mock_backend, mock_time):
     forwards from the per-profile provider_init_timeout — so no settings mock is
     needed and the Task 3<->Task 4 wiring is what is under test.
     """
-    mock_time.sleep = MagicMock()
     mock_time.monotonic.side_effect = [
         0.0,  # outer_deadline = 0 + 180 (per-profile init timeout)
         0.0,  # last_prompt_time = 0
@@ -213,7 +214,7 @@ def test_idle_timeout_prompt_handler(mock_backend, mock_time):
     ]
 
     provider = ClaudeCodeProvider("t1", "sess", "win")
-    provider._handle_startup_prompts(idle_gap=20.0, outer_timeout=180.0)
+    await provider._handle_startup_prompts(idle_gap=20.0, outer_timeout=180.0)
 
     # Bypass: Down arrow (send_keys) + Enter (send_special_key). Trust: Enter.
     assert mock_backend.send_keys.call_count == 1

--- a/test/providers/test_provider_init_timeout.py
+++ b/test/providers/test_provider_init_timeout.py
@@ -19,7 +19,7 @@ a longer per-profile override -- see ``TestKimiInitTimeoutWiring`` /
 ``TestAntigravityInitTimeoutWiring`` below.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/test/providers/test_provider_init_timeout.py
+++ b/test/providers/test_provider_init_timeout.py
@@ -58,7 +58,6 @@ class TestInitializePassesResolvedInitTimeout:
             yield
 
     @pytest.mark.asyncio
-    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
     @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
@@ -75,7 +74,6 @@ class TestInitializePassesResolvedInitTimeout:
         mock_handle,
         mock_build,
         mock_ensure,
-        mock_wait_ready,
     ):
         """provider_init_timeout=180 caps wait_for_shell, handler, and wait_until_status."""
         mock_wait_shell.return_value = True
@@ -92,7 +90,6 @@ class TestInitializePassesResolvedInitTimeout:
         assert mock_handle.call_args.kwargs["outer_timeout"] == 180
 
     @pytest.mark.asyncio
-    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
@@ -111,7 +108,6 @@ class TestInitializePassesResolvedInitTimeout:
         mock_build,
         mock_ensure,
         mock_settings,
-        mock_wait_ready,
     ):
         """No provider_init_timeout on the profile -> the 60s server default flows through."""
         mock_wait_shell.return_value = True
@@ -128,7 +124,6 @@ class TestInitializePassesResolvedInitTimeout:
         assert mock_handle.call_args.kwargs["outer_timeout"] == 60
 
     @pytest.mark.asyncio
-    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
@@ -145,7 +140,6 @@ class TestInitializePassesResolvedInitTimeout:
         mock_build,
         mock_ensure,
         mock_settings,
-        mock_wait_ready,
     ):
         """No agent profile at all (_load_profile -> None) -> server default flows through."""
         mock_wait_shell.return_value = True
@@ -161,7 +155,6 @@ class TestInitializePassesResolvedInitTimeout:
         assert mock_handle.call_args.kwargs["outer_timeout"] == 60
 
     @pytest.mark.asyncio
-    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
     @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
@@ -178,7 +171,6 @@ class TestInitializePassesResolvedInitTimeout:
         mock_handle,
         mock_build,
         mock_ensure,
-        mock_wait_ready,
     ):
         """initialize() must pass the timeout as outer_timeout, never positionally.
 
@@ -246,10 +238,12 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
     from the per-profile value) governs the outer deadline instead.
     """
 
+    @pytest.mark.asyncio
+    @patch(f"{_CC}.asyncio.sleep")
     @patch(f"{_CC}.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_passed_outer_timeout_extends_deadline_past_settings_default(
-        self, mock_backend, mock_time
+    async def test_passed_outer_timeout_extends_deadline_past_settings_default(
+        self, mock_backend, mock_time, mock_sleep
     ):
         """A prompt at t=100 is still handled when outer_timeout=180.
 
@@ -260,7 +254,6 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
         get_history -- so the trust Enter firing is the discriminating signal.
         idle_gap is pinned huge so only the outer cap can end the loop.
         """
-        mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 0 + 180 = 180
             0.0,  # last_prompt_time = 0
@@ -269,13 +262,17 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
         mock_backend.get_history.return_value = "Yes, I trust this folder"
 
         provider = ClaudeCodeProvider("t1", "sess", "win")
-        provider._handle_startup_prompts(idle_gap=1000, outer_timeout=180)
+        await provider._handle_startup_prompts(idle_gap=1000, outer_timeout=180)
 
         mock_backend.send_special_key.assert_called_once()
 
+    @pytest.mark.asyncio
+    @patch(f"{_CC}.asyncio.sleep")
     @patch(f"{_CC}.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_passed_outer_timeout_caps_a_wedged_start(self, mock_backend, mock_time):
+    async def test_passed_outer_timeout_caps_a_wedged_start(
+        self, mock_backend, mock_time, mock_sleep
+    ):
         """With no prompt ever appearing, the loop exits at the passed outer_timeout.
 
         idle_gap is pinned above outer_timeout so the idle-gap exit can never
@@ -283,7 +280,6 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
         """
         import logging
 
-        mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 180
             0.0,  # last_prompt_time = 0
@@ -293,7 +289,7 @@ class TestStartupPromptHandlerHonorsOuterTimeout:
         mock_backend.get_history.return_value = "still starting..."
         provider = ClaudeCodeProvider("t1", "sess", "win")
         with patch.object(logging.getLogger(_CC), "warning") as mock_warn:
-            provider._handle_startup_prompts(idle_gap=1000, outer_timeout=180)
+            await provider._handle_startup_prompts(idle_gap=1000, outer_timeout=180)
 
         mock_backend.send_special_key.assert_not_called()
         mock_backend.send_keys.assert_not_called()

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -55,9 +55,11 @@ class TestClaudeCodeIdleGap:
         return ClaudeCodeProvider("t1", "sess", "win")
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_late_prompt_handled(self, mock_backend, mock_time):
+    async def test_late_prompt_handled(self, mock_backend, mock_time, mock_sleep):
         """A prompt at t=35s (past the old 20s window) is still handled.
 
         Two prompts: bypass at t=18 resets the idle timer; the trust prompt at
@@ -65,7 +67,6 @@ class TestClaudeCodeIdleGap:
         answered. Under the old fixed-window logic the handler would have exited
         at t=20 and never seen the trust prompt.
         """
-        mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
@@ -80,7 +81,7 @@ class TestClaudeCodeIdleGap:
         ]
 
         p = self._make()
-        p._handle_startup_prompts()
+        await p._handle_startup_prompts()
 
         # Bypass at t=18 (Down + Enter) and the late trust prompt at t=35 (Enter)
         # are both handled — proving the idle-gap reset kept the loop polling past
@@ -89,9 +90,11 @@ class TestClaudeCodeIdleGap:
         assert mock_backend.send_special_key.call_count == 2  # bypass Enter + trust Enter
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_backend, mock_time):
+    async def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_backend, mock_time, mock_sleep):
         """No prompt ever appears — the idle gap does NOT apply until a first prompt lands.
 
         Before any prompt is observed, ``last_prompt_time`` has nothing real to
@@ -99,7 +102,6 @@ class TestClaudeCodeIdleGap:
         should-fix-3 rework: the exit at t=25 (old idle-gap boundary) must NOT
         fire here — only t=61 (past the 60s outer cap) does.
         """
-        mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
@@ -110,16 +112,18 @@ class TestClaudeCodeIdleGap:
         mock_backend.get_history.return_value = "Loading..."
 
         p = self._make()
-        p._handle_startup_prompts()
+        await p._handle_startup_prompts()
 
         # No prompts handled
         mock_backend.send_special_key.assert_not_called()
         mock_backend.send_keys.assert_not_called()
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_first_prompt_later_than_idle_gap_still_handled(self, mock_backend, mock_time):
+    async def test_first_prompt_later_than_idle_gap_still_handled(self, mock_backend, mock_time, mock_sleep):
         """A FIRST dialog later than idle_gap (the issue #400 scenario) is now caught.
 
         Before this fix, a first prompt at t=35 (past the 20s idle-gap default)
@@ -128,7 +132,6 @@ class TestClaudeCodeIdleGap:
         starts once a prompt has actually been handled, so a first prompt at
         t=35 is well within the still-open outer cap and is handled.
         """
-        mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
@@ -138,14 +141,16 @@ class TestClaudeCodeIdleGap:
         mock_backend.get_history.return_value = "Yes, I trust this folder"
 
         p = self._make()
-        p._handle_startup_prompts()
+        await p._handle_startup_prompts()
 
         mock_backend.send_special_key.assert_called_once_with("sess", "win", "Enter")
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _outer_cap_settings)
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_outer_cap_respected(self, mock_backend, mock_time):
+    async def test_outer_cap_respected(self, mock_backend, mock_time, mock_sleep):
         """Loop exits at provider_init_timeout, NOT via the idle gap.
 
         idle_gap=100 > provider_init_timeout=60, so the idle-gap check can never
@@ -153,7 +158,6 @@ class TestClaudeCodeIdleGap:
         bypass prompt is handled once (resetting the timer), then the loop idles
         until t=61 trips the outer cap.
         """
-        mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
@@ -169,18 +173,19 @@ class TestClaudeCodeIdleGap:
         )
 
         p = self._make()
-        p._handle_startup_prompts()
+        await p._handle_startup_prompts()
 
         # Bypass accepted once
         mock_backend.send_keys.assert_called_once()
         mock_backend.send_special_key.assert_called_once()
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_cascading_prompts_all_handled(self, mock_backend, mock_time):
+    async def test_cascading_prompts_all_handled(self, mock_backend, mock_time, mock_sleep):
         """Multiple prompts in sequence — bypass then trust, both handled."""
-        mock_time.sleep = MagicMock()
         mock_time.monotonic.side_effect = [
             0.0,  # outer_deadline = 60
             0.0,  # last_prompt_time = 0
@@ -195,7 +200,7 @@ class TestClaudeCodeIdleGap:
         ]
 
         p = self._make()
-        p._handle_startup_prompts()
+        await p._handle_startup_prompts()
 
         # Bypass: send_keys (Down arrow) + send_special_key (Enter)
         # Trust: send_special_key (Enter)
@@ -203,11 +208,12 @@ class TestClaudeCodeIdleGap:
         assert mock_backend.send_special_key.call_count == 2
 
     @patch("cli_agent_orchestrator.providers.claude_code.get_server_settings", _settings)
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    def test_idle_gap_resets_on_each_prompt(self, mock_backend, mock_time):
+    async def test_idle_gap_resets_on_each_prompt(self, mock_backend, mock_time, mock_sleep):
         """First prompt at t=5s resets timer; second at t=22s still within gap of first."""
-        mock_time.sleep = MagicMock()
         # idle_gap=20. First prompt at t=5, resets last_prompt_time to 5.
         # Second prompt at t=22: gap=22-5=17<20, so still polled and handled.
         # Without reset, gap would be 22-0=22>=20 → would have exited.
@@ -225,7 +231,7 @@ class TestClaudeCodeIdleGap:
         ]
 
         p = self._make()
-        p._handle_startup_prompts()
+        await p._handle_startup_prompts()
 
         # Both prompts handled
         assert mock_backend.send_keys.call_count == 1  # bypass Down arrow

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -94,7 +94,9 @@ class TestClaudeCodeIdleGap:
     @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    async def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_backend, mock_time, mock_sleep):
+    async def test_no_prompt_exits_at_outer_cap_not_idle_gap(
+        self, mock_backend, mock_time, mock_sleep
+    ):
         """No prompt ever appears — the idle gap does NOT apply until a first prompt lands.
 
         Before any prompt is observed, ``last_prompt_time`` has nothing real to
@@ -123,7 +125,9 @@ class TestClaudeCodeIdleGap:
     @patch("cli_agent_orchestrator.providers.claude_code.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.claude_code.time")
     @patch("cli_agent_orchestrator.backends.registry._backend")
-    async def test_first_prompt_later_than_idle_gap_still_handled(self, mock_backend, mock_time, mock_sleep):
+    async def test_first_prompt_later_than_idle_gap_still_handled(
+        self, mock_backend, mock_time, mock_sleep
+    ):
         """A FIRST dialog later than idle_gap (the issue #400 scenario) is now caught.
 
         Before this fix, a first prompt at t=35 (past the 20s idle-gap default)


### PR DESCRIPTION
## Problem

`ClaudeCodeProvider._handle_startup_prompts` was a synchronous method (`time.sleep()`-based) called directly, un-awaited, from `initialize()` — which itself is `async def` and runs on the cao-server's single asyncio event loop (no `workers=`). Because it was a plain sync call, it blocked the *entire OS thread* for its full duration, freezing every other concurrent request on the server — including unrelated endpoints like `GET /health` — for as long as one session's startup-prompt handling was in flight.

This converges N concurrent `POST /sessions` calls into a fully serial queue whose wall-clock scales with N, purely from this self-inflicted single-thread serialization — not from any real backend/tmux bottleneck.

### Proof

- Live concurrency sweep: 18 concurrent session creates cluster at ~56.5s each, vs ~18s at N=1.
- Standalone async heartbeat-starvation probe: a lightweight coroutine ticking every ~100ms records 0 ticks over 3s while `_handle_startup_prompts` runs synchronously (pre-fix), vs the full ~29/29 expected ticks once it's made properly async (post-fix).

## Fix

Converted `_handle_startup_prompts` to a real `async def` coroutine:
- Every `time.sleep()` → `await asyncio.sleep()`
- Every tmux-backed blocking call (`get_backend().get_history/send_keys/send_special_key`, and the settings-file I/O touched by the same startup path) → wrapped in `await asyncio.to_thread(...)`
- Call site in `initialize()` updated to `await self._handle_startup_prompts(...)`

This preserves the exact `idle_gap`/`outer_timeout` cold-start-tolerant loop structure from #400/#428 (merged after this fix was originally written against an older `main` — this PR was rebased to merge both sets of changes rather than regress either one) — only the blocking-vs-async mechanics changed, not the prompt-detection or timeout semantics.

## Testing

- All existing unit/coverage tests for this provider updated to `async`/`await` where they call `_handle_startup_prompts` directly (mechanical, no behavior change).
- Full suite: `4302 passed, 21 skipped, 97 deselected, 0 failed` on this branch (rebased onto current `main`).
- Originating context: this fix was developed and load-tested against downstream harness-control#215/#222, which first surfaced the serialization via real concurrent session-creation latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)