### PR TITLE
fix(tests): strip leaked CAO env vars so the suite passes inside CAO terminals

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -141,6 +141,24 @@ def _no_llm_compile_in_tests(monkeypatch):
     monkeypatch.setenv("CAO_MEMORY_COMPILE_MODE", "append")
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_cao_env(monkeypatch):
+    """Strip CAO runtime env vars that leak when the suite runs inside a CAO terminal.
+
+    Without this, tests that assert default values (e.g. sender_id=="supervisor")
+    fail because the real terminal's CAO_TERMINAL_ID overrides the default.
+    monkeypatch.delenv runs BEFORE the test body, so tests that explicitly
+    monkeypatch.setenv one of these after fixture setup still work correctly.
+    """
+    # server.py defaults sender_id to "supervisor" when unset
+    monkeypatch.delenv("CAO_TERMINAL_ID", raising=False)
+    # server.py reads these for workflow_return context detection
+    monkeypatch.delenv("CAO_WORKFLOW_RUN_ID", raising=False)
+    monkeypatch.delenv("CAO_WORKFLOW_STEP_ID", raising=False)
+    # cli/commands/info.py uses this for session detection
+    monkeypatch.delenv("CAO_SESSION_NAME", raising=False)
+
+
 @pytest.fixture
 def isolated_memory_db(tmp_path, monkeypatch):
     """Route default memory sessions to an initialized per-test SQLite database."""


### PR DESCRIPTION
Running the test suite inside a CAO-managed terminal fails two tests in `test_answer_user_prompt.py`: the worker's `CAO_TERMINAL_ID` leaks into the test process and `answer_user_prompt` reports it as `sender_id` instead of the expected default "supervisor". As CAO agents increasingly develop this repo from inside CAO sessions, this shows up as confusing phantom failures.

Adds an autouse fixture next to the existing `_no_llm_compile_in_tests` that removes `CAO_TERMINAL_ID`, `CAO_WORKFLOW_RUN_ID`, `CAO_WORKFLOW_STEP_ID`, and `CAO_SESSION_NAME` before each test. Tests that set these themselves still win, since their monkeypatch runs after fixture setup. Vars read at module import time are intentionally excluded (delenv at test time cannot affect them; those tests already patch the constants).

Verified both directions: with `CAO_TERMINAL_ID=fake1234` exported, the affected file goes from 2 failed to 7 passed; a clean environment is unchanged (full suite green both ways).
