### PR TITLE
fix(codex): classify workspace-trust prompt as WAITING_USER_ANSWER; block delivery into dead terminals

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -76,8 +76,14 @@ TUI_FOOTER_PATTERN = r"(?:\?\s+for shortcuts|context left|\d+%\s+left|·\s+[~/])
 # ASSISTANT_PREFIX_PATTERN and the TUI footer › matches idle prompt).
 TUI_PROGRESS_PATTERN = r"•.*\(\d+s\s*•\s*esc to interrupt\)"
 
-# Workspace trust/approval prompt shown when Codex opens a new directory
+# Workspace trust/approval prompt shown when Codex opens a new directory.
+# Two known variants:
+#   v0.98+: "allow Codex to work in this folder"
+#   v0.130+ (git worktree): "Do you trust the contents of this directory?"
+# Both indicate the TUI is blocked waiting for user input.
 TRUST_PROMPT_PATTERN = r"allow Codex to work in this folder"
+TRUST_PROMPT_PATTERN_V2 = r"Do you trust the contents of this directory\?"
+TRUST_PROMPT_FOOTER = r"Press enter to continue"
 # Codex welcome banner indicating normal startup (no trust prompt)
 CODEX_WELCOME_PATTERN = r"OpenAI Codex"
 
@@ -373,6 +379,10 @@ class CodexProvider(BaseProvider):
         This sends Enter to accept the default option (allow Codex to work).
         CAO assumes the user trusts the working directory since they confirmed
         workspace access during the launch command.
+
+        Two known dialog variants:
+          v0.98+: "allow Codex to work in this folder"
+          v0.130+ (git worktree): "Do you trust the contents of this directory?"
         """
         start_time = time.time()
         while time.time() - start_time < timeout:
@@ -387,7 +397,17 @@ class CodexProvider(BaseProvider):
             if re.search(TRUST_PROMPT_PATTERN, clean_output):
                 from cli_agent_orchestrator.services.status_monitor import status_monitor
 
-                logger.info("Codex workspace trust prompt detected, auto-accepting")
+                logger.info("Codex workspace trust prompt (v1) detected, auto-accepting")
+                status_monitor.notify_input_sent(self.terminal_id)
+                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                return
+
+            if re.search(TRUST_PROMPT_PATTERN_V2, clean_output) and re.search(
+                TRUST_PROMPT_FOOTER, clean_output
+            ):
+                from cli_agent_orchestrator.services.status_monitor import status_monitor
+
+                logger.info("Codex workspace trust prompt (v2) detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
                 get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 return
@@ -398,7 +418,19 @@ class CodexProvider(BaseProvider):
                 return
 
             await asyncio.sleep(1.0)
-        logger.warning("Codex trust prompt handler timed out")
+
+        pane_tail = ""
+        try:
+            output = get_backend().get_history(self.session_name, self.window_name)
+            if output:
+                pane_tail = "\n".join(output.splitlines()[-10:])
+        except Exception:
+            pass
+        logger.error(
+            "Codex trust prompt handler timed out — no trust dialog or welcome banner detected. "
+            "Pane tail:\n%s",
+            pane_tail,
+        )
 
     async def initialize(self) -> bool:
         """Initialize Codex provider by starting codex command."""
@@ -407,6 +439,12 @@ class CodexProvider(BaseProvider):
         init_timeout = get_server_settings()["provider_init_timeout"]
         if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
+
+        # Capture the shell process name before launching codex — used later to
+        # detect when codex has exited and the pane is back to a bare shell.
+        self.shell_baseline = get_backend().get_pane_current_command(
+            self.session_name, self.window_name
+        )
 
         # Send a warm-up command before launching codex.
         # Codex exits immediately in freshly-created tmux sessions where the shell
@@ -454,6 +492,18 @@ class CodexProvider(BaseProvider):
         if not output:
             return TerminalStatus.UNKNOWN
 
+        # Detect when the codex process has exited and the pane is back to a
+        # bare shell. The pane's current command will revert to the shell
+        # (e.g. "zsh") that was running before we launched codex. Returning
+        # ERROR prevents the inbox service from typing a queued message into
+        # the shell — which would execute it as arbitrary commands.
+        if self._initialized and self.shell_baseline:
+            current_cmd = get_backend().get_pane_current_command(
+                self.session_name, self.window_name
+            )
+            if current_cmd == self.shell_baseline:
+                return TerminalStatus.ERROR
+
         # Strip the RAW pipe-pane escapes (cursor positioning, in-place redraws),
         # not just SGR colour codes — otherwise cursor sequences survive and the
         # idle ``›`` prompt / structural checks below misfire on the raw stream.
@@ -491,6 +541,16 @@ class CodexProvider(BaseProvider):
         # Check trust prompt early — the trust menu uses › which matches the idle prompt
         # pattern, and PROCESSING_PATTERN matches "running" in "You are running Codex in..."
         if re.search(TRUST_PROMPT_PATTERN, clean_output):
+            return TerminalStatus.WAITING_USER_ANSWER
+
+        # V2 trust dialog ("Do you trust the contents of this directory?" / "Press enter
+        # to continue"). Only classify as WAITING when BOTH the question AND the footer
+        # appear in the bottom region — avoids false positives if the question text
+        # appears in scrollback from a previous model response.
+        bottom_region = "\n".join(clean_output.splitlines()[-15:])
+        if re.search(TRUST_PROMPT_PATTERN_V2, bottom_region) and re.search(
+            TRUST_PROMPT_FOOTER, bottom_region
+        ):
             return TerminalStatus.WAITING_USER_ANSWER
 
         # Check bottom of captured output for idle prompt.

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -722,18 +722,30 @@ def send_input(
             if isinstance(orchestration_type, OrchestrationType)
             else str(orchestration_type or "")
         )
-        if (
-            provider
-            and provider.blocks_orchestrated_input_while_waiting_user_answer is True
-            and orchestration_value
-            in {OrchestrationType.ASSIGN.value, OrchestrationType.HANDOFF.value}
-            and status_monitor.get_status(terminal_id) == TerminalStatus.WAITING_USER_ANSWER
-        ):
-            raise TerminalInputBlockedError(
-                f"Terminal {terminal_id} is waiting for a user answer. "
-                "Use answer_user_prompt to submit a selection or approval before "
-                f"sending {orchestration_value} input."
-            )
+
+        if provider:
+            current_status = status_monitor.get_status(terminal_id)
+
+            # Guard: refuse to type into a terminal whose provider process has
+            # exited. Without this check, queued messages would be pasted into
+            # a bare shell and executed as arbitrary commands.
+            if current_status == TerminalStatus.ERROR:
+                raise TerminalInputBlockedError(
+                    f"Terminal {terminal_id} provider is in ERROR state "
+                    "(provider process may have exited). Refusing to deliver input."
+                )
+
+            if (
+                provider.blocks_orchestrated_input_while_waiting_user_answer is True
+                and orchestration_value
+                in {OrchestrationType.ASSIGN.value, OrchestrationType.HANDOFF.value}
+                and current_status == TerminalStatus.WAITING_USER_ANSWER
+            ):
+                raise TerminalInputBlockedError(
+                    f"Terminal {terminal_id} is waiting for a user answer. "
+                    "Use answer_user_prompt to submit a selection or approval before "
+                    f"sending {orchestration_value} input."
+                )
 
         # Inject memory context into the very first user message after init.
         # Phase 1 wires injection inline for every provider. The Kiro

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -1,5 +1,7 @@
 """Unit tests for Codex provider."""
 
+import os
+import shlex
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1685,3 +1687,217 @@ class TestCodexProviderTrustPrompt:
         mock_tmux.return_value.send_special_key.assert_called_with(
             "test-session", "window-0", "Enter"
         )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_initialize_with_trust_prompt_v2(
+        self, mock_tmux, mock_wait_shell, mock_wait_status
+    ):
+        """Test that initialize handles v2 trust prompt (git worktree variant)."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_tmux.return_value.get_history.return_value = (
+            "Note: You're in a subdirectory of a Git project. Trusting will apply\n"
+            "to the repository root: /Users/test/project\n"
+            "\n"
+            "Do you trust the contents of this directory?\n"
+            "\n"
+            "› 1. Yes, continue\n"
+            "  2. No, quit\n"
+            "\n"
+            "Press enter to continue\n"
+        )
+        mock_tmux.return_value.get_pane_current_command.return_value = "zsh"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        result = await provider.initialize()
+
+        assert result is True
+        mock_tmux.return_value.send_special_key.assert_called_with(
+            "test-session", "window-0", "Enter"
+        )
+
+    def test_get_status_trust_prompt_v2_is_waiting(self):
+        """V2 trust dialog in bottom region classifies WAITING_USER_ANSWER."""
+        output = (
+            "Note: You're in a subdirectory of a Git project.\n"
+            "Trusting will apply to the repository root: /Users/test/project\n"
+            "\n"
+            "Do you trust the contents of this directory?\n"
+            "\n"
+            "› 1. Yes, continue\n"
+            "  2. No, quit\n"
+            "\n"
+            "Press enter to continue\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = True
+        provider.shell_baseline = "zsh"
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_trust_v2_in_scrollback_does_not_false_positive(self):
+        """V2 trust text in scrollback (not bottom) must NOT trigger WAITING."""
+        output = (
+            "› explain trust prompts\n"
+            '• The dialog says "Do you trust the contents of this directory?"\n'
+            "• and shows options like Yes/No.\n"
+            "\n"
+            "• Here's more explanation about how it works.\n"
+            "• The trust system is directory-based.\n"
+            "• It remembers your choice for future sessions.\n"
+            "• You can reset trust settings in ~/.codex/config.toml.\n"
+            "• Each project root has its own trust state.\n"
+            "• Subdirectories inherit the parent trust level.\n"
+            "• Git worktrees prompt separately from the main repo.\n"
+            "• You can pre-trust with --full-auto flag.\n"
+            "• The dialog only shows on first visit to a new directory.\n"
+            "• Once trusted, Codex won't ask again.\n"
+            "• The trust prompt has two variants depending on version.\n"
+            "• Newer versions use the git-aware prompt.\n"
+            "\n"
+            "› \n"
+            "  ? for shortcuts                     95% context left\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = True
+        provider.shell_baseline = "zsh"
+        status = provider.get_status(output)
+
+        # Should be COMPLETED (model replied to user question), NOT WAITING
+        assert status == TerminalStatus.COMPLETED
+
+
+class TestCodexProviderExitDetection:
+    """Tests for detecting when the codex process has exited."""
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_error_when_provider_exited(self, mock_tmux):
+        """ERROR when pane command reverts to shell (codex process exited)."""
+        mock_tmux.return_value.get_native_status.return_value = None
+        mock_tmux.return_value.get_pane_current_command.return_value = "zsh"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = True
+        provider.shell_baseline = "zsh"
+        output = "OpenAI Codex (v0.98.0)\n› \n% \n"
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.ERROR
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_normal_when_codex_running(self, mock_tmux):
+        """Normal status detection when codex is still running (pane command != shell)."""
+        mock_tmux.return_value.get_native_status.return_value = None
+        mock_tmux.return_value.get_pane_current_command.return_value = "codex"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = True
+        provider.shell_baseline = "zsh"
+        output = (
+            "OpenAI Codex (v0.98.0)\n"
+            "› \n"
+            "  ? for shortcuts                     100% context left\n"
+        )
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_skips_exit_check_before_init(self, mock_tmux):
+        """Exit check skipped before initialization (avoids false ERROR on launch)."""
+        mock_tmux.return_value.get_native_status.return_value = None
+        mock_tmux.return_value.get_pane_current_command.return_value = "zsh"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = False
+        provider.shell_baseline = "zsh"
+        output = "OpenAI Codex (v0.98.0)\n› \n"
+        status = provider.get_status(output)
+
+        # Should NOT be ERROR — exit check gated on _initialized
+        assert status == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_skips_exit_check_without_baseline(self, mock_tmux):
+        """Exit check skipped when no shell_baseline was captured."""
+        mock_tmux.return_value.get_native_status.return_value = None
+        mock_tmux.return_value.get_pane_current_command.return_value = "zsh"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = True
+        provider.shell_baseline = None
+        output = "OpenAI Codex (v0.98.0)\n› \n"
+        status = provider.get_status(output)
+
+        # Should NOT be ERROR — no baseline to compare against
+        assert status == TerminalStatus.IDLE
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_initialize_captures_shell_baseline(
+        self, mock_tmux, mock_wait_shell, mock_wait_status
+    ):
+        """Initialize captures shell_baseline for exit detection."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
+        mock_tmux.return_value.get_pane_current_command.return_value = "zsh"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider.initialize()
+
+        assert provider.shell_baseline == "zsh"
+        mock_tmux.return_value.get_pane_current_command.assert_called_with(
+            "test-session", "window-0"
+        )
+
+
+class TestCodexLaunchFlagsValidity:
+    """Validate that all flags in the codex launch command are accepted by the binary.
+
+    Gated behind CAO_RUN_LIVE_PROVIDER_TESTS=1 since it invokes the real codex binary.
+    """
+
+    @pytest.mark.skipif(
+        os.environ.get("CAO_RUN_LIVE_PROVIDER_TESTS", "") != "1",
+        reason="Live provider tests disabled. Set CAO_RUN_LIVE_PROVIDER_TESTS=1 to enable.",
+    )
+    def test_codex_launch_flags_are_valid(self):
+        """Every flag in the default launch command must be accepted by codex."""
+        import subprocess
+
+        provider = CodexProvider("test1234", "test-session", "window-0", None)
+        command = provider._build_codex_command()
+        parts = shlex.split(command)
+
+        # Extract flags (anything starting with -)
+        flags = [p for p in parts if p.startswith("-")]
+        assert flags, "Expected flags in codex launch command"
+
+        # Get codex help to validate flags exist
+        help_result = subprocess.run(
+            ["codex", "--help"], capture_output=True, text=True, timeout=10
+        )
+        help_text = help_result.stdout + help_result.stderr
+
+        for flag in flags:
+            flag_name = flag.lstrip("-").split("=")[0]
+            if flag_name in help_text or f"--{flag_name}" in help_text:
+                continue
+            # Hidden aliases (e.g. --yolo) don't appear in --help; probe the
+            # binary directly — an unknown flag makes clap exit non-zero with
+            # "unexpected argument".
+            probe = subprocess.run(
+                ["codex", flag, "--help"], capture_output=True, text=True, timeout=10
+            )
+            assert (
+                probe.returncode == 0 and "unexpected argument" not in probe.stderr
+            ), f"Flag '{flag}' in launch command rejected by codex binary"

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1150,6 +1150,29 @@ class TestSendInput:
         )
         mock_update.assert_called_once_with("test1234")
 
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_send_input_blocks_delivery_into_error_terminal(
+        self, mock_get_metadata, mock_tmux, mock_pm, mock_update, mock_status_monitor
+    ):
+        """Delivery into a terminal in ERROR state must be refused (dead-terminal guard)."""
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "codex-abcd",
+        }
+        mock_provider = mock_pm.get_provider.return_value
+        mock_provider.blocks_orchestrated_input_while_waiting_user_answer = False
+        mock_status_monitor.get_status.return_value = TerminalStatus.ERROR
+
+        with pytest.raises(TerminalInputBlockedError, match="ERROR state"):
+            send_input("test1234", "hello worker")
+
+        mock_tmux.send_keys.assert_not_called()
+        mock_update.assert_not_called()
+
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_not_found(self, mock_get_metadata):
         """Test sending input to non-existent terminal."""


### PR DESCRIPTION
Observed live while orchestrating workers: a codex session launched in a git worktree showed the workspace trust dialog ("Do you trust the contents of this directory?"), status detection reported PROCESSING, the TUI subsequently exited to a bare shell — and a queued multi-line inbox message was then typed into zsh and executed line-by-line. Same bug class as #405, on the codex provider, with an arbitrary-command-execution result.

Three changes:

1. **Trust-prompt classification.** The trust dialog (both variants; matched on the question text + "Press enter to continue" footer) classifies WAITING_USER_ANSWER, anchored to the bottom 15 lines so scrollback mentions can't cause false-WAITING.
2. **Dead-terminal delivery guard.** `initialize()` captures the pane's shell baseline; when the pane's current command reverts to it, `get_status()` returns ERROR, and `terminal_service.send_input` now refuses delivery into any terminal reporting ERROR (raises loudly instead of typing a task payload into a shell). Consistent with existing provider ERROR semantics; no behavior change for healthy paths.
3. **Flag-validity regression test** (opt-in via `CAO_RUN_LIVE_PROVIDER_TESTS=1`): asserts every flag in the constructed launch command is accepted by the installed codex binary, probing `codex <flag> --help` for hidden aliases (e.g. `--yolo`). Added after review caught an invalid flag that mocked command-string tests could never catch.

Tests: `test_codex_provider_unit.py` + `test_terminal_service_full.py`: 185 passed, 1 skipped (live-binary test, skipped by default). Real-launch verified against codex-cli 0.142.5.
