### PR TITLE
fix(security): inline select_autoescape so bandit B701 recognizes the autoescape config

### DIFF
--- a/src/cli_agent_orchestrator/services/agent_scaffold.py
+++ b/src/cli_agent_orchestrator/services/agent_scaffold.py
@@ -16,28 +16,13 @@ from jsonschema import Draft202012Validator
 # Templates live under src/cli_agent_orchestrator/templates/
 _TEMPLATES_ROOT = Path(__file__).resolve().parent.parent / "templates"
 
-# Base Jinja2 autoescape selector: escape only HTML/XML template extensions.
-_autoescape_selector = select_autoescape(
-    enabled_extensions=("html", "htm", "xml"),
-    default_for_string=False,
-)
-
-
-def _autoescape_for_template(template_name: Optional[str]) -> bool:
-    """Autoescape selector that understands the ``*.<ext>.j2`` naming convention.
-
-    CAO scaffold templates are named ``template.<ext>.j2`` (e.g.
-    ``template.md.j2``). Jinja2's stock ``select_autoescape`` matches on the
-    *final* filename suffix, which is always ``.j2`` here, so it would never
-    enable escaping for a future ``template.html.j2`` / ``template.xml.j2``.
-    Strip a single trailing ``.j2`` before delegating so an HTML/XML template
-    is treated as HTML/XML and its output is escaped (XSS-safe). The existing
-    ``template.md.j2`` still resolves to ``md`` (not in the enabled set), so
-    markdown/bash output stays byte-identical.
-    """
-    if template_name and template_name.endswith(".j2"):
-        template_name = template_name[: -len(".j2")]
-    return _autoescape_selector(template_name)
+# Extensions that enable Jinja2 autoescape. CAO scaffold templates are named
+# ``template.<ext>.j2`` (e.g. ``template.md.j2``), and ``select_autoescape``
+# matches on the *final* filename suffix, so the compound ``<ext>.j2`` forms
+# are listed alongside the bare extensions: a future ``template.html.j2`` /
+# ``template.xml.j2`` is escaped (XSS-safe), while ``template.md.j2`` stays
+# unescaped so markdown/bash output is byte-identical.
+_AUTOESCAPE_EXTENSIONS = ("html", "htm", "xml", "html.j2", "htm.j2", "xml.j2")
 
 
 def _check_containment(path: Path, root: Path) -> None:
@@ -145,17 +130,17 @@ def render_template(template_name: str, config: dict) -> str:
         )
 
     # Templates use {{ config.x }} for values and bash ${VAR} passes through
-    # unchanged (not Jinja2 syntax). Autoescape is enabled via a custom
-    # selector so it is never off by default (Jinja2's own default is
-    # autoescape=False, flagged by security scanners as an XSS risk). The
-    # scaffold renders markdown/bash profile files, so escaping does not engage
-    # for the current template.md.j2 (byte-identical output). The selector
-    # strips a trailing .j2 before matching, so a future template.html.j2 /
-    # template.xml.j2 would be treated as HTML/XML and escaped (XSS-safe).
+    # unchanged (not Jinja2 syntax). select_autoescape must be called inline
+    # here — bandit B701 (ACAT) only recognizes autoescape=True or a literal
+    # select_autoescape(...) at the Environment() call site, not a reference
+    # to a custom selector function.
     env = Environment(
         loader=FileSystemLoader(str(template_dir)),
         keep_trailing_newline=True,
-        autoescape=_autoescape_for_template,
+        autoescape=select_autoescape(
+            enabled_extensions=_AUTOESCAPE_EXTENSIONS,
+            default_for_string=False,
+        ),
     )
     template = env.get_template("template.md.j2")
 

--- a/test/services/test_agent_scaffold.py
+++ b/test/services/test_agent_scaffold.py
@@ -232,15 +232,25 @@ class TestAutoescapeBehavior:
     def test_selector_engages_for_html_and_xml_templates(self):
         """The advertised safety net is real: a future ``template.html.j2`` /
         ``template.xml.j2`` would be escaped despite the trailing ``.j2``."""
+        from jinja2 import select_autoescape
+
         from cli_agent_orchestrator.services.agent_scaffold import (
-            _autoescape_for_template,
+            _AUTOESCAPE_EXTENSIONS,
+        )
+
+        selector = select_autoescape(
+            enabled_extensions=_AUTOESCAPE_EXTENSIONS,
+            default_for_string=False,
         )
 
         # Escaping engages for HTML/XML under the *.ext.j2 naming convention.
-        assert _autoescape_for_template("template.html.j2") is True
-        assert _autoescape_for_template("template.htm.j2") is True
-        assert _autoescape_for_template("template.xml.j2") is True
+        assert selector("template.html.j2") is True
+        assert selector("template.htm.j2") is True
+        assert selector("template.xml.j2") is True
+        # ... and for bare HTML/XML extensions.
+        assert selector("template.html") is True
+        assert selector("template.xml") is True
         # ... and stays off for markdown and unknown inputs (byte-identical).
-        assert _autoescape_for_template("template.md.j2") is False
-        assert _autoescape_for_template("template.md") is False
-        assert _autoescape_for_template(None) is False
+        assert selector("template.md.j2") is False
+        assert selector("template.md") is False
+        assert selector(None) is False


### PR DESCRIPTION
## Why

after #429 / #434 PRs enabled autoescape correctly at runtime via a custom selector function (`_autoescape_for_template`), but bandit's B701 check only recognizes `autoescape=True` or a **literal `select_autoescape(...)` call at the `Environment()` call site**. A reference to a custom function is classified as autoescape-disabled, so ACAT keeps the finding open and keeps reopening the ticket.

## What

Replace the custom selector with an inline `select_autoescape()` whose `enabled_extensions` include the compound `*.<ext>.j2` forms alongside the bare extensions:

```python
autoescape=select_autoescape(
    enabled_extensions=("html", "htm", "xml", "html.j2", "htm.j2", "xml.j2"),
    default_for_string=False,
)
```

`select_autoescape` matches on the final filename suffix, so listing `html.j2` / `htm.j2` / `xml.j2` covers exactly the cases the custom `.j2`-stripping selector handled.

## Behavior parity (verified)

| Input | Before (custom selector) | After (inline) |
|---|---|---|
| `template.md.j2` / `template.md` / `None` | unescaped | unescaped |
| `template.html.j2` / `.htm.j2` / `.xml.j2` | escaped | escaped |
| `template.html` / `.xml` | escaped | escaped |

Markdown/bash profile output stays byte-identical (locked by `test_markdown_output_is_not_escaped`); the HTML/XML safety net remains real (updated `test_selector_engages_for_html_and_xml_templates`).

## Verification

- `bandit -t B701 src/cli_agent_orchestrator/services/agent_scaffold.py` → **No issues identified** (was: 1 High)
- `pytest test/services/test_agent_scaffold.py` → **20 passed**

## Notes for ticket closure

- `alert-autofix-142` branch still carries the pre-#429 unfixed code and is separately flagged; it should be deleted or rebased.
- `feat/graph-layer-b4-renderer` no longer exists on the remote; its finding should clear on rescan.