### PR TITLE
fix: harden tmux terminal lifecycle

### DIFF
--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+import threading
 import time
 import uuid
 from typing import Dict, List, Optional
@@ -22,8 +23,83 @@ logger = logging.getLogger(__name__)
 class TmuxClient:
     """Simplified tmux client for basic operations."""
 
+    _LOGICAL_WINDOW_OPTION = "@cao_logical_window"
+
     def __init__(self) -> None:
         self.server = libtmux.Server()
+        # Window names are presentation labels, not stable identifiers. Shells
+        # and TUIs (notably zsh + Claude Code) can rename a tmux window while
+        # they start. Keep the immutable tmux window id behind the adapter so
+        # application code can continue using its logical CAO window name.
+        self._window_ids: dict[tuple[str, str], str] = {}
+        self._window_ids_lock = threading.Lock()
+
+    def _remember_window(self, session_name: str, logical_name: str, window) -> None:
+        window_id = getattr(window, "window_id", None)
+        if isinstance(window_id, str) and window_id.startswith("@"):
+            with self._window_ids_lock:
+                self._window_ids[(session_name, logical_name)] = window_id
+            try:
+                window.set_option(self._LOGICAL_WINDOW_OPTION, logical_name)
+            except Exception as exc:
+                # The in-memory id still protects the active server process.
+                # Metadata is best-effort compatibility for CAO restarts.
+                logger.warning(
+                    "Could not persist logical tmux window identity for %s:%s: %s",
+                    session_name,
+                    logical_name,
+                    exc,
+                )
+
+    def _window_id(self, session_name: str, logical_name: str) -> Optional[str]:
+        with self._window_ids_lock:
+            return self._window_ids.get((session_name, logical_name))
+
+    def _get_window(self, session, session_name: str, logical_name: str):
+        """Resolve a logical CAO window name to the stable tmux window object."""
+        window_id = self._window_id(session_name, logical_name)
+        if window_id:
+            try:
+                return session.windows.get(window_id=window_id)
+            except libtmux.exc.ObjectDoesNotExist:
+                # The id may be stale after an external tmux teardown. Fall
+                # through to metadata/name recovery.
+                pass
+
+        # User options live in tmux itself, so they survive a CAO process
+        # restart even when a shell or TUI has changed the display name.
+        for candidate in session.windows:
+            try:
+                persisted_name = candidate.show_option(
+                    self._LOGICAL_WINDOW_OPTION,
+                    ignore_errors=True,
+                )
+            except Exception:
+                continue
+            if persisted_name == logical_name:
+                self._remember_window(session_name, logical_name, candidate)
+                return candidate
+
+        # Compatibility path for windows created before identity metadata was
+        # introduced. If the display name still matches, migrate it in place.
+        window = session.windows.get(window_name=logical_name)
+        if window:
+            self._remember_window(session_name, logical_name, window)
+        return window
+
+    def _target(self, session_name: str, logical_name: str) -> str:
+        """Return a tmux CLI target, preferring immutable ``@window_id``."""
+        window_id = self._window_id(session_name, logical_name)
+        if window_id:
+            return window_id
+
+        try:
+            session = self.server.sessions.get(session_name=session_name)
+            if session:
+                self._get_window(session, session_name, logical_name)
+        except libtmux.exc.ObjectDoesNotExist:
+            pass
+        return self._window_id(session_name, logical_name) or f"{session_name}:{logical_name}"
 
     # Kept as an alias so existing callers/tests referencing the class
     # attribute keep working; the canonical set lives in
@@ -188,10 +264,11 @@ class TmuxClient:
             logger.info(
                 f"Created tmux session: {session_name} with window: {window_name} in directory: {working_directory}"
             )
-            window_name_result = session.windows[0].name
-            if window_name_result is None:
+            window = session.windows[0]
+            self._remember_window(session_name, window_name, window)
+            if window.name is None:
                 raise ValueError(f"Window name is None for session {session_name}")
-            return window_name_result
+            return window_name
         except Exception as e:
             logger.error(f"Failed to create session {session_name}: {e}")
             raise
@@ -231,14 +308,14 @@ class TmuxClient:
                 kwargs["window_shell"] = window_shell
 
             window = session.new_window(**kwargs)
+            self._remember_window(session_name, window_name, window)
 
             logger.info(
                 f"Created window '{window.name}' in session '{session_name}' in directory: {working_directory}"
             )
-            window_name_result = window.name
-            if window_name_result is None:
+            if window.name is None:
                 raise ValueError(f"Window name is None for session {session_name}")
-            return window_name_result
+            return window_name
         except Exception as e:
             logger.error(f"Failed to create window in session {session_name}: {e}")
             raise
@@ -281,7 +358,7 @@ class TmuxClient:
         # also clears the CodeQL py/command-line-injection data flow.
         validated_session = validate_tmux_name(session_name, "session_name")
         validated_window = validate_tmux_name(window_name, "window_name")
-        target = f"{validated_session}:{validated_window}"
+        target = self._target(validated_session, validated_window)
         buf_name = f"cao_{uuid.uuid4().hex[:8]}"
         try:
             # Log metadata only at INFO: the payload is the full launch
@@ -360,7 +437,7 @@ class TmuxClient:
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
@@ -410,7 +487,7 @@ class TmuxClient:
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
@@ -444,7 +521,7 @@ class TmuxClient:
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
@@ -510,6 +587,10 @@ class TmuxClient:
             session = self.server.sessions.get(session_name=session_name)
             if session:
                 session.kill()
+                with self._window_ids_lock:
+                    stale = [key for key in self._window_ids if key[0] == session_name]
+                    for key in stale:
+                        self._window_ids.pop(key, None)
                 logger.info(f"Killed tmux session: {session_name}")
                 return True
             return False
@@ -523,9 +604,11 @@ class TmuxClient:
             session = self.server.sessions.get(session_name=session_name)
             if not session:
                 return False
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if window:
                 window.kill()
+                with self._window_ids_lock:
+                    self._window_ids.pop((session_name, window_name), None)
                 logger.info(f"Killed tmux window: {session_name}:{window_name}")
                 return True
             return False
@@ -548,7 +631,7 @@ class TmuxClient:
             if not session:
                 return None
 
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if not window:
                 return None
 
@@ -557,7 +640,7 @@ class TmuxClient:
                 # Get pane_current_path from tmux
                 result = pane.cmd("display-message", "-p", "#{pane_current_path}")
                 if result.stdout:
-                    return result.stdout[0].strip()
+                    return str(result.stdout[0]).strip()
             return None
         except Exception as e:
             logger.error(f"Failed to get working directory for {session_name}:{window_name}: {e}")
@@ -569,14 +652,14 @@ class TmuxClient:
             session = self.server.sessions.get(session_name=session_name)
             if not session:
                 return None
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if not window:
                 return None
             pane = window.active_pane
             if pane:
                 result = pane.cmd("display-message", "-p", "#{pane_current_command}")
                 if result.stdout:
-                    return result.stdout[0].strip()
+                    return str(result.stdout[0]).strip()
             return None
         except Exception as e:
             logger.error(f"Failed to get pane command for {session_name}:{window_name}: {e}")
@@ -595,7 +678,7 @@ class TmuxClient:
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
@@ -619,7 +702,7 @@ class TmuxClient:
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._get_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -7,6 +7,7 @@ Publisher: terminal.{id}.status
 import asyncio
 import logging
 import threading
+from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple
 
 from cli_agent_orchestrator.constants import (
@@ -44,6 +45,12 @@ _STICKY_READY_STATUSES = frozenset(
         TerminalStatus.ERROR,
     }
 )
+
+# Deleted terminal IDs are retained long enough to reject output that was
+# already queued in EventBus or still in flight in a detection worker.  IDs are
+# random and are not normally reused; bounding the registry avoids turning the
+# lifecycle guard itself into an unbounded server-lifetime allocation.
+_MAX_TERMINAL_TOMBSTONES = 4096
 
 
 class StatusMonitor:
@@ -91,6 +98,35 @@ class StatusMonitor:
         # this a detection task can be garbage-collected mid-run and silently drop
         # a status transition. Tasks remove themselves on completion.
         self._detect_tasks: set = set()
+        # A generation identifies one runtime incarnation of a terminal ID.
+        # clear_terminal() advances it and installs a tombstone before resources
+        # are removed; callbacks that captured an older generation then become
+        # harmless no-ops.  register_terminal() starts a fresh incarnation and
+        # removes the tombstone (supporting deterministic ID reuse in tests and
+        # future restore paths).
+        self._generations: Dict[str, int] = {}
+        self._tombstones: OrderedDict[str, int] = OrderedDict()
+
+    def register_terminal(self, terminal_id: str) -> int:
+        """Start a new monitored runtime generation for ``terminal_id``."""
+        with self._lock:
+            generation = self._generations.get(terminal_id, 0) + 1
+            self._generations[terminal_id] = generation
+            self._tombstones.pop(terminal_id, None)
+            return generation
+
+    def _is_current_generation_locked(
+        self, terminal_id: str, generation: Optional[int] = None
+    ) -> bool:
+        """Return whether work still belongs to a live terminal generation.
+
+        The caller must hold ``_lock``.  ``generation=None`` is used by legacy
+        direct/unit paths and means "any live generation", while still honoring
+        a teardown tombstone.
+        """
+        if terminal_id in self._tombstones:
+            return False
+        return generation is None or self._generations.get(terminal_id, 0) == generation
 
     async def run(self) -> None:
         """Subscribe to output events and detect status changes.
@@ -134,7 +170,24 @@ class StatusMonitor:
           resumed) and at quiescence (output stopped) — see
           _schedule_screen_detection.
         """
-        provider = provider_manager.get_provider(terminal_id)
+        with self._lock:
+            if not self._is_current_generation_locked(terminal_id):
+                logger.debug("Ignoring output for stopped terminal %s", terminal_id)
+                return
+            generation = self._generations.get(terminal_id, 0)
+
+        try:
+            provider = provider_manager.get_provider(terminal_id)
+        except ValueError:
+            # Teardown may win after the first generation check but before the
+            # provider lookup reaches the database.  Suppress only that proven
+            # stale-generation case; real lookup failures still propagate to
+            # run(), where they remain visible in logs.
+            with self._lock:
+                if not self._is_current_generation_locked(terminal_id, generation):
+                    logger.debug("Ignoring provider lookup for stopped terminal %s", terminal_id)
+                    return
+            raise
         use_screen = (
             CAO_PYTE_STATUS
             and provider is not None
@@ -142,6 +195,9 @@ class StatusMonitor:
         )
 
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id, generation):
+                logger.debug("Ignoring in-flight output for stopped terminal %s", terminal_id)
+                return
             buffer = self._buffers.get(terminal_id, "") + chunk
             if len(buffer) > STATE_BUFFER_MAX:
                 buffer = buffer[-STATE_BUFFER_MAX:]
@@ -155,12 +211,17 @@ class StatusMonitor:
             # (catches PROCESSING transition), then waits for output to settle
             # before re-detecting (catches IDLE/COMPLETED without running costly
             # regex on every single chunk during bursts).
-            self._schedule_raw_detection(terminal_id, buffer)
+            self._schedule_raw_detection(terminal_id, buffer, generation)
             return
 
-        self._schedule_screen_detection(terminal_id, provider)
+        self._schedule_screen_detection(terminal_id, provider, generation)
 
-    def _apply_detection(self, terminal_id: str, detected: TerminalStatus) -> None:
+    def _apply_detection(
+        self,
+        terminal_id: str,
+        detected: TerminalStatus,
+        generation: Optional[int] = None,
+    ) -> None:
         """Apply the sticky-latch rules to a freshly detected status and publish
         on change. Shared by the raw and pyte detection paths.
 
@@ -174,6 +235,9 @@ class StatusMonitor:
         paste into a busy agent).
         """
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id, generation):
+                logger.debug("Ignoring stale status detection for terminal %s", terminal_id)
+                return
             last = self._last_status.get(terminal_id)
 
             # UNKNOWN is "no signal", not a state: never let it overwrite a known
@@ -276,7 +340,9 @@ class StatusMonitor:
             logger.exception(f"Error detecting screen status for {terminal_id}")
             return TerminalStatus.UNKNOWN
 
-    def _schedule_screen_detection(self, terminal_id: str, provider) -> None:
+    def _schedule_screen_detection(
+        self, terminal_id: str, provider, generation: Optional[int] = None
+    ) -> None:
         """Edge-debounce detection on the pyte screen.
 
         Rising edge (first chunk after quiet) → detect immediately (catches the
@@ -290,41 +356,59 @@ class StatusMonitor:
         if loop is None:
             # No event loop (unit tests / offline replay): detect immediately
             # on the current screen — deterministic, no timing.
-            self._apply_detection(terminal_id, self._detect_screen(terminal_id, provider))
+            self._apply_detection(
+                terminal_id,
+                self._detect_screen(terminal_id, provider),
+                generation=generation,
+            )
             return
 
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id, generation):
+                return
             was_bursting = self._bursting.get(terminal_id, False)
             self._bursting[terminal_id] = True
             handle = self._quiesce_handle.pop(terminal_id, None)
         self._cancel_quiesce_handle(handle)
 
         if not was_bursting:
-            self._apply_detection(terminal_id, self._detect_screen(terminal_id, provider))
+            self._apply_detection(
+                terminal_id,
+                self._detect_screen(terminal_id, provider),
+                generation=generation,
+            )
 
-        self._arm_quiesce_timer(loop, terminal_id, self._on_screen_quiescent, provider)
+        self._arm_quiesce_timer(loop, terminal_id, generation, self._on_screen_quiescent, provider)
 
-    def _on_screen_quiescent(self, terminal_id: str, provider) -> None:
+    def _on_screen_quiescent(self, terminal_id: str, generation: Optional[int], provider) -> None:
         """Quiescence timer fired: output stopped, so the screen has settled.
 
         Fires on the loop; offload the (potentially blocking) screen detection
         to a worker thread so the loop stays free.
         """
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id, generation):
+                return
             self._bursting[terminal_id] = False
             self._quiesce_handle.pop(terminal_id, None)
 
         async def _detect_and_apply() -> None:
             detected = await asyncio.to_thread(self._detect_screen, terminal_id, provider)
-            self._apply_detection(terminal_id, detected)
+            self._apply_detection(terminal_id, detected, generation=generation)
 
         loop = self._loop or self._running_loop()
         if loop is None:
-            self._apply_detection(terminal_id, self._detect_screen(terminal_id, provider))
+            self._apply_detection(
+                terminal_id,
+                self._detect_screen(terminal_id, provider),
+                generation=generation,
+            )
         else:
             self._spawn_tracked(loop, _detect_and_apply())
 
-    def _schedule_raw_detection(self, terminal_id: str, buffer: str) -> None:
+    def _schedule_raw_detection(
+        self, terminal_id: str, buffer: str, generation: Optional[int] = None
+    ) -> None:
         """Edge-debounce detection on the raw rolling buffer.
 
         Detects on every chunk while the terminal is in a ready/armed state
@@ -345,10 +429,16 @@ class StatusMonitor:
         if loop is None:
             # No loop ever captured (unit tests / offline replay): detect
             # inline and skip the debounce timer.
-            self._apply_detection(terminal_id, self._detect_status(terminal_id, buffer))
+            self._apply_detection(
+                terminal_id,
+                self._detect_status(terminal_id, buffer, generation=generation),
+                generation=generation,
+            )
             return
 
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id, generation):
+                return
             was_bursting = self._bursting.get(terminal_id, False)
             self._bursting[terminal_id] = True
             handle = self._quiesce_handle.pop(terminal_id, None)
@@ -359,12 +449,19 @@ class StatusMonitor:
         # IDLE→PROCESSING transition is never missed (prevents stale-IDLE
         # delivery by InboxService). Once PROCESSING is observed, debounce.
         if not was_bursting or last_status in _STICKY_READY_STATUSES or last_status is None:
-            detected = self._detect_status(terminal_id, buffer)
-            self._apply_detection(terminal_id, detected)
+            detected = self._detect_status(terminal_id, buffer, generation=generation)
+            self._apply_detection(terminal_id, detected, generation=generation)
 
-        self._arm_quiesce_timer(loop, terminal_id, self._on_raw_quiescent)
+        self._arm_quiesce_timer(loop, terminal_id, generation, self._on_raw_quiescent)
 
-    def _arm_quiesce_timer(self, loop, terminal_id: str, callback, *cb_args) -> None:
+    def _arm_quiesce_timer(
+        self,
+        loop,
+        terminal_id: str,
+        generation: Optional[int],
+        callback,
+        *cb_args,
+    ) -> None:
         """Schedule the quiescence timer on ``loop`` from any thread.
 
         ``loop.call_later`` is not thread-safe and this may run on a worker
@@ -372,7 +469,8 @@ class StatusMonitor:
         ``call_soon_threadsafe``. The resulting TimerHandle is stored from
         inside the marshaled closure (still on the loop thread) so cancel
         marshaling in ``_cancel_quiesce_handle`` stays correct. ``cb_args``
-        are extra positional args passed to ``callback`` after ``terminal_id``.
+        are extra positional args passed after ``terminal_id`` and its captured
+        runtime generation.
         """
 
         def _arm() -> None:
@@ -386,10 +484,18 @@ class StatusMonitor:
             # quiescence detections and status flaps. One outstanding timer per
             # terminal, always the latest.
             with self._lock:
+                if not self._is_current_generation_locked(terminal_id, generation):
+                    return
                 prior = self._quiesce_handle.get(terminal_id)
                 if prior is not None:
                     prior.cancel()
-                handle = loop.call_later(PYTE_QUIESCENCE_DELAY_S, callback, terminal_id, *cb_args)
+                handle = loop.call_later(
+                    PYTE_QUIESCENCE_DELAY_S,
+                    callback,
+                    terminal_id,
+                    generation,
+                    *cb_args,
+                )
                 self._quiesce_handle[terminal_id] = handle
 
         try:
@@ -398,7 +504,7 @@ class StatusMonitor:
             # Loop closed during shutdown — quiescence re-detect is moot.
             pass
 
-    def _on_raw_quiescent(self, terminal_id: str) -> None:
+    def _on_raw_quiescent(self, terminal_id: str, generation: Optional[int]) -> None:
         """Quiescence timer fired for raw path: re-detect from current buffer.
 
         Fires on the event loop (via call_later), so the blocking
@@ -407,17 +513,23 @@ class StatusMonitor:
         on the loop.
         """
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id, generation):
+                return
             self._bursting[terminal_id] = False
             self._quiesce_handle.pop(terminal_id, None)
             buffer = self._buffers.get(terminal_id, "")
 
         async def _detect_and_apply() -> None:
-            detected = await asyncio.to_thread(self._detect_status, terminal_id, buffer)
-            self._apply_detection(terminal_id, detected)
+            detected = await asyncio.to_thread(self._detect_status, terminal_id, buffer, generation)
+            self._apply_detection(terminal_id, detected, generation=generation)
 
         loop = self._loop or self._running_loop()
         if loop is None:
-            self._apply_detection(terminal_id, self._detect_status(terminal_id, buffer))
+            self._apply_detection(
+                terminal_id,
+                self._detect_status(terminal_id, buffer, generation=generation),
+                generation=generation,
+            )
         else:
             self._spawn_tracked(loop, _detect_and_apply())
 
@@ -472,6 +584,8 @@ class StatusMonitor:
         IDLE/COMPLETED would block the genuine PROCESSING transition.
         """
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id):
+                return
             self._allow_processing_revert[terminal_id] = True
 
     def clear_rolling_buffer(self, terminal_id: str) -> None:
@@ -486,11 +600,27 @@ class StatusMonitor:
         survives and the subsequent IDLE→PROCESSING transition is honored.
         """
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id):
+                return
             self._buffers[terminal_id] = ""
 
-    def _detect_status(self, terminal_id: str, buffer: str) -> TerminalStatus:
+    def _detect_status(
+        self,
+        terminal_id: str,
+        buffer: str,
+        generation: Optional[int] = None,
+    ) -> TerminalStatus:
         """Detect status: provider-specific patterns or UNKNOWN if no provider."""
-        provider = provider_manager.get_provider(terminal_id)
+        with self._lock:
+            if not self._is_current_generation_locked(terminal_id, generation):
+                return TerminalStatus.UNKNOWN
+        try:
+            provider = provider_manager.get_provider(terminal_id)
+        except ValueError:
+            with self._lock:
+                if not self._is_current_generation_locked(terminal_id, generation):
+                    return TerminalStatus.UNKNOWN
+            raise
         if provider is None:
             return TerminalStatus.UNKNOWN
 
@@ -501,8 +631,22 @@ class StatusMonitor:
             return TerminalStatus.UNKNOWN
 
     def clear_terminal(self, terminal_id: str) -> None:
-        """Free buffer and status for a deleted terminal."""
+        """Stop a runtime generation and free its monitor state.
+
+        The tombstone is installed before timers are cancelled or other state
+        is removed, making queued chunks and in-flight detection results stale
+        immediately. terminal_service removes the provider/database only after
+        this lifecycle barrier is in place.
+        """
         with self._lock:
+            generation = self._generations.get(terminal_id, 0) + 1
+            self._generations[terminal_id] = generation
+            self._tombstones[terminal_id] = generation
+            self._tombstones.move_to_end(terminal_id)
+            while len(self._tombstones) > _MAX_TERMINAL_TOMBSTONES:
+                evicted_id, evicted_generation = self._tombstones.popitem(last=False)
+                if self._generations.get(evicted_id) == evicted_generation:
+                    self._generations.pop(evicted_id, None)
             self._buffers.pop(terminal_id, None)
             self._last_status.pop(terminal_id, None)
             self._allow_processing_revert.pop(terminal_id, None)
@@ -521,6 +665,8 @@ class StatusMonitor:
         from the failed first attempt and can spuriously time out.
         """
         with self._lock:
+            if not self._is_current_generation_locked(terminal_id):
+                return
             self._buffers[terminal_id] = ""
             self._last_status.pop(terminal_id, None)
             self._allow_processing_revert.pop(terminal_id, None)
@@ -543,6 +689,10 @@ class StatusMonitor:
         liveness) works on herdr without each having to special-case the backend.
         """
         from cli_agent_orchestrator.backends.registry import get_backend
+
+        with self._lock:
+            if not self._is_current_generation_locked(terminal_id):
+                return TerminalStatus.UNKNOWN
 
         if get_backend().supports_event_inbox():
             try:

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -305,6 +305,12 @@ async def create_terminal(
             caller_id=caller_id,
         )
 
+        # Establish the monitor lifecycle barrier before the FIFO can publish
+        # output. A prior failed/deleted incarnation of the same ID may have a
+        # tombstone; registration starts a new generation and makes only this
+        # runtime eligible for status detection.
+        status_monitor.register_terminal(terminal_id)
+
         # Step 4/5: Set up the FIFO event-driven output pipeline for pipe-pane
         # backends (tmux). Event-inbox backends (herdr) deliver via their own
         # socket events and their pipe_pane is a no-op, so skip the FIFO there and

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -53,6 +53,7 @@ class TestCreateSession:
     def test_create_session_success(self, tmux, tmp_path):
         mock_window = MagicMock()
         mock_window.name = "my-window"
+        mock_window.window_id = "@1"
         mock_session = MagicMock()
         mock_session.windows = [mock_window]
         tmux.server.new_session.return_value = mock_session
@@ -61,6 +62,8 @@ class TestCreateSession:
 
         assert result == "my-window"
         tmux.server.new_session.assert_called_once()
+        assert tmux._window_ids[("ses", "my-window")] == "@1"
+        mock_window.set_option.assert_called_once_with("@cao_logical_window", "my-window")
 
     def test_create_session_window_name_none(self, tmux, tmp_path):
         mock_window = MagicMock()
@@ -298,6 +301,43 @@ class TestSendKeys:
         with pytest.raises(Exception, match="tmux send failed"):
             tmux.send_keys("ses", "win", "hello")
 
+    @patch("cli_agent_orchestrator.clients.tmux.time")
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess")
+    def test_send_keys_targets_stable_window_id_after_application_rename(
+        self, mock_subprocess, mock_time, tmux
+    ):
+        """Claude/zsh changing the window title must not break later input."""
+        mock_subprocess.run.return_value = MagicMock(returncode=0)
+        tmux._window_ids[("ses", "logical-win")] = "@7"
+
+        tmux.send_keys("ses", "logical-win", "hello")
+
+        paste_call = mock_subprocess.run.call_args_list[1]
+        enter_call = mock_subprocess.run.call_args_list[2]
+        assert paste_call.args[0][-1] == "@7"
+        assert enter_call.args[0][-2:] == ["@7", "Enter"]
+
+    @patch("cli_agent_orchestrator.clients.tmux.time")
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess")
+    def test_send_keys_recovers_stable_id_from_tmux_metadata_after_restart(
+        self, mock_subprocess, mock_time, tmux
+    ):
+        mock_subprocess.run.return_value = MagicMock(returncode=0)
+        renamed_window = MagicMock()
+        renamed_window.window_id = "@12"
+        renamed_window.show_option.return_value = "logical-win"
+        mock_session = MagicMock()
+        mock_session.windows = [renamed_window]
+        tmux.server.sessions.get.return_value = mock_session
+
+        tmux.send_keys("ses", "logical-win", "hello")
+
+        paste_call = mock_subprocess.run.call_args_list[1]
+        enter_call = mock_subprocess.run.call_args_list[2]
+        assert paste_call.args[0][-1] == "@12"
+        assert enter_call.args[0][-2:] == ["@12", "Enter"]
+        assert tmux._window_ids[("ses", "logical-win")] == "@12"
+
 
 # ── send_keys_via_paste ──────────────────────────────────────────────
 
@@ -384,6 +424,38 @@ class TestGetHistory:
         result = tmux.get_history("ses", "win")
 
         assert result == "line1\nline2\nline3"
+
+    def test_get_history_resolves_stable_window_id_after_application_rename(self, tmux):
+        mock_pane = MagicMock()
+        mock_pane.cmd.return_value.stdout = ["Claude is alive"]
+        renamed_window = MagicMock()
+        renamed_window.panes = [mock_pane]
+        mock_session = MagicMock()
+        mock_session.windows.get.return_value = renamed_window
+        tmux.server.sessions.get.return_value = mock_session
+        tmux._window_ids[("ses", "logical-win")] = "@9"
+
+        result = tmux.get_history("ses", "logical-win")
+
+        assert result == "Claude is alive"
+        mock_session.windows.get.assert_called_once_with(window_id="@9")
+
+    def test_get_history_recovers_renamed_window_from_tmux_metadata_after_restart(self, tmux):
+        mock_pane = MagicMock()
+        mock_pane.cmd.return_value.stdout = ["Claude survived restart"]
+        renamed_window = MagicMock()
+        renamed_window.window_id = "@15"
+        renamed_window.show_option.return_value = "logical-win"
+        renamed_window.panes = [mock_pane]
+        mock_session = MagicMock()
+        mock_session.windows = [renamed_window]
+        tmux.server.sessions.get.return_value = mock_session
+
+        result = tmux.get_history("ses", "logical-win")
+
+        assert result == "Claude survived restart"
+        assert tmux._window_ids[("ses", "logical-win")] == "@15"
+        renamed_window.set_option.assert_called_once_with("@cao_logical_window", "logical-win")
 
     def test_get_history_empty_output(self, tmux):
         mock_pane = MagicMock()

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -108,6 +108,76 @@ class TestScreenDetection:
         mock_pm.get_provider.assert_not_called()
 
 
+class TestLifecycleGeneration:
+    """Late output and detection results must not resurrect a deleted runtime."""
+
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_late_chunk_after_clear_skips_provider_lookup(self, mock_pm):
+        sm = StatusMonitor()
+        sm.register_terminal("t1")
+        sm.clear_terminal("t1")
+
+        sm._process_chunk("t1", "late output")
+
+        mock_pm.get_provider.assert_not_called()
+        assert sm.get_buffer("t1") == ""
+
+    @patch("cli_agent_orchestrator.services.status_monitor.bus")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_inflight_chunk_is_dropped_when_clear_wins_race(self, mock_pm, mock_bus):
+        sm = StatusMonitor()
+        sm.register_terminal("t1")
+        lookup_started = threading.Event()
+        release_lookup = threading.Event()
+        provider = MagicMock()
+        provider.supports_screen_detection = False
+        provider.get_status.return_value = TerminalStatus.IDLE
+
+        def _blocking_lookup(_terminal_id):
+            lookup_started.set()
+            assert release_lookup.wait(timeout=1)
+            return provider
+
+        mock_pm.get_provider.side_effect = _blocking_lookup
+        worker = threading.Thread(target=sm._process_chunk, args=("t1", "late output"))
+        worker.start()
+        assert lookup_started.wait(timeout=1)
+
+        sm.clear_terminal("t1")
+        release_lookup.set()
+        worker.join(timeout=1)
+
+        assert not worker.is_alive()
+        provider.get_status.assert_not_called()
+        mock_bus.publish.assert_not_called()
+        assert sm.get_buffer("t1") == ""
+
+    @patch("cli_agent_orchestrator.services.status_monitor.bus")
+    def test_old_generation_result_ignored_after_terminal_id_reuse(self, mock_bus):
+        sm = StatusMonitor()
+        first_generation = sm.register_terminal("t1")
+        sm.clear_terminal("t1")
+        second_generation = sm.register_terminal("t1")
+
+        sm._apply_detection("t1", TerminalStatus.ERROR, generation=first_generation)
+        sm._apply_detection("t1", TerminalStatus.IDLE, generation=second_generation)
+
+        assert second_generation > first_generation
+        assert sm._last_status["t1"] == TerminalStatus.IDLE
+        mock_bus.publish.assert_called_once_with("terminal.t1.status", {"status": "idle"})
+
+    @patch("cli_agent_orchestrator.services.status_monitor._MAX_TERMINAL_TOMBSTONES", 2)
+    def test_tombstone_and_generation_history_are_bounded(self):
+        sm = StatusMonitor()
+
+        for terminal_id in ("t1", "t2", "t3"):
+            sm.register_terminal(terminal_id)
+            sm.clear_terminal(terminal_id)
+
+        assert list(sm._tombstones) == ["t2", "t3"]
+        assert "t1" not in sm._generations
+
+
 class _SequencedMonitor:
     """Drive _process_chunk with a scripted sequence of detected statuses.
 
@@ -389,7 +459,7 @@ class TestRawDebounceArmedDetection:
 
         # Mock _detect_status: first call returns UNKNOWN, second returns PROCESSING
         detect_results = iter([TerminalStatus.UNKNOWN, TerminalStatus.PROCESSING])
-        sm._detect_status = lambda tid, buf: next(detect_results)
+        sm._detect_status = lambda tid, buf, generation=None: next(detect_results)
 
         # Chunk 1: UNKNOWN — should still attempt detection (terminal is ready)
         sm._process_chunk("t1", "neutral output")

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -665,6 +665,7 @@ class TestCreateTerminal:
         result = await create_terminal("kiro_cli", "my-agent", new_session=True)
 
         assert result.id == "test1234"
+        mock_status_monitor.register_terminal.assert_called_once_with("test1234")
         mock_provider.initialize.assert_called_once()
         # allowed_tools should be None since profile was not found
         assert mock_provider_manager.create_provider.call_args.kwargs.get("allowed_tools") is None


### PR DESCRIPTION
## What changed

- guard `StatusMonitor` against terminal events from an obsolete runtime generation
- install bounded tombstones before terminal teardown so queued work is discarded safely
- address tmux windows by immutable `@window_id` instead of mutable display names
- persist the logical CAO window name as tmux metadata and rebuild the ID mapping after a CAO restart
- add deterministic lifecycle, concurrency, rename, and restart regressions

## Root cause

Two lifecycle races combined during Claude Code startup:

1. zsh/Claude renamed the tmux window while CAO still used the original display name as its identity. The pane remained healthy, but libtmux raised `ObjectDoesNotExist`, causing `create_terminal` to roll the session back.
2. terminal chunks already queued or in flight could outlive that rollback and attempt to recreate a provider after its database row had been deleted.

## Impact

Claude Code terminals no longer fail initialization merely because the application changes the tmux title. Late events from a stopped runtime are discarded without hiding lookup failures for active terminals. Window identity also survives CAO process restarts for windows created with this version.

## Validation

- relevant tmux backend, Claude provider, StatusMonitor, and TerminalService suite: `297 passed`
- focused tmux client suite: `69 passed`
- targeted mypy check: no issues
- real launch reproduction: HTTP 500 before, HTTP 201 after
- real tmux restart simulation recovered the same renamed `@window_id`
- `git diff --check`
