### PR TITLE
fix(assign): verify deferred-init worker started and re-submit dropped input

### DIFF
--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -19,6 +19,7 @@ Terminal Workflow:
 
 import asyncio
 import logging
+import re
 import threading
 import time
 from datetime import datetime
@@ -68,6 +69,7 @@ from cli_agent_orchestrator.utils.terminal import (
     generate_session_name,
     generate_terminal_id,
     generate_window_name,
+    wait_until_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -543,6 +545,104 @@ def _notify_caller_of_deferred_failure(
             )
 
 
+# --- deferred-init submit verification ----------------------------------------
+# send_input delivers via paste-buffer → fixed sleep → Enter (clients/tmux.py).
+# That fixed sleep only guesses when the TUI is input-ready; when it guesses
+# wrong the Enter (or the whole paste) is dropped and the message sits
+# unsubmitted in the prompt box. In the deferred-init path nobody blocks on
+# completion, so a dropped submit leaves the worker IDLE forever with the task
+# never started and NO exception raised — the supervisor then waits on a
+# callback that can never arrive. Confirm the worker actually began processing
+# and re-submit if it did not.
+_DEFERRED_SUBMIT_CONFIRM_TIMEOUT = 8.0  # per-attempt wait for the PROCESSING edge
+_DEFERRED_SUBMIT_MAX_RESUBMITS = 3
+# Statuses proving the worker accepted the task (left the ready IDLE state).
+# WAITING_USER_ANSWER counts: the worker consumed the input and is now asking.
+_DEFERRED_STARTED_STATUSES = {
+    TerminalStatus.PROCESSING,
+    TerminalStatus.COMPLETED,
+    TerminalStatus.WAITING_USER_ANSWER,
+}
+
+
+def _message_visible_in_box(terminal_id: str, message: str) -> bool:
+    """True when the delivered message is still sitting in the input box.
+
+    Decides the resubmit action: if our text is there the paste landed and only
+    the Enter was dropped (send a bare Enter); if it is absent the paste itself
+    was dropped (re-deliver the full message). Guessing wrong the other way must
+    be avoided — a bare Enter into an EMPTY box would submit a blank prompt and
+    the real task would be lost. Collapse to [a-z0-9] so wrapping / whitespace /
+    unicode punctuation in the rendered box can't defeat the match.
+    """
+    probe = re.sub(r"[^a-z0-9]", "", message.lower())[:24]
+    if len(probe) < 8:
+        # Too short to match reliably — treat as "not shown" so we re-deliver
+        # in full rather than risk a blank submit.
+        return False
+    try:
+        rendered = get_output(terminal_id)
+    except Exception:
+        return False
+    return probe in re.sub(r"[^a-z0-9]", "", rendered.lower())
+
+
+async def _confirm_worker_started_or_resubmit(
+    terminal_id: str,
+    message: str,
+    registry: "PluginRegistry | None",
+    sender_id: Optional[str],
+    orchestration_type: Optional[OrchestrationType],
+) -> bool:
+    """Confirm a deferred-init worker began processing; re-submit if not.
+
+    Returns True once the terminal reaches a started status, False if it is
+    still stuck at IDLE after all resubmit attempts. Blocking tmux/DB I/O runs
+    off the loop via to_thread so concurrent deferred inits aren't frozen.
+    """
+    if await wait_until_status(
+        terminal_id,
+        _DEFERRED_STARTED_STATUSES,
+        timeout=_DEFERRED_SUBMIT_CONFIRM_TIMEOUT,
+        polling_interval=0.5,
+    ):
+        return True
+
+    for attempt in range(1, _DEFERRED_SUBMIT_MAX_RESUBMITS + 1):
+        if await asyncio.to_thread(_message_visible_in_box, terminal_id, message):
+            logger.warning(
+                "Deferred assign to %s unsubmitted (Enter swallowed); "
+                "re-submitting via Enter (attempt %d)",
+                terminal_id,
+                attempt,
+            )
+            await asyncio.to_thread(send_special_key, terminal_id, "Enter")
+        else:
+            logger.warning(
+                "Deferred assign to %s not accepted (paste dropped); "
+                "re-delivering message (attempt %d)",
+                terminal_id,
+                attempt,
+            )
+            await asyncio.to_thread(
+                send_input,
+                terminal_id,
+                message,
+                registry=registry,
+                sender_id=sender_id,
+                orchestration_type=orchestration_type,
+            )
+        if await wait_until_status(
+            terminal_id,
+            _DEFERRED_STARTED_STATUSES,
+            timeout=_DEFERRED_SUBMIT_CONFIRM_TIMEOUT,
+            polling_interval=0.5,
+        ):
+            return True
+
+    return False
+
+
 def _schedule_deferred_init(
     provider_instance,
     terminal_id: str,
@@ -592,6 +692,36 @@ def _schedule_deferred_init(
                     sender_id=caller_id,
                     orchestration_type=orchestration_type,
                 )
+                # Delivery can be silently dropped (Enter swallowed / paste lost)
+                # when the TUI isn't input-ready. Confirm the worker actually
+                # started and re-submit if not; if it never starts, surface the
+                # failure so the supervisor re-routes instead of waiting forever.
+                started = await _confirm_worker_started_or_resubmit(
+                    terminal_id,
+                    initial_message,
+                    registry,
+                    caller_id,
+                    orchestration_type,
+                )
+                if not started:
+                    logger.error(
+                        "Deferred init for %s: worker never started after "
+                        "resubmits; task not delivered — notifying caller and "
+                        "tearing down.",
+                        terminal_id,
+                    )
+                    await asyncio.to_thread(
+                        _notify_caller_of_deferred_failure,
+                        terminal_id,
+                        (
+                            f"Worker {terminal_id} received the assigned task but "
+                            f"never started processing (input not accepted after "
+                            f"retries). It has been deleted — re-assign the task."
+                        ),
+                        registry,
+                        True,  # delete_worker
+                    )
+                    return
         except TerminalInputBlockedError as e:
             # The worker initialized but is parked on an interactive prompt
             # (WAITING_USER_ANSWER). It is alive and can be driven via

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -1,0 +1,100 @@
+"""Tests for the deferred-init submit-verification guard.
+
+The deferred-init delivery (send_input: paste -> fixed sleep -> Enter) can drop
+the Enter (message left in the box) or the whole paste (TUI not input-ready).
+Nothing blocks on completion in that path, so a dropped submit would leave the
+worker idle forever. These cover the confirm + re-submit logic that closes it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.services import terminal_service as ts
+
+
+class TestMessageVisibleInBox:
+    def test_true_when_probe_present(self):
+        with patch.object(ts, "get_output", return_value="❯ Analyze the logs now"):
+            assert ts._message_visible_in_box("t1", "Analyze the logs") is True
+
+    def test_false_when_absent(self):
+        with patch.object(ts, "get_output", return_value="❯ (empty prompt)"):
+            assert ts._message_visible_in_box("t1", "Analyze the logs") is False
+
+    def test_false_when_message_too_short(self):
+        # < 8 alnum chars → don't risk a blank submit; report not-shown.
+        with patch.object(ts, "get_output", return_value="go go go") as mock_out:
+            assert ts._message_visible_in_box("t1", "go") is False
+            mock_out.assert_not_called()
+
+    def test_false_when_output_fetch_raises(self):
+        with patch.object(ts, "get_output", side_effect=Exception("boom")):
+            assert ts._message_visible_in_box("t1", "Analyze the logs") is False
+
+    def test_match_survives_wrapping_and_whitespace(self):
+        # Rendered box wraps the text across lines / pads with spaces.
+        with patch.object(ts, "get_output", return_value="❯ Analyze the\n  logs carefully"):
+            assert ts._message_visible_in_box("t1", "Analyze the logs") is True
+
+
+@pytest.mark.asyncio
+class TestConfirmWorkerStartedOrResubmit:
+    async def test_started_on_first_confirm_no_resubmit(self):
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=True)),
+            patch.object(ts, "send_special_key") as key,
+            patch.object(ts, "send_input") as send,
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", None, "sup", None
+            )
+        assert ok is True
+        key.assert_not_called()
+        send.assert_not_called()
+
+    async def test_enter_resubmit_when_message_in_box(self):
+        # First confirm fails, box shows our text (Enter swallowed) → bare Enter,
+        # second confirm succeeds.
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(ts, "_message_visible_in_box", return_value=True),
+            patch.object(ts, "send_special_key") as key,
+            patch.object(ts, "send_input") as send,
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", None, "sup", None
+            )
+        assert ok is True
+        key.assert_called_once_with("t1", "Enter")
+        send.assert_not_called()
+
+    async def test_full_redeliver_when_box_empty(self):
+        # First confirm fails, box empty (paste dropped) → re-deliver full msg.
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(ts, "_message_visible_in_box", return_value=False),
+            patch.object(ts, "send_special_key") as key,
+            patch.object(ts, "send_input") as send,
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", "reg", "sup", None
+            )
+        assert ok is True
+        key.assert_not_called()
+        send.assert_called_once()
+        assert send.call_args.args[0] == "t1"
+        assert send.call_args.args[1] == "Analyze the logs"
+
+    async def test_returns_false_when_worker_never_starts(self):
+        # Every confirm fails through all resubmit attempts.
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
+            patch.object(ts, "_message_visible_in_box", return_value=True),
+            patch.object(ts, "send_special_key"),
+            patch.object(ts, "send_input"),
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", None, "sup", None
+            )
+        assert ok is False


### PR DESCRIPTION
**Problem:** Assigned workers sometimes spin up and then sit IDLE forever — the task silently never runs, and the supervisor waits on a callback that never comes.

**Root cause:** In the deferred-init path, `_schedule_deferred_init` delivers the assigned task via `send_input` (paste-buffer → fixed sleep → Enter) inside a background task, and nothing blocks on completion. When the TUI is not yet input-ready, the Enter (or the whole paste) is dropped, the message sits unsubmitted in the prompt box, and **no exception is raised** — so the failure is invisible: the worker stays IDLE and the caller waits indefinitely. (`handoff` avoids this because it blocks on COMPLETED; `assign`/deferred-init had no such guard.)

**Fix:** After delivery, confirm the worker reaches a started status (`PROCESSING` / `COMPLETED` / `WAITING_USER_ANSWER`). If it does not, re-submit:
- a bare **Enter** when our text is visibly in the input box (Enter was swallowed), or
- a full **re-delivery** when the box is empty (the paste itself was dropped) — guarded so we never send a bare Enter into an empty box, which would submit a blank prompt and lose the task,

bounded to 3 attempts. If it still never starts, the existing `_notify_caller_of_deferred_failure` path notifies the caller and tears the worker down so the task can be re-routed instead of stalling.

Complements #430 (which changes *how* the bracketed paste is formed) — this verifies the *outcome* regardless of the paste mechanism.

**Tests:** adds `test/services/test_deferred_submit_verification.py` (9 tests covering the box-visibility probe and each resubmit branch). Full suite green locally (1565 passed).