### PR TITLE
fix(claude_code): content-based staleness guard prevents stale COMPLETED after send_input (#407)

### DIFF
--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -1,6 +1,7 @@
 """Claude Code provider implementation."""
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -203,6 +204,8 @@ NEW_TUI_BOX_SPINNER_PATTERN = re.compile(r"^[ \t]*[✶✢✽✻✳·*][ \t]+\w*i
 class ClaudeCodeProvider(BaseProvider):
     """Provider for Claude Code CLI tool integration."""
 
+    _TAIL_HASH_LINES = 30
+
     def __init__(
         self,
         terminal_id: str,
@@ -218,6 +221,46 @@ class ClaudeCodeProvider(BaseProvider):
         self._agent_profile = agent_profile
         # Native-status dispatch tracking (_task_dispatched + flush-wait timers)
         # lives on BaseProvider and is consumed by _resolve_native_status().
+        self._input_generation: int = 0
+        self._snapshot_tail_hash: Optional[str] = None
+        self._snapshot_last_response: Optional[str] = None
+        self._snapshot_response_count: int = 0
+
+    @staticmethod
+    def _tail_hash(output: str, n: int = 30) -> str:
+        """Hash the ANSI-stripped last *n* lines of *output*."""
+        clean = re.sub(ANSI_CODE_PATTERN, "", output)
+        tail = "\n".join(clean.split("\n")[-n:])
+        return hashlib.md5(tail.encode()).hexdigest()
+
+    @staticmethod
+    def _strip_effort_footer_lines(clean: str) -> str:
+        """Drop own-line effort-footer lines ("● high · /effort") before marker
+        counting/extraction — their glyph is not a response marker (GH #459)."""
+        return "\n".join(
+            line for line in clean.split("\n") if not EFFORT_FOOTER_LINE_PATTERN.match(line)
+        )
+
+    @staticmethod
+    def _extract_last_response_text(output: str) -> Optional[str]:
+        """Extract the text of the last response marker (⏺/●) in *output*, ANSI-stripped."""
+        clean = ClaudeCodeProvider._strip_effort_footer_lines(re.sub(ANSI_CODE_PATTERN, "", output))
+        matches = list(re.finditer(r"[⏺●]\s+", clean))
+        if not matches:
+            return None
+        last = matches[-1]
+        remaining = clean[last.end() :]
+        lines = remaining.split("\n")
+        response_lines = []
+        for line in lines:
+            stripped = line.strip()
+            if re.match(r"^[>❯]\s", stripped):
+                break
+            if re.search(r"─{20,}", stripped):
+                break
+            response_lines.append(stripped)
+        text = "\n".join(response_lines).strip()
+        return text if text else None
 
     def _load_profile(self) -> Optional["AgentProfile"]:
         """Load this terminal's CAO agent profile from disk, if any.
@@ -660,6 +703,16 @@ class ClaudeCodeProvider(BaseProvider):
         if not output.strip():
             return TerminalStatus.UNKNOWN
 
+        # Issue #407: content-based staleness guard. The tmux sliding window
+        # (-S -200) is NOT monotonically growing — Ink composer-collapse and
+        # short-line eviction can shrink it. Instead of raw length, compare a
+        # hash of the tail region: while unchanged since mark_input_received,
+        # the screen hasn't updated yet → PROCESSING.
+        if self._input_generation > 0 and self._snapshot_tail_hash is not None:
+            current_hash = self._tail_hash(output, self._TAIL_HASH_LINES)
+            if current_hash == self._snapshot_tail_hash:
+                return TerminalStatus.PROCESSING
+
         # PRIMARY PROCESSING check: walk backwards from the *last* separator.
         _sep_re = re.compile(r"(?:\x1b\[[0-9;]*m)*\u2500{20,}")
         _sep_positions = [m.start() for m in _sep_re.finditer(output)]
@@ -818,6 +871,16 @@ class ClaudeCodeProvider(BaseProvider):
             or last_sol_response is not None
             or last_response is not None
         ):
+            # Issue #407 paste-echo guard: when tail-hash differs but the
+            # extracted last-response text matches the snapshot, block COMPLETED
+            # unless the response marker count changed (proving new activity).
+            if self._input_generation > 0 and self._snapshot_last_response is not None:
+                current_response = self._extract_last_response_text(output)
+                if current_response == self._snapshot_last_response:
+                    clean = self._strip_effort_footer_lines(re.sub(ANSI_CODE_PATTERN, "", output))
+                    current_count = len(list(re.finditer(r"[⏺●]\s+", clean)))
+                    if current_count == self._snapshot_response_count:
+                        return TerminalStatus.PROCESSING
             return TerminalStatus.COMPLETED
 
         # IDLE: shell prompt visible but no response yet (e.g. just initialized).
@@ -937,6 +1000,20 @@ class ClaudeCodeProvider(BaseProvider):
         isn't ready to accept input even though get_status() sees PROCESSING.
         """
         return self._initialized
+
+    def mark_input_received(self) -> None:
+        """Capture content-based snapshots for the staleness guard (issue #407).
+
+        Uses tail-hash instead of raw length because the tmux sliding window
+        is not monotonically growing.
+        """
+        output = get_backend().get_history(self.session_name, self.window_name) or ""
+        self._snapshot_tail_hash = self._tail_hash(output, self._TAIL_HASH_LINES)
+        self._snapshot_last_response = self._extract_last_response_text(output)
+        clean = self._strip_effort_footer_lines(re.sub(ANSI_CODE_PATTERN, "", output))
+        self._snapshot_response_count = len(list(re.finditer(r"[⏺●]\s+", clean)))
+        self._input_generation += 1
+        super().mark_input_received()
 
     def get_idle_pattern_for_log(self) -> str:
         """Return Claude Code IDLE prompt pattern for log files."""

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -979,6 +979,8 @@ class TestClaudeCodeProviderNativeStatus:
     @patch("cli_agent_orchestrator.backends.registry._backend")
     def test_mark_input_received_resets_detection_flags(self, mock_backend):
         """mark_input_received() sets _task_dispatched=True and resets detection flags."""
+        mock_backend.get_history.return_value = "❯ "
+
         provider = ClaudeCodeProvider("test123", "test-session", "window-0")
         provider._done_first_detected = 999.0
         provider._idle_first_detected = 999.0

--- a/test/providers/test_native_status_shared.py
+++ b/test/providers/test_native_status_shared.py
@@ -106,6 +106,9 @@ class TestSharedNativeStatus:
     def test_native_idle_dispatched_flushes_then_completed(self, mock_backend, provider_cls, _flag):
         """herdr 'idle' after dispatch: PROCESSING within 10s flush, COMPLETED after."""
         mock_backend.get_native_status.return_value = TerminalStatus.IDLE
+        # claude_code's mark_input_received snapshots get_history() for the
+        # staleness guard (#407); stub it so the hash sees a string.
+        mock_backend.get_history.return_value = ""
         provider = _make(provider_cls)
         provider.mark_input_received()
 
@@ -119,6 +122,7 @@ class TestSharedNativeStatus:
     def test_native_done_dispatched_flushes_then_completed(self, mock_backend, provider_cls, _flag):
         """herdr 'done' after dispatch: PROCESSING within 10s flush, COMPLETED after."""
         mock_backend.get_native_status.return_value = TerminalStatus.COMPLETED
+        mock_backend.get_history.return_value = ""
         provider = _make(provider_cls)
         provider.mark_input_received()
 
@@ -175,8 +179,10 @@ class TestSharedNativeStatus:
         provider._last_dispatch_time = time.time() - 300.0  # would have been "stale" pre-fix
         assert provider.get_status("") == self._empty_output_default(provider_cls)
 
-    def test_mark_input_received_sets_dispatch_flags(self, provider_cls, _flag):
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_mark_input_received_sets_dispatch_flags(self, mock_backend, provider_cls, _flag):
         """mark_input_received() sets shared _task_dispatched AND the provider's own flag."""
+        mock_backend.get_history.return_value = ""
         provider = _make(provider_cls)
         assert provider._task_dispatched is False
         provider.mark_input_received()

--- a/test/providers/test_status_staleness_guard.py
+++ b/test/providers/test_status_staleness_guard.py
@@ -1,0 +1,339 @@
+"""Tests for issue #407: content-based staleness guard after send_input.
+
+The real bug: after send_input pastes into tmux, the buffer still returns
+the previous turn's response + idle prompt. get_status() would re-derive
+COMPLETED from that stale buffer, causing wait_until_status(COMPLETED) to
+return immediately on the OLD turn's output.
+
+The fix: mark_input_received() captures a tail-hash (ANSI-stripped hash of
+the last N lines) and the extracted last-response text. The buffer-path
+get_status() returns PROCESSING while the tail-hash matches the snapshot
+(screen unchanged). Once the tail differs, normal derivation runs but a
+secondary guard prevents COMPLETED when the derived last-response is still
+the old turn's text (handles paste-echo growing the buffer without new output).
+
+Critical property: buffer length is NOT monotonic (Ink composer-collapse,
+sliding -S -200 window), so the guard uses content hashing, not length.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
+
+
+class TestContentBasedStalenessGuard:
+    """Test the content-based staleness check on the buffer path."""
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_stale_buffer_after_send_input_returns_processing(self, mock_backend):
+        """Right after mark_input_received, unchanged buffer → PROCESSING."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        stale_buffer = "⏺ Previous response\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = stale_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+
+        assert provider.get_status(stale_buffer) == TerminalStatus.COMPLETED
+
+        provider.mark_input_received()
+
+        assert provider.get_status(stale_buffer) == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_shorter_buffer_after_input_still_processing(self, mock_backend):
+        """Buffer SHRINKS after input (Ink composer-collapse) → still PROCESSING
+        while tail content unchanged. This is the key regression the length-based
+        guard got wrong."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = (
+            "Some long preamble\n" * 10 + "⏺ Previous response\n────────────────────────\n❯ "
+        )
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # Buffer shrinks (Ink collapse) but tail content is identical
+        shorter_buffer = "⏺ Previous response\n────────────────────────\n❯ "
+        assert provider.get_status(shorter_buffer) == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_new_response_completes_even_with_shorter_buffer(self, mock_backend):
+        """New turn produces SHORTER total buffer than snapshot but with different
+        content → must reach COMPLETED (the hang case from the review)."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = (
+            "A" * 500
+            + "\n"
+            + "⏺ Original long response text here\n"
+            + "────────────────────────\n❯ "
+        )
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # New response is shorter total but different content
+        new_buffer = "⏺ Short new reply\n────────────────────────\n❯ "
+        assert provider.get_status(new_buffer) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_identical_response_text_across_turns_still_completes(self, mock_backend):
+        """New turn produces IDENTICAL response text to previous turn → must
+        reach COMPLETED because the tail hash differs (echo of new input)."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = "⏺ Done.\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # New turn: user input echo + same response text → tail hash differs
+        new_buffer = (
+            "⏺ Done.\n────────────────────────\n"
+            "❯ do it again\n"
+            "⏺ Done.\n────────────────────────\n❯ "
+        )
+        assert provider.get_status(new_buffer) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_paste_echo_with_old_response_not_completed(self, mock_backend):
+        """Immediately after paste, buffer shows paste echo but old response
+        still visible → NOT COMPLETED (the original stale-COMPLETED bug).
+
+        Realistic scenario: tmux sliding window captures old response + separator
+        + pasted user input at the new ❯ prompt. The pasted text changes the
+        tail hash but the last ⏺ marker is still the old response. The prompt
+        character in the pasted line satisfies last_idle; old ⏺ satisfies
+        last_response → would falsely derive COMPLETED without the guard.
+        """
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = "⏺ Old answer\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # Paste echo: user text appended after the prompt. The ❯ with text after
+        # it still matches IDLE_PROMPT_PATTERN. The last response marker is still
+        # "Old answer" with the same count as at snapshot time.
+        paste_echo_buffer = (
+            "⏺ Old answer\n────────────────────────\n" "❯ this is my new task that I pasted in"
+        )
+        # Tail hash differs from snapshot (new text) but last-response is still
+        # "Old answer" with same response count → PROCESSING
+        assert provider.get_status(paste_echo_buffer) == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_buffer_grows_after_input_resumes_normal_detection(self, mock_backend):
+        """Once buffer shows new content with different response, normal derivation resumes."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        stale_buffer = "⏺ Previous response\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = stale_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider.get_status(stale_buffer) == TerminalStatus.PROCESSING
+
+        # Agent finishes with new response text
+        done_buffer = (
+            stale_buffer + "\n❯ new task text\n⏺ New response\n" "────────────────────────\n❯ "
+        )
+        assert provider.get_status(done_buffer) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_staleness_guard_inactive_before_first_input(self, mock_backend):
+        """Before any mark_input_received, guard is inactive (generation=0)."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider._input_generation == 0
+        assert provider.get_status("⏺ Response\n❯ ") == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_two_turns_staleness_guard_resets(self, mock_backend):
+        """Second mark_input_received resets the snapshot for the new turn."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+
+        # Turn 1
+        turn1_buffer = "⏺ Turn 1 response\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = turn1_buffer
+        provider.mark_input_received()
+        assert provider.get_status(turn1_buffer) == TerminalStatus.PROCESSING
+
+        # Turn 1 completes
+        turn1_done = turn1_buffer + "\n❯ task1\n⏺ Done task 1\n────────────────────────\n❯ "
+        assert provider.get_status(turn1_done) == TerminalStatus.COMPLETED
+
+        # Turn 2: mark_input_received with current buffer
+        mock_backend.get_history.return_value = turn1_done
+        provider.mark_input_received()
+        assert provider.get_status(turn1_done) == TerminalStatus.PROCESSING
+
+        # Turn 2 completes
+        turn2_done = turn1_done + "\n❯ task2\n⏺ Done task 2\n────────────────────────\n❯ "
+        assert provider.get_status(turn2_done) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_native_path_unaffected_by_staleness_guard(self, mock_backend):
+        """Native path (herdr) bypasses the staleness guard entirely."""
+        mock_backend.get_history.return_value = "⏺ Previous\n❯ "
+        mock_backend.get_native_status.return_value = TerminalStatus.COMPLETED
+        mock_backend.supports_event_inbox.return_value = True
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # Native returns COMPLETED + _task_dispatched=True → flush-wait logic
+        result = provider.get_status("")
+        assert result == TerminalStatus.PROCESSING  # flush wait, not staleness guard
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_mark_input_received_increments_generation(self, mock_backend):
+        """Each mark_input_received call increments _input_generation."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        mock_backend.get_history.return_value = "❯ "
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        assert provider._input_generation == 0
+
+        provider.mark_input_received()
+        assert provider._input_generation == 1
+
+        provider.mark_input_received()
+        assert provider._input_generation == 2
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_no_snapshot_response_allows_any_completed(self, mock_backend):
+        """When snapshot had no response (e.g. first turn from IDLE), any
+        COMPLETED with a response is accepted immediately."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        # Initial buffer: just idle prompt, no response marker
+        idle_buffer = "────────────────────────\n❯ "
+        mock_backend.get_history.return_value = idle_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # Agent responds
+        response_buffer = "────────────────────────\n❯ task\n⏺ Here is the answer\n❯ "
+        assert provider.get_status(response_buffer) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_marker_count_decrease_via_eviction_reaches_completed(self, mock_backend):
+        """Sliding window evicts old markers → count DECREASES below snapshot.
+        Identical response text but fewer markers means the window slid (new
+        activity pushed old markers out) — must NOT hang in PROCESSING.
+
+        Repro scenario: snapshot has 2 markers (old response A + earlier one);
+        new turn completes with identical text "Response A" while intervening
+        output evicts the earlier marker → current_count=1 < snapshot_count=2.
+        """
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        # Snapshot: 2 response markers visible in window
+        initial_buffer = (
+            "⏺ Earlier response\n────────────────────────\n"
+            "❯ task A\n"
+            "⏺ Response A\n────────────────────────\n❯ "
+        )
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        # Snapshot captures: last_response="Response A", count=2
+        provider.mark_input_received()
+
+        # New turn: window slid, earlier marker evicted; new identical response
+        evicted_buffer = "⏺ Response A\n────────────────────────\n❯ "
+        # current_count=1 < snapshot_count=2 → must be COMPLETED (not stuck)
+        assert provider.get_status(evicted_buffer) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_paste_echo_same_count_still_processing(self, mock_backend):
+        """Paste-echo case: text matches AND count unchanged → PROCESSING.
+        This is the legitimate hold case the guard protects against."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = "⏺ Old answer\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        # Snapshot: last_response="Old answer", count=1
+        provider.mark_input_received()
+
+        # Paste echo: same response marker, same count, same text
+        paste_buffer = "⏺ Old answer\n────────────────────────\n" "❯ some new pasted input here"
+        # count=1 == snapshot_count=1, text matches → PROCESSING
+        assert provider.get_status(paste_buffer) == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_identical_response_count_increased_reaches_completed(self, mock_backend):
+        """New turn produces identical response text with MORE markers →
+        COMPLETED (a new response was emitted, count proves it)."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = "⏺ Done.\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        # Snapshot: last_response="Done.", count=1
+        provider.mark_input_received()
+
+        # New turn: same response text, but 2 markers now
+        new_buffer = (
+            "⏺ Done.\n────────────────────────\n"
+            "❯ repeat\n"
+            "⏺ Done.\n────────────────────────\n❯ "
+        )
+        # current_count=2 > snapshot_count=1 → COMPLETED
+        assert provider.get_status(new_buffer) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_effort_footer_does_not_perturb_marker_count(self, mock_backend):
+        """Own-line effort footer ("● high · /effort", GH #459) appearing after
+        the snapshot must not increment the marker count or hijack last-response
+        extraction — the guard must keep holding PROCESSING, not release early."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = "⏺ Old answer\n────────────────────────\n❯ "
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        # Snapshot: last_response="Old answer", count=1 (footer absent)
+        provider.mark_input_received()
+
+        # Footer renders on a later poll while the old response is still the
+        # only real response on screen. Without footer exclusion this counted
+        # as a second marker AND became the extracted "last response",
+        # releasing the guard into a stale COMPLETED.
+        footer_buffer = "⏺ Old answer\n────────────────────────\n" "● high · /effort\n" "❯ "
+        assert provider.get_status(footer_buffer) == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    def test_effort_footer_present_at_snapshot_and_poll_holds(self, mock_backend):
+        """Footer visible at both snapshot and poll: counts match with the
+        footer excluded on both sides — guard holds PROCESSING."""
+        mock_backend.get_native_status.return_value = None
+        mock_backend.supports_event_inbox.return_value = False
+        initial_buffer = "⏺ Old answer\n────────────────────────\n" "● high · /effort\n" "❯ "
+        mock_backend.get_history.return_value = initial_buffer
+
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        provider.mark_input_received()
+        assert provider.get_status(initial_buffer) == TerminalStatus.PROCESSING


### PR DESCRIPTION
Fixes #407.

On a reused terminal, `send_input` followed by `wait_until_status(COMPLETED)` could return immediately with the *previous* turn's output: nothing invalidated the screen-derived status, so the first post-input poll re-derived COMPLETED from the old response + idle prompt still visible in the pane.

Mechanism (per the maintainer guidance on the issue: completion may only be re-satisfied by post-input detection):

- `mark_input_received()` snapshots the pane state: an ANSI-stripped hash of the last 30 lines, the extracted last-response text, and the response-marker count.
- `get_status()` holds PROCESSING while the tail is unchanged since input.
- When the tail has changed but the extracted response text equals the snapshot **and** the marker count is exactly unchanged, it still holds PROCESSING (paste-echo defense — the echo of the pasted input changes the tail before the agent produces anything).
- Any marker-count change exits the guard: an increase is a new response; a decrease means the 200-line capture window slid past the snapshot state (requiring an increase caused a verified hang, since the sliding window is non-monotonic).

Notes for reviewers:
- Content hashing rather than buffer length: the capture window makes length non-monotonic (short new lines evict long old ones), so length comparisons hang or pass stale results.
- Identical response text across turns (idempotent commands) is handled via the marker-count / tail-hash combination, not content equality alone.
- Regression tests drive the real `get_status()` derivation with realistic pane sequences (old-response-visible-after-paste, shorter-completion, identical-response, eviction).

The guard's marker counting and last-response extraction exclude the own-line reasoning-effort footer ("● high · /effort", GH #459/#466): the footer's glyph would otherwise increment the count / hijack extraction when it renders after the input snapshot, releasing the guard into exactly the premature-COMPLETED this PR prevents. Regression tests cover footer-appears-after-snapshot and footer-stable cases.

Tests: `test/providers/` 1057 passed, 4 skipped (includes 16 staleness-guard tests).
