### PR TITLE
docs(examples): add tags and capabilities to aws example profiles

### DIFF
--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -62,6 +62,22 @@ runtime.
 cao launch --agents sqs-monitor-agent --provider claude_code
 ```
 
+## Profile Discovery
+
+Each profile declares `tags` and `capabilities` in its frontmatter. These
+fields are indexed by `cao profile find` (and the `find_profiles` MCP tool),
+so installed agents can be discovered by what they do:
+
+```bash
+cao profile find "dead letter queue"
+cao profile find "query dynamodb"
+```
+
+Only `name`, `description`, `tags`, and `capabilities` are indexed; the
+profile body is never indexed or returned in search results. When you copy
+these examples for your own agents, keep tags as short keywords and
+capabilities as short verb phrases.
+
 ## Configuration Reference
 
 The `config.json` in each folder is **not** read at runtime. It exists as a

--- a/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
+++ b/examples/aws/cloudwatch-logs/cloudwatch-logs-agent.md
@@ -1,6 +1,16 @@
 ---
 name: cloudwatch-logs-agent
 description: Search CloudWatch Logs for execution traces and error patterns
+tags:
+  - aws
+  - cloudwatch
+  - logs
+  - search
+  - errors
+  - verification
+capabilities:
+  - "search CloudWatch log groups for execution IDs"
+  - "analyze log events for success or error patterns"
 allowedTools:
   - execute_bash
   - fs_read

--- a/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
+++ b/examples/aws/dynamodb-delete/dynamodb-delete-agent.md
@@ -1,6 +1,15 @@
 ---
 name: dynamodb-delete-agent
 description: Delete all items matching a partition key from a DynamoDB table
+tags:
+  - aws
+  - dynamodb
+  - delete
+  - cleanup
+  - destructive
+capabilities:
+  - "delete items matching a partition key from a DynamoDB table"
+  - "query and confirm before destructive deletes"
 allowedTools:
   - execute_bash
   - fs_read

--- a/examples/aws/dynamodb-query/dynamodb-query-agent.md
+++ b/examples/aws/dynamodb-query/dynamodb-query-agent.md
@@ -1,6 +1,14 @@
 ---
 name: dynamodb-query-agent
 description: Query DynamoDB tables by partition key
+tags:
+  - aws
+  - dynamodb
+  - query
+  - read
+capabilities:
+  - "query DynamoDB tables by partition key"
+  - "inspect item attributes and counts"
 allowedTools:
   - execute_bash
   - fs_read

--- a/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
+++ b/examples/aws/sqs-dlq-check/sqs-dlq-check-agent.md
@@ -1,6 +1,16 @@
 ---
 name: sqs-dlq-check-agent
 description: Inspect a Dead Letter Queue for failed messages
+tags:
+  - aws
+  - sqs
+  - dlq
+  - dead-letter-queue
+  - failures
+  - monitoring
+capabilities:
+  - "check a dead letter queue for failed messages"
+  - "inspect DLQ message contents and counts"
 allowedTools:
   - execute_bash
   - fs_read

--- a/examples/aws/sqs-monitor/sqs-monitor-agent.md
+++ b/examples/aws/sqs-monitor/sqs-monitor-agent.md
@@ -1,6 +1,15 @@
 ---
 name: sqs-monitor-agent
 description: Poll an SQS queue until all messages are consumed
+tags:
+  - aws
+  - sqs
+  - queue
+  - monitoring
+  - polling
+capabilities:
+  - "poll an SQS queue until messages are consumed"
+  - "report queue depth over time"
 allowedTools:
   - execute_bash
   - fs_read

--- a/examples/aws/sqs-send/sqs-send-agent.md
+++ b/examples/aws/sqs-send/sqs-send-agent.md
@@ -1,6 +1,14 @@
 ---
 name: sqs-send-agent
 description: Send a message to an SQS queue
+tags:
+  - aws
+  - sqs
+  - send
+  - message
+capabilities:
+  - "send messages to an SQS queue"
+  - "set message attributes and group IDs"
 allowedTools:
   - execute_bash
   - fs_read

--- a/examples/aws/stepfunction/stepfunction-agent.md
+++ b/examples/aws/stepfunction/stepfunction-agent.md
@@ -1,6 +1,15 @@
 ---
 name: stepfunction-agent
 description: Trigger and monitor AWS Step Functions executions
+tags:
+  - aws
+  - stepfunctions
+  - state-machine
+  - workflow
+  - execution
+capabilities:
+  - "start Step Functions state machine executions"
+  - "poll execution status until completion"
 allowedTools:
   - execute_bash
   - fs_read


### PR DESCRIPTION
Populate the profile discovery fields introduced in #438 across all 7 examples/aws agent profiles so they demonstrate and exercise `cao profile find`. Add a Profile Discovery section to the README documenting the indexed fields and the metadata-only boundary.

*Issue #, if available:* N/A (follow-up to #438)

*Description of changes:*

The examples/aws profiles predate `cao profile find`, so none of them declared `tags` or `capabilities`. Anyone copying these examples as a starting point gets profiles that are invisible to capability search.

- Add `tags` and `capabilities` frontmatter to all 7 agent profiles (cloudwatch-logs, dynamodb-delete, dynamodb-query, sqs-dlq-check, sqs-monitor, sqs-send, stepfunction)
- Add a "Profile Discovery" section to examples/aws/README.md covering the indexed fields, example `cao profile find` queries, and the boundary that profile bodies are never indexed or returned
- Tags close a concrete gap: "dead letter queue" previously couldn't match the DLQ agent because its description only says "Dead Letter Queue" in prose form; the `dead-letter-queue` tag makes multi-word discovery work

Testing:
- `cao profile validate` passes on all 7 profiles
- Full JSON-schema validation (pattern, maxItems, maxLength) + Pydantic model round-trip: fields survive intact
- Install round-trip: `cao install` with `--env` substitution keeps the new fields; `cao profile find "dead letter queue"` ranks sqs-dlq-check-agent first (3.94)
- `scripts/validate_markdown_links.py` passes

Docs/metadata only, no code changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
