### PR TITLE
feat(config): make CAO_HOME_DIR env-overridable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CAO_HOME_DIR` environment variable to relocate CAO's entire data directory outside `~/.aws` (#467)
 - `cao profile find <query>` CLI verb and `find_profiles` MCP tool for keyword/BM25 profile discovery over metadata (name, description, tags, capabilities); metadata-only, never exposes prompt bodies (#340)
 - Optional `capabilities` and `tags` arrays in the agent profile frontmatter schema (#340)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,12 +24,12 @@ Every derived path resolves from this value, so one override moves everything �
 
 **When to use it.** Some environments restrict or sandbox access to `~/.aws` at the OS level to protect AWS credentials. Because CAO otherwise stores its data there, including the agent profiles it reads during a `handoff`, a locked-down `~/.aws` can leave CAO unable to read its own data (a handoff then fails with `Permission denied`). Relocating `CAO_HOME_DIR` outside `~/.aws` keeps CAO working while leaving those credential protections in place.
 
-**Security note.** When relocating outside `~/.aws`, choose a dedicated directory that is not world-readable or shared with other users. CAO creates its log and FIFO directories with owner-only permissions (mode `0700`), but the chosen parent path should also be private since terminal logs can capture secrets and tokens.
+**Security note.** When relocating outside `~/.aws`, choose a dedicated directory that is not world-readable or shared with other users. CAO creates its base directory and log/FIFO subdirectories with owner-only permissions (mode `0700`), and applies a best-effort `chmod` to an existing base directory, but the chosen parent path should also be private since terminal logs can capture secrets and tokens.
 
-**Exceptions.** Two provider-specific config directories do **not** follow `CAO_HOME_DIR`:
+**Exceptions.** Two categories of provider-specific config directories do **not** follow `CAO_HOME_DIR`:
 
 - `~/.aws/opencode` (OpenCode provider config, managed via `OPENCODE_CONFIG_DIR` in `constants.py`) — OpenCode is told its config location at launch via env vars; a follow-up can repoint this.
-- `~/.kiro/agents` (Kiro CLI agent directory) — intentionally separate since Kiro manages its own agent install path independently of CAO's data tree.
+- Provider-native agent directories (`~/.kiro/agents`, `~/.copilot/agents`) — intentionally separate since each provider manages its own agent install path independently of CAO's data tree.
 
 ## settings.json schema
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,9 +20,16 @@ Set the `CAO_HOME_DIR` environment variable to relocate that entire tree:
 export CAO_HOME_DIR="$HOME/.cli-agent-orchestrator"
 ```
 
-Every derived path resolves from this value, so one override moves everything. `CAO_HOME_DIR` is read once, when CAO's `constants` module is first imported (the same convention as `CAO_AGENTS_DIR`), so export it **before** starting `cao-server`, the MCP servers, or any `cao` command. All CAO processes must resolve the same location.
+Every derived path resolves from this value, so one override moves everything — with two exceptions noted below. `CAO_HOME_DIR` is read once, when CAO's `constants` module is first imported (the same convention as `CAO_AGENTS_DIR`), so export it **before** starting `cao-server`, the MCP servers, or any `cao` command. All CAO processes must resolve the same location. Empty or whitespace-only values are treated as unset, and tilde (`~`) is expanded.
 
 **When to use it.** Some environments restrict or sandbox access to `~/.aws` at the OS level to protect AWS credentials. Because CAO otherwise stores its data there, including the agent profiles it reads during a `handoff`, a locked-down `~/.aws` can leave CAO unable to read its own data (a handoff then fails with `Permission denied`). Relocating `CAO_HOME_DIR` outside `~/.aws` keeps CAO working while leaving those credential protections in place.
+
+**Security note.** When relocating outside `~/.aws`, choose a dedicated directory that is not world-readable or shared with other users. CAO creates its log and FIFO directories with owner-only permissions (mode `0700`), but the chosen parent path should also be private since terminal logs can capture secrets and tokens.
+
+**Exceptions.** Two provider-specific config directories do **not** follow `CAO_HOME_DIR`:
+
+- `~/.aws/opencode` (OpenCode provider config, managed via `OPENCODE_CONFIG_DIR` in `constants.py`) — OpenCode is told its config location at launch via env vars; a follow-up can repoint this.
+- `~/.kiro/agents` (Kiro CLI agent directory) — intentionally separate since Kiro manages its own agent install path independently of CAO's data tree.
 
 ## settings.json schema
 
@@ -246,6 +253,10 @@ These map to `network.*` / `auth.*` schema paths for documentation purposes, but
 ### Not yet routed through ConfigService
 
 A number of other `CAO_*` variables (runtime/process-identity vars like `CAO_TERMINAL_ID`, `CAO_SESSION_NAME`, `CAO_WORKFLOW_RUN_ID`; provider-tuning vars like `CAO_HERMES_*`, `CAO_AGENTS_DIR`, `CAO_API_HOST`/`CAO_API_PORT`, `CAO_PYTE_STATUS`, `CAO_EAGER_INBOX_DELIVERY`; and `CAO_AUTH_LOCAL_TOKEN`) are still read ad hoc via `os.getenv` at their call sites, mostly in `constants.py`, `mcp_server/server.py`, `security/auth.py`, and the `providers/*` modules. These were deliberately left out of this pass to keep the diff scoped to the two surfaces issue #357 named explicitly (`settings.json` + `config.json`); folding them into the registry is a natural follow-up but not required for config unification.
+
+| Env var | Default | Type | Purpose |
+|---|---|---|---|
+| `CAO_HOME_DIR` | `~/.aws/cli-agent-orchestrator` | str (path) | Base directory for all CAO state. See [Data directory](#data-directory-cao_home_dir) above. |
 
 The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds six more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,20 @@ CLI flag  >  CAO_* environment variable  >  settings.json  >  built-in default
 
 > `.env` file handling (`utils/env.py`, forwarded provider env vars) is a separate, out-of-scope surface — unaffected by this doc.
 
+## Data directory (`CAO_HOME_DIR`)
+
+All CAO state lives under a single base directory, `~/.aws/cli-agent-orchestrator` by default: the SQLite DB, logs, FIFOs, memory, the `agent-store` / `agent-context` profile dirs, skills, workflow scratch, and `settings.json` itself.
+
+Set the `CAO_HOME_DIR` environment variable to relocate that entire tree:
+
+```bash
+export CAO_HOME_DIR="$HOME/.cli-agent-orchestrator"
+```
+
+Every derived path resolves from this value, so one override moves everything. `CAO_HOME_DIR` is read once, when CAO's `constants` module is first imported (the same convention as `CAO_AGENTS_DIR`), so export it **before** starting `cao-server`, the MCP servers, or any `cao` command. All CAO processes must resolve the same location.
+
+**When to use it.** Some environments restrict or sandbox access to `~/.aws` at the OS level to protect AWS credentials. Because CAO otherwise stores its data there, including the agent profiles it reads during a `handoff`, a locked-down `~/.aws` can leave CAO unable to read its own data (a handoff then fails with `Permission denied`). Relocating `CAO_HOME_DIR` outside `~/.aws` keeps CAO working while leaving those credential protections in place.
+
 ## settings.json schema
 
 ```json

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import re
+import shlex
 import subprocess
 import time
 import uuid
@@ -718,7 +719,7 @@ class TmuxClient:
 
             pane = window.active_pane
             if pane:
-                pane.cmd("pipe-pane", "-o", f"cat >> {file_path}")
+                pane.cmd("pipe-pane", "-o", f"cat >> {shlex.quote(str(file_path))}")
                 logger.info(f"Started pipe-pane for {session_name}:{window_name} to {file_path}")
         except Exception as e:
             logger.error(f"Failed to start pipe-pane for {session_name}:{window_name}: {e}")

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -92,11 +92,16 @@ BRACKETED_PASTE_INCOMPATIBLE_SHELLS = frozenset(
 # overridable via the ``CAO_HOME_DIR`` env var (read at import, mirroring the
 # ``CAO_AGENTS_DIR`` / ``CAO_GRAPH_EXPORT_ROOT`` convention). Every path below
 # derives from it, so one override relocates the whole tree. Motivating case:
-# Kiro CLI Agent Sandboxing blocks reads under ``~/.aws`` at the OS level
-# (seccomp-bpf) to protect credentials; pointing this outside ``~/.aws`` keeps
-# the sandbox enabled. Must be set before this module is first imported.
-CAO_HOME_DIR = Path(
-    os.environ.get("CAO_HOME_DIR", str(Path.home() / ".aws" / "cli-agent-orchestrator"))
+# environments that restrict reads under ``~/.aws`` at the OS level (e.g.
+# seccomp-bpf sandboxing) to protect credentials; pointing this outside
+# ``~/.aws`` keeps the sandbox enabled. Must be set before this module is first
+# imported. Empty or whitespace-only values are treated as unset; tilde is
+# expanded and the result is resolved to an absolute path.
+_cao_home_raw = os.environ.get("CAO_HOME_DIR", "").strip()
+CAO_HOME_DIR = (
+    Path(_cao_home_raw).expanduser().resolve()
+    if _cao_home_raw
+    else Path.home() / ".aws" / "cli-agent-orchestrator"
 )
 
 # Managed environment variable file
@@ -108,11 +113,11 @@ DB_DIR = CAO_HOME_DIR / "db"
 # Log file directory structure
 LOG_DIR = CAO_HOME_DIR / "logs"
 TERMINAL_LOG_DIR = LOG_DIR / "terminal"  # Per-terminal log files for pipe-pane output
-TERMINAL_LOG_DIR.mkdir(parents=True, exist_ok=True)
+TERMINAL_LOG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
 
 # FIFO directory for event-driven terminal output streaming
 FIFO_DIR = CAO_HOME_DIR / "fifos"  # Named pipes for tmux pipe-pane streaming
-FIFO_DIR.mkdir(parents=True, exist_ok=True)
+FIFO_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
 
 # =============================================================================
 # Event-Driven State Detection Configuration

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -93,16 +93,26 @@ BRACKETED_PASTE_INCOMPATIBLE_SHELLS = frozenset(
 # ``CAO_AGENTS_DIR`` / ``CAO_GRAPH_EXPORT_ROOT`` convention). Every path below
 # derives from it, so one override relocates the whole tree. Motivating case:
 # environments that restrict reads under ``~/.aws`` at the OS level (e.g.
-# seccomp-bpf sandboxing) to protect credentials; pointing this outside
-# ``~/.aws`` keeps the sandbox enabled. Must be set before this module is first
-# imported. Empty or whitespace-only values are treated as unset; tilde is
-# expanded and the result is resolved to an absolute path.
+# AppArmor, mount namespaces, or similar path-based sandboxing) to protect
+# credentials; pointing this outside ``~/.aws`` keeps the sandbox enabled.
+# Must be set before this module is first imported. Empty or whitespace-only
+# values are treated as unset; tilde is expanded and the result is resolved to
+# an absolute path.
 _cao_home_raw = os.environ.get("CAO_HOME_DIR", "").strip()
 CAO_HOME_DIR = (
     Path(_cao_home_raw).expanduser().resolve()
     if _cao_home_raw
     else Path.home() / ".aws" / "cli-agent-orchestrator"
 )
+
+# Ensure the base directory exists with owner-only permissions. When relocated
+# outside ~/.aws there is no parent permission umbrella protecting the DB,
+# memory, agent-store, and terminal logs from other local users.
+CAO_HOME_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+try:
+    os.chmod(CAO_HOME_DIR, 0o700)
+except OSError:
+    pass  # best-effort: may fail on read-only mounts or non-owned dirs
 
 # Managed environment variable file
 CAO_ENV_FILE = CAO_HOME_DIR / ".env"

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -88,8 +88,16 @@ BRACKETED_PASTE_INCOMPATIBLE_SHELLS = frozenset(
 # =============================================================================
 # Application Directory Structure
 # =============================================================================
-# Base directory for all CAO data (~/.aws/cli-agent-orchestrator)
-CAO_HOME_DIR = Path.home() / ".aws" / "cli-agent-orchestrator"
+# Base directory for all CAO data. Defaults to ``~/.aws/cli-agent-orchestrator``,
+# overridable via the ``CAO_HOME_DIR`` env var (read at import, mirroring the
+# ``CAO_AGENTS_DIR`` / ``CAO_GRAPH_EXPORT_ROOT`` convention). Every path below
+# derives from it, so one override relocates the whole tree. Motivating case:
+# Kiro CLI Agent Sandboxing blocks reads under ``~/.aws`` at the OS level
+# (seccomp-bpf) to protect credentials; pointing this outside ``~/.aws`` keeps
+# the sandbox enabled. Must be set before this module is first imported.
+CAO_HOME_DIR = Path(
+    os.environ.get("CAO_HOME_DIR", str(Path.home() / ".aws" / "cli-agent-orchestrator"))
+)
 
 # Managed environment variable file
 CAO_ENV_FILE = CAO_HOME_DIR / ".env"

--- a/src/cli_agent_orchestrator/providers/cursor_cli.py
+++ b/src/cli_agent_orchestrator/providers/cursor_cli.py
@@ -71,6 +71,7 @@ from pathlib import Path
 from typing import Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
+from cli_agent_orchestrator.constants import CAO_HOME_DIR
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.services.settings_service import get_server_settings
@@ -531,16 +532,13 @@ class CursorCliProvider(BaseProvider):
 
         Honours the ``CAO_TMP_DIR`` env var so tests can redirect
         temp output to ``/tmp/cao_test`` instead of polluting the
-        user's ``~/.aws/cli-agent-orchestrator/tmp``. Defaults to
-        ``~/.aws/cli-agent-orchestrator/tmp`` for production.
+        user's CAO data dir. Defaults to ``<CAO_HOME_DIR>/tmp`` (i.e.
+        ``~/.aws/cli-agent-orchestrator/tmp`` unless ``CAO_HOME_DIR`` is
+        overridden), matching where the other providers write temp files.
         """
         import os
 
-        cao_tmp = Path(
-            os.environ.get(
-                "CAO_TMP_DIR", str(Path.home() / ".aws" / "cli-agent-orchestrator" / "tmp")
-            )
-        )
+        cao_tmp = Path(os.environ.get("CAO_TMP_DIR", str(CAO_HOME_DIR / "tmp")))
         cao_tmp.mkdir(parents=True, exist_ok=True)
         return cao_tmp
 

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -16,9 +16,9 @@ SETTINGS_FILE = CAO_HOME_DIR / "settings.json"
 # Default agent directories per provider
 _DEFAULTS = {
     "kiro_cli": str(Path.home() / ".kiro" / "agents"),
-    "claude_code": str(Path.home() / ".aws" / "cli-agent-orchestrator" / "agent-store"),
-    "codex": str(Path.home() / ".aws" / "cli-agent-orchestrator" / "agent-store"),
-    "cao_installed": str(Path.home() / ".aws" / "cli-agent-orchestrator" / "agent-context"),
+    "claude_code": str(CAO_HOME_DIR / "agent-store"),
+    "codex": str(CAO_HOME_DIR / "agent-store"),
+    "cao_installed": str(CAO_HOME_DIR / "agent-context"),
 }
 
 _BOOL_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})

--- a/src/cli_agent_orchestrator/utils/agent_profiles.py
+++ b/src/cli_agent_orchestrator/utils/agent_profiles.py
@@ -205,7 +205,8 @@ def list_agent_profiles() -> List[Dict]:
     disabled = {normalized_path(d) for d in get_disabled_agent_dirs()}
     scanned_paths: Set[str] = set()
 
-    # 1. Local agent store (~/.aws/cli-agent-orchestrator/agent-store/).
+    # 1. Local agent store (derives from CAO_HOME_DIR, default
+    # ~/.aws/cli-agent-orchestrator/agent-store/).
     # It shares a path with the claude_code/codex default, so honour the
     # disable toggle here too — otherwise disabling that default wouldn't hide
     # its profiles.
@@ -292,7 +293,8 @@ def _read_agent_profile_source(agent_name: str) -> str:
     """Locate an agent profile across configured stores and return the raw text.
 
     Search order:
-    1. Local store: ~/.aws/cli-agent-orchestrator/agent-store/{name}.md
+    1. Local store: <CAO_HOME_DIR>/agent-store/{name}.md (default
+       ~/.aws/cli-agent-orchestrator/agent-store/)
     2. Provider-specific directories (flat {name}.md or {name}/agent.md)
     3. Extra user-added directories (flat {name}.md or {name}/agent.md)
     4. Built-in store (packaged with CAO)

--- a/test/providers/test_cursor_cli_unit.py
+++ b/test/providers/test_cursor_cli_unit.py
@@ -1223,6 +1223,39 @@ class TestMiscInterface:
         assert provider._tmp_paths == []
         provider.cleanup()  # should not raise
 
+    def test_cao_tmp_dir_fallback_follows_cao_home_dir(self, tmp_path, monkeypatch):
+        # When CAO_TMP_DIR is unset, _cao_tmp_dir() must fall back to
+        # <CAO_HOME_DIR>/tmp. Since cursor_cli binds CAO_HOME_DIR at its own
+        # import time, we must reload both constants and cursor_cli.
+        import importlib
+
+        override = tmp_path / "cao-home"
+        monkeypatch.setenv("CAO_HOME_DIR", str(override))
+        monkeypatch.delenv("CAO_TMP_DIR", raising=False)
+
+        import cli_agent_orchestrator.constants as constants_module
+
+        importlib.reload(constants_module)
+
+        import cli_agent_orchestrator.providers.cursor_cli as cursor_module
+
+        importlib.reload(cursor_module)
+
+        provider = make_provider()
+        result = provider._cao_tmp_dir()
+        resolved_override = override.resolve()
+        assert result == resolved_override / "tmp"
+        assert result.is_dir()
+
+    def test_cao_tmp_dir_env_override_wins(self, tmp_path, monkeypatch):
+        # CAO_TMP_DIR takes precedence over the CAO_HOME_DIR-derived fallback.
+        explicit_tmp = tmp_path / "explicit-tmp"
+        monkeypatch.setenv("CAO_TMP_DIR", str(explicit_tmp))
+        provider = make_provider()
+        result = provider._cao_tmp_dir()
+        assert result == explicit_tmp
+        assert result.is_dir()
+
     def test_paste_enter_count_is_one(self):
         assert make_provider().paste_enter_count == 1
 

--- a/test/providers/test_cursor_cli_unit.py
+++ b/test/providers/test_cursor_cli_unit.py
@@ -1228,7 +1228,9 @@ class TestMiscInterface:
         # <CAO_HOME_DIR>/tmp. Since cursor_cli binds CAO_HOME_DIR at its own
         # import time, we must reload both constants and cursor_cli.
         import importlib
+        import os
 
+        original_value = os.environ.get("CAO_HOME_DIR")
         override = tmp_path / "cao-home"
         monkeypatch.setenv("CAO_HOME_DIR", str(override))
         monkeypatch.delenv("CAO_TMP_DIR", raising=False)
@@ -1241,11 +1243,20 @@ class TestMiscInterface:
 
         importlib.reload(cursor_module)
 
-        provider = make_provider()
-        result = provider._cao_tmp_dir()
-        resolved_override = override.resolve()
-        assert result == resolved_override / "tmp"
-        assert result.is_dir()
+        try:
+            provider = make_provider()
+            result = provider._cao_tmp_dir()
+            resolved_override = override.resolve()
+            assert result == resolved_override / "tmp"
+            assert result.is_dir()
+        finally:
+            # Restore module state so the reload doesn't leak into later tests.
+            if original_value is not None:
+                monkeypatch.setenv("CAO_HOME_DIR", original_value)
+            else:
+                monkeypatch.delenv("CAO_HOME_DIR", raising=False)
+            importlib.reload(constants_module)
+            importlib.reload(cursor_module)
 
     def test_cao_tmp_dir_env_override_wins(self, tmp_path, monkeypatch):
         # CAO_TMP_DIR takes precedence over the CAO_HOME_DIR-derived fallback.

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -445,14 +445,27 @@ class TestCaoHomeDirEnvOverride:
         assert "~" not in str(mod.CAO_HOME_DIR)
 
     def test_import_time_dirs_have_restricted_permissions(self, tmp_path):
-        # Directories created at import time must be owner-only (0o700) to
-        # protect secret-bearing terminal logs when relocated outside ~/.aws.
+        # Directories created at import time must have no group/other access
+        # to protect secret-bearing terminal logs when relocated outside ~/.aws.
         override = tmp_path / "cao-home"
         self._reload_constants({"CAO_HOME_DIR": str(override)})
-        terminal_log_dir = override / "logs" / "terminal"
-        fifo_dir = override / "fifos"
-        assert terminal_log_dir.stat().st_mode & 0o777 == 0o700
-        assert fifo_dir.stat().st_mode & 0o777 == 0o700
+        resolved = override.resolve()
+        # Base dir itself is hardened
+        assert resolved.stat().st_mode & 0o077 == 0
+        # Leaf dirs are hardened
+        terminal_log_dir = resolved / "logs" / "terminal"
+        fifo_dir = resolved / "fifos"
+        assert terminal_log_dir.stat().st_mode & 0o077 == 0
+        assert fifo_dir.stat().st_mode & 0o077 == 0
+
+    def test_pre_existing_base_dir_is_chmodded(self, tmp_path):
+        # If the base dir already exists with lax permissions, the import-time
+        # chmod tightens it to owner-only.
+        override = tmp_path / "cao-home"
+        override.mkdir(mode=0o755)
+        self._reload_constants({"CAO_HOME_DIR": str(override)})
+        resolved = override.resolve()
+        assert resolved.stat().st_mode & 0o077 == 0
 
 
 class TestSessionConstants:

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 
 class TestServerConstants:
     """Tests for server configuration constants."""
@@ -324,6 +326,100 @@ class TestCaoHomeDir:
         from cli_agent_orchestrator.constants import CAO_HOME_DIR, SKILLS_DIR
 
         assert SKILLS_DIR == CAO_HOME_DIR / "skills"
+
+
+class TestCaoHomeDirEnvOverride:
+    """The ``CAO_HOME_DIR`` env var relocates CAO's entire data tree.
+
+    Some environments restrict access to ``~/.aws`` (where CAO stores its data
+    by default) to protect AWS credentials, which can leave CAO unable to read
+    its own agent profiles. Setting ``CAO_HOME_DIR`` moves the whole tree
+    elsewhere. The override is read at import, so a single reload must
+    propagate to every derived path.
+    """
+
+    def _reload_constants(self, env_overrides):
+        import importlib
+        import os
+
+        env_copy = os.environ.copy()
+        env_copy.pop("CAO_HOME_DIR", None)
+        env_copy.update(env_overrides)
+        with patch.dict("os.environ", env_copy, clear=True):
+            import cli_agent_orchestrator.constants as constants_module
+
+            importlib.reload(constants_module)
+            return constants_module
+
+    def _reload_constants_and_settings(self, override):
+        """Reload constants, then settings_service, under a CAO_HOME_DIR override.
+
+        ``settings_service`` binds ``CAO_HOME_DIR`` at its own import time, so it
+        must be reloaded *after* constants for the override to reach its
+        ``_DEFAULTS`` agent-dir map. Passing ``None`` restores the defaults.
+        """
+        import importlib
+        import os
+
+        env_copy = os.environ.copy()
+        env_copy.pop("CAO_HOME_DIR", None)
+        if override is not None:
+            env_copy["CAO_HOME_DIR"] = str(override)
+        with patch.dict("os.environ", env_copy, clear=True):
+            import cli_agent_orchestrator.constants as constants_module
+            import cli_agent_orchestrator.services.settings_service as settings_module
+
+            importlib.reload(constants_module)
+            importlib.reload(settings_module)
+            return constants_module, settings_module
+
+    @pytest.fixture(autouse=True)
+    def _restore_default_constants(self):
+        # Reloading under an override mutates the shared modules in place; reload
+        # them back to their default-env state after each test so the override
+        # cannot leak into tests (here or in other files) that import directly.
+        yield
+        self._reload_constants_and_settings(None)
+
+    def test_override_relocates_home_dir(self, tmp_path):
+        override = tmp_path / "cao-home"
+        mod = self._reload_constants({"CAO_HOME_DIR": str(override)})
+        assert mod.CAO_HOME_DIR == override
+
+    def test_derived_paths_follow_override(self, tmp_path):
+        override = tmp_path / "cao-home"
+        mod = self._reload_constants({"CAO_HOME_DIR": str(override)})
+        assert mod.DB_DIR == override / "db"
+        assert mod.LOG_DIR == override / "logs"
+        assert mod.FIFO_DIR == override / "fifos"
+        assert mod.AGENT_CONTEXT_DIR == override / "agent-context"
+        assert mod.LOCAL_AGENT_STORE_DIR == override / "agent-store"
+        assert mod.SKILLS_DIR == override / "skills"
+        assert mod.MEMORY_BASE_DIR == override / "memory"
+        assert mod.DATABASE_FILE == override / "db" / "cli-agent-orchestrator.db"
+
+    def test_import_time_dirs_created_under_override(self, tmp_path):
+        # constants.py mkdirs TERMINAL_LOG_DIR and FIFO_DIR at import; under the
+        # override they must be created below the new root, never under ~/.aws.
+        override = tmp_path / "cao-home"
+        self._reload_constants({"CAO_HOME_DIR": str(override)})
+        assert (override / "logs" / "terminal").is_dir()
+        assert (override / "fifos").is_dir()
+
+    def test_agent_dir_defaults_follow_override(self, tmp_path):
+        # Load-bearing for the restricted-~/.aws case: the agent-store and
+        # agent-context defaults used for the handoff profile read must relocate.
+        override = tmp_path / "cao-home"
+        _, settings_module = self._reload_constants_and_settings(override)
+        assert settings_module._DEFAULTS["claude_code"] == str(override / "agent-store")
+        assert settings_module._DEFAULTS["codex"] == str(override / "agent-store")
+        assert settings_module._DEFAULTS["cao_installed"] == str(override / "agent-context")
+        # kiro_cli tracks ~/.kiro, not CAO_HOME_DIR, so it is intentionally unchanged.
+        assert settings_module._DEFAULTS["kiro_cli"] == str(Path.home() / ".kiro" / "agents")
+
+    def test_default_when_env_not_set(self):
+        mod = self._reload_constants({})
+        assert mod.CAO_HOME_DIR == Path.home() / ".aws" / "cli-agent-orchestrator"
 
 
 class TestSessionConstants:

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -376,50 +376,83 @@ class TestCaoHomeDirEnvOverride:
     @pytest.fixture(autouse=True)
     def _restore_default_constants(self):
         # Reloading under an override mutates the shared modules in place; reload
-        # them back to their default-env state after each test so the override
+        # them back to their original-env state after each test so the override
         # cannot leak into tests (here or in other files) that import directly.
+        import os
+
+        original_value = os.environ.get("CAO_HOME_DIR")
         yield
-        self._reload_constants_and_settings(None)
+        self._reload_constants_and_settings(original_value)
 
     def test_override_relocates_home_dir(self, tmp_path):
         override = tmp_path / "cao-home"
         mod = self._reload_constants({"CAO_HOME_DIR": str(override)})
-        assert mod.CAO_HOME_DIR == override
+        assert mod.CAO_HOME_DIR == override.resolve()
 
     def test_derived_paths_follow_override(self, tmp_path):
         override = tmp_path / "cao-home"
         mod = self._reload_constants({"CAO_HOME_DIR": str(override)})
-        assert mod.DB_DIR == override / "db"
-        assert mod.LOG_DIR == override / "logs"
-        assert mod.FIFO_DIR == override / "fifos"
-        assert mod.AGENT_CONTEXT_DIR == override / "agent-context"
-        assert mod.LOCAL_AGENT_STORE_DIR == override / "agent-store"
-        assert mod.SKILLS_DIR == override / "skills"
-        assert mod.MEMORY_BASE_DIR == override / "memory"
-        assert mod.DATABASE_FILE == override / "db" / "cli-agent-orchestrator.db"
+        resolved = override.resolve()
+        assert mod.DB_DIR == resolved / "db"
+        assert mod.LOG_DIR == resolved / "logs"
+        assert mod.FIFO_DIR == resolved / "fifos"
+        assert mod.AGENT_CONTEXT_DIR == resolved / "agent-context"
+        assert mod.LOCAL_AGENT_STORE_DIR == resolved / "agent-store"
+        assert mod.SKILLS_DIR == resolved / "skills"
+        assert mod.MEMORY_BASE_DIR == resolved / "memory"
+        assert mod.DATABASE_FILE == resolved / "db" / "cli-agent-orchestrator.db"
 
     def test_import_time_dirs_created_under_override(self, tmp_path):
         # constants.py mkdirs TERMINAL_LOG_DIR and FIFO_DIR at import; under the
         # override they must be created below the new root, never under ~/.aws.
         override = tmp_path / "cao-home"
         self._reload_constants({"CAO_HOME_DIR": str(override)})
-        assert (override / "logs" / "terminal").is_dir()
-        assert (override / "fifos").is_dir()
+        resolved = override.resolve()
+        assert (resolved / "logs" / "terminal").is_dir()
+        assert (resolved / "fifos").is_dir()
 
     def test_agent_dir_defaults_follow_override(self, tmp_path):
         # Load-bearing for the restricted-~/.aws case: the agent-store and
         # agent-context defaults used for the handoff profile read must relocate.
         override = tmp_path / "cao-home"
         _, settings_module = self._reload_constants_and_settings(override)
-        assert settings_module._DEFAULTS["claude_code"] == str(override / "agent-store")
-        assert settings_module._DEFAULTS["codex"] == str(override / "agent-store")
-        assert settings_module._DEFAULTS["cao_installed"] == str(override / "agent-context")
+        resolved = override.resolve()
+        assert settings_module._DEFAULTS["claude_code"] == str(resolved / "agent-store")
+        assert settings_module._DEFAULTS["codex"] == str(resolved / "agent-store")
+        assert settings_module._DEFAULTS["cao_installed"] == str(resolved / "agent-context")
         # kiro_cli tracks ~/.kiro, not CAO_HOME_DIR, so it is intentionally unchanged.
         assert settings_module._DEFAULTS["kiro_cli"] == str(Path.home() / ".kiro" / "agents")
 
     def test_default_when_env_not_set(self):
         mod = self._reload_constants({})
         assert mod.CAO_HOME_DIR == Path.home() / ".aws" / "cli-agent-orchestrator"
+
+    def test_empty_string_treated_as_unset(self):
+        # An empty CAO_HOME_DIR (e.g. `export CAO_HOME_DIR=`) must not resolve
+        # to CWD; treat it as unset and fall back to the default.
+        mod = self._reload_constants({"CAO_HOME_DIR": ""})
+        assert mod.CAO_HOME_DIR == Path.home() / ".aws" / "cli-agent-orchestrator"
+
+    def test_whitespace_only_treated_as_unset(self):
+        mod = self._reload_constants({"CAO_HOME_DIR": "   "})
+        assert mod.CAO_HOME_DIR == Path.home() / ".aws" / "cli-agent-orchestrator"
+
+    def test_tilde_expanded(self, tmp_path):
+        # A literal ~/some-path must be expanded, not create a dir named "~".
+        mod = self._reload_constants({"CAO_HOME_DIR": "~/cao-test-data"})
+        expected = Path("~/cao-test-data").expanduser().resolve()
+        assert mod.CAO_HOME_DIR == expected
+        assert "~" not in str(mod.CAO_HOME_DIR)
+
+    def test_import_time_dirs_have_restricted_permissions(self, tmp_path):
+        # Directories created at import time must be owner-only (0o700) to
+        # protect secret-bearing terminal logs when relocated outside ~/.aws.
+        override = tmp_path / "cao-home"
+        self._reload_constants({"CAO_HOME_DIR": str(override)})
+        terminal_log_dir = override / "logs" / "terminal"
+        fifo_dir = override / "fifos"
+        assert terminal_log_dir.stat().st_mode & 0o777 == 0o700
+        assert fifo_dir.stat().st_mode & 0o777 == 0o700
 
 
 class TestSessionConstants:


### PR DESCRIPTION
## What

`CAO_HOME_DIR`, the base directory for all CAO data (SQLite DB, logs, FIFOs, memory, `agent-store` / `agent-context`, skills, workflow scratch, and `settings.json`), was hardcoded to `~/.aws/cli-agent-orchestrator`. It now reads the `CAO_HOME_DIR` environment variable, falling back to that same default, so the whole data tree can be relocated with a single override. This mirrors the existing `CAO_AGENTS_DIR` and `CAO_GRAPH_EXPORT_ROOT` overrides in `constants.py`. It is read once, when `constants` is first imported, so export it before `cao-server`, the MCP servers, or any `cao` command.

## Why

Some environments restrict or sandbox access to `~/.aws` at the OS level to protect AWS credentials. Because CAO stores its data there, including the agent profiles it reads during a `handoff`, a locked-down `~/.aws` leaves CAO unable to read its own data and handoffs fail with `Permission denied`. Relocating `CAO_HOME_DIR` outside `~/.aws` resolves this while leaving credential protections in place; the only workaround today is to move the directory and symlink it back.

## Changes

- `constants.py`: `CAO_HOME_DIR` now reads from the env var (default unchanged).
- `services/settings_service.py`: the `claude_code` / `codex` / `cao_installed` agent-dir defaults now derive from `CAO_HOME_DIR` instead of re-hardcoding the path. These are the profile dirs the `handoff` read uses, so this is what makes the override actually fix the restricted-`~/.aws` case.
- `providers/cursor_cli.py`: the `CAO_TMP_DIR` fallback now derives from `CAO_HOME_DIR` (was a hardcoded duplicate), so the override is complete.
- `test/test_constants.py`: adds `TestCaoHomeDirEnvOverride` (override applies, derived paths follow, import-time `mkdir`s land under the override, `settings_service` defaults follow, default when unset), with a restore fixture so the module reloads don't leak.
- `docs/configuration.md`: new "Data directory (`CAO_HOME_DIR`)" section.

## Testing

- `uv run black --check` and `uv run isort --check-only`: clean.
- `uv run mypy src/`: no new type errors.
- `uv run pytest test/ --ignore=test/e2e -m "not integration"`: full unit suite passes, including the 5 new tests.

## Notes / out of scope

- `settings_service`'s `kiro_cli` default still hardcodes `~/.kiro/agents` and does not honor `CAO_AGENTS_DIR`; pre-existing and separate, left alone to keep this diff focused.
- `OPENCODE_CONFIG_DIR` (`~/.aws/opencode`) is a distinct directory, not under `CAO_HOME_DIR`, so it is unaffected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
