### PR TITLE
feat(security): secret scanning + leak-response runbook (#457)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,66 @@
+name: Secret Scan
+
+# Secret scanning (issue #457), split from ci.yml so the weekly full-history
+# sweep does not drag the entire CI matrix (unit/web/e2e/lint/Trivy) onto a
+# schedule. Two triggers, two scopes:
+#   - pull_request: scan only the PR's commit range (fast; a pre-existing secret
+#     on an unrelated branch must not block every PR).
+#   - schedule: weekly full-history sweep to surface a secret committed before
+#     the per-PR gate existed.
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 07:00 UTC.
+    - cron: "0 7 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  GITLEAKS_VERSION: "8.30.1"
+  # Pinned release asset + its published SHA-256 (verified before execution so a
+  # tampered/mutated asset can't run in CI). Update both together on version bump.
+  GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need history for both scopes; on a PR this is the PR's commits, for
+          # the scheduled run it's the whole default branch.
+          fetch-depth: 0
+
+      - name: Install gitleaks (pinned + checksum-verified)
+        run: |
+          set -euo pipefail
+          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}" -o "$asset"
+          echo "${GITLEAKS_SHA256}  ${asset}" | sha256sum -c -
+          tar -xzf "$asset" -C /tmp gitleaks
+          /tmp/gitleaks version
+
+      - name: Scan PR commit range
+        if: github.event_name == 'pull_request'
+        run: |
+          /tmp/gitleaks detect \
+            --source . \
+            --config .gitleaks.toml \
+            --redact \
+            --verbose \
+            --exit-code 1 \
+            --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
+      - name: Full-history scan (scheduled)
+        if: github.event_name == 'schedule'
+        run: |
+          /tmp/gitleaks detect \
+            --source . \
+            --config .gitleaks.toml \
+            --redact \
+            --verbose \
+            --exit-code 1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -41,26 +41,73 @@ jobs:
           asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}" -o "$asset"
           echo "${GITLEAKS_SHA256}  ${asset}" | sha256sum -c -
-          tar -xzf "$asset" -C /tmp gitleaks
-          /tmp/gitleaks version
+          sudo tar -xzf "$asset" -C /usr/local/bin gitleaks
+          gitleaks version
 
       - name: Scan PR commit range
         if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          /tmp/gitleaks detect \
+          set -euo pipefail
+          # Fail closed: gitleaks exits 0 (secret undetected) if the log range
+          # can't be resolved — e.g. the base SHA isn't in the checkout. Verify
+          # both endpoints exist first so a broken range can't silently pass.
+          for sha in "$BASE_SHA" "$HEAD_SHA"; do
+            git cat-file -e "${sha}^{commit}" 2>/dev/null || {
+              echo "::error::commit $sha not present in checkout; cannot scan the PR range safely"
+              exit 1
+            }
+          done
+          gitleaks detect \
             --source . \
             --config .gitleaks.toml \
             --redact \
             --verbose \
             --exit-code 1 \
-            --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+            --log-opts "${BASE_SHA}..${HEAD_SHA}"
 
+      # A hit here should be triaged per the leak-response runbook
+      # (docs/security.md): rotate/revoke first, rewrite
+      # history only if the severity table calls for it.
       - name: Full-history scan (scheduled)
         if: github.event_name == 'schedule'
         run: |
-          /tmp/gitleaks detect \
+          gitleaks detect \
             --source . \
             --config .gitleaks.toml \
             --redact \
             --verbose \
             --exit-code 1
+
+  # Regression tests for the custom rules + allowlist in .gitleaks.toml. Runs
+  # here (not in the pip-only unit-test job) because it needs the gitleaks
+  # binary on PATH; without this job the tests would skip everywhere.
+  config-tests:
+    name: gitleaks config tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install gitleaks (pinned + checksum-verified)
+        run: |
+          set -euo pipefail
+          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}" -o "$asset"
+          echo "${GITLEAKS_SHA256}  ${asset}" | sha256sum -c -
+          sudo tar -xzf "$asset" -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run gitleaks config regression tests
+        run: uv run pytest test/test_gitleaks_config.py -v

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,76 @@
+# gitleaks configuration for cli-agent-orchestrator (issue #457).
+#
+# Extends gitleaks' built-in rule set via `useDefault` so we stay current with
+# upstream credential detections rather than maintaining our own copy, adds two
+# custom rules for shapes still missing from the defaults, and allowlists one
+# well-known documentation placeholder.
+#
+# This complements — it does not replace — the runtime redactor in
+# secret_gate.py (which guards memory writes / archive export at runtime). This
+# config gates git content in CI so a real credential can't land on a branch.
+#
+# False positives: the scan keys on real credential SHAPES (AWS/GitHub/GitLab
+# keys, PEM private keys, JWTs, Slack webhooks), not on placeholders, env
+# references, hashes, UUIDs, or the word "secret". Ordinary code/docs/fixtures
+# pass. The one realistic edge case for this repo is a provider fixture that
+# captures a JWT-shaped token from a live CLI banner. If that happens and the
+# token is NOT a real credential, either scrub it (preferred — see the fixture
+# hygiene guidance) or exempt that single line with a trailing `# gitleaks:allow`
+# annotation. Do NOT broadly allowlist `test/providers/fixtures/**` — that would
+# blind the gate to a real key captured into a fixture, which is exactly the
+# incident (#436) this guards against.
+title = "CAO gitleaks config"
+
+[extend]
+useDefault = true
+
+# Custom rules closing gaps still present in gitleaks' default set (verified
+# missing as of gitleaks 8.30.1). These credential shapes are real and worth
+# catching.
+[[rules]]
+id = "aws-secret-access-key"
+description = "AWS secret access key (40-char base64) in an assignment"
+# Anchored to an aws-ish key name so we match the secret in context rather than
+# flagging every 40-char base64 blob (which would false-positive on hashes).
+# The trailing (?:[^A-Za-z0-9/+]|$) requires the 40-char run to END at a
+# non-base64 char OR end-of-line, so a key terminated by ; , ) & etc. (common in
+# code/shell) is still caught, while a 41st base64 char correctly disqualifies
+# it (real AWS secrets are exactly 40).
+regex = '''(?i)aws.{0,20}(?:secret|access).{0,20}['"=:\s]([A-Za-z0-9/+]{40})(?:[^A-Za-z0-9/+]|$)'''
+keywords = ["aws"]
+
+[[rules]]
+id = "github-fine-grained-pat"
+description = "GitHub fine-grained personal access token (github_pat_...)"
+# Structure-accurate to avoid flagging doc placeholders like
+# `github_pat_..._example_placeholder`: the real format is `github_pat_` + 22
+# alphanumerics + `_` + 59+ alphanumerics. Requiring that shape (not a loose
+# [0-9a-zA-Z_]{22,255}) rejects underscore-laden placeholders while catching
+# real tokens.
+#
+# This id matches a built-in rule, so `useDefault` merges the two; we set
+# `entropy` explicitly (rather than inheriting the built-in's 3.0) so a
+# low-entropy placeholder that happens to fit the shape is still rejected and
+# the threshold is visible here instead of implied.
+regex = '''github_pat_[0-9a-zA-Z]{22}_[0-9a-zA-Z]{59,}'''
+entropy = 3.0
+keywords = ["github_pat_"]
+
+# Array-table form ([[allowlists]], plural) rather than the singular [allowlist],
+# which gitleaks has deprecated for removal in v9.
+[[allowlists]]
+description = "Intentional non-secrets."
+
+# We deliberately do NOT allowlist whole test files, PEM key material, or whole
+# commits — each of those would suppress real findings too. The synthetic PEM
+# sample in test/services/test_secret_gate.py has only 16 chars of key body,
+# below gitleaks' private-key rule threshold (>=64), so it isn't flagged and
+# needs no allowlist. The only allowlisted value is AWS's documented example
+# access key: the exact 20-char string, word-bounded so a real key merely
+# containing it as a substring is NOT exempt.
+#
+# For any genuine historical false positive, prefer a finding-level
+# .gitleaksignore fingerprint over a commit- or path-level allowlist.
+regexes = [
+  '''\bAKIAIOSFODNN7EXAMPLE\b''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Optional pre-commit hooks (issue #457). Opt-in — not required to contribute.
+#
+# Enable locally with:
+#   uv tool install pre-commit   # or: pipx install pre-commit
+#   pre-commit install
+#
+# The gitleaks hook scans STAGED changes (gitleaks git --staged) so a secret is
+# caught before it enters a commit — the earliest possible point. It uses this
+# repo's .gitleaks.toml automatically. CI runs the same scanner as a backstop
+# (.github/workflows/secret-scan.yml), so skipping the hook never lets a secret
+# through; the hook just shortens the feedback loop.
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1 # keep in sync with .github/workflows/secret-scan.yml
+    hooks:
+      - id: gitleaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,35 @@ for how to start `cao-server`, forward port `9889`, and troubleshoot 404s on the
 forwarded URL.
 
 
+## Recording test fixtures safely
+
+Many provider tests use fixtures captured from **live CLI output** (see
+`test/providers/fixtures/`). That output can embed personal or sensitive data —
+notably login/banner lines that print your account email, and tokens that hide
+inside ANSI escape sequences where they are easy to miss in review. A real
+incident (#436) merged personal emails this way.
+
+When recording or updating a live-output fixture:
+
+- **Capture on a synthetic/throwaway account** where possible, not your personal
+  or corporate account.
+- **Scrub any login/banner/identity line before committing** — replace a real
+  email with `user@example.com`, an account name with a placeholder, etc.
+- **Skim the raw bytes, not just the rendered view.** A secret can sit next to
+  ANSI escape codes and not be visible in a normal terminal render or diff.
+- Prefer the reserved placeholders scanners already treat as safe:
+  `user@example.com`, and for AWS the documented `AKIAIOSFODNN7EXAMPLE`.
+
+A gitleaks secret scan runs on every PR and weekly over full history (see
+[SECURITY.md](SECURITY.md#secret-scanning)); you can run it locally with
+`scripts/security-scan.sh gitleaks`, or enable the optional pre-commit hook
+([`.pre-commit-config.yaml`](.pre-commit-config.yaml)) with `pre-commit install`
+to catch secrets before they enter a commit. If a secret ever lands, follow the
+[Leak Response & Git-History Scrub Runbook](docs/security.md)
+— **rotate/revoke first**, rewrite history only if warranted by the runbook's
+severity triage table.
+
+
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,6 +74,12 @@ The Vite dev server proxies API calls to the backend at `localhost:9889`. Make s
 
 ## Running Tests
 
+> **Recording test fixtures?** Provider fixtures are captured from live CLI
+> output and can embed secrets/PII (including in ANSI escape streams). Record on
+> a synthetic account and scrub identity/banner lines before committing — see
+> [CONTRIBUTING.md](CONTRIBUTING.md#recording-test-fixtures-safely). A gitleaks
+> scan gates every PR; run it locally with `scripts/security-scan.sh gitleaks`.
+
 ### Unit Tests
 
 Unit tests are fast and use mocked dependencies:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,23 @@ Pull requests are automatically checked for:
 - License compliance issues
 - Dependency version changes
 
+### Secret Scanning
+
+We use [gitleaks](https://github.com/gitleaks/gitleaks) to keep credentials out
+of the repository (see [`.gitleaks.toml`](.gitleaks.toml) and
+[`.github/workflows/secret-scan.yml`](.github/workflows/secret-scan.yml)):
+
+- **On every pull request**: scans the PR's commit range; a detected secret
+  fails the check so it can't merge.
+- **Weekly (scheduled)**: a full-history sweep, to surface a secret that may
+  predate the per-PR gate.
+
+If a secret ever does land, follow the
+[Leak Response & Git-History Scrub Runbook](docs/security.md).
+The rule of thumb is **rotate/revoke first**; rewriting history is a secondary,
+high-cost step that never substitutes for rotation. See
+[docs/security.md](docs/security.md) for the full operational procedures.
+
 ### Running Security Scans Locally
 
 You can run Trivy locally to check for vulnerabilities before committing:
@@ -91,6 +108,7 @@ Or use the bundled wrapper that mirrors CI (`trivy` + optional local CodeQL):
 scripts/security-scan.sh           # run all available scanners
 scripts/security-scan.sh trivy     # just Trivy
 scripts/security-scan.sh codeql    # just CodeQL (requires the CodeQL CLI)
+scripts/security-scan.sh gitleaks  # just gitleaks (requires the gitleaks CLI)
 ```
 
 ## Tool Restrictions (allowedTools)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,187 @@
+# PII / Secret Leak Response & Git-History Scrub Runbook
+
+What to do when a secret or PII lands in the repository — on a branch, in a PR,
+or on `main`. The guiding principle: **rotation/revocation is the fix; rewriting
+history reduces exposure of an already-compromised secret but never substitutes
+for rotating it.** Assume any secret is captured the instant it is pushed.
+
+This runbook is referenced from [SECURITY.md](../SECURITY.md). Prevention
+(the secret scanner that keeps most leaks out) is documented there and in
+[`.gitleaks.toml`](../.gitleaks.toml).
+
+## 0. Triage first — severity decides the response
+
+| Leak type | Rotate/revoke? | Rewrite history? | Notes |
+|---|---|---|---|
+| Live credential (API key, token, private key, password) | **Yes — immediately, first** | Yes, after rotation | Assume compromised the moment it hit a pushed commit. |
+| Internal hostnames / infra details | Case-by-case | Usually no | Evaluate exposure; often just remove going forward. |
+| Personal PII (email, name) | N/A (rotation impossible) | Rarely — only on request / legal need | Remove going forward; notify the person; weigh rewrite cost. |
+| Synthetic/sample data (`user@example.com`, `AKIAIOSFODNN7EXAMPLE`) | No | No | Not a leak. |
+
+**Golden rule:** rotate/revoke first. A history rewrite on a public repo is
+high-cost and never makes an exposed live secret safe again — only rotation
+does.
+
+## 1. Contain (minutes)
+
+1. **Rotate/revoke** the leaked credential at its source (cloud console, token
+   settings, key authority). Do this before anything else.
+2. If a scheduled deploy or workflow could exfiltrate further, pause it.
+3. Open a private security advisory / notify maintainers per
+   [SECURITY.md](../SECURITY.md). **Do not** disclose the secret value in a
+   public issue or PR comment.
+
+## 2. Assess scope
+
+```bash
+# Read the value once via a hidden prompt so it never lands in shell history.
+# Pipe it to git from stdin (never as an argv arg, which `ps` would expose).
+read -rs -p 'Leaked value: ' SECRET; echo
+
+# Commits + paths that contain the string. -l = list matching blobs only (path,
+# no matching line — so the secret itself is never printed); -F = fixed string;
+# -f - = read the pattern from stdin. Output rows are "<commit>:<path>".
+# NOTE: $(git rev-list --all) expands as arguments. For repos with >100k
+# commits this can hit shell ARG_MAX; if so, pipe through xargs:
+#   git rev-list --all | xargs git grep -lF -f <(printf '%s' "$SECRET")
+printf '%s' "$SECRET" | git grep -lF -f - $(git rev-list --all) | sort -u > /tmp/hits.txt
+cut -d: -f1 /tmp/hits.txt | sort -u   # offending commits
+cut -d: -f2- /tmp/hits.txt | sort -u  # offending paths
+rm -f /tmp/hits.txt
+unset SECRET
+
+# For each offending commit, find which branches and tags reach it:
+git branch --all --contains <commit>
+git tag --contains <commit>
+```
+
+Record the affected **files, commits, branches, and tags** — you need the branch
+and tag list to know the full blast radius and what must be re-cut in step 5.
+(`git grep -l` deliberately omits the matching line so the secret value is never
+echoed to your terminal or CI logs.)
+
+## 3. Coordinate before rewriting
+
+- A default-branch rewrite changes every downstream SHA and **breaks every
+  existing clone, fork, and open PR**. Get maintainer sign-off first.
+- Announce a short freeze window; ask contributors to pause pushes.
+
+## 4. Execute the scrub (prefer `git filter-repo`)
+
+```bash
+# Fresh mirror clone — never rewrite your working clone.
+git clone --mirror git@github.com:awslabs/cli-agent-orchestrator.git cao-scrub
+cd cao-scrub
+
+# a) Redact a string everywhere. Keep the secret out of shell history AND out of
+#    process args (`ps`): read it from a hidden prompt into a mode-0600 file.
+#    An idempotent cleanup, trapped on INT/TERM/EXIT, removes the plaintext even
+#    if filter-repo is Ctrl-C'd; we also delete it explicitly the moment
+#    filter-repo finishes. One `OLD==>NEW` per line.
+repl="$(mktemp)"; chmod 600 "$repl"
+cleanup() { [ -n "${repl:-}" ] && { shred -u "$repl" 2>/dev/null || rm -f "$repl"; }; repl=; }
+trap cleanup INT TERM EXIT            # covers Ctrl-C, kill, and normal exit
+read -rs -p 'Leaked value to redact: ' SECRET; echo
+printf '%s==>REDACTED\n' "$SECRET" > "$repl"
+unset SECRET                          # drop it from the shell environment
+git filter-repo --replace-text "$repl"
+cleanup; trap - INT TERM EXIT         # remove plaintext now; clear the trap
+
+# b) OR purge whole files/paths from all history (no secret on disk at all):
+git filter-repo --path path/to/leaky-file --invert-paths
+
+# Verify the secret is gone from all history. -F = fixed string, -f - reads the
+# pattern from stdin, -q suppresses the matching line so the secret is never
+# echoed. git grep exits 0 = FOUND, 1 = absent, >1 = ERROR — distinguish all
+# three so an error (e.g. a bad ref, exit 128) is never misread as "clean".
+# (Same ARG_MAX note as above applies for very large repos.)
+read -rs -p 'Value to verify absent: ' CHECK; echo
+printf '%s' "$CHECK" | git grep -qF -f - $(git rev-list --all); rc=$?
+unset CHECK
+case "$rc" in
+  0) echo "STILL PRESENT — do not publish" ;;
+  1) echo "clean" ;;
+  *) echo "ERROR running git grep (exit $rc) — verify manually before publishing" ;;
+esac
+```
+
+`git filter-branch` is deprecated — avoid it. BFG Repo-Cleaner
+(`bfg --replace-text` / `--delete-files`) is an acceptable alternative.
+
+> **Note:** `git filter-repo` removes the `origin` remote by design (to stop you
+> accidentally pushing a half-rewritten history). Re-add it before publishing.
+
+## 5. Publish the rewritten history
+
+```bash
+# filter-repo dropped 'origin' — re-add it, then force-push all refs from the mirror.
+git remote add origin git@github.com:awslabs/cli-agent-orchestrator.git
+git push --force --mirror origin   # after maintainer sign-off
+```
+
+Expected results and gotchas:
+
+- **`refs/pull/*` errors are expected and OK.** GitHub advertises PR refs but
+  they are **read-only** — `--mirror` will try to update them and print
+  `[remote rejected] refs/pull/... (deny updating a hidden ref)`. Ignore those.
+  **Every _other_ ref (branches, tags) must succeed** — if a branch push is
+  rejected, that's the real problem, not the PR refs.
+- **Branch protection** on `main` will reject a force-push. Temporarily relax
+  the protection rule (or use an admin override), push, then **re-enable it
+  immediately**.
+- **Delete/re-cut affected tags and releases** — they pin old SHAs and a
+  release asset can still reference the pre-scrub commit.
+- **Contact GitHub Support** to purge cached views of old commits and PR diffs
+  and to GC unreachable objects — force-pushing alone leaves the old SHAs
+  reachable via the API / PR timeline for a while.
+
+## 6. Everyone re-syncs
+
+Rewritten history means every existing clone, fork, and open PR now descends
+from commits that no longer exist. **A plain `git pull`/merge would re-introduce
+the removed history** — so it must not be used.
+
+- **Simplest and safest: re-clone.** Tell contributors to delete their clone and
+  clone fresh.
+- **To keep local work**, rebase or cherry-pick it onto the rewritten branch —
+  never merge:
+  ```bash
+  git fetch origin
+  git rebase --onto origin/main <old-base> <your-feature-branch>
+  ```
+- **Open PRs** do not rebase themselves when closed/reopened. Each author must
+  rebase their branch onto the rewritten base (as above) and force-push, or
+  re-open the PR from a freshly-rebased branch. Stale branches and tags that
+  still point at pre-scrub commits must be deleted or rebased too, or they
+  re-expose the secret.
+- **Forks are separate repositories you cannot rewrite.** Every fork keeps the
+  leaked commit in its own history; a force-push to the canonical repo does not
+  touch them, and you have no write access to purge someone else's fork. Ask
+  fork owners to re-sync (or delete) their copy, but treat this as best-effort —
+  which is another reason the leaked credential must be **rotated**, never merely
+  scrubbed: you cannot guarantee removal from every fork the secret reached.
+
+## 7. Post-incident
+
+- Confirm the credential is fully rotated and the old one is dead.
+- Add or extend a scanner rule so the specific pattern is caught in future
+  (see [`.gitleaks.toml`](../.gitleaks.toml)).
+- Write a short post-mortem: what leaked, how, blast radius, time-to-rotate.
+
+## Prevention (steady state)
+
+- **Secret scanning in CI.** gitleaks runs on every PR (commit range) and weekly
+  over full history — see
+  [`.github/workflows/secret-scan.yml`](../.github/workflows/secret-scan.yml)
+  and [`.gitleaks.toml`](../.gitleaks.toml). Run it locally with
+  `scripts/security-scan.sh gitleaks`.
+- **Optional pre-commit hook.** [`.pre-commit-config.yaml`](../.pre-commit-config.yaml)
+  wires gitleaks' staged-diff scan (`gitleaks git --staged`) so a secret is
+  caught before it enters a commit. Opt in with `pre-commit install`. CI is the
+  backstop, so the hook is a convenience, not a requirement.
+- **Fixture-recording hygiene** — see
+  [CONTRIBUTING.md](../CONTRIBUTING.md#recording-test-fixtures-safely):
+  capture live-CLI fixtures on a synthetic/throwaway account and scrub any
+  login/banner line before committing.
+- **The runtime redactor** (`src/cli_agent_orchestrator/services/secret_gate.py`)
+  strips credential shapes from memory writes and archive exports at runtime.

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Local mirror of the `security` and `codeql` CI jobs so contributors can catch
-# SSRF/path-injection/SCA findings before pushing. Exits non-zero on any
+# SSRF/path-injection/SCA/secret findings before pushing. Exits non-zero on any
 # scanner failure so it's safe to wire into pre-push hooks or Makefile targets.
 #
 # Usage:
 #   scripts/security-scan.sh                 # run all available scanners
 #   scripts/security-scan.sh trivy           # just Trivy
 #   scripts/security-scan.sh codeql          # just CodeQL (python)
+#   scripts/security-scan.sh gitleaks        # just gitleaks (secret scan, #457)
 #
 # CodeQL installs from Homebrew (macOS) are often broken by Apple's Gatekeeper
 # quarantine (xattr errors followed by silent exit 1). If that's happening,
@@ -83,11 +84,39 @@ run_codeql() {
     fi
 }
 
+# CI pins this gitleaks version; the config's custom rules and the built-in
+# ruleset are validated against it. Older local builds may behave differently
+# (e.g. the private-key rule's key-length threshold changed), so warn on a
+# mismatch rather than trusting whatever is installed.
+GITLEAKS_EXPECTED_VERSION="8.30.1"
+
+run_gitleaks() {
+    echo "==> gitleaks secret scan (git history; config .gitleaks.toml)"
+    if ! command -v gitleaks >/dev/null 2>&1; then
+        echo "  SKIP: gitleaks not on PATH (brew install gitleaks, or see"
+        echo "        https://github.com/gitleaks/gitleaks/releases)"
+        return 0
+    fi
+    local have
+    have="$(gitleaks version 2>/dev/null | tr -d '[:space:]')"
+    if [[ "$have" != "$GITLEAKS_EXPECTED_VERSION" ]]; then
+        echo "  NOTE: local gitleaks $have != CI-pinned $GITLEAKS_EXPECTED_VERSION;"
+        echo "        results may differ from CI. Match the pinned version for parity."
+    fi
+    gitleaks detect \
+        --source "$ROOT_DIR" \
+        --config "$ROOT_DIR/.gitleaks.toml" \
+        --redact \
+        --verbose \
+        --exit-code 1 || exit_code=1
+}
+
 case "$target" in
-    trivy)  run_trivy ;;
-    codeql) run_codeql ;;
-    all)    run_trivy; run_codeql ;;
-    *)      echo "Unknown target: $target (use trivy|codeql|all)"; exit 2 ;;
+    trivy)    run_trivy ;;
+    codeql)   run_codeql ;;
+    gitleaks) run_gitleaks ;;
+    all)      run_trivy; run_codeql; run_gitleaks ;;
+    *)        echo "Unknown target: $target (use trivy|codeql|gitleaks|all)"; exit 2 ;;
 esac
 
 exit "$exit_code"

--- a/test/test_gitleaks_config.py
+++ b/test/test_gitleaks_config.py
@@ -1,0 +1,181 @@
+# ABOUTME: Regression tests for the custom rules + allowlist in .gitleaks.toml.
+# ABOUTME: Skips when the gitleaks binary is absent (e.g. the pip-only CI test job).
+"""Lock in the behaviour of the hand-written gitleaks rules (issue #457).
+
+The two custom rules in ``.gitleaks.toml`` (AWS secret access keys; GitHub
+fine-grained PATs) and the AWS-example allowlist were tuned by hand against
+gitleaks 8.30.1 during review — closing real gaps in the default ruleset while
+avoiding false positives on placeholders, hashes, and the repo's live-TUI
+fixtures. These tests pin that boundary so a later config edit can't silently
+regress it.
+
+gitleaks is a Go binary, not a Python dependency, so it is absent from the
+pip-only CI unit-test job (these tests skip there). They are executed by the
+dedicated ``config-tests`` job in .github/workflows/secret-scan.yml, which
+installs gitleaks on PATH and runs this file explicitly, and by any local run
+where the binary is installed.
+"""
+
+import random
+import shutil
+import string
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _rand(n: int) -> str:
+    """A random high-entropy [A-Za-z0-9] run of length n.
+
+    Real tokens are random; hand-crafted samples with sequential runs
+    (``1234567890``, ``AbCdEf``) can trip gitleaks' built-in ``stopwords`` /
+    low-signal heuristics and read as non-secrets. Generating random material
+    keeps these tests exercising the rule's shape/boundary, not those filters.
+    Uses the stdlib ``random`` (test data only — not a security context).
+    """
+    return "".join(random.choices(string.ascii_letters + string.digits, k=n))
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CONFIG = _REPO_ROOT / ".gitleaks.toml"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("gitleaks") is None,
+    reason="gitleaks binary not on PATH (Go tool; absent in the pip-only test job)",
+)
+
+
+def _scan(content: str) -> int:
+    """Scan ``content`` with the repo config via stdin, return the exit code.
+
+    gitleaks exits 1 when a secret is detected, 0 when clean (``--exit-code 1``).
+    ``--pipe`` reads the input from stdin, so the (synthetic) test material is
+    never written to disk — this keeps the test itself from being a clear-text
+    secret sink, which is exactly the kind of thing this PR guards against.
+    """
+    result = subprocess.run(
+        [
+            "gitleaks",
+            "detect",
+            "--pipe",
+            "--config",
+            str(_CONFIG),
+            "--redact",
+            "--exit-code",
+            "1",
+        ],
+        input=content.encode(),
+        capture_output=True,
+        timeout=30,
+    )
+    return result.returncode
+
+
+def _caught(content: str) -> bool:
+    return _scan(content) == 1
+
+
+# --- custom rules must catch real credential shapes the defaults miss ---
+
+
+def test_aws_secret_access_key_caught():
+    # 40-char secret in an aws-labelled assignment (default rules miss this).
+    assert _caught(f'aws_secret_access_key = "{_rand(40)}"')
+
+
+def test_aws_secret_caught_with_base64_chars():
+    # Real AWS secrets use the full base64 alphabet (A-Z, a-z, 0-9, +, /).
+    # Ensure +/ in the 40-char body don't break detection.
+    body = _rand(30) + "+/+" + _rand(7)  # 40 chars total with +/
+    assert _caught(f'aws_secret_access_key = "{body}"')
+
+
+def test_aws_secret_caught_when_terminated_by_punctuation_or_eof():
+    # The end-boundary must accept ; , ) & etc. AND end-of-file (no trailing
+    # newline), not only quote/whitespace.
+    secret = _rand(40)
+    for term in (";", ",", ")", "&", ""):  # "" = key sits at EOF
+        content = f"aws_secret_access_key={secret}{term}"
+        label = repr(term) if term else "EOF"
+        assert _caught(content), f"missed AWS secret terminated by {label}"
+
+
+def test_aws_secret_rule_requires_exactly_40_chars():
+    # The custom aws-secret rule is length-anchored to 40 (real AWS secret
+    # length). Verify the RULE's boundary in isolation so a config edit that
+    # loosens {40} is caught. (Note: the full repo config also runs gitleaks'
+    # default generic-api-key rule, which independently flags long high-entropy
+    # key values — so a 41-char blob is still caught overall; here we assert the
+    # custom rule specifically, not the whole config.)
+    import re
+
+    rule = None
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # py3.10
+        import tomli as tomllib
+    cfg = tomllib.loads(_CONFIG.read_text())
+    for r in cfg.get("rules", []):
+        if r["id"] == "aws-secret-access-key":
+            rule = re.compile(r["regex"])
+    assert rule is not None, "aws-secret-access-key rule not found"
+
+    assert rule.search('aws_secret_access_key = "' + _rand(40) + '"')  # 40 → match
+    assert not rule.search("aws_secret_access_key = " + _rand(39) + " ")  # 39 → no match
+    # 41 → no match: the delimiter-anchored prefix can't line up a 40-char window
+    # inside a 41-char run. Asserted at the regex level to avoid interference from
+    # the default generic-api-key rule (which flags long high-entropy values).
+    assert not rule.search('aws_secret_access_key = "' + _rand(41) + '"')
+
+
+def test_github_fine_grained_pat_caught():
+    # github_pat_ + 22 chars + _ + 59 chars, random/high-entropy (real shape).
+    tok = f"github_pat_{_rand(22)}_{_rand(59)}"
+    assert _caught(f'token = "{tok}"')
+
+
+# --- must NOT fire on placeholders / non-secrets ---
+
+
+def test_placeholders_not_flagged():
+    assert not _caught(
+        'API_KEY = "your-api-key-here"\n'
+        'password = "changeme"\n'
+        'token = os.environ["CAO_TOKEN"]\n'
+    )
+
+
+def test_hashes_and_ids_not_flagged():
+    assert not _caught(
+        'git_sha = "9f2554cbe13877a43ebd9fb12490ba7aa892d438"\n'
+        'uuid = "550e8400-e29b-41d4-a716-446655440000"\n'
+        'sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"\n'
+    )
+
+
+def test_github_pat_low_entropy_placeholder_not_flagged():
+    # A token of the RIGHT shape (22 + "_" + 59) but low entropy — a repeated
+    # placeholder — must be rejected by the entropy=3.0 threshold, not caught.
+    # (Shape alone matching would false-positive on docs; this exercises entropy.)
+    seg1 = "x" * 22
+    seg2 = "x" * 59
+    assert not _caught(f'doc = "github_pat_{seg1}_{seg2}"')
+
+
+# --- allowlist is precise, not global ---
+
+
+def test_aws_example_key_allowlisted():
+    assert not _caught('aws_key = "AKIAIOSFODNN7EXAMPLE"')
+
+
+def test_allowlist_does_not_exempt_other_secrets():
+    # The AWS-example allowlist must be scoped to that exact string only — it
+    # must not blanket-exempt other credentials appearing on the same line or
+    # file. A real AWS secret alongside the example key is still caught.
+    secret = _rand(40)
+    assert _caught(
+        'aws_key = "AKIAIOSFODNN7EXAMPLE"  # allowlisted example\n'
+        f'aws_secret_access_key = "{secret}"  # real secret — must fire\n'
+    )


### PR DESCRIPTION
Closes #457.

## What & why

#457 asked for two things: keep secrets out of the repo (prevention) and adopt a git-history scrub / leak-response process (response). This PR delivers both as one change because they're the two halves of a single capability — a scanner without a documented response leaves maintainers improvising during an incident, and a runbook without a scanner never catches the leak in the first place.

This complements (does not replace) the runtime redactor in `secret_gate.py`: that strips secrets from memory/archive exports at runtime; this gates *git content* so a credential can't land in the repo to begin with.

## Prevention

- **`.gitleaks.toml`** — extends gitleaks' built-in ruleset, adds two custom rules (40-char AWS secret keys; GitHub fine-grained PATs) for shapes the defaults miss, and allowlists exactly one value: AWS's documented example key. No path/file/commit allowlists (each would blind the gate to a real key).
- **`.github/workflows/secret-scan.yml`** — split from `ci.yml`. On every PR it scans the commit range (`base..head`, with a `git cat-file -e` fail-closed guard so an unresolvable range can't silently pass); weekly it scans full history. Binary is pinned + SHA-256 verified before it runs. A second job runs the config regression tests (they need the gitleaks binary on PATH).
- **`scripts/security-scan.sh`** — adds a `gitleaks` target for local CI parity.
- **`.pre-commit-config.yaml`** — optional staged-diff hook; CI is the backstop.
- **`test/test_gitleaks_config.py`** — 9 regression tests pinning the custom rules' boundary (catch real AWS/GitHub secrets incl. punctuation/EOF terminators; exempt only the exact AWS example; reject placeholders, hashes, low-entropy PATs).

## Response

- **`docs/security/history-scrub-runbook.md`** — incident runbook. Golden rule: **rotate/revoke first**; history rewrite is a secondary, high-cost step that never substitutes for rotation. Covers severity triage, `git filter-repo`, publish/re-sync, and the limits of a rewrite (forks retain the secret; you can't purge someone else's fork).
- **`SECURITY.md` / `CONTRIBUTING.md` / `DEVELOPMENT.md`** — cross-links plus a "Recording test fixtures safely" section (the #436 class of leak: secrets/PII captured from live CLI output, sometimes hidden in ANSI escapes).

## Testing

- gitleaks 8.30.1 full-history scan over all of `main` (269 commits): **clean**.
- Per-commit replay of the PR gate across all merged PRs: **0 would block**; negative control (planted synthetic AWS key): **correctly blocked**.
- End-to-end CI dry run on a throwaway repo: both jobs green — checksum-verified install, `fetch-depth: 0`, range scan, and the 9 regression tests all ran on a real runner.

## Reviewer note

Would appreciate a second maintainer's eyes on the runbook specifically — it's incident-response guidance others will follow under pressure, so a review there is worth more than the mechanical scanner bits.
