### PR TITLE
fix(test): repair main CI — isolate wait_until_input_ready in claude_code init-timeout tests (regression from #441)

### DIFF
--- a/test/providers/test_provider_init_timeout.py
+++ b/test/providers/test_provider_init_timeout.py
@@ -45,6 +45,7 @@ class TestInitializePassesResolvedInitTimeout:
     """
 
     @pytest.mark.asyncio
+    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
     @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
@@ -61,6 +62,7 @@ class TestInitializePassesResolvedInitTimeout:
         mock_handle,
         mock_build,
         mock_ensure,
+        mock_wait_ready,
     ):
         """provider_init_timeout=180 caps wait_for_shell, handler, and wait_until_status."""
         mock_wait_shell.return_value = True
@@ -76,6 +78,7 @@ class TestInitializePassesResolvedInitTimeout:
         assert mock_handle.call_args.kwargs["outer_timeout"] == 180
 
     @pytest.mark.asyncio
+    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
@@ -94,6 +97,7 @@ class TestInitializePassesResolvedInitTimeout:
         mock_build,
         mock_ensure,
         mock_settings,
+        mock_wait_ready,
     ):
         """No provider_init_timeout on the profile -> the 60s server default flows through."""
         mock_wait_shell.return_value = True
@@ -109,6 +113,7 @@ class TestInitializePassesResolvedInitTimeout:
         assert mock_handle.call_args.kwargs["outer_timeout"] == 60
 
     @pytest.mark.asyncio
+    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch(_SETTINGS, return_value={"provider_init_timeout": 60})
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
@@ -125,6 +130,7 @@ class TestInitializePassesResolvedInitTimeout:
         mock_build,
         mock_ensure,
         mock_settings,
+        mock_wait_ready,
     ):
         """No agent profile at all (_load_profile -> None) -> server default flows through."""
         mock_wait_shell.return_value = True
@@ -139,6 +145,7 @@ class TestInitializePassesResolvedInitTimeout:
         assert mock_handle.call_args.kwargs["outer_timeout"] == 60
 
     @pytest.mark.asyncio
+    @patch.object(ClaudeCodeProvider, "wait_until_input_ready")
     @patch.object(ClaudeCodeProvider, "_ensure_skip_bypass_prompt_setting")
     @patch.object(ClaudeCodeProvider, "_build_claude_command", return_value="claude")
     @patch.object(ClaudeCodeProvider, "_handle_startup_prompts")
@@ -155,6 +162,7 @@ class TestInitializePassesResolvedInitTimeout:
         mock_handle,
         mock_build,
         mock_ensure,
+        mock_wait_ready,
     ):
         """initialize() must pass the timeout as outer_timeout, never positionally.
 


### PR DESCRIPTION
## Summary

Fixes **`main` CI**, which has been red since #441 ("gate first paste on real input
readiness"). That PR added `await self.wait_until_input_ready()` to
`ClaudeCodeProvider.initialize()`, which reads `get_backend().get_history()`. The four
`TestInitializePassesResolvedInitTimeout` tests in
`test/providers/test_provider_init_timeout.py` mock the backend but never configure
`get_history`, so it returned a `MagicMock` that `strip_terminal_escapes()` rejected:

```
TypeError: expected string or bytes-like object, got 'MagicMock'
```

This failed **Unit Tests (3.10 / 3.11 / 3.12)** and the **CAO MCP Apps** backend-coverage
step on every push to `main` since #441 (last green was #400/#428).

## Fix

These four tests only assert that the resolved init timeout flows into `wait_for_shell` /
`wait_until_status` / `_handle_startup_prompts`; the settle-check gate is incidental to
what they verify. Patch it out with
`@patch.object(ClaudeCodeProvider, "wait_until_input_ready")` — mirroring the existing
`_handle_startup_prompts` patch — so the tests stay focused and no longer exercise the real
`get_history` path.

**Test-only change; no production code touched.**

## Testing

```
uv run pytest test/providers/test_provider_init_timeout.py   # 18 passed (was 4 failed / 14 passed)
uv run black --check / isort --check-only                    # clean
```

Root cause is a single stale mock, so this also greens the CAO MCP Apps backend-coverage
step (same tests).

Co-authored-by: Kiro Agent
