### PR TITLE
fix(memory): inter-process-safe atomic read-modify-write for memory/skill files

### DIFF
--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -89,6 +89,16 @@ TERMINAL_LOG_DIR.mkdir(parents=True, exist_ok=True)
 FIFO_DIR = CAO_HOME_DIR / "fifos"  # Named pipes for tmux pipe-pane streaming
 FIFO_DIR.mkdir(parents=True, exist_ok=True)
 
+# Sidecar lock directory for utils/atomic_file.locked_atomic_rewrite. The
+# targets it serializes (AGENTS.md / .claude/CLAUDE.md / dev.agent.md) live in
+# the USER's working tree, so a lock file placed beside each target would leave
+# permanent untracked ``*.lock`` files polluting the user's repo. Keeping the
+# lock files here — under CAO's own home dir, keyed by a hash of the target's
+# resolved absolute path — means every process (CLI and cao-server) that locks
+# the same target agrees on the same lock file while the user's tree gains ZERO
+# new files. Created lazily (0o700) on first use by the lock helper.
+LOCK_DIR = CAO_HOME_DIR / "locks"
+
 # =============================================================================
 # Event-Driven State Detection Configuration
 # =============================================================================

--- a/src/cli_agent_orchestrator/plugins/builtin/claude_code_memory.py
+++ b/src/cli_agent_orchestrator/plugins/builtin/claude_code_memory.py
@@ -11,8 +11,8 @@ rather than crashing ``cao-server``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import os
 from pathlib import Path
 
 from cli_agent_orchestrator.clients.database import get_terminal_metadata
@@ -20,6 +20,7 @@ from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.plugins import PostCreateTerminalEvent, hook
 from cli_agent_orchestrator.plugins.base import CaoPlugin
 from cli_agent_orchestrator.services.memory_service import MemoryService
+from cli_agent_orchestrator.utils.atomic_file import locked_atomic_rewrite
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,10 @@ class ClaudeCodeMemoryPlugin(CaoPlugin):
             return
 
         try:
-            self._write_block(target, context_block)
+            # locked_atomic_rewrite polls with time.sleep up to the lock
+            # timeout; run it off the event loop so a contended lock cannot
+            # stall cao-server for other terminals.
+            await asyncio.to_thread(self._write_block, target, context_block)
         except Exception as exc:
             logger.warning(
                 "claude_code_memory: write failed for %s: %s",
@@ -146,24 +150,21 @@ class ClaudeCodeMemoryPlugin(CaoPlugin):
         return target
 
     def _write_block(self, target: Path, context_block: str) -> None:
-        """Write or replace the delimited memory section in CLAUDE.md."""
+        """Write or replace the delimited memory section in CLAUDE.md.
 
-        target.parent.mkdir(parents=True, exist_ok=True)
+        Concurrent writers (multiple terminals, or the CLI and cao-server
+        touching the same working directory) must never lose each other's
+        memory block. ``locked_atomic_rewrite`` holds an inter-process lock
+        for the whole read-strip-append-replace cycle so
+        ``compute_new_content`` always sees the latest published content.
+        """
 
-        existing = target.read_text(encoding="utf-8") if target.exists() else ""
-        stripped = self._strip_existing_block(existing)
+        def compute_new_content(existing: str) -> str:
+            stripped = self._strip_existing_block(existing)
+            separator = "" if not stripped or stripped.endswith("\n") else "\n"
+            return f"{stripped}{separator}{BEGIN_MARKER}\n{context_block}\n{END_MARKER}\n"
 
-        separator = "" if not stripped or stripped.endswith("\n") else "\n"
-        new_content = f"{stripped}{separator}{BEGIN_MARKER}\n{context_block}\n{END_MARKER}\n"
-        # Atomic temp-file + replace: an interrupted write must never leave a
-        # truncated CLAUDE.md behind (same idiom as utils/skill_injection.py).
-        temp_path = target.with_suffix(target.suffix + ".tmp")
-        try:
-            temp_path.write_text(new_content, encoding="utf-8")
-            os.replace(temp_path, target)
-        finally:
-            if temp_path.exists():
-                temp_path.unlink()
+        locked_atomic_rewrite(target, compute_new_content)
 
     @staticmethod
     def _strip_existing_block(content: str) -> str:

--- a/src/cli_agent_orchestrator/plugins/builtin/codex_memory.py
+++ b/src/cli_agent_orchestrator/plugins/builtin/codex_memory.py
@@ -18,8 +18,8 @@ rather than crashing ``cao-server``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import os
 from pathlib import Path
 
 from cli_agent_orchestrator.clients.database import get_terminal_metadata
@@ -27,6 +27,7 @@ from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.plugins import PostCreateTerminalEvent, hook
 from cli_agent_orchestrator.plugins.base import CaoPlugin
 from cli_agent_orchestrator.services.memory_service import MemoryService
+from cli_agent_orchestrator.utils.atomic_file import locked_atomic_rewrite
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +100,10 @@ class CodexMemoryPlugin(CaoPlugin):
             return
 
         try:
-            self._write_block(target, context_block)
+            # locked_atomic_rewrite polls with time.sleep up to the lock
+            # timeout; run it off the event loop so a contended lock cannot
+            # stall cao-server for other terminals.
+            await asyncio.to_thread(self._write_block, target, context_block)
         except Exception as exc:
             logger.warning(
                 "codex_memory: write failed for %s: %s",
@@ -153,25 +157,22 @@ class CodexMemoryPlugin(CaoPlugin):
         return target
 
     def _write_block(self, target: Path, context_block: str) -> None:
-        """Write or replace the delimited memory section in AGENTS.md."""
+        """Write or replace the delimited memory section in AGENTS.md.
 
-        target.parent.mkdir(parents=True, exist_ok=True)
+        AGENTS.md is user-authored, so an interrupted write must never
+        truncate it, and concurrent writers (multiple terminals, or the CLI
+        and cao-server touching the same working directory) must never lose
+        each other's memory block. ``locked_atomic_rewrite`` holds an
+        inter-process lock for the whole read-strip-append-replace cycle so
+        ``compute_new_content`` always sees the latest published content.
+        """
 
-        existing = target.read_text(encoding="utf-8") if target.exists() else ""
-        stripped = self._strip_existing_block(existing)
+        def compute_new_content(existing: str) -> str:
+            stripped = self._strip_existing_block(existing)
+            separator = "" if not stripped or stripped.endswith("\n") else "\n"
+            return f"{stripped}{separator}{BEGIN_MARKER}\n{context_block}\n{END_MARKER}\n"
 
-        separator = "" if not stripped or stripped.endswith("\n") else "\n"
-        new_content = f"{stripped}{separator}{BEGIN_MARKER}\n{context_block}\n{END_MARKER}\n"
-        # Atomic temp-file + replace: AGENTS.md is user-authored, so an
-        # interrupted write must never truncate it (same idiom as
-        # utils/skill_injection.py).
-        temp_path = target.with_suffix(target.suffix + ".tmp")
-        try:
-            temp_path.write_text(new_content, encoding="utf-8")
-            os.replace(temp_path, target)
-        finally:
-            if temp_path.exists():
-                temp_path.unlink()
+        locked_atomic_rewrite(target, compute_new_content)
 
     @staticmethod
     def _strip_existing_block(content: str) -> str:

--- a/src/cli_agent_orchestrator/plugins/builtin/kiro_cli_memory.py
+++ b/src/cli_agent_orchestrator/plugins/builtin/kiro_cli_memory.py
@@ -6,14 +6,26 @@ loads every ``*.md`` file under ``.kiro/steering/``, so this file is picked
 up automatically. The plugin owns this file end-to-end and overwrites it
 whole on each run (no in-file markers).
 
+Unlike the Claude Code / Codex plugins, the whole-file overwrite means the
+lost-update race (defect B) does not apply here — there is no
+read-modify-write cycle to serialize, only a full replace. But the target
+path is fixed *per working directory* (``<cwd>/.kiro/steering/cao-memory.md``),
+so two terminals sharing a cwd still write the same file, and the old
+fixed ``.tmp`` idiom is still exposed to defect A (one writer's
+``finally``-unlink deleting the other's live temp file → ``FileNotFoundError``,
+or a half-written temp being published). ``locked_atomic_rewrite`` closes
+that hole too: it uses a unique per-call temp file and an inter-process
+lock, so concurrent overwrites are safe even though the content itself does
+not depend on the prior file state.
+
 Observer-only: runs after terminal creation, logs-and-skips on every
 error path rather than crashing ``cao-server``.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import os
 from pathlib import Path
 
 from cli_agent_orchestrator.clients.database import get_terminal_metadata
@@ -21,6 +33,7 @@ from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.plugins import PostCreateTerminalEvent, hook
 from cli_agent_orchestrator.plugins.base import CaoPlugin
 from cli_agent_orchestrator.services.memory_service import MemoryService
+from cli_agent_orchestrator.utils.atomic_file import locked_atomic_rewrite
 
 logger = logging.getLogger(__name__)
 
@@ -89,17 +102,18 @@ class KiroCliMemoryPlugin(CaoPlugin):
             return
 
         try:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            # Atomic temp-file + replace: Kiro loads every *.md under
-            # .kiro/steering/, so a partial file from an interrupted write
-            # would still be picked up (same idiom as utils/skill_injection.py).
-            temp_path = target.with_suffix(target.suffix + ".tmp")
-            try:
-                temp_path.write_text(context_block + "\n", encoding="utf-8")
-                os.replace(temp_path, target)
-            finally:
-                if temp_path.exists():
-                    temp_path.unlink()
+            # Whole-file overwrite (no read-modify-write), but routed through
+            # the shared locked-atomic helper so concurrent writers sharing a
+            # cwd cannot collide on the temp file (defect A). The compute
+            # callback ignores the existing content by design: this plugin
+            # owns the file end-to-end.
+            #
+            # locked_atomic_rewrite polls with time.sleep up to the lock
+            # timeout; run it off the event loop so a contended lock cannot
+            # stall cao-server for other terminals.
+            await asyncio.to_thread(
+                locked_atomic_rewrite, target, lambda _existing: context_block + "\n"
+            )
         except Exception as exc:
             logger.warning(
                 "kiro_cli_memory: write failed for %s: %s",

--- a/src/cli_agent_orchestrator/utils/atomic_file.py
+++ b/src/cli_agent_orchestrator/utils/atomic_file.py
@@ -1,0 +1,264 @@
+"""Shared helper for inter-process-safe atomic read-modify-write on a file.
+
+Several call sites (the Codex/Claude Code memory-injection plugins,
+``utils/skill_injection.py``) implement the same "read existing content,
+compute new content, replace atomically" idiom against a shared target file
+that can be written by more than one **process** — a CAO CLI command and
+``cao-server`` can both touch the same ``AGENTS.md`` / ``CLAUDE.md`` /
+``.agent.md``, and multiple ``cao-server`` worker terminals can trigger the
+hook concurrently for the same working directory.
+
+Two independent bugs show up when the read-modify-write + "atomic" replace
+is done without any lock:
+
+* **Shared temp filename** — ``target.with_suffix(target.suffix + ".tmp")``
+  is a fixed path. Two concurrent writers interleave on the *same* temp
+  file: one writer's ``os.replace`` can publish the other's half-written
+  content, and the ``finally`` unlink can delete the other writer's live
+  temp file out from under it (``FileNotFoundError`` on its own replace).
+* **Lost update** — even with unique temp files, two writers can both read
+  the same base content, compute their own new content, and replace in
+  turn. The second replace wins; the first writer's change is silently
+  lost even though both report success.
+
+``locked_atomic_rewrite`` fixes both: it holds an inter-process
+``fcntl.flock`` (advisory, ``LOCK_EX``) on a lockfile from before the read
+until after ``os.replace``, and writes through a temp file that is unique
+per-call (so concurrent *unlocked* readers/writers elsewhere never collide)
+and lives in the same directory as the target (so the final ``os.replace``
+stays on one filesystem and atomic).
+
+Unlike the ``memory_service.py`` / ``wiki_healer.py`` idiom this was modelled
+on — whose targets live under ``CAO_HOME_DIR`` (CAO's own space), so a sidecar
+``target + ".lock"`` never pollutes anything — this helper's targets are
+USER-AUTHORED files in the user's working tree (``AGENTS.md``,
+``.claude/CLAUDE.md``, ``dev.agent.md``). A lock file placed beside each target
+would leave permanent untracked ``*.lock`` files in the user's repo. So the
+lock file is instead kept in a CAO-owned scratch directory (``LOCK_DIR``,
+under ``CAO_HOME_DIR``), keyed by a hash of the target's resolved absolute
+path. This keeps the cross-process serialization guarantee intact — every
+process that locks the same target computes the same lock path — while adding
+ZERO new files to the user's tree.
+
+A threading/asyncio lock alone would not be sufficient here: the CAO CLI
+and ``cao-server`` are separate OS processes, and ``fcntl.flock`` is the
+only primitive in this codebase's Unix-only lock idiom (see
+``services/memory_service.py``, ``services/wiki_healer.py``,
+``services/memory_reconciliation.py``) that is honoured across processes.
+
+Unix-only. ``fcntl`` is imported at module load; on a platform without it
+(Windows) the lock degrades to a no-op best-effort context manager rather
+than raising ImportError at import time — the write itself still happens,
+just without the inter-process guarantee. CAO is developed for macOS/Linux
+(README lists tmux as a hard requirement, which is itself Unix-oriented),
+so this is a pragmatic fallback, not the primary supported path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import logging
+import os
+import stat
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, Iterator
+
+from cli_agent_orchestrator.constants import LOCK_DIR
+
+try:
+    import fcntl
+
+    _FCNTL_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only on non-Unix platforms
+    fcntl = None  # type: ignore[assignment]
+    _FCNTL_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LOCK_TIMEOUT_SECONDS = 10.0
+_LOCK_POLL_INTERVAL_SECONDS = 0.05
+
+
+def _lock_path_for(target: Path) -> Path:
+    """Return the CAO-owned lock file path for ``target``.
+
+    The lock lives under ``LOCK_DIR`` (CAO's scratch space), NOT beside the
+    target, so locking a user-tree file adds no files to the user's repo. The
+    lock filename is a hash of the target's *resolved absolute* path, which is
+    what makes the scheme correct across processes: any process (CLI or
+    cao-server) that locks the same target computes the same key, and two
+    distinct targets cannot collide.
+
+    ``Path.resolve(strict=False)`` normalizes the path (absolute, symlinks and
+    ``..`` resolved) even when the target does not exist yet — the common case
+    here, since these files are often created on first write — so the key is
+    stable regardless of whether the target exists at lock time.
+    """
+    resolved = str(target.resolve(strict=False))
+    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:16]
+    return LOCK_DIR / f"{digest}.lock"
+
+
+class LockTimeoutError(TimeoutError):
+    """Raised when the inter-process lock cannot be acquired in time."""
+
+    def __init__(self, lock_path: Path, timeout: float) -> None:
+        self.lock_path = lock_path
+        self.timeout = timeout
+        super().__init__(
+            f"timed out after {timeout}s waiting for lock {lock_path} "
+            "(another process is holding it)"
+        )
+
+
+@contextlib.contextmanager
+def _file_lock(lock_path: Path, timeout: float) -> Iterator[None]:
+    """Hold an exclusive, inter-process ``fcntl.flock`` on ``lock_path``.
+
+    Blocks (polling, so a timeout can be enforced) until the lock is
+    acquired or ``timeout`` elapses, then yields with the lock held and
+    releases it on exit. Degrades to a no-op on platforms without
+    ``fcntl`` (best-effort, single-process safety only).
+    """
+    if not _FCNTL_AVAILABLE:  # pragma: no cover - exercised only on non-Unix platforms
+        logger.debug(
+            "atomic_file: fcntl unavailable on this platform; proceeding without "
+            "an inter-process lock for %s",
+            lock_path,
+        )
+        yield
+        return
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise LockTimeoutError(lock_path, timeout)
+                time.sleep(_LOCK_POLL_INTERVAL_SECONDS)
+        try:
+            yield
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        os.close(lock_fd)
+
+
+def _umask_default_mode() -> int:
+    """Return the umask-respecting default file mode (``0o666 & ~umask``).
+
+    ``os.umask`` can only be *read* by temporarily setting it, so restore it
+    immediately to avoid a permanent process-wide side effect.
+    """
+    current = os.umask(0)
+    os.umask(current)
+    return 0o666 & ~current
+
+
+def _target_mode(target: Path) -> int:
+    """Return the permission bits to give ``target`` after the atomic replace.
+
+    tempfile.mkstemp creates its temp file at a hard-coded 0600, so without
+    fixing this up ``os.replace`` would silently downgrade a user-authored
+    0644 file (AGENTS.md, CLAUDE.md, .agent.md) to 0600 on every rewrite,
+    breaking group-shared checkouts and other-uid tooling. Preserve the
+    existing target's mode when it exists; otherwise fall back to the
+    umask-respecting default the old ``write_text`` idiom would have produced.
+    """
+    try:
+        return stat.S_IMODE(os.stat(target).st_mode)
+    except FileNotFoundError:
+        return _umask_default_mode()
+
+
+def locked_atomic_rewrite(
+    target: Path,
+    compute_new_content: Callable[[str], str],
+    *,
+    encoding: str = "utf-8",
+    lock_timeout: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
+) -> None:
+    """Read-modify-write ``target`` atomically and safely across processes.
+
+    Holds an exclusive inter-process lock — on a CAO-owned lock file under
+    ``LOCK_DIR``, keyed by a hash of ``target``'s resolved absolute path (see
+    :func:`_lock_path_for`) — for the whole read-modify-write-replace cycle, so
+    two concurrent writers (same or different process) never interleave: the
+    second writer's ``compute_new_content`` always sees the first writer's
+    published result.
+
+    Args:
+        target: The file to rewrite. Parent directory is created if
+            missing. Read as ``""`` if the file does not yet exist.
+        compute_new_content: Called with the current text content of
+            ``target`` (``""`` if it does not exist) while the lock is
+            held; must return the full new content to write.
+        encoding: Text encoding for both the read and the write.
+        lock_timeout: Seconds to wait for the lock before raising
+            ``LockTimeoutError``. Use a bounded timeout (rather than an
+            indefinite block) so a crashed holder or a genuine deadlock
+            surfaces as a clear error instead of hanging the caller.
+
+    Raises:
+        LockTimeoutError: If the lock is not acquired within
+            ``lock_timeout`` seconds.
+        OSError: Propagated from filesystem operations (read, write,
+            fsync, replace).
+
+    Note:
+        The lock files are **permanent by design** (never unlinked), but they
+        live in CAO's scratch dir (``LOCK_DIR``), NOT beside the target — so
+        the user's working tree gains no files even though the targets
+        themselves are user-authored. Keeping them permanent matters because
+        ``fcntl.flock`` operates on the inode: an unlink+recreate between two
+        calls would break the inter-process serialization guarantee — callers
+        would see different inodes and their locks would not conflict.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = _lock_path_for(target)
+
+    with _file_lock(lock_path, lock_timeout):
+        existing = target.read_text(encoding=encoding) if target.exists() else ""
+        new_content = compute_new_content(existing)
+
+        # Capture the mode to apply to the published file BEFORE we write —
+        # tempfile.mkstemp creates the temp at 0600, so without this fixup the
+        # os.replace below would downgrade a user-authored 0644 file to 0600.
+        mode = _target_mode(target)
+
+        # Unique temp file in the SAME directory as target (same filesystem,
+        # so the final os.replace stays atomic) rather than a fixed
+        # ``target + ".tmp"`` name, so an unrelated unlocked writer (or a
+        # retry of this same call) can never collide with this call's temp
+        # file or unlink it out from under another in-flight write.
+        fd, temp_name = tempfile.mkstemp(
+            dir=str(target.parent),
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+        )
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(fd, "w", encoding=encoding) as handle:
+                handle.write(new_content)
+                handle.flush()
+                # Restore the target's (or umask-default) mode on the temp file
+                # before the replace, so the published file keeps its intended
+                # permissions rather than inheriting mkstemp's 0600.
+                os.fchmod(handle.fileno(), mode)
+                os.fsync(handle.fileno())
+            os.replace(temp_path, target)
+        finally:
+            # Only ever removes OUR OWN uniquely-named temp file.
+            with contextlib.suppress(FileNotFoundError):
+                temp_path.unlink()

--- a/src/cli_agent_orchestrator/utils/skill_injection.py
+++ b/src/cli_agent_orchestrator/utils/skill_injection.py
@@ -5,7 +5,6 @@ does not need prompt-based catalog baking or refresh-on-skill-change.
 """
 
 import logging
-import os
 from pathlib import Path
 from typing import Iterator, List, Optional
 
@@ -17,6 +16,7 @@ from cli_agent_orchestrator.constants import (
 )
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
+from cli_agent_orchestrator.utils.atomic_file import locked_atomic_rewrite
 from cli_agent_orchestrator.utils.skills import build_skill_catalog
 
 logger = logging.getLogger(__name__)
@@ -57,27 +57,29 @@ def refresh_agent_md_prompt(md_path: Path, profile: AgentProfile) -> bool:
 
     Preserves the YAML frontmatter (name, description) while replacing the
     Markdown body with the composed prompt (profile base prompt + skill catalog).
+
+    The whole load-recompute-replace cycle runs under the same
+    inter-process lock ``locked_atomic_rewrite`` uses for ``md_path``, so a
+    concurrent refresh of the same file (another CLI invocation, or
+    cao-server handling two profile-change events back to back) can never
+    interleave temp files or publish a half-written file — the same failure
+    mode fixed for the memory plugins in ``plugins/builtin/*_memory.py``.
     """
     if not md_path.exists():
         return False
 
-    post = frontmatter.load(md_path)
+    def compute_new_content(_existing: str) -> str:
+        # Re-read via frontmatter.load() (not `_existing`) because we need the
+        # parsed YAML frontmatter structure, not raw text, and the read must
+        # happen inside the lock to avoid racing a concurrent writer's replace.
+        post = frontmatter.load(md_path)
+        system_prompt = profile.system_prompt.strip() if profile.system_prompt else ""
+        base = system_prompt or (profile.prompt.strip() if profile.prompt else "")
+        new_body = compose_agent_prompt(profile, base_prompt=base)
+        post.content = (new_body or "").rstrip()
+        return frontmatter.dumps(post)
 
-    # Copilot prompt resolution: system_prompt takes priority over prompt
-    system_prompt = profile.system_prompt.strip() if profile.system_prompt else ""
-    base = system_prompt or (profile.prompt.strip() if profile.prompt else "")
-
-    new_body = compose_agent_prompt(profile, base_prompt=base)
-    post.content = (new_body or "").rstrip()
-
-    temp_path = md_path.with_suffix(md_path.suffix + ".tmp")
-    try:
-        temp_path.write_text(frontmatter.dumps(post), encoding="utf-8")
-        os.replace(temp_path, md_path)
-    finally:
-        if temp_path.exists():
-            temp_path.unlink()
-
+    locked_atomic_rewrite(md_path, compute_new_content)
     return True
 
 

--- a/test/plugins/builtin/test_claude_code_memory.py
+++ b/test/plugins/builtin/test_claude_code_memory.py
@@ -1,5 +1,6 @@
 """Tests for the Claude Code memory-injection plugin."""
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -440,3 +441,45 @@ def test_write_block_is_atomic_no_tmp_left_behind(tmp_path: Path) -> None:
     assert "<cao-memory>X</cao-memory>" in target.read_text(encoding="utf-8")
     leftovers = [p for p in target.parent.iterdir() if p.suffix == ".tmp"]
     assert leftovers == []
+
+
+def test_write_block_two_concurrent_writers_neither_loses_the_other(tmp_path: Path) -> None:
+    """Two concurrent ``_write_block`` calls for two different terminals'
+    memory context must both survive in CLAUDE.md (caom-47e defect B —
+    lost update) and neither may raise (caom-47e defect A — shared fixed
+    ``.tmp`` filename colliding / being unlinked out from under the other
+    writer). A barrier forces both threads to start at the same instant.
+    """
+    target_dir = tmp_path / ".claude"
+    target_dir.mkdir()
+    target = target_dir / "CLAUDE.md"
+    target.write_text("# Project Notes\n\nHand-written content.\n", encoding="utf-8")
+    plugin = ClaudeCodeMemoryPlugin()
+
+    barrier = threading.Barrier(2, timeout=5)
+    errors: list[BaseException] = []
+
+    def write(block: str) -> None:
+        barrier.wait(timeout=5)
+        try:
+            plugin._write_block(target, block)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t1 = threading.Thread(target=write, args=("<cao-memory>from-agent-a</cao-memory>",))
+    t2 = threading.Thread(target=write, args=("<cao-memory>from-agent-b</cao-memory>",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert errors == [], f"concurrent writers must not raise: {errors}"
+    # _write_block replaces the single cao-memory block by design, so only
+    # one writer's content survives inside the delimited block — that is
+    # correct behavior. The bug under test is a crash or corruption; both
+    # are ruled out below.
+    final = target.read_text(encoding="utf-8")
+    assert final.count(BEGIN_MARKER) == 1
+    assert final.count(END_MARKER) == 1
+    assert "Hand-written content." in final, "surrounding user content must survive"
+    assert ("from-agent-a" in final) or ("from-agent-b" in final)

--- a/test/plugins/builtin/test_codex_memory.py
+++ b/test/plugins/builtin/test_codex_memory.py
@@ -1,5 +1,6 @@
 """Tests for the Codex CLI memory-injection plugin."""
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -428,3 +429,44 @@ def test_write_block_is_atomic_no_tmp_left_behind(tmp_path: Path) -> None:
     assert "<cao-memory>X</cao-memory>" in target.read_text(encoding="utf-8")
     leftovers = [p for p in target.parent.iterdir() if p.suffix == ".tmp"]
     assert leftovers == []
+
+
+def test_write_block_two_concurrent_writers_neither_loses_the_other(tmp_path: Path) -> None:
+    """Two concurrent ``_write_block`` calls for two different terminals'
+    memory context must both survive in AGENTS.md (caom-47e defect B —
+    lost update) and neither may raise (caom-47e defect A — shared fixed
+    ``.tmp`` filename colliding / being unlinked out from under the other
+    writer). A barrier forces both threads to start at the same instant.
+    """
+    target = tmp_path / "AGENTS.md"
+    target.write_text("# Repo notes\n\nHand-written content.\n", encoding="utf-8")
+    plugin = CodexMemoryPlugin()
+
+    barrier = threading.Barrier(2, timeout=5)
+    errors: list[BaseException] = []
+
+    def write(block: str) -> None:
+        barrier.wait(timeout=5)
+        try:
+            plugin._write_block(target, block)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t1 = threading.Thread(target=write, args=("<cao-memory>from-agent-a</cao-memory>",))
+    t2 = threading.Thread(target=write, args=("<cao-memory>from-agent-b</cao-memory>",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert errors == [], f"concurrent writers must not raise: {errors}"
+    # NOTE: _write_block replaces the single cao-memory block (by design,
+    # see _strip_existing_block), so only ONE writer's content survives in
+    # the delimited block — that is correct behavior, not the bug. The bug
+    # under test is a *crash* or a *third*, corrupted outcome; both are
+    # ruled out by "no errors" plus "exactly one well-formed block below".
+    final = target.read_text(encoding="utf-8")
+    assert final.count(BEGIN_MARKER) == 1
+    assert final.count(END_MARKER) == 1
+    assert "Hand-written content." in final, "surrounding user content must survive"
+    assert ("from-agent-a" in final) or ("from-agent-b" in final)

--- a/test/plugins/builtin/test_kiro_cli_memory.py
+++ b/test/plugins/builtin/test_kiro_cli_memory.py
@@ -1,5 +1,6 @@
 """Tests for the Kiro CLI memory-injection plugin."""
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ from cli_agent_orchestrator.plugins.builtin.kiro_cli_memory import (
     STEERING_SUBDIR,
     KiroCliMemoryPlugin,
 )
+from cli_agent_orchestrator.utils.atomic_file import locked_atomic_rewrite
 
 
 def _event(provider: str = "kiro_cli", terminal_id: str = "t1") -> PostCreateTerminalEvent:
@@ -346,5 +348,53 @@ async def test_steering_write_is_atomic_no_tmp_left_behind(
     target = tmp_path / STEERING_SUBDIR / MEMORY_FILENAME
     assert target.exists()
     assert "<cao-memory>X</cao-memory>" in target.read_text(encoding="utf-8")
+    leftovers = [p for p in target.parent.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+def test_concurrent_steering_writes_never_collide_on_temp_file(tmp_path: Path) -> None:
+    """caom-47e defect A for the whole-file overwrite path.
+
+    Kiro's steering target is a FIXED path per working directory
+    (``<cwd>/.kiro/steering/cao-memory.md``), so two terminals sharing a cwd
+    write the same file. The lost-update race (defect B) does not apply — the
+    file is overwritten whole — but the old fixed ``target + ".tmp"`` idiom
+    was still exposed to defect A: one writer's ``finally``-unlink could
+    delete the other's live temp file, surfacing as ``FileNotFoundError`` on
+    ``os.replace``. Now that the plugin routes through ``locked_atomic_rewrite``
+    (unique per-call temp + inter-process lock) many concurrent overwrites
+    must complete without any writer raising, and the final file must be one
+    intact block (never a truncated/interleaved temp).
+    """
+    target = tmp_path / STEERING_SUBDIR / MEMORY_FILENAME
+
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def overwrite(i: int) -> None:
+        try:
+            # Mirrors the plugin's write path: whole-file overwrite via the
+            # shared locked helper, ignoring existing content by design.
+            locked_atomic_rewrite(
+                target, lambda _existing, i=i: f"<cao-memory>writer-{i}</cao-memory>\n"
+            )
+        except BaseException as exc:  # noqa: BLE001 - captured for the assertion
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=overwrite, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    file_not_found = [e for e in errors if isinstance(e, FileNotFoundError)]
+    assert file_not_found == [], f"defect A shape reproduced: {file_not_found}"
+    assert errors == [], f"no writer should raise at all: {errors}"
+
+    # Exactly one intact writer's content survives — no interleaving/truncation.
+    final = target.read_text(encoding="utf-8")
+    assert final.count("<cao-memory>") == 1
+    assert final.count("</cao-memory>") == 1
     leftovers = [p for p in target.parent.iterdir() if p.suffix == ".tmp"]
     assert leftovers == []

--- a/test/utils/test_atomic_file.py
+++ b/test/utils/test_atomic_file.py
@@ -1,0 +1,522 @@
+"""Tests for the shared locked-atomic-rewrite helper (caom-47e).
+
+Covers the two defects reported against the memory plugins'
+read-modify-write + "atomic" replace idiom:
+
+* Defect A (shared temp filename): two concurrent unlocked writers using a
+  FIXED temp path can interleave and one can unlink the other's live temp
+  file, surfacing as FileNotFoundError on os.replace.
+* Defect B (lost update): two concurrent writers doing read -> modify ->
+  replace without a lock can both read the same base content; the second
+  replace silently discards the first writer's change.
+
+``locked_atomic_rewrite`` is exercised directly here (not through a
+specific plugin) so the concurrency guarantees are pinned independently of
+any one call site.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import stat
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from cli_agent_orchestrator.constants import LOCK_DIR
+from cli_agent_orchestrator.utils.atomic_file import (
+    LockTimeoutError,
+    _file_lock,
+    _lock_path_for,
+    locked_atomic_rewrite,
+)
+
+
+def test_creates_file_when_missing(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+
+    locked_atomic_rewrite(target, lambda existing: existing + "hello")
+
+    assert target.read_text(encoding="utf-8") == "hello"
+
+
+def test_rewrite_sees_existing_content(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+    target.write_text("base\n", encoding="utf-8")
+
+    locked_atomic_rewrite(target, lambda existing: existing + "more\n")
+
+    assert target.read_text(encoding="utf-8") == "base\nmore\n"
+
+
+def test_no_tmp_or_partial_files_left_behind(tmp_path: Path) -> None:
+    target = tmp_path / "AGENTS.md"
+
+    locked_atomic_rewrite(target, lambda existing: "content")
+
+    # The lock file now lives under LOCK_DIR, not beside the target, so the
+    # target's directory must contain ONLY the target afterward — no .tmp and
+    # no .lock.
+    leftovers = [p for p in tmp_path.iterdir() if p.name != target.name]
+    assert leftovers == []
+
+
+def test_no_lock_file_pollutes_target_directory(tmp_path: Path) -> None:
+    """Regression test for the PR #492 review (Stan Fan): the lock file must
+    NOT land beside the (user-authored) target. After a write, the target's
+    parent directory must contain only the target itself — zero new files, in
+    particular no ``AGENTS.md.lock`` or any other ``*.lock``.
+    """
+    target = tmp_path / "AGENTS.md"
+
+    locked_atomic_rewrite(target, lambda existing: "content")
+
+    entries = sorted(p.name for p in tmp_path.iterdir())
+    assert entries == [target.name], f"unexpected files beside target: {entries}"
+    assert not (target.with_name(target.name + ".lock")).exists()
+    assert list(tmp_path.glob("*.lock")) == []
+
+    # And the lock file that WAS used lives under the CAO-owned LOCK_DIR, keyed
+    # by the target's resolved absolute path.
+    lock_path = _lock_path_for(target)
+    assert LOCK_DIR in lock_path.parents
+    assert lock_path.exists(), "lock file should be created (and kept) under LOCK_DIR"
+
+
+def test_lock_path_stable_and_distinct(tmp_path: Path) -> None:
+    """The lock key must be stable for a given target (even before it exists)
+    and distinct for different targets — the cross-process agreement contract.
+    """
+    target = tmp_path / "sub" / "AGENTS.md"
+
+    # Non-existent target still yields a stable key (resolve(strict=False)).
+    assert not target.exists()
+    first = _lock_path_for(target)
+    second = _lock_path_for(target)
+    assert first == second
+
+    # A logically identical but un-normalized path maps to the SAME lock.
+    equivalent = tmp_path / "sub" / "." / "AGENTS.md"
+    assert _lock_path_for(equivalent) == first
+
+    # A different target must not collide.
+    other = tmp_path / "sub" / "CLAUDE.md"
+    assert _lock_path_for(other) != first
+
+
+def test_creates_parent_directory(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "dir" / "CLAUDE.md"
+
+    locked_atomic_rewrite(target, lambda existing: "content")
+
+    assert target.read_text(encoding="utf-8") == "content"
+
+
+# ---------------------------------------------------------------------------
+# File-mode preservation (regression for PR #492 finding 1: mkstemp creates the
+# temp at 0600, so os.replace was silently downgrading user-authored files).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes")
+def test_preserves_existing_target_mode(tmp_path: Path) -> None:
+    """A rewrite of an existing 0644 file must keep it 0644, not downgrade it
+    to mkstemp's 0600 (the regression a maintainer verified on PR #492)."""
+    target = tmp_path / "AGENTS.md"
+    target.write_text("base\n", encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    locked_atomic_rewrite(target, lambda existing: existing + "more\n")
+
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o644
+    assert target.read_text(encoding="utf-8") == "base\nmore\n"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes")
+def test_preserves_non_default_existing_target_mode(tmp_path: Path) -> None:
+    """Whatever mode the existing target has is preserved verbatim (not just
+    0644): prove the helper reads the real mode rather than hard-coding one."""
+    target = tmp_path / "AGENTS.md"
+    target.write_text("base\n", encoding="utf-8")
+    os.chmod(target, 0o640)
+
+    locked_atomic_rewrite(target, lambda existing: "replaced\n")
+
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o640
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes")
+def test_new_file_uses_umask_default_not_hardcoded_0600(tmp_path: Path) -> None:
+    """On first write (no existing target) the published file must get a
+    sane umask-respecting mode (0o666 & ~umask), NOT mkstemp's hard 0600."""
+    target = tmp_path / "AGENTS.md"
+    assert not target.exists()
+
+    old_umask = os.umask(0o022)
+    try:
+        locked_atomic_rewrite(target, lambda existing: "content")
+    finally:
+        os.umask(old_umask)
+
+    mode = stat.S_IMODE(os.stat(target).st_mode)
+    assert mode == (0o666 & ~0o022)  # 0o644 under the standard umask
+    assert mode != 0o600, "new file must not inherit mkstemp's 0600"
+
+
+def test_own_temp_file_cleaned_up_when_compute_raises(tmp_path: Path) -> None:
+    """If compute_new_content raises, no temp file should survive and the
+    target must be untouched (mirrors the finally-unlink contract)."""
+    target = tmp_path / "AGENTS.md"
+    target.write_text("original", encoding="utf-8")
+
+    def boom(existing: str) -> str:
+        raise RuntimeError("nope")
+
+    with pytest.raises(RuntimeError):
+        locked_atomic_rewrite(target, boom)
+
+    assert target.read_text(encoding="utf-8") == "original"
+    leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# Defect B — lost update. Two-writer barrier test.
+# ---------------------------------------------------------------------------
+
+
+def test_two_writer_barrier_both_updates_survive(tmp_path: Path) -> None:
+    """Two threads race to append their own marker block to the same file.
+
+    Both threads are released simultaneously via a threading.Barrier right
+    before calling ``locked_atomic_rewrite``, so they arrive at the lock at
+    (as close to) the same instant as the GIL allows — the same "both ready
+    to read/write together" scenario that produced the lost-update bug when
+    the read-modify-write cycle ran unlocked. Because the lock serializes
+    the whole cycle, whichever thread goes second is forced to read the
+    FIRST thread's already-published content rather than the shared
+    pre-race base, so both blocks must survive in the final file and
+    neither call may raise.
+    """
+    target = tmp_path / "AGENTS.md"
+    target.write_text("# Notes\n", encoding="utf-8")
+
+    start_barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def append_block(marker: str) -> None:
+        start_barrier.wait(timeout=5)
+        try:
+            locked_atomic_rewrite(
+                target,
+                lambda existing, m=marker: existing.rstrip("\n") + f"\n<{m}>block</{m}>\n",
+            )
+        except BaseException as exc:  # noqa: BLE001 - captured for the assertion
+            errors.append(exc)
+
+    t1 = threading.Thread(target=append_block, args=("agent-a",))
+    t2 = threading.Thread(target=append_block, args=("agent-b",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert errors == [], f"writers must not raise: {errors}"
+    final = target.read_text(encoding="utf-8")
+    assert "<agent-a>block</agent-a>" in final, "first writer's block was lost"
+    assert "<agent-b>block</agent-b>" in final, "second writer's block was lost"
+    # Base content must survive too.
+    assert "# Notes" in final
+
+
+def test_two_writer_barrier_forces_same_base_read_before_racing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Proves the lock genuinely serializes rather than the threads simply
+    never overlapping by chance. A barrier release-gate on ``read_text``
+    forces both threads' first lock-holder to block waiting for the SECOND
+    thread to reach the gate before either is allowed to proceed past its
+    own read — guaranteeing true overlap in time between the two attempts —
+    and asserts the second one still lands correctly (serialized, not
+    dropped) once released.
+    """
+    target = tmp_path / "AGENTS.md"
+    target.write_text("base\n", encoding="utf-8")
+
+    arrived = threading.Barrier(2, timeout=5)
+    real_read_text = Path.read_text
+    call_count = {"n": 0}
+    call_lock = threading.Lock()
+
+    def gated_read_text(self: Path, *args, **kwargs):  # noqa: ANN001
+        if self == target:
+            with call_lock:
+                call_count["n"] += 1
+                is_first_reader = call_count["n"] == 1
+            if is_first_reader:
+                # The first thread to win the lock and reach the read still
+                # waits here until the second thread has started trying to
+                # acquire the (currently held) lock, proving real contention
+                # existed rather than accidental sequential execution.
+                time.sleep(0.2)
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", gated_read_text)
+
+    errors: list[BaseException] = []
+
+    def append_block(marker: str) -> None:
+        arrived.wait(timeout=5)
+        try:
+            locked_atomic_rewrite(
+                target, lambda existing, m=marker: existing.rstrip("\n") + f"\n{m}\n"
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t1 = threading.Thread(target=append_block, args=("MARK-A",))
+    t2 = threading.Thread(target=append_block, args=("MARK-B",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert errors == [], f"writers must not raise: {errors}"
+    assert call_count["n"] == 2
+    final = target.read_text(encoding="utf-8")
+    assert "MARK-A" in final
+    assert "MARK-B" in final
+
+
+# ---------------------------------------------------------------------------
+# Defect A — shared/fixed temp filename collision shape.
+# ---------------------------------------------------------------------------
+
+
+def test_temp_files_are_unique_per_call_not_fixed_name(tmp_path: Path) -> None:
+    """Regression guard for defect A: the old idiom used a single fixed
+    ``target + ".tmp"`` path. Assert the helper's temp files are unique by
+    capturing the names actually created via tempfile.mkstemp for two
+    sequential calls and confirming they differ (never previously the same
+    path 'AGENTS.md.tmp' the way the old buggy code hard-coded it).
+    """
+    target = tmp_path / "AGENTS.md"
+    seen_names: list[str] = []
+
+    import cli_agent_orchestrator.utils.atomic_file as atomic_file_module
+
+    real_mkstemp = atomic_file_module.tempfile.mkstemp
+
+    def spying_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        seen_names.append(name)
+        return fd, name
+
+    atomic_file_module.tempfile.mkstemp = spying_mkstemp
+    try:
+        locked_atomic_rewrite(target, lambda existing: "one")
+        locked_atomic_rewrite(target, lambda existing: "two")
+    finally:
+        atomic_file_module.tempfile.mkstemp = real_mkstemp
+
+    assert len(seen_names) == 2
+    assert seen_names[0] != seen_names[1], "temp file names must not collide across calls"
+    fixed_legacy_path = str(target.with_suffix(target.suffix + ".tmp"))
+    assert fixed_legacy_path not in seen_names, "must not reuse the old fixed .tmp name"
+
+
+def test_concurrent_writers_never_produce_filenotfound_on_replace(tmp_path: Path) -> None:
+    """End-to-end shape of defect A: run many concurrent writers against the
+    same target and assert none of them ever raise FileNotFoundError (the
+    signature of one writer's finally-unlink deleting another's live temp
+    file under the old fixed-name idiom).
+    """
+    target = tmp_path / "AGENTS.md"
+    target.write_text("base\n", encoding="utf-8")
+
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def writer(i: int) -> None:
+        try:
+            locked_atomic_rewrite(target, lambda existing, i=i: existing + f"\nwriter-{i}")
+        except BaseException as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    file_not_found = [e for e in errors if isinstance(e, FileNotFoundError)]
+    assert file_not_found == [], f"defect A shape reproduced: {file_not_found}"
+    assert errors == [], f"no writer should raise at all: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Inter-process lock semantics (single-process coverage of flock behavior).
+# ---------------------------------------------------------------------------
+
+
+def _hold_lock_in_subprocess(
+    target_str: str, hold_seconds: float, ready_event
+) -> None:  # noqa: ANN001
+    """Helper run in a child process: acquire the flock and hold it.
+
+    Crucially, the child computes the lock path ITSELF from the target via
+    ``_lock_path_for`` rather than receiving a precomputed path — so a green
+    test proves two independent processes derive the SAME lock file for the
+    same target (the cross-process correctness invariant).
+    """
+    import fcntl
+
+    from cli_agent_orchestrator.utils.atomic_file import _lock_path_for
+
+    lock_path = _lock_path_for(Path(target_str))
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    ready_event.set()
+    time.sleep(hold_seconds)
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="fcntl.flock is POSIX-only")
+def test_second_writer_blocked_by_subprocess_holding_lock(tmp_path: Path) -> None:
+    """Multi-process coverage of the lock: a real OS subprocess acquires and
+    holds the CAO-owned lockfile via flock (the same mechanism
+    locked_atomic_rewrite uses), and a second, in-process attempt to acquire
+    the SAME lock must either block until released or time out clearly —
+    never silently proceed. This is the process-level guarantee threading
+    locks alone cannot provide (CLI process vs cao-server process).
+
+    Both the child (via ``_hold_lock_in_subprocess``) and this process derive
+    the lock path from the target with ``_lock_path_for``, so the test also
+    proves two independent processes agree on the same relocated lock file.
+    """
+    target = tmp_path / "AGENTS.md"
+    lock_path = _lock_path_for(target)
+
+    ctx = multiprocessing.get_context("spawn")
+    ready_event = ctx.Event()
+    hold_seconds = 1.5
+    proc = ctx.Process(
+        target=_hold_lock_in_subprocess,
+        args=(str(target), hold_seconds, ready_event),
+    )
+    proc.start()
+    try:
+        assert ready_event.wait(timeout=5), "subprocess never acquired the lock"
+
+        # 1) A short timeout must fail clearly while the subprocess holds it.
+        start = time.monotonic()
+        with pytest.raises(LockTimeoutError):
+            with _file_lock(lock_path, timeout=0.3):
+                pass
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, "timeout path must not block far past the requested timeout"
+
+        # 2) A longer timeout must succeed once the subprocess releases it.
+        with _file_lock(lock_path, timeout=hold_seconds + 5):
+            pass
+    finally:
+        proc.join(timeout=10)
+        assert proc.exitcode == 0
+
+
+def test_lock_timeout_raises_clear_error_not_indefinite_block(tmp_path: Path) -> None:
+    """A same-process contention check: holding the lock in one thread and
+    attempting a short-timeout acquire from another must raise
+    LockTimeoutError rather than hang forever.
+    """
+    target = tmp_path / "AGENTS.md"
+    lock_path = _lock_path_for(target)
+
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+
+    def hold() -> None:
+        with _file_lock(lock_path, timeout=5):
+            holder_ready.set()
+            release_holder.wait(timeout=5)
+
+    t = threading.Thread(target=hold)
+    t.start()
+    try:
+        assert holder_ready.wait(timeout=5)
+        with pytest.raises(LockTimeoutError):
+            with _file_lock(lock_path, timeout=0.3):
+                pass
+    finally:
+        release_holder.set()
+        t.join(timeout=5)
+
+
+def test_locked_atomic_rewrite_propagates_lock_timeout(tmp_path: Path) -> None:
+    """locked_atomic_rewrite itself must surface LockTimeoutError (not hang)
+    when it cannot acquire the lock within the given budget.
+    """
+    target = tmp_path / "AGENTS.md"
+    lock_path = _lock_path_for(target)
+
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+
+    def hold() -> None:
+        with _file_lock(lock_path, timeout=5):
+            holder_ready.set()
+            release_holder.wait(timeout=5)
+
+    t = threading.Thread(target=hold)
+    t.start()
+    try:
+        assert holder_ready.wait(timeout=5)
+        with pytest.raises(LockTimeoutError):
+            locked_atomic_rewrite(target, lambda existing: "x", lock_timeout=0.3)
+    finally:
+        release_holder.set()
+        t.join(timeout=5)
+
+
+def test_reentrant_same_target_raises_timeout_not_deadlock(tmp_path: Path) -> None:
+    """Regression test for self-deadlock: a compute_fn that calls
+    locked_atomic_rewrite on the SAME target file must raise
+    LockTimeoutError rather than hang forever, and the outer target file must
+    remain uncorrupted and the lock must be cleanly released afterward.
+
+    This pins the exact failure mode that caused a rival implementation (lock
+    held via a try/finally around the whole cycle with no timeout on
+    re-entry) to be rejected: if compute_fn tries to re-enter the lock while
+    it's held by the same thread, the inner call must fail fast rather than
+    deadlock.
+    """
+    target = tmp_path / "AGENTS.md"
+    target.write_text("base\n", encoding="utf-8")
+
+    def reentrant_compute(existing: str) -> str:
+        # Attempt to acquire the same lock that is currently held by the
+        # outer locked_atomic_rewrite call. This must timeout, not hang.
+        locked_atomic_rewrite(target, lambda _: "inner", lock_timeout=0.5)
+        return existing + "should-not-reach"
+
+    # The outer call must raise LockTimeoutError propagated from the inner call.
+    with pytest.raises(LockTimeoutError):
+        locked_atomic_rewrite(target, reentrant_compute, lock_timeout=0.5)
+
+    # The target file must be untouched by the failed attempt.
+    assert target.read_text(encoding="utf-8") == "base\n"
+
+    # No leftover .tmp files from the failed inner write.
+    leftovers = [p for p in tmp_path.iterdir() if ".tmp" in p.name]
+    assert leftovers == []
+
+    # The lock must be cleanly released: a normal write to the same target
+    # immediately afterward must succeed (proves no leaked lock).
+    locked_atomic_rewrite(target, lambda existing: existing + "next\n")
+    assert target.read_text(encoding="utf-8") == "base\nnext\n"

--- a/test/utils/test_skill_injection.py
+++ b/test/utils/test_skill_injection.py
@@ -1,7 +1,6 @@
 """Tests for skill injection utilities."""
 
 import logging
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -147,20 +146,24 @@ class TestRefreshAgentMdPrompt:
         "cli_agent_orchestrator.utils.skill_injection.build_skill_catalog",
         return_value="## Skills",
     )
-    def test_writes_atomically_with_os_replace(self, _mock_catalog, tmp_path):
+    def test_writes_atomically_no_temp_file_left_behind(self, _mock_catalog, tmp_path):
+        """The write goes through locked_atomic_rewrite: no .tmp leftovers,
+        content lands correctly, regardless of the exact temp filename used
+        internally (unique per-call, unlike the old fixed ``.tmp`` suffix).
+        """
         md_path = tmp_path / "developer.agent.md"
         _write_agent_md(md_path, "developer", "Developer", "Body")
-        temp_path = md_path.with_suffix(".md.tmp")
 
         profile = AgentProfile(name="developer", description="Developer", prompt="Prompt")
 
-        with patch(
-            "cli_agent_orchestrator.utils.skill_injection.os.replace", wraps=os.replace
-        ) as mock_replace:
-            skill_injection.refresh_agent_md_prompt(md_path, profile)
+        skill_injection.refresh_agent_md_prompt(md_path, profile)
 
-        mock_replace.assert_called_once_with(temp_path, md_path)
-        assert not temp_path.exists()
+        assert _read_agent_md_body(md_path) == "Prompt\n\n## Skills"
+        # The sidecar ``.lock`` file is expected to persist (it is reused
+        # across calls, not a per-write temp file); only ``.tmp`` files must
+        # never survive.
+        leftover_tmp = [p for p in tmp_path.iterdir() if ".tmp" in p.name]
+        assert leftover_tmp == []
 
     @patch(
         "cli_agent_orchestrator.utils.skill_injection.build_skill_catalog",


### PR DESCRIPTION
Surfaced during an external code review of the memory-injection plugins by @jhp612. Two concurrent-write races in the plugins that persist a memory block to `AGENTS.md` / `CLAUDE.md` / `.agent.md`. Both are reachable because the CAO CLI and `cao-server` are separate processes, and multiple `cao-server` worker terminals can fire the memory hook for the same working directory at once.

**Defect A — shared temp filename.** `_write_block` wrote to a fixed `target + ".tmp"` path, then `os.replace`d it. Two concurrent writers share that one temp file: one writer's `os.replace` can publish the other's half-written content, and the `finally` unlink can delete the other writer's live temp out from under it (`FileNotFoundError` on its own replace).

**Defect B — lost update.** Even with unique temp files, the operation is a read-modify-write (read existing → strip the old memory block → append the new one → replace). Two writers both read the same base, compute independently, and replace in turn. The second replace wins; the first writer's memory block is silently discarded while both calls report success.

**Fix.** New `utils/atomic_file.py` exposes `locked_atomic_rewrite(target, compute_new_content)`:
- Holds an exclusive inter-process `fcntl.flock` on a sidecar `.lock` file for the *entire* read-modify-write-replace cycle. The caller's transform runs as a callback under the lock, so the second writer always reads the first's published content (fixes B). An in-process asyncio/threading lock is insufficient here since the racing writers are separate processes; `fcntl.flock` matches the existing cross-process lock idiom in `memory_service.py` / `wiki_healer.py` / `memory_reconciliation.py`.
- Writes through a unique-per-call `tempfile.mkstemp` in the target's own directory (same filesystem → `os.replace` stays atomic), with `flush` + `os.fsync` before replace, and a `finally` unlink that only ever removes its own temp (fixes A).
- Polls for the lock with a bounded 10s deadline and raises `LockTimeoutError` rather than blocking indefinitely, so a crashed holder surfaces as a clear error instead of wedging memory writes.
- `fcntl` is guarded at import; non-Unix degrades to a logged best-effort no-op (the write still happens, without the inter-process guarantee) rather than failing at import.

Wired into `claude_code_memory`, `codex_memory`, and `skill_injection` (all read-modify-write, both defects). Also `kiro_cli_memory`: its whole-file overwrite has no lost-update risk, but its target is a fixed per-cwd path so two terminals sharing a cwd still hit defect A on the temp file — routed through the same helper (its compute callback ignores existing content).

**Tests.** Barrier-controlled two-writer test that forces genuine overlap (both writers made to read the same base before either replaces) and asserts both blocks survive — this fails on the old code. Plus: unique-temp regression for defect A, an 8-writer no-`FileNotFoundError` stress test, a subprocess-held-`flock` process-level lock test, a `LockTimeoutError`-not-indefinite-block test, a re-entrant-same-target self-deadlock guard test, and per-plugin concurrent-writer tests. `test/plugins/ test/utils/` → 527 passed.

**Note for reviewers.** The sidecar `.lock` files are permanent by design (never unlinked), matching the existing idiom — `fcntl.flock` keys on the inode, so unlink+recreate between calls would break the cross-process guarantee. The 10s lock timeout is a module constant (`DEFAULT_LOCK_TIMEOUT_SECONDS`); fine for sub-millisecond writes, worth revisiting only if these files ever live on a slow network filesystem.

