### PR TITLE
fix(kiro): gate live integration tests behind env flag; classify trust-all-tools dialog (leak + safety)

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -125,6 +125,11 @@ TUI_PERMISSION_PATTERN = (
     r"|Yes,\s*single permission[\s\S]{0,200}?Trust,\s*always allow[\s\S]{0,200}?No"
 )
 
+# TUI trust-all-tools acceptance dialog: shown at startup when --trust-all-tools is passed.
+# Matches the footer navigation chrome to avoid false positives on warning text in agent output.
+# Must be anchored to bottom screen region (see get_status WAITING check) to avoid stale matches.
+TUI_TRUST_ALL_TOOLS_FOOTER = r"esc to cancel · ↑↓ to navigate · ↵ to select"
+
 # =============================================================================
 # Error Detection
 # =============================================================================
@@ -439,6 +444,22 @@ class KiroCliProvider(BaseProvider):
             )
             if not idle_after_working:
                 return TerminalStatus.PROCESSING
+
+        # Check 2a: Trust-all-tools acceptance dialog at startup (no idle prompt case).
+        # Must come BEFORE the "no idle prompt → PROCESSING" check below, since
+        # the dialog has no idle prompt but should classify WAITING_USER_ANSWER.
+        # Anchored to bottom 20 lines to avoid false positives when the warning text
+        # appears in scrollback with an idle prompt below (same class as issue #405).
+        lines = clean_output.split("\n")
+        bottom_region = "\n".join(lines[-20:]) if len(lines) > 20 else clean_output
+        footer_match = re.search(TUI_TRUST_ALL_TOOLS_FOOTER, bottom_region)
+        if footer_match:
+            after_footer = bottom_region[footer_match.end() :]
+            has_idle_after = re.search(self._idle_prompt_pattern, after_footer) or re.search(
+                NEW_TUI_IDLE_PATTERN, after_footer
+            )
+            if not has_idle_after:
+                return TerminalStatus.WAITING_USER_ANSWER
 
         # Check 3: If no idle prompt found, determine if kiro is still running.
         # Compare current pane command against the shell captured before kiro launched.

--- a/test/providers/fixtures/kiro_trust_all_tools_dialog_active.txt
+++ b/test/providers/fixtures/kiro_trust_all_tools_dialog_active.txt
@@ -1,0 +1,10 @@
+ Warning: Kiro is running in trust all tools mode
+ In this mode, Kiro will execute all tool calls — including shell commands, file operations, and MCP tools — without asking for your approval.
+
+ This mode is designed for fast iteration in safe environments. Use it with caution.
+
+ ❯ No, exit
+   Yes, I accept
+   Yes, and don't ask again
+
+ esc to cancel · ↑↓ to navigate · ↵ to select

--- a/test/providers/fixtures/kiro_trust_all_tools_dialog_in_scrollback.txt
+++ b/test/providers/fixtures/kiro_trust_all_tools_dialog_in_scrollback.txt
@@ -1,0 +1,20 @@
+ Warning: Kiro is running in trust all tools mode
+ In this mode, Kiro will execute all tool calls — including shell commands, file operations, and MCP tools — without asking for your approval.
+
+ This mode is designed for fast iteration in safe environments. Use it with caution.
+
+ ❯ No, exit
+   Yes, I accept
+   Yes, and don't ask again
+
+ esc to cancel · ↑↓ to navigate · ↵ to select
+
+> Here is the information you requested.
+
+Line 1 of response
+Line 2 of response
+Line 3 of response
+Line 4 of response
+Line 5 of response
+
+[developer] >

--- a/test/providers/fixtures/kiro_trust_all_tools_dialog_stale.txt
+++ b/test/providers/fixtures/kiro_trust_all_tools_dialog_stale.txt
@@ -1,0 +1,12 @@
+ Warning: Kiro is running in trust all tools mode
+ In this mode, Kiro will execute all tool calls — including shell commands, file operations, and MCP tools — without asking for your approval.
+
+ This mode is designed for fast iteration in safe environments. Use it with caution.
+
+ ❯ No, exit
+   Yes, I accept
+   Yes, and don't ask again
+
+ esc to cancel · ↑↓ to navigate · ↵ to select
+
+[developer] >

--- a/test/providers/test_kiro_cli_integration.py
+++ b/test/providers/test_kiro_cli_integration.py
@@ -36,7 +36,16 @@ from cli_agent_orchestrator.services.terminal_service import (
     send_input,
 )
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+# Skip integration tests by default (deselected in pyproject.toml addopts).
+# Run with: CAO_RUN_LIVE_PROVIDER_TESTS=1 pytest test/providers/test_kiro_cli_integration.py
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        os.environ.get("CAO_RUN_LIVE_PROVIDER_TESTS", "") != "1",
+        reason="Live provider tests disabled. Set CAO_RUN_LIVE_PROVIDER_TESTS=1 to enable.",
+    ),
+]
 
 KIRO_AGENTS_DIR = Path.home() / ".kiro" / "agents"
 TEST_AGENT_NAME = "agent-kiro-cli-integration-test"
@@ -84,10 +93,12 @@ async def terminal(event_pipeline, mock_db, ensure_test_agent):
         delete_terminal(t.id)
     except Exception:
         pass
-    try:
-        tmux_client.kill_session(t.session_name)
-    except Exception:
-        pass
+    # Kill the tmux session unconditionally, regardless of test outcome.
+    # Prevents leaked sessions when tests timeout or fail during init.
+    # kill_session() handles exceptions internally and returns bool; a False
+    # is ambiguous (already gone vs. kill failed), so keep the warning soft.
+    if not tmux_client.kill_session(t.session_name):
+        print(f"\n[CLEANUP WARNING] Failed to kill session {t.session_name} (may already be gone)")
 
 
 @pytest.fixture(autouse=True)

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -295,6 +295,33 @@ class TestKiroCliProviderStatusDetection:
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
+    def test_get_status_trust_all_tools_dialog_active(self):
+        """Trust-all-tools dialog at startup classifies WAITING_USER_ANSWER."""
+        output = load_fixture("kiro_trust_all_tools_dialog_active.txt")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_trust_all_tools_dialog_stale(self):
+        """Stale trust-all-tools dialog with idle prompt does NOT classify WAITING."""
+        output = load_fixture("kiro_trust_all_tools_dialog_stale.txt")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.IDLE
+
+    def test_get_status_trust_all_tools_dialog_in_scrollback(self):
+        """Trust-all-tools dialog far in scrollback does NOT classify WAITING."""
+        output = load_fixture("kiro_trust_all_tools_dialog_in_scrollback.txt")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.COMPLETED
+
     def test_get_status_error(self):
         """Test ERROR status detection."""
         output = load_fixture("kiro_cli_error_output.txt")


### PR DESCRIPTION
Two related fixes from the same incident (orphaned kiro tmux sessions found stuck at interactive prompts after a plain `uv run pytest`):

1. **Live-provider tests are now opt-in.** kiro integration tests spawn real provider TUIs; on timeout/failure these leaked as orphaned tmux sessions (one found stuck at a per-command approval prompt). They're now gated behind `CAO_RUN_LIVE_PROVIDER_TESTS=1` (module-level skip), and the cleanup fixture kills the tmux session unconditionally, even when terminal deletion fails. Plain `pytest` spawns zero live terminals.
2. **kiro trust-all-tools dialog classifies WAITING_USER_ANSWER.** The startup acceptance dialog's focused default is **"No, exit"** — if it classified idle and a queued message was delivered, the trailing Enter would kill the TUI and subsequent typing would land in a bare shell (same class as #405). Detection matches the dialog footer, anchored to the bottom 20 lines; fixtures cover the live dialog (→ WAITING) and the dialog text in scrollback with an idle prompt below (→ not WAITING). CAO's own yolo launch path forces `--legacy-ui`, which avoids this dialog, so the pattern is a backstop for non-yolo / direct TUI use and version drift.

Tests: `test_kiro_cli_unit.py` + `test_kiro_cli_integration.py`: 118 passed, 7 skipped (the gated live tests).
