### PR TITLE
feat(worktree): worktree_service.py + use_worktree on handoff/assign (Phase 1 of #100)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -77,6 +77,14 @@ See [Skills](skills.md) for discovery, installation, and catalog behavior.
   server setting, 32KB by default, see [Configuration](configuration.md)),
   not unbounded scrollback. Long sessions are truncated to the tail; use the
   on-disk terminal log for complete history.
+- Terminal creation accepts `use_worktree` (bool, default `false`, issue #100
+  Phase 1): provisions an isolated `git worktree` on its own branch instead of
+  sharing `working_directory` as given, requiring the resolved directory to be
+  inside a git repository. At deletion, the worktree's working-tree contents
+  are always discarded, but the branch is only deleted if it has no unmerged
+  commits — commit and merge/push results before the terminal is deleted if
+  they need to be kept. See the MCP `handoff`/`assign` tool descriptions for
+  the full behavior.
 
 Terminal identifiers used in these routes are eight-character hexadecimal
 strings. See [Control Planes](control-planes.md) for operator-facing choices.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -128,6 +128,7 @@ from cli_agent_orchestrator.services.profile_search import (
 from cli_agent_orchestrator.services.status_monitor import status_monitor
 from cli_agent_orchestrator.services.step_output_store import _validate_key_part
 from cli_agent_orchestrator.services.terminal_service import OutputMode, TerminalInputBlockedError
+from cli_agent_orchestrator.services.worktree_service import WorktreeError
 from cli_agent_orchestrator.telemetry import init_telemetry, shutdown_telemetry
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile, resolve_provider
 from cli_agent_orchestrator.utils.logging import install_access_log_redaction, setup_logging
@@ -276,6 +277,14 @@ class RunStepRequest(BaseModel):
     allowed_tools: Optional[list[str]] = Field(
         default=None,
         description="Resolved allowed-tools list for a freshly created terminal (handoff inheritance)",
+    )
+    use_worktree: bool = Field(
+        default=False,
+        description=(
+            "Issue #100 Phase 1: provision an isolated git worktree for a freshly "
+            "created terminal instead of sharing working_directory as given. "
+            "Requires the resolved directory to be inside a git repository."
+        ),
     )
     env_vars: Optional[Dict[str, str]] = Field(
         default=None,
@@ -2084,6 +2093,7 @@ async def create_terminal_in_session(
     caller_id: Optional[TerminalId] = None,
     defer_init: bool = False,
     model: Optional[str] = None,
+    use_worktree: bool = False,
     body: Optional[CreateTerminalBody] = None,
     _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
 ) -> Terminal:
@@ -2108,6 +2118,13 @@ async def create_terminal_in_session(
     supports it -- see ``terminal_service.create_terminal``'s own docstring).
     Lets a caller pin a specific model for one worker without needing a
     dedicated agent profile.
+
+    ``use_worktree`` (issue #100 Phase 1): provision an isolated git worktree
+    for this terminal instead of sharing ``working_directory`` as given. A
+    plain boolean routing flag, so it stays a query param alongside
+    ``defer_init`` rather than moving into the JSON body. Runs synchronously
+    before the deferred-init background task (if any) is scheduled, so it
+    applies the same way regardless of ``defer_init``.
     """
     try:
         validate_tmux_name(session_name, "session_name")
@@ -2175,6 +2192,7 @@ async def create_terminal_in_session(
             initial_message_orchestration_type=orch_type,
             engine=engine,
             model=model,
+            use_worktree=use_worktree,
         )
         return result
     except HTTPException:
@@ -2188,6 +2206,11 @@ async def create_terminal_in_session(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except WorktreeError as e:
+        # use_worktree=true against a working_directory that isn't a git repo,
+        # or the 'git worktree add' itself failed -- a client-input problem,
+        # not a server crash.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -2491,6 +2514,7 @@ async def run_step(
             env_vars=body.env_vars,
             on_terminal_created=on_terminal_created,
             model=body.model,
+            use_worktree=body.use_worktree,
         )
         # Success -> transition the script step RUNNING->COMPLETED (no-op for
         # non-script callers). Before building the response so a settle failure
@@ -2529,6 +2553,12 @@ async def run_step(
     except ValueError as e:
         # Unknown terminal / bad input surfaced by the terminal layer.
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except WorktreeError as e:
+        # use_worktree=true against a working_directory that isn't a git repo,
+        # or the 'git worktree add' itself failed -- a client-input problem
+        # (bad/missing repo), not a server crash.
+        _settle_step(None, str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         _settle_step(None, str(e))
         raise HTTPException(

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -905,9 +905,12 @@ if ENABLE_WORKING_DIRECTORY:
             description=(
                 "If true, provision an isolated git worktree for this handoff instead of "
                 "sharing the supervisor's working directory -- the worktree checkout is "
-                "created on its own branch from the target repo's current HEAD and removed "
-                "automatically when the handoff completes. Requires the resolved working "
-                "directory (explicit or inherited) to be inside a git repository."
+                "created on its own branch from the target repo's current HEAD. At "
+                "teardown, the checkout's working-tree contents are always discarded, but "
+                "the branch is only deleted if it has no unmerged commits -- commit AND "
+                "merge/push results before finishing if you need them kept. Requires the "
+                "resolved working directory (explicit or inherited) to be inside a git "
+                "repository."
             ),
         ),
     ) -> HandoffResult:
@@ -945,8 +948,11 @@ if ENABLE_WORKING_DIRECTORY:
           sharing the supervisor's (or working_directory's) checkout -- closes the
           "parallel agents editing the same branch/files" race.
         - The worktree is created from the resolved directory's repo, on its own
-          branch, and is automatically removed when the handoff's terminal is torn
-          down (success or failure).
+          branch, and torn down when the handoff's terminal is torn down (success or
+          failure): the checkout's working-tree contents are always discarded, but the
+          branch is only deleted if it has no unmerged commits. Commit AND merge/push
+          any results you need kept before the handoff completes -- an uncommitted or
+          unmerged result is not preserved.
         - Requires the resolved working directory to actually be inside a git
           repository; otherwise the handoff fails with a clear error.
 
@@ -1000,9 +1006,11 @@ else:
             description=(
                 "If true, provision an isolated git worktree for this handoff instead of "
                 "sharing the supervisor's working directory -- the worktree checkout is "
-                "created on its own branch from the target repo's current HEAD and removed "
-                "automatically when the handoff completes. Requires the supervisor's "
-                "current directory to be inside a git repository."
+                "created on its own branch from the target repo's current HEAD. At "
+                "teardown, the checkout's working-tree contents are always discarded, but "
+                "the branch is only deleted if it has no unmerged commits -- commit AND "
+                "merge/push results before finishing if you need them kept. Requires the "
+                "supervisor's current directory to be inside a git repository."
             ),
         ),
     ) -> HandoffResult:
@@ -1032,7 +1040,10 @@ else:
         - Set use_worktree=true to give this handoff its own git worktree instead of
           sharing the supervisor's checkout -- closes the "parallel agents editing the
           same branch/files" race.
-        - Automatically removed when the handoff's terminal is torn down.
+        - Torn down when the handoff's terminal is torn down: the checkout's
+          working-tree contents are always discarded, but the branch is only deleted if
+          it has no unmerged commits. Commit AND merge/push any results you need kept
+          before the handoff completes.
         - Requires the supervisor's current directory to be inside a git repository.
 
         ## Requirements
@@ -1196,8 +1207,10 @@ Example message: "Analyze the logs. When done, send results back to terminal ee3
 - Set use_worktree=true to give this worker its own git worktree instead of sharing
   the supervisor's checkout -- closes the "parallel agents editing the same
   branch/files" race.
-- The worktree is created on its own branch and removed automatically when you
-  call delete_terminal on the worker.
+- The worktree is created on its own branch. When you call delete_terminal on the
+  worker, the checkout's working-tree contents are always discarded, but the branch
+  is only deleted if it has no unmerged commits -- commit AND merge/push results
+  before deleting the worker if you need them kept.
 - Requires the resolved working directory to be inside a git repository.
 
 ## Cleanup
@@ -1251,8 +1264,11 @@ if ENABLE_WORKING_DIRECTORY:
             default=False,
             description=(
                 "If true, provision an isolated git worktree for this worker instead of "
-                "sharing the supervisor's working directory. Requires the resolved working "
-                "directory to be inside a git repository."
+                "sharing the supervisor's working directory. At teardown (delete_terminal), "
+                "the checkout's working-tree contents are always discarded, but the branch "
+                "is only deleted if it has no unmerged commits -- commit AND merge/push "
+                "results before deleting the worker if you need them kept. Requires the "
+                "resolved working directory to be inside a git repository."
             ),
         ),
     ) -> Dict[str, Any]:
@@ -1281,8 +1297,11 @@ else:
             default=False,
             description=(
                 "If true, provision an isolated git worktree for this worker instead of "
-                "sharing the supervisor's working directory. Requires the supervisor's "
-                "current directory to be inside a git repository."
+                "sharing the supervisor's working directory. At teardown (delete_terminal), "
+                "the checkout's working-tree contents are always discarded, but the branch "
+                "is only deleted if it has no unmerged commits -- commit AND merge/push "
+                "results before deleting the worker if you need them kept. Requires the "
+                "supervisor's current directory to be inside a git repository."
             ),
         ),
     ) -> Dict[str, Any]:

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -183,6 +183,7 @@ def _create_terminal(
     initial_message: Optional[str] = None,
     initial_message_orchestration_type: Optional[OrchestrationType] = None,
     model: Optional[str] = None,
+    use_worktree: bool = False,
 ) -> Tuple[str, str]:
     """Create a new terminal with the specified agent profile.
 
@@ -207,6 +208,11 @@ def _create_terminal(
             ahead of the agent profile's own static model field (where the
             resolved provider supports it). Honored by both the existing-
             session and new-session branches.
+        use_worktree: If True, the created terminal gets an isolated git
+            worktree (issue #100 Phase 1) instead of sharing
+            ``working_directory`` as given. Only meaningful on the
+            existing-session (assign) branch below -- the new-session branch
+            has no live caller today.
 
     Returns:
         Tuple of (terminal_id, provider)
@@ -268,6 +274,8 @@ def _create_terminal(
             params["engine"] = engine
         if model is not None:
             params["model"] = model
+        if use_worktree:
+            params["use_worktree"] = "true"
         # The message payload goes in the JSON body, not the query string, so
         # prompt content isn't exposed in HTTP access logs and isn't subject to
         # URL-length limits. Only routing flags stay in params.
@@ -713,6 +721,7 @@ async def _handoff_impl(
     working_directory: Optional[str] = None,
     engine: Optional[str] = None,
     model: Optional[str] = None,
+    use_worktree: bool = False,
 ) -> HandoffResult:
     """Implementation of handoff logic.
 
@@ -775,6 +784,7 @@ async def _handoff_impl(
             "prompt": shaped_message,
             "teardown": True,
             "timeout": float(timeout),
+            "use_worktree": use_worktree,
         }
         if ctx.session_name:
             payload["session_name"] = ctx.session_name
@@ -890,6 +900,16 @@ if ENABLE_WORKING_DIRECTORY:
             default=None, description="Explicit Kiro engine for the worker (v2 or kas)"
         ),
         model: Optional[str] = Field(default=None, description=_model_field_desc),
+        use_worktree: bool = Field(
+            default=False,
+            description=(
+                "If true, provision an isolated git worktree for this handoff instead of "
+                "sharing the supervisor's working directory -- the worktree checkout is "
+                "created on its own branch from the target repo's current HEAD and removed "
+                "automatically when the handoff completes. Requires the resolved working "
+                "directory (explicit or inherited) to be inside a git repository."
+            ),
+        ),
     ) -> HandoffResult:
         """Hand off a task to another agent via CAO terminal and wait for completion.
 
@@ -919,6 +939,17 @@ if ENABLE_WORKING_DIRECTORY:
         - You can pin a specific model via the model parameter, without needing a
           dedicated agent profile -- not honored by every provider
 
+        ## Isolated worktrees (use_worktree)
+
+        - Set use_worktree=true to give this handoff its own git worktree instead of
+          sharing the supervisor's (or working_directory's) checkout -- closes the
+          "parallel agents editing the same branch/files" race.
+        - The worktree is created from the resolved directory's repo, on its own
+          branch, and is automatically removed when the handoff's terminal is torn
+          down (success or failure).
+        - Requires the resolved working directory to actually be inside a git
+          repository; otherwise the handoff fails with a clear error.
+
         ## Requirements
 
         - Must be called from within a CAO terminal (CAO_TERMINAL_ID environment variable)
@@ -931,12 +962,19 @@ if ENABLE_WORKING_DIRECTORY:
             timeout: Maximum wait time in seconds
             working_directory: Optional directory path where agent should execute
             model: Optional model override (not honored by every provider)
+            use_worktree: If true, isolate this handoff in its own git worktree
 
         Returns:
             HandoffResult with success status, message, and agent output
         """
         return await _handoff_impl(
-            agent_profile, message, timeout, working_directory, engine=engine, model=model
+            agent_profile,
+            message,
+            timeout,
+            working_directory,
+            engine=engine,
+            model=model,
+            use_worktree=use_worktree,
         )
 
 else:
@@ -957,6 +995,16 @@ else:
             default=None, description="Explicit Kiro engine for the worker (v2 or kas)"
         ),
         model: Optional[str] = Field(default=None, description=_model_field_desc),
+        use_worktree: bool = Field(
+            default=False,
+            description=(
+                "If true, provision an isolated git worktree for this handoff instead of "
+                "sharing the supervisor's working directory -- the worktree checkout is "
+                "created on its own branch from the target repo's current HEAD and removed "
+                "automatically when the handoff completes. Requires the supervisor's "
+                "current directory to be inside a git repository."
+            ),
+        ),
     ) -> HandoffResult:
         """Hand off a task to another agent via CAO terminal and wait for completion.
 
@@ -979,6 +1027,14 @@ else:
         - You can pin a specific model via the model parameter, without needing a
           dedicated agent profile -- not honored by every provider
 
+        ## Isolated worktrees (use_worktree)
+
+        - Set use_worktree=true to give this handoff its own git worktree instead of
+          sharing the supervisor's checkout -- closes the "parallel agents editing the
+          same branch/files" race.
+        - Automatically removed when the handoff's terminal is torn down.
+        - Requires the supervisor's current directory to be inside a git repository.
+
         ## Requirements
 
         - Must be called from within a CAO terminal (CAO_TERMINAL_ID environment variable)
@@ -989,12 +1045,19 @@ else:
             message: The task/message to send
             timeout: Maximum wait time in seconds
             model: Optional model override (not honored by every provider)
+            use_worktree: If true, isolate this handoff in its own git worktree
 
         Returns:
             HandoffResult with success status, message, and agent output
         """
         return await _handoff_impl(
-            agent_profile, message, timeout, None, engine=engine, model=model
+            agent_profile,
+            message,
+            timeout,
+            None,
+            engine=engine,
+            model=model,
+            use_worktree=use_worktree,
         )
 
 
@@ -1005,6 +1068,7 @@ def _assign_impl(
     working_directory: Optional[str] = None,
     engine: Optional[str] = None,
     model: Optional[str] = None,
+    use_worktree: bool = False,
 ) -> Dict[str, Any]:
     """Implementation of assign logic.
 
@@ -1065,6 +1129,7 @@ def _assign_impl(
             initial_message=worker_message,
             initial_message_orchestration_type=OrchestrationType.ASSIGN,
             model=model,
+            use_worktree=use_worktree,
         )
 
         return {
@@ -1126,6 +1191,15 @@ Example message: "Analyze the logs. When done, send results back to terminal ee3
 - You can pin a specific model for this one worker via the model parameter, without
   needing a dedicated agent profile -- not honored by every provider
 
+## Isolated worktrees (use_worktree)
+
+- Set use_worktree=true to give this worker its own git worktree instead of sharing
+  the supervisor's checkout -- closes the "parallel agents editing the same
+  branch/files" race.
+- The worktree is created on its own branch and removed automatically when you
+  call delete_terminal on the worker.
+- Requires the resolved working directory to be inside a git repository.
+
 ## Cleanup
 
 When you are done with an assigned terminal (received results or no longer need it),
@@ -1141,6 +1215,7 @@ Args:
 
     desc += """
     model: Optional model override for the worker (not honored by every provider)
+    use_worktree: If true, isolate this worker in its own git worktree
 
 Returns:
     Dict with success status, worker terminal_id, and message"""
@@ -1172,8 +1247,23 @@ if ENABLE_WORKING_DIRECTORY:
             default=None, description="Explicit Kiro engine for the worker (v2 or kas)"
         ),
         model: Optional[str] = Field(default=None, description=_model_field_desc),
+        use_worktree: bool = Field(
+            default=False,
+            description=(
+                "If true, provision an isolated git worktree for this worker instead of "
+                "sharing the supervisor's working directory. Requires the resolved working "
+                "directory to be inside a git repository."
+            ),
+        ),
     ) -> Dict[str, Any]:
-        return _assign_impl(agent_profile, message, working_directory, engine=engine, model=model)
+        return _assign_impl(
+            agent_profile,
+            message,
+            working_directory,
+            engine=engine,
+            model=model,
+            use_worktree=use_worktree,
+        )
 
 else:
 
@@ -1187,8 +1277,23 @@ else:
             default=None, description="Explicit Kiro engine for the worker (v2 or kas)"
         ),
         model: Optional[str] = Field(default=None, description=_model_field_desc),
+        use_worktree: bool = Field(
+            default=False,
+            description=(
+                "If true, provision an isolated git worktree for this worker instead of "
+                "sharing the supervisor's working directory. Requires the supervisor's "
+                "current directory to be inside a git repository."
+            ),
+        ),
     ) -> Dict[str, Any]:
-        return _assign_impl(agent_profile, message, None, engine=engine, model=model)
+        return _assign_impl(
+            agent_profile,
+            message,
+            None,
+            engine=engine,
+            model=model,
+            use_worktree=use_worktree,
+        )
 
 
 # Implementation function for send_message

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -258,6 +258,7 @@ async def run_agent_step(
     cancel_event: Optional[asyncio.Event] = None,
     engine: Optional[KiroEngine | str] = None,
     model: Optional[str] = None,
+    use_worktree: bool = False,
 ) -> AgentStepResult:
     """Run one agent step and return its result (success only).
 
@@ -341,6 +342,13 @@ async def run_agent_step(
             a specific model for this one worker without a dedicated agent
             profile. Default None = behavior unchanged (profile.model, if
             any, still applies).
+        use_worktree: Issue #100 Phase 1. When True and a terminal is created
+            here (``reuse_terminal_id`` is None), the freshly created terminal
+            gets an isolated ``git worktree`` instead of sharing
+            ``working_directory`` as given — see
+            ``terminal_service.create_terminal``'s own docstring for the
+            resolution/teardown mechanics. Ignored when reusing a terminal.
+            Default False = behavior unchanged.
 
     Returns:
         ``AgentStepResult`` with status COMPLETED — ONLY on success.
@@ -409,6 +417,7 @@ async def run_agent_step(
             env_vars=env_vars,
             engine=engine,
             model=model,
+            use_worktree=use_worktree,
         )
         terminal_id = terminal.id
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -19,6 +19,7 @@ Terminal Workflow:
 
 import asyncio
 import logging
+import os
 import re
 import threading
 import time
@@ -61,6 +62,7 @@ from cli_agent_orchestrator.providers.kiro_capabilities import (
     requested_kiro_capabilities,
 )
 from cli_agent_orchestrator.providers.manager import provider_manager
+from cli_agent_orchestrator.services import worktree_service
 from cli_agent_orchestrator.services.fifo_reader import fifo_manager
 from cli_agent_orchestrator.services.herdr_inbox_registry import get_herdr_inbox_service
 from cli_agent_orchestrator.services.memory_service import MemoryService
@@ -170,6 +172,7 @@ async def create_terminal(
     engine: Optional[KiroEngine | str] = None,
     kiro_capability_probe: Optional[Callable[[KiroEngine, set[str]], KiroCapabilities]] = None,
     model: Optional[str] = None,
+    use_worktree: bool = False,
 ) -> Terminal:
     """Create a new terminal with an initialized CLI agent.
 
@@ -207,6 +210,13 @@ async def create_terminal(
             (e.g. MCP handoff/assign's own `model` parameter) pin a specific
             model for one worker without needing a dedicated agent profile.
             None = behavior unchanged (profile.model, if any, still applies).
+        use_worktree: If True, provision an isolated ``git worktree`` (issue
+            #100) for this terminal instead of using ``working_directory`` as
+            given -- resolves the repo root from ``working_directory`` (or the
+            server's own cwd when unset), creates a fresh worktree on its own
+            branch there, and overrides ``working_directory`` to the new
+            worktree path before the tmux session/window is created. Requires
+            the resolved directory to actually be inside a git repository.
 
     Returns:
         Terminal object with all metadata populated
@@ -225,6 +235,11 @@ async def create_terminal(
     # new one, but had no equivalent for a window added to a session that
     # already existed — see the `except` block.
     window_created = False
+    # Reassigned to the resolved repo root once a worktree is actually created
+    # below (Step 1b), so the failure-cleanup path (the `except` block) knows
+    # whether there is a worktree to roll back too. Still None if Step 1b never
+    # ran (use_worktree=False) or itself failed before create_worktree returned.
+    worktree_repo_root: Optional[str] = None
     try:
         # Resolve profile policy and Kiro engine BEFORE allocating any backend
         # resource. A KAS request must probe then fail closed with no window,
@@ -289,6 +304,16 @@ async def create_terminal(
             session_name = generate_session_name()
 
         window_name = generate_window_name(agent_profile)
+
+        # Step 1b: Provision an isolated git worktree (issue #100, Phase 1) before
+        # the tmux session/window below consumes `working_directory` -- the
+        # worktree's own path REPLACES whatever `working_directory` was given
+        # (explicit or caller-inherited), so the terminal always launches inside
+        # its own isolated checkout rather than the shared one it would
+        # otherwise have used.
+        if use_worktree:
+            worktree_repo_root = worktree_service.find_repo_root(working_directory or os.getcwd())
+            working_directory = worktree_service.create_worktree(worktree_repo_root, terminal_id)
 
         # Step 2: Create tmux session or window
         if new_session:
@@ -553,6 +578,13 @@ async def create_terminal(
                 get_backend().kill_window(session_name, window_name)
             except Exception:
                 pass  # Ignore cleanup errors
+        if worktree_repo_root is not None:
+            # A worktree WAS created (Step 1b succeeded) before some later step
+            # failed -- roll it back too, same best-effort posture as everything
+            # else in this block. Without this, a provider-init timeout (or any
+            # later failure) on a worktree-backed terminal would leave an orphan
+            # worktree + branch behind with no CAO-side record pointing at it.
+            worktree_service.remove_worktree(worktree_repo_root, terminal_id)
         raise
 
 
@@ -1388,11 +1420,37 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
             except Exception as e:
                 logger.warning(f"Failed to clear state detector for {terminal_id}: {e}")
 
+            # Read the pane's live working directory BEFORE kill_window below
+            # destroys the pane -- issue #100 Phase 1's worktree cleanup (just
+            # after kill_window) needs this to recognize a worktree-backed
+            # terminal; there is no separate CAO-side record of which
+            # terminals are worktree-backed, so this live read is the only
+            # source. Best-effort: a read failure just means no worktree
+            # cleanup runs below (same fail-open posture as the snapshot
+            # above, which reads this same value for a different purpose).
+            live_working_directory = None
+            try:
+                live_working_directory = get_backend().get_pane_working_directory(
+                    metadata["tmux_session"], metadata["tmux_window"]
+                )
+            except Exception as e:
+                logger.warning(f"Failed to read working directory for {terminal_id}: {e}")
+
             # Kill the tmux window (this terminates the agent process)
             try:
                 get_backend().kill_window(metadata["tmux_session"], metadata["tmux_window"])
             except Exception as e:
                 logger.warning(f"Failed to kill tmux window for {terminal_id}: {e}")
+
+            # issue #100 Phase 1: if this terminal was worktree-backed (its live
+            # cwd matched the CAO-managed worktree path shape), remove the
+            # worktree + branch now that the process using it is gone.
+            # `remove_worktree` is itself best-effort/never-raises, matching
+            # every other step in this teardown.
+            parsed = worktree_service.parse_worktree_path(live_working_directory)
+            if parsed is not None:
+                worktree_repo_root, worktree_terminal_id = parsed
+                worktree_service.remove_worktree(worktree_repo_root, worktree_terminal_id)
 
         # Cleanup provider state and database record
         provider_manager.cleanup_provider(terminal_id)

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -312,8 +312,20 @@ async def create_terminal(
         # its own isolated checkout rather than the shared one it would
         # otherwise have used.
         if use_worktree:
-            worktree_repo_root = worktree_service.find_repo_root(working_directory or os.getcwd())
-            working_directory = worktree_service.create_worktree(worktree_repo_root, terminal_id)
+            # `find_repo_root`/`create_worktree` are synchronous `subprocess.run`
+            # calls (a full worktree checkout can take seconds to tens of
+            # seconds on a large repo); `create_terminal` is awaited directly on
+            # the shared event loop, so running them in-line here would freeze
+            # every other cao-server request (status monitor ticks, inbox
+            # delivery, unrelated terminal calls) for the duration. Offload to a
+            # thread, same posture as `delete_terminal`'s own blocking subprocess
+            # work (see its `run_in_executor` call site in api/main.py).
+            worktree_repo_root = await asyncio.to_thread(
+                worktree_service.find_repo_root, working_directory or os.getcwd()
+            )
+            working_directory = await asyncio.to_thread(
+                worktree_service.create_worktree, worktree_repo_root, terminal_id
+            )
 
         # Step 2: Create tmux session or window
         if new_session:
@@ -584,7 +596,12 @@ async def create_terminal(
             # else in this block. Without this, a provider-init timeout (or any
             # later failure) on a worktree-backed terminal would leave an orphan
             # worktree + branch behind with no CAO-side record pointing at it.
-            worktree_service.remove_worktree(worktree_repo_root, terminal_id)
+            # Offloaded to a thread for the same reason Step 1b's create is:
+            # `git worktree remove` is a blocking subprocess call and this
+            # `except` block still runs on the shared event loop.
+            await asyncio.to_thread(
+                worktree_service.remove_worktree, worktree_repo_root, terminal_id
+            )
         raise
 
 
@@ -1369,6 +1386,22 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
         metadata = get_terminal_metadata(terminal_id)
 
         if metadata:
+            # Read the pane's live working directory BEFORE kill_window below
+            # destroys the pane. Single read, reused for two purposes: the
+            # scrollback snapshot below, and issue #100 Phase 1's worktree
+            # cleanup (recognizing a worktree-backed terminal from its live
+            # cwd alone -- there is no separate CAO-side record of which
+            # terminals are worktree-backed). Best-effort: a read failure
+            # means the snapshot's working_directory field is None and no
+            # worktree cleanup runs below.
+            live_working_directory = None
+            try:
+                live_working_directory = get_backend().get_pane_working_directory(
+                    metadata["tmux_session"], metadata["tmux_window"]
+                )
+            except Exception as e:
+                logger.warning(f"Failed to read working directory for {terminal_id}: {e}")
+
             # Snapshot scrollback + metadata before killing (for debugging/restore)
             try:
                 # Capture plain text full scrollback (no -e, no line cap)
@@ -1389,9 +1422,7 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
                     "window_name": metadata["tmux_window"],
                     "agent_profile": metadata.get("agent_profile"),
                     "provider": metadata["provider"],
-                    "working_directory": get_backend().get_pane_working_directory(
-                        metadata["tmux_session"], metadata["tmux_window"]
-                    ),
+                    "working_directory": live_working_directory,
                     "allowed_tools": metadata.get("allowed_tools"),
                     "caller_id": metadata.get("caller_id"),
                 }
@@ -1420,22 +1451,6 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
             except Exception as e:
                 logger.warning(f"Failed to clear state detector for {terminal_id}: {e}")
 
-            # Read the pane's live working directory BEFORE kill_window below
-            # destroys the pane -- issue #100 Phase 1's worktree cleanup (just
-            # after kill_window) needs this to recognize a worktree-backed
-            # terminal; there is no separate CAO-side record of which
-            # terminals are worktree-backed, so this live read is the only
-            # source. Best-effort: a read failure just means no worktree
-            # cleanup runs below (same fail-open posture as the snapshot
-            # above, which reads this same value for a different purpose).
-            live_working_directory = None
-            try:
-                live_working_directory = get_backend().get_pane_working_directory(
-                    metadata["tmux_session"], metadata["tmux_window"]
-                )
-            except Exception as e:
-                logger.warning(f"Failed to read working directory for {terminal_id}: {e}")
-
             # Kill the tmux window (this terminates the agent process)
             try:
                 get_backend().kill_window(metadata["tmux_session"], metadata["tmux_window"])
@@ -1447,10 +1462,24 @@ def delete_terminal(terminal_id: str, registry: PluginRegistry | None = None) ->
             # worktree + branch now that the process using it is gone.
             # `remove_worktree` is itself best-effort/never-raises, matching
             # every other step in this teardown.
+            #
+            # The parsed terminal_id MUST match the terminal actually being
+            # deleted here, not just "some" CAO worktree path. Without this
+            # guard: a worktree-backed terminal A (cwd
+            # .../.cao/worktrees/A) can spawn a non-worktree terminal B with
+            # working_directory explicitly set to A's cwd (handoff/assign
+            # both accept an explicit working_directory, and "here" -- the
+            # caller's own directory -- is a common choice). Deleting B --
+            # including handoff's automatic success teardown -- would then
+            # read B's pane cwd (== A's worktree path), parse terminal_id
+            # "A" out of it, and force-remove A's still-running worktree.
+            # Mismatched parses now fall through as a no-op leak (Phase 3
+            # territory) instead of destroying another terminal's checkout.
             parsed = worktree_service.parse_worktree_path(live_working_directory)
             if parsed is not None:
                 worktree_repo_root, worktree_terminal_id = parsed
-                worktree_service.remove_worktree(worktree_repo_root, worktree_terminal_id)
+                if worktree_terminal_id == terminal_id:
+                    worktree_service.remove_worktree(worktree_repo_root, worktree_terminal_id)
 
         # Cleanup provider state and database record
         provider_manager.cleanup_provider(terminal_id)

--- a/src/cli_agent_orchestrator/services/worktree_service.py
+++ b/src/cli_agent_orchestrator/services/worktree_service.py
@@ -1,0 +1,206 @@
+"""Git worktree provisioning for per-terminal isolation (issue #100, Phase 1).
+
+When a supervisor spawns multiple workers via ``handoff``/``assign``, they
+share the same git branch and working directory by default -- the exact
+"merge conflicts, overwritten files, race conditions" gap issue #100 names.
+Passing ``use_worktree=True`` on a spawn gives that one worker an isolated
+``git worktree`` checkout on its own branch instead.
+
+Scoped strictly to the maintainer's own suggested Phase 1 (this module +
+``use_worktree`` on ``handoff``/``assign``) -- the ``--enable-worktrees``
+global launch flag and the ``cao worktrees clean`` CLI command are Phase 2/3,
+intentionally not built here to keep this PR reviewable-sized.
+
+No new CAO-side persistence: a worktree's path and branch are both derived
+deterministically from the terminal_id CAO already generates for every
+terminal (``generate_terminal_id()``, unique and server-controlled, never
+user-supplied), so ``create_terminal``/``delete_terminal`` can locate a
+worktree at teardown time from the terminal_id alone -- git's own
+``.git/worktrees`` bookkeeping is the single source of truth, matching how
+this project already treats git as authoritative elsewhere.
+"""
+
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# Kept out of the repo's own working tree root and namespaced under one
+# directory so a single `git worktree list`/`rm -rf` scopes cleanly to
+# everything CAO has ever provisioned here.
+WORKTREE_SUBDIR = ".cao/worktrees"
+BRANCH_PREFIX = "cao/"
+
+# Local-only git operations (add/remove/list); generous but bounded so a
+# hung git process cannot hang terminal creation/deletion indefinitely.
+_GIT_TIMEOUT_SECONDS = 30
+
+_WORKTREE_PATH_MARKER = f"{os.sep}{WORKTREE_SUBDIR}{os.sep}"
+
+
+class WorktreeError(Exception):
+    """A git-worktree operation failed (repo resolution, add, or list)."""
+
+
+def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess:
+    """Run ``git <args>`` in ``cwd``, never raising -- a nonexistent ``cwd``
+    (``OSError``/``FileNotFoundError``) or a hung git process
+    (``subprocess.TimeoutExpired``) is reported the SAME way a nonzero exit
+    code is: a synthetic failed ``CompletedProcess`` with the exception text
+    in ``stderr``. Every caller below already branches on ``returncode != 0``
+    for a normal git failure -- routing infra failures through that same
+    path (instead of letting them escape as a raw, uncaught exception) is
+    what makes ``remove_worktree``'s "never raises" contract, and
+    ``find_repo_root``/``create_worktree``/``list_worktrees``'s own
+    ``WorktreeError`` contract, both actually hold rather than being
+    docstring claims that a missing/unreadable directory quietly breaks."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return subprocess.CompletedProcess(
+            args=["git", *args], returncode=1, stdout="", stderr=str(e)
+        )
+
+
+def find_repo_root(start_path: str) -> str:
+    """The git repository root containing ``start_path``.
+
+    ``git worktree add`` must run from inside a real repo's own working
+    tree; ``start_path`` may be any subdirectory of it (a supervisor's own
+    working directory is not necessarily the repo root).
+
+    Raises:
+        WorktreeError: ``start_path`` is not inside a git repository.
+    """
+    result = _run_git(["rev-parse", "--show-toplevel"], cwd=start_path)
+    if result.returncode != 0:
+        raise WorktreeError(
+            f"'{start_path}' is not inside a git repository -- use_worktree requires "
+            f"a real git repo ('git rev-parse --show-toplevel' failed: {result.stderr.strip()})"
+        )
+    stdout: str = result.stdout
+    return stdout.strip()
+
+
+def worktree_path_for(repo_root: str, terminal_id: str) -> str:
+    return os.path.join(repo_root, WORKTREE_SUBDIR, terminal_id)
+
+
+def branch_for(terminal_id: str) -> str:
+    return f"{BRANCH_PREFIX}{terminal_id}"
+
+
+def create_worktree(repo_root: str, terminal_id: str) -> str:
+    """``git worktree add`` a fresh checkout on its own branch, based on the
+    repo's current HEAD. Returns the new worktree's absolute path.
+
+    ``terminal_id`` is server-generated (never user-supplied), so the
+    derived path/branch need no additional sanitization beyond what CAO's
+    own terminal-id generator already guarantees (a fixed-alphabet,
+    fixed-length id -- see ``generate_terminal_id``).
+
+    Raises:
+        WorktreeError: ``git worktree add`` failed (e.g. a stale directory
+            or branch from an earlier crashed attempt under the same id --
+            unreachable in practice since terminal_id is always fresh, but
+            surfaced as a clear error rather than a confusing git failure).
+    """
+    path = worktree_path_for(repo_root, terminal_id)
+    branch = branch_for(terminal_id)
+    result = _run_git(["worktree", "add", "-b", branch, path], cwd=repo_root)
+    if result.returncode != 0:
+        raise WorktreeError(
+            f"'git worktree add' failed for terminal {terminal_id}: {result.stderr.strip()}"
+        )
+    return path
+
+
+def remove_worktree(repo_root: str, terminal_id: str) -> None:
+    """Best-effort teardown: ``git worktree remove --force`` (agents commonly
+    leave modified/untracked files behind, so a plain ``remove`` would
+    refuse) followed by deleting the branch.
+
+    Never raises -- called from terminal-teardown paths (``delete_terminal``,
+    and the failure-cleanup path in ``create_terminal``) that must not fail
+    the terminal's own deletion/rollback over a worktree cleanup issue.
+    Failures are logged, not swallowed silently.
+    """
+    path = worktree_path_for(repo_root, terminal_id)
+    branch = branch_for(terminal_id)
+    result = _run_git(["worktree", "remove", "--force", path], cwd=repo_root)
+    if result.returncode != 0:
+        logger.warning(
+            "worktree cleanup: 'git worktree remove --force %s' failed: %s",
+            path,
+            result.stderr.strip(),
+        )
+    result = _run_git(["branch", "-D", branch], cwd=repo_root)
+    if result.returncode != 0:
+        logger.warning(
+            "worktree cleanup: 'git branch -D %s' failed: %s", branch, result.stderr.strip()
+        )
+
+
+def list_worktrees(repo_root: str) -> list[dict[str, str | bool]]:
+    """Parsed ``git worktree list --porcelain`` for ``repo_root`` -- the AC's
+    'list' operation. No CAO-side persistence to query: git's own
+    bookkeeping is authoritative, so this always reflects reality even if a
+    worktree was added/removed outside CAO.
+
+    Raises:
+        WorktreeError: ``repo_root`` is not a git repository, or the list
+            command otherwise failed.
+    """
+    result = _run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    if result.returncode != 0:
+        raise WorktreeError(f"'git worktree list' failed: {result.stderr.strip()}")
+    worktrees: list[dict[str, str | bool]] = []
+    current: dict[str, str | bool] = {}
+    for line in result.stdout.splitlines():
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value if value else True
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+def parse_worktree_path(path: object) -> tuple[str, str] | None:
+    """If ``path`` looks like a CAO-managed worktree
+    (``<repo_root>/.cao/worktrees/<terminal_id>``), return
+    ``(repo_root, terminal_id)``; otherwise ``None``.
+
+    Used at teardown time to recognize a worktree-provisioned terminal from
+    its own live pane working directory alone -- no separate CAO-side
+    tracking of "which terminals are worktree-backed" is needed, since the
+    path shape itself is the marker.
+
+    Accepts ``object`` (not just ``str | None``) and returns ``None`` for
+    anything that isn't a real string, deliberately: the caller
+    (``delete_terminal``) reads this from a backend call whose real contract
+    is ``str | None``, but its actual value at any given call site can be
+    something else entirely under test doubles/mocks -- this must degrade to
+    "not a worktree" rather than raise, since it feeds a real ``git``
+    subprocess call two steps downstream.
+    """
+    if not isinstance(path, str) or not path:
+        return None
+    idx = path.find(_WORKTREE_PATH_MARKER)
+    if idx == -1:
+        return None
+    repo_root = path[:idx]
+    terminal_id = path[idx + len(_WORKTREE_PATH_MARKER) :]
+    if not repo_root or not terminal_id or os.sep in terminal_id:
+        return None
+    return repo_root, terminal_id

--- a/src/cli_agent_orchestrator/services/worktree_service.py
+++ b/src/cli_agent_orchestrator/services/worktree_service.py
@@ -82,7 +82,7 @@ def find_repo_root(start_path: str) -> str:
     result = _run_git(["rev-parse", "--show-toplevel"], cwd=start_path)
     if result.returncode != 0:
         raise WorktreeError(
-            f"'{start_path}' is not inside a git repository -- use_worktree requires "
+            f"{start_path!r} is not inside a git repository -- use_worktree requires "
             f"a real git repo ('git rev-parse --show-toplevel' failed: {result.stderr.strip()})"
         )
     stdout: str = result.stdout
@@ -119,13 +119,48 @@ def create_worktree(repo_root: str, terminal_id: str) -> str:
         raise WorktreeError(
             f"'git worktree add' failed for terminal {terminal_id}: {result.stderr.strip()}"
         )
+    _ensure_worktree_subdir_gitignored(repo_root)
     return path
+
+
+def _ensure_worktree_subdir_gitignored(repo_root: str) -> None:
+    """Best-effort: write ``<repo_root>/.cao/worktrees/.gitignore`` (``*``) the
+    first time a worktree is created there, so the main checkout's own
+    ``git status``/``git add -A`` never sees -- and never stages as an
+    embedded-repo gitlink -- the worktrees CAO provisions inside it. The
+    target repo is arbitrary user code; we cannot assume its own
+    ``.gitignore`` already excludes ``.cao/worktrees`` (this repo's own
+    ``.gitignore`` only excludes its unrelated ``.worktrees``), so CAO must
+    write its own ignore file rather than rely on one being present.
+
+    Never raises: a failure here (e.g. read-only filesystem) must not fail
+    the worktree creation that already succeeded.
+    """
+    gitignore_path = os.path.join(repo_root, WORKTREE_SUBDIR, ".gitignore")
+    try:
+        if not os.path.exists(gitignore_path):
+            with open(gitignore_path, "w", encoding="utf-8") as f:
+                f.write("*\n")
+    except OSError as e:
+        logger.warning("worktree setup: failed to write %s: %s", gitignore_path, e)
 
 
 def remove_worktree(repo_root: str, terminal_id: str) -> None:
     """Best-effort teardown: ``git worktree remove --force`` (agents commonly
     leave modified/untracked files behind, so a plain ``remove`` would
-    refuse) followed by deleting the branch.
+    refuse) followed by a SAFE branch delete (``git branch -d``, not
+    ``-D``).
+
+    Deliberately never force-deletes the branch: a worker that committed
+    its results to ``cao/<terminal_id>`` before completing (exactly what
+    agents are usually instructed to do) must not have that history
+    destroyed just because Phase 1 has no merge-back story yet. ``-d``
+    only succeeds when the branch has no commits that would be lost (i.e.
+    it is unchanged, or already merged); a worker that committed real work
+    fails the safe delete and the branch is left behind -- a leak for
+    Phase 3's ``cao worktrees clean`` to sweep up later, not silent data
+    loss. Only the (uncommitted/untracked) working-tree contents of the
+    worktree itself are ever force-discarded.
 
     Never raises -- called from terminal-teardown paths (``delete_terminal``,
     and the failure-cleanup path in ``create_terminal``) that must not fail
@@ -141,10 +176,13 @@ def remove_worktree(repo_root: str, terminal_id: str) -> None:
             path,
             result.stderr.strip(),
         )
-    result = _run_git(["branch", "-D", branch], cwd=repo_root)
+    result = _run_git(["branch", "-d", branch], cwd=repo_root)
     if result.returncode != 0:
         logger.warning(
-            "worktree cleanup: 'git branch -D %s' failed: %s", branch, result.stderr.strip()
+            "worktree cleanup: 'git branch -d %s' failed (left in place -- likely has "
+            "unmerged commits; merge/push the work, then delete it manually): %s",
+            branch,
+            result.stderr.strip(),
         )
 
 
@@ -177,14 +215,27 @@ def list_worktrees(repo_root: str) -> list[dict[str, str | bool]]:
 
 
 def parse_worktree_path(path: object) -> tuple[str, str] | None:
-    """If ``path`` looks like a CAO-managed worktree
-    (``<repo_root>/.cao/worktrees/<terminal_id>``), return
+    """If ``path`` looks like a CAO-managed worktree, or a subdirectory of
+    one (``<repo_root>/.cao/worktrees/<terminal_id>[/...]``), return
     ``(repo_root, terminal_id)``; otherwise ``None``.
 
     Used at teardown time to recognize a worktree-provisioned terminal from
     its own live pane working directory alone -- no separate CAO-side
     tracking of "which terminals are worktree-backed" is needed, since the
     path shape itself is the marker.
+
+    Two deliberate choices beyond a naive split:
+
+    - Subdirectories of the worktree are accepted, not just the worktree
+      root exactly. tmux reports the pane's CURRENT directory
+      (``pane_current_path``): a worker that ``cd``s into a subdirectory
+      (very likely) would otherwise no longer be recognized as
+      worktree-backed at teardown, leaking the worktree/branch.
+    - ``rfind`` (last occurrence), not ``find`` (first), so a
+      worktree-backed supervisor spawning a worktree-backed worker --
+      nesting ``<repo_root>/.cao/worktrees/A/.cao/worktrees/B`` -- resolves
+      to B's own ``(repo_root, terminal_id)`` (repo_root = A's worktree
+      root, terminal_id = B) instead of failing to parse and leaking B.
 
     Accepts ``object`` (not just ``str | None``) and returns ``None`` for
     anything that isn't a real string, deliberately: the caller
@@ -196,11 +247,12 @@ def parse_worktree_path(path: object) -> tuple[str, str] | None:
     """
     if not isinstance(path, str) or not path:
         return None
-    idx = path.find(_WORKTREE_PATH_MARKER)
+    idx = path.rfind(_WORKTREE_PATH_MARKER)
     if idx == -1:
         return None
     repo_root = path[:idx]
-    terminal_id = path[idx + len(_WORKTREE_PATH_MARKER) :]
-    if not repo_root or not terminal_id or os.sep in terminal_id:
+    remainder = path[idx + len(_WORKTREE_PATH_MARKER) :]
+    terminal_id = remainder.split(os.sep, 1)[0]
+    if not repo_root or not terminal_id:
         return None
     return repo_root, terminal_id

--- a/test/api/test_run_step.py
+++ b/test/api/test_run_step.py
@@ -229,3 +229,42 @@ class TestRunStepEndpoint:
         # Pydantic request-model validation rejects a missing prompt.
         resp = client.post(TERMINALS_RUN_STEP_ROUTE, json={"provider": "p", "agent": "a"})
         assert resp.status_code == 422
+
+    def test_use_worktree_defaults_to_false_and_is_forwarded(self, client):
+        """issue #100 Phase 1: the field is unconditionally forwarded (not
+        omitted-when-falsy like the Optional fields above), so a caller that
+        never mentions it still gets an explicit False into run_agent_step --
+        no ambiguity between 'not set' and 'set to false'."""
+        result = AgentStepResult(
+            terminal_id="abc12345", last_message="done", status=TerminalStatus.COMPLETED
+        )
+        with patch(_RUN_STEP, new=AsyncMock(return_value=result)) as m_run:
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body())
+
+        assert resp.status_code == 200
+        assert m_run.await_args.kwargs["use_worktree"] is False
+
+    def test_use_worktree_true_is_forwarded(self, client):
+        result = AgentStepResult(
+            terminal_id="abc12345", last_message="done", status=TerminalStatus.COMPLETED
+        )
+        with patch(_RUN_STEP, new=AsyncMock(return_value=result)) as m_run:
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(use_worktree=True))
+
+        assert resp.status_code == 200
+        assert m_run.await_args.kwargs["use_worktree"] is True
+
+    def test_worktree_error_maps_to_400_not_500(self, client):
+        """A working_directory that isn't a git repo (or a failed
+        'git worktree add') is a client-input problem, not a server crash --
+        distinct from the generic 500 fallback."""
+        from cli_agent_orchestrator.services.worktree_service import WorktreeError
+
+        with patch(
+            _RUN_STEP,
+            new=AsyncMock(side_effect=WorktreeError("'/tmp/x' is not inside a git repository")),
+        ):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(use_worktree=True))
+
+        assert resp.status_code == 400
+        assert "not inside a git repository" in resp.json()["detail"]

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -364,6 +364,94 @@ class TestTerminalCreationWithWorkingDirectory:
             call_kwargs = mock_svc.create_terminal.call_args.kwargs
             assert call_kwargs.get("working_directory") == "/session/path"
 
+    def test_create_terminal_in_session_forwards_use_worktree_true(self, client):
+        """issue #100 Phase 1: the use_worktree query param reaches
+        terminal_service.create_terminal unchanged."""
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            mock_svc.create_terminal = AsyncMock(
+                return_value=Terminal(
+                    id="abcd5678",
+                    name="test-window",
+                    session_name="test-session",
+                    provider="kiro_cli",
+                    agent_profile="analyst",
+                )
+            )
+
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "analyst",
+                    "use_worktree": "true",
+                },
+            )
+
+            assert response.status_code == 201
+            call_kwargs = mock_svc.create_terminal.call_args.kwargs
+            assert call_kwargs.get("use_worktree") is True
+
+    def test_create_terminal_in_session_defaults_use_worktree_false(self, client):
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            mock_svc.create_terminal = AsyncMock(
+                return_value=Terminal(
+                    id="abcd5678",
+                    name="test-window",
+                    session_name="test-session",
+                    provider="kiro_cli",
+                    agent_profile="analyst",
+                )
+            )
+
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={"provider": "kiro_cli", "agent_profile": "analyst"},
+            )
+
+            assert response.status_code == 201
+            call_kwargs = mock_svc.create_terminal.call_args.kwargs
+            assert call_kwargs.get("use_worktree") is False
+
+    def test_create_terminal_in_session_worktree_error_maps_to_400(self, client):
+        """A working_directory that isn't a git repo is a client-input
+        problem, not a server crash."""
+        from cli_agent_orchestrator.services.worktree_service import WorktreeError
+
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            mock_svc.create_terminal = AsyncMock(
+                side_effect=WorktreeError("'/tmp/x' is not inside a git repository")
+            )
+
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "analyst",
+                    "use_worktree": "true",
+                },
+            )
+
+            assert response.status_code == 400
+            assert "not inside a git repository" in response.json()["detail"]
+
     def test_create_terminal_rejects_initial_message_without_defer_init(self, client):
         """initial_message is only delivered on the deferred-init path; sending
         it with defer_init=false must 400 rather than silently drop the payload."""

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -346,6 +346,96 @@ class TestCreateTerminalModelOverride:
         assert "model" not in kwargs["params"]
 
 
+class TestCreateTerminalUseWorktree:
+    """issue #100 Phase 1: use_worktree is a routing flag, same shape as
+    defer_init -- stays in query params (not the JSON body), and is only
+    included when True (matching defer_init's own conditional-inclusion, not
+    unconditional like run-step's JSON field -- a plain query string has no
+    natural way to distinguish 'absent' from 'false' anyway)."""
+
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
+    )
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="claude_code")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_use_worktree_true_is_included_in_params(
+        self, mock_requests, mock_resolve_provider, mock_allowed_tools
+    ):
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        metadata_response = MagicMock()
+        metadata_response.json.return_value = {
+            "provider": "kiro_cli",
+            "session_name": "cao-session",
+            "allowed_tools": None,
+        }
+        metadata_response.raise_for_status.return_value = None
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-1", "provider": "claude_code"}
+        post_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = metadata_response
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervisor-1"}):
+            _create_terminal("reviewer", "/repo", use_worktree=True)
+
+        _, kwargs = mock_requests.post.call_args
+        assert kwargs["params"]["use_worktree"] == "true"
+
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
+    )
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="claude_code")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_use_worktree_false_is_omitted_from_params(
+        self, mock_requests, mock_resolve_provider, mock_allowed_tools
+    ):
+        """Default False = today's exact behavior unchanged -- no new query
+        param reaches the server for a caller that never mentions it."""
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        metadata_response = MagicMock()
+        metadata_response.json.return_value = {
+            "provider": "kiro_cli",
+            "session_name": "cao-session",
+            "allowed_tools": None,
+        }
+        metadata_response.raise_for_status.return_value = None
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-1", "provider": "claude_code"}
+        post_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = metadata_response
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervisor-1"}):
+            _create_terminal("reviewer", "/repo")
+
+        _, kwargs = mock_requests.post.call_args
+        assert "use_worktree" not in kwargs["params"]
+
+    @patch("cli_agent_orchestrator.mcp_server.server._assign_impl")
+    def test_assign_tool_forwards_use_worktree_to_impl(self, mock_impl):
+        """The public `assign` MCP tool itself threads use_worktree through to
+        _assign_impl -- both the workdir-enabled and disabled variants.
+
+        _assign_impl's non-message/working_directory args (engine, model,
+        use_worktree) are forwarded as keywords (see server.py's assign()),
+        not positionally -- assert via kwargs rather than a positional index.
+        """
+        from cli_agent_orchestrator.mcp_server import server as server_module
+
+        mock_impl.return_value = {"success": True, "terminal_id": "w1", "message": "ok"}
+
+        import asyncio
+
+        asyncio.run(
+            server_module.assign(agent_profile="reviewer", message="do it", use_worktree=True)
+        )
+
+        _, kwargs = mock_impl.call_args
+        assert kwargs["use_worktree"] is True
+
+
 class TestAssignSenderIdInjection:
     """Tests for sender ID injection in _assign_impl.
 

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -376,7 +376,7 @@ class TestCreateTerminalUseWorktree:
         mock_requests.get.return_value = metadata_response
         mock_requests.post.return_value = post_response
 
-        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervisor-1"}):
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "a1b2c3d4"}):
             _create_terminal("reviewer", "/repo", use_worktree=True)
 
         _, kwargs = mock_requests.post.call_args
@@ -407,7 +407,7 @@ class TestCreateTerminalUseWorktree:
         mock_requests.get.return_value = metadata_response
         mock_requests.post.return_value = post_response
 
-        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "supervisor-1"}):
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "a1b2c3d4"}):
             _create_terminal("reviewer", "/repo")
 
         _, kwargs = mock_requests.post.call_args

--- a/test/mcp_server/test_handoff.py
+++ b/test/mcp_server/test_handoff.py
@@ -215,6 +215,33 @@ class TestHandoffOutcomes:
         # The single combined call requests server-side teardown.
         assert mock_requests.post.call_args[1]["json"]["teardown"] is True
 
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
+    @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
+    def test_use_worktree_defaults_to_false_in_the_payload(self, mock_provider, _nudge):
+        """issue #100 Phase 1: unconditionally present in the payload (unlike
+        the Optional fields above) so the server always sees an explicit
+        value, matching RunStepRequest's own unconditional default."""
+        mock_provider.return_value = _ctx("kiro_cli")
+
+        with patch("cli_agent_orchestrator.mcp_server.server.requests") as mock_requests:
+            mock_requests.post.return_value = _ok_run_step_response()
+            mock_requests.Timeout = Exception
+            asyncio.run(_handoff_impl("developer", "Do task"))
+
+        assert mock_requests.post.call_args[1]["json"]["use_worktree"] is False
+
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
+    @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
+    def test_use_worktree_true_reaches_the_payload(self, mock_provider, _nudge):
+        mock_provider.return_value = _ctx("kiro_cli")
+
+        with patch("cli_agent_orchestrator.mcp_server.server.requests") as mock_requests:
+            mock_requests.post.return_value = _ok_run_step_response()
+            mock_requests.Timeout = Exception
+            asyncio.run(_handoff_impl("developer", "Do task", use_worktree=True))
+
+        assert mock_requests.post.call_args[1]["json"]["use_worktree"] is True
+
     @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
     def test_endpoint_504_maps_to_timeout_result(self, mock_provider):
         """A 504 (worker ran long) becomes a timeout failure and reads the live

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1894,6 +1894,49 @@ class TestDeleteTerminalWorktree:
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_does_not_remove_another_terminals_worktree(
+        self,
+        mock_get_metadata,
+        mock_tmux,
+        mock_provider_manager,
+        mock_db_delete,
+        mock_fifo_manager,
+        mock_status_monitor,
+        mock_worktree_service,
+    ):
+        """Regression: worktree-backed terminal A (cwd
+        .../.cao/worktrees/A) spawns non-worktree terminal B with
+        working_directory explicitly set to A's cwd -- a common choice
+        (handoff/assign both accept an explicit working_directory, and "here"
+        is A's own directory). Deleting B must NOT force-remove A's
+        still-running worktree just because B's pane cwd happens to
+        path-match it; the parsed terminal_id must match the terminal
+        actually being deleted (B), not A."""
+        from cli_agent_orchestrator.services.worktree_service import (
+            parse_worktree_path as real_parse_worktree_path,
+        )
+
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-bbbb",
+        }
+        # B's pane cwd is A's worktree root -- NOT B's own terminal_id.
+        mock_tmux.get_pane_working_directory.return_value = "/repo/.cao/worktrees/terminalA"
+        mock_worktree_service.parse_worktree_path.side_effect = real_parse_worktree_path
+        mock_db_delete.return_value = True
+
+        result = delete_terminal("terminalB")
+
+        assert result is True
+        mock_worktree_service.remove_worktree.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_does_not_touch_worktree_service_for_an_ordinary_shared_directory(
         self,
         mock_get_metadata,

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -833,6 +833,193 @@ class TestCreateTerminal:
         assert mock_provider_manager.create_provider.call_args.kwargs.get("allowed_tools") is None
 
 
+class TestCreateTerminalWorktree:
+    """issue #100 Phase 1: use_worktree wiring in create_terminal.
+
+    worktree_service itself is real-git-tested in test_worktree_service.py;
+    these tests mock it to verify create_terminal's OWN wiring (call order,
+    working_directory override, rollback-on-failure) without needing a real
+    git repo.
+    """
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    async def test_use_worktree_overrides_working_directory_for_the_new_window(
+        self,
+        mock_worktree_service,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = True
+        mock_tmux.create_window.return_value = "developer-abcd"
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+        mock_worktree_service.find_repo_root.return_value = "/repo"
+        mock_worktree_service.create_worktree.return_value = "/repo/.cao/worktrees/test1234"
+
+        result = await create_terminal(
+            "kiro_cli",
+            "developer",
+            session_name="cao-existing",
+            working_directory="/repo/some/subdir",
+            use_worktree=True,
+        )
+
+        assert result.id == "test1234"
+        mock_worktree_service.find_repo_root.assert_called_once_with("/repo/some/subdir")
+        mock_worktree_service.create_worktree.assert_called_once_with("/repo", "test1234")
+        # The worktree path -- NOT the originally-given working_directory -- is
+        # what actually reaches the tmux window (create_window's 4th positional
+        # arg, per its own call site in terminal_service.py).
+        assert mock_tmux.create_window.call_args.args[3] == "/repo/.cao/worktrees/test1234"
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    async def test_use_worktree_false_never_touches_worktree_service(
+        self,
+        mock_worktree_service,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        """Default False = today's exact behavior, unchanged."""
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = True
+        mock_tmux.create_window.return_value = "developer-abcd"
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        await create_terminal("kiro_cli", "developer", session_name="cao-existing")
+
+        mock_worktree_service.find_repo_root.assert_not_called()
+        mock_worktree_service.create_worktree.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    async def test_use_worktree_propagates_a_repo_resolution_failure(
+        self,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_worktree_service,
+    ):
+        """A non-git working_directory must fail fast, before any tmux session/
+        window is touched -- not silently fall back to shared-directory
+        behavior, which would defeat the isolation use_worktree promises."""
+        from cli_agent_orchestrator.services.worktree_service import WorktreeError
+
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_worktree_service.WorktreeError = WorktreeError
+        mock_worktree_service.find_repo_root.side_effect = WorktreeError("not a git repo")
+
+        with pytest.raises(WorktreeError):
+            await create_terminal("kiro_cli", "developer", new_session=True, use_worktree=True)
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    async def test_use_worktree_rolls_back_the_worktree_on_a_later_failure(
+        self,
+        mock_worktree_service,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        """The worktree WAS created before provider.initialize() failed later --
+        the failure-cleanup path must roll it back too, or a provider-init
+        timeout on a worktree-backed terminal leaves an orphan worktree/branch
+        with no CAO-side record pointing at it."""
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = True
+        mock_tmux.create_window.return_value = "developer-abcd"
+        mock_load_profile.return_value = AgentProfile(name="developer", description="Developer")
+        mock_provider = AsyncMock()
+        mock_provider.initialize.side_effect = TimeoutError("provider init timed out")
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+        mock_worktree_service.find_repo_root.return_value = "/repo"
+        mock_worktree_service.create_worktree.return_value = "/repo/.cao/worktrees/test1234"
+
+        with pytest.raises(TimeoutError):
+            await create_terminal(
+                "kiro_cli",
+                "developer",
+                session_name="cao-existing",
+                use_worktree=True,
+            )
+
+        mock_worktree_service.remove_worktree.assert_called_once_with("/repo", "test1234")
+
+
 class TestCreateTerminalEnvVars:
     """Tests for env_vars handling on both session paths (issues #248/#408).
 
@@ -1659,6 +1846,122 @@ class TestDeleteTerminal:
         result = delete_terminal("test1234")
 
         assert result is True
+
+
+class TestDeleteTerminalWorktree:
+    """issue #100 Phase 1: delete_terminal recognizes and removes a
+    worktree-backed terminal's worktree from its own live pane cwd -- there
+    is no separate CAO-side record of which terminals are worktree-backed."""
+
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_removes_the_worktree_when_the_live_cwd_matches_the_worktree_shape(
+        self,
+        mock_get_metadata,
+        mock_tmux,
+        mock_provider_manager,
+        mock_db_delete,
+        mock_fifo_manager,
+        mock_status_monitor,
+        mock_worktree_service,
+    ):
+        from cli_agent_orchestrator.services.worktree_service import (
+            parse_worktree_path as real_parse_worktree_path,
+        )
+
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_tmux.get_pane_working_directory.return_value = "/repo/.cao/worktrees/test1234"
+        mock_worktree_service.parse_worktree_path.side_effect = real_parse_worktree_path
+        mock_db_delete.return_value = True
+
+        result = delete_terminal("test1234")
+
+        assert result is True
+        mock_worktree_service.remove_worktree.assert_called_once_with("/repo", "test1234")
+
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_does_not_touch_worktree_service_for_an_ordinary_shared_directory(
+        self,
+        mock_get_metadata,
+        mock_tmux,
+        mock_provider_manager,
+        mock_db_delete,
+        mock_fifo_manager,
+        mock_status_monitor,
+        mock_worktree_service,
+    ):
+        from cli_agent_orchestrator.services.worktree_service import (
+            parse_worktree_path as real_parse_worktree_path,
+        )
+
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_tmux.get_pane_working_directory.return_value = "/home/user/some/ordinary/project"
+        mock_worktree_service.parse_worktree_path.side_effect = real_parse_worktree_path
+        mock_db_delete.return_value = True
+
+        result = delete_terminal("test1234")
+
+        assert result is True
+        mock_worktree_service.remove_worktree.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.terminal_service.worktree_service")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_delete_terminal")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_a_non_string_live_cwd_from_the_backend_does_not_raise(
+        self,
+        mock_get_metadata,
+        mock_tmux,
+        mock_provider_manager,
+        mock_db_delete,
+        mock_fifo_manager,
+        mock_status_monitor,
+        mock_worktree_service,
+    ):
+        """Regression: an unconfigured/misbehaving backend call returning
+        something other than str | None (e.g. a raw mock/object in a test
+        double, or a defensive future change elsewhere) must degrade to
+        'not a worktree', not propagate into a real subprocess call two
+        steps downstream. This is exactly the shape every OTHER
+        TestDeleteTerminal test above relies on implicitly (they never
+        configure get_pane_working_directory)."""
+        from cli_agent_orchestrator.services.worktree_service import (
+            parse_worktree_path as real_parse_worktree_path,
+        )
+
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        # Deliberately NOT a string -- mock_tmux.get_pane_working_directory()
+        # returns a bare MagicMock by default when unconfigured.
+        mock_worktree_service.parse_worktree_path.side_effect = real_parse_worktree_path
+        mock_db_delete.return_value = True
+
+        result = delete_terminal("test1234")  # must not raise
+
+        assert result is True
+        mock_worktree_service.remove_worktree.assert_not_called()
 
 
 class TestDeferredInitFailureNotification:

--- a/test/services/test_worktree_service.py
+++ b/test/services/test_worktree_service.py
@@ -1,0 +1,222 @@
+"""issue #100 Phase 1 -- worktree_service tests.
+
+Covers:
+- ``find_repo_root``: resolves from a subdirectory, raises outside a repo.
+- ``create_worktree`` / ``remove_worktree``: real ``git worktree add``/
+  ``remove``/branch-delete against a real local repo -- no subprocess mocking,
+  same posture as ``test_project_identity.py``'s own real-git tests.
+- ``remove_worktree`` tolerates uncommitted/untracked content left behind
+  (agents commonly leave modified files -- ``--force`` is required for this).
+- ``list_worktrees`` reflects real ``git worktree`` state, including entries
+  ``create_worktree`` did not itself create.
+- ``parse_worktree_path`` round-trips against paths ``worktree_path_for``
+  produces, and rejects unrelated paths.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from cli_agent_orchestrator.services.worktree_service import (
+    WorktreeError,
+    branch_for,
+    create_worktree,
+    find_repo_root,
+    list_worktrees,
+    parse_worktree_path,
+    remove_worktree,
+    worktree_path_for,
+)
+
+
+def _git_available() -> bool:
+    try:
+        subprocess.run(["git", "--version"], capture_output=True, check=True, timeout=2)
+        return True
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _git_available(), reason="git executable required")
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=path, check=True, capture_output=True
+    )
+    (path / "README.md").write_text("hello\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial"], cwd=path, check=True, capture_output=True
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo_path = tmp_path / "repo"
+    _init_repo(repo_path)
+    return repo_path
+
+
+class TestFindRepoRoot:
+    def test_resolves_from_repo_root_itself(self, repo: Path) -> None:
+        assert find_repo_root(str(repo)) == str(repo.resolve())
+
+    def test_resolves_from_a_subdirectory(self, repo: Path) -> None:
+        subdir = repo / "src" / "pkg"
+        subdir.mkdir(parents=True)
+        assert find_repo_root(str(subdir)) == str(repo.resolve())
+
+    def test_raises_outside_any_git_repository(self, tmp_path: Path) -> None:
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        with pytest.raises(WorktreeError, match="is not inside a git repository"):
+            find_repo_root(str(non_repo))
+
+    def test_raises_worktree_error_not_a_raw_os_error_for_a_nonexistent_path(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: a nonexistent start_path (e.g. a typo'd
+        working_directory) must surface as the same clean WorktreeError as
+        'exists but isn't a repo' -- not an uncaught FileNotFoundError from
+        subprocess.run's own cwd resolution, which would reach the API
+        boundary as an unhandled 500 instead of the intended 400."""
+        nonexistent = tmp_path / "does" / "not" / "exist"
+        with pytest.raises(WorktreeError):
+            find_repo_root(str(nonexistent))
+
+
+class TestCreateAndRemoveWorktree:
+    def test_create_worktree_produces_a_real_checkout_on_its_own_branch(self, repo: Path) -> None:
+        terminal_id = "term_abc123"
+        path = create_worktree(str(repo), terminal_id)
+
+        assert Path(path) == Path(worktree_path_for(str(repo), terminal_id))
+        assert (Path(path) / "README.md").is_file()  # real checkout of HEAD's tree
+
+        branch_result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert branch_result.stdout.strip() == branch_for(terminal_id)
+
+        # git itself agrees this is a real worktree of `repo`.
+        list_result = subprocess.run(
+            ["git", "worktree", "list"], cwd=repo, capture_output=True, text=True, check=True
+        )
+        assert path in list_result.stdout
+
+    def test_create_worktree_raises_a_clear_error_outside_a_git_repository(
+        self, tmp_path: Path
+    ) -> None:
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        with pytest.raises(WorktreeError):
+            create_worktree(str(non_repo), "term_xyz")
+
+    def test_remove_worktree_deletes_the_directory_and_the_branch(self, repo: Path) -> None:
+        terminal_id = "term_clean01"
+        path = create_worktree(str(repo), terminal_id)
+
+        remove_worktree(str(repo), terminal_id)
+
+        assert not Path(path).exists()
+        branch_result = subprocess.run(
+            ["git", "branch", "--list", branch_for(terminal_id)],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert branch_result.stdout.strip() == ""
+
+    def test_remove_worktree_force_removes_uncommitted_and_untracked_content(
+        self, repo: Path
+    ) -> None:
+        """Agents commonly leave modified/untracked files behind -- a plain
+        (non-force) ``git worktree remove`` refuses in that case; this must
+        not surface as a failure to the caller (teardown paths call this
+        best-effort and must never raise)."""
+        terminal_id = "term_dirty01"
+        path = create_worktree(str(repo), terminal_id)
+        (Path(path) / "scratch.txt").write_text("uncommitted work\n")
+        (Path(path) / "README.md").write_text("modified\n")
+
+        remove_worktree(str(repo), terminal_id)  # must not raise
+
+        assert not Path(path).exists()
+
+    def test_remove_worktree_on_an_already_removed_worktree_does_not_raise(
+        self, repo: Path
+    ) -> None:
+        terminal_id = "term_gone01"
+        create_worktree(str(repo), terminal_id)
+        remove_worktree(str(repo), terminal_id)
+
+        remove_worktree(str(repo), terminal_id)  # second call: must not raise
+
+    def test_remove_worktree_on_a_nonexistent_repo_root_does_not_raise(self) -> None:
+        """Regression: this function's own docstring promises 'never raises'
+        (both terminal_service.delete_terminal's teardown path and
+        create_terminal's own failure-cleanup path call it with no
+        try/except, relying on that contract). A repo_root that no longer
+        exists on disk (e.g. the parent clone was itself deleted between
+        worktree creation and teardown) previously raised an uncaught
+        FileNotFoundError from subprocess.run's own cwd resolution."""
+        remove_worktree("/definitely/not/a/real/repo/root/anywhere", "term_x")  # must not raise
+
+
+class TestListWorktrees:
+    def test_lists_the_main_checkout_and_every_created_worktree(self, repo: Path) -> None:
+        create_worktree(str(repo), "term_one")
+        create_worktree(str(repo), "term_two")
+
+        entries = list_worktrees(str(repo))
+
+        paths = {e["worktree"] for e in entries if "worktree" in e}
+        assert str(repo.resolve()) in paths
+        assert worktree_path_for(str(repo), "term_one") in paths
+        assert worktree_path_for(str(repo), "term_two") in paths
+
+    def test_raises_outside_a_git_repository(self, tmp_path: Path) -> None:
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        with pytest.raises(WorktreeError):
+            list_worktrees(str(non_repo))
+
+
+class TestParseWorktreePath:
+    def test_round_trips_against_worktree_path_for(self) -> None:
+        repo_root = "/home/user/myrepo"
+        terminal_id = "term_9f8e7d"
+        path = worktree_path_for(repo_root, terminal_id)
+
+        parsed = parse_worktree_path(path)
+
+        assert parsed == (repo_root, terminal_id)
+
+    def test_returns_none_for_a_path_outside_any_worktree_subdir(self) -> None:
+        assert parse_worktree_path("/home/user/myrepo/src/pkg") is None
+
+    def test_returns_none_for_none(self) -> None:
+        assert parse_worktree_path(None) is None
+
+    def test_returns_none_for_a_worktree_subdir_path_with_no_terminal_segment(self) -> None:
+        # `.cao/worktrees` itself, or a nested extra path segment past the
+        # terminal_id -- neither is a valid single terminal_id leaf.
+        assert parse_worktree_path("/home/user/myrepo/.cao/worktrees/") is None
+        assert parse_worktree_path("/home/user/myrepo/.cao/worktrees/term_x/extra") is None

--- a/test/services/test_worktree_service.py
+++ b/test/services/test_worktree_service.py
@@ -128,6 +128,30 @@ class TestCreateAndRemoveWorktree:
         with pytest.raises(WorktreeError):
             create_worktree(str(non_repo), "term_xyz")
 
+    def test_create_worktree_gitignores_the_worktrees_subdir(self, repo: Path) -> None:
+        # Without this, every `git status` in the main checkout shows the
+        # provisioned worktree as an untracked/embedded-repo gitlink, and
+        # `git add -A` there (agents do this constantly) stages it.
+        create_worktree(str(repo), "term_first")
+
+        gitignore = repo / ".cao" / "worktrees" / ".gitignore"
+        assert gitignore.is_file()
+        assert gitignore.read_text() == "*\n"
+
+        status = subprocess.run(
+            ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True, check=True
+        )
+        assert ".cao" not in status.stdout
+
+    def test_create_worktree_does_not_clobber_an_existing_gitignore(self, repo: Path) -> None:
+        create_worktree(str(repo), "term_first")
+        gitignore = repo / ".cao" / "worktrees" / ".gitignore"
+        gitignore.write_text("custom\n")
+
+        create_worktree(str(repo), "term_second")
+
+        assert gitignore.read_text() == "custom\n"
+
     def test_remove_worktree_deletes_the_directory_and_the_branch(self, repo: Path) -> None:
         terminal_id = "term_clean01"
         path = create_worktree(str(repo), terminal_id)
@@ -143,6 +167,36 @@ class TestCreateAndRemoveWorktree:
             check=True,
         )
         assert branch_result.stdout.strip() == ""
+
+    def test_remove_worktree_retains_a_branch_with_unmerged_commits(self, repo: Path) -> None:
+        """A worker that committed real work to its branch before completing
+        must not have that history destroyed just because Phase 1 has no
+        merge-back story -- the worktree's working-tree contents are force
+        -discarded, but the branch itself is only safe-deleted (``git branch
+        -d``), which refuses when there are commits that would be lost."""
+        terminal_id = "term_committed01"
+        path = create_worktree(str(repo), terminal_id)
+        (Path(path) / "result.txt").write_text("important output\n")
+        subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "worker output"],
+            cwd=path,
+            check=True,
+            capture_output=True,
+        )
+
+        remove_worktree(str(repo), terminal_id)  # must not raise
+
+        assert not Path(path).exists()  # worktree checkout itself is gone
+        branch_result = subprocess.run(
+            ["git", "branch", "--list", branch_for(terminal_id)],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Branch survives -- a leak for Phase 3 to sweep, not data loss.
+        assert branch_for(terminal_id) in branch_result.stdout
 
     def test_remove_worktree_force_removes_uncommitted_and_untracked_content(
         self, repo: Path
@@ -215,8 +269,33 @@ class TestParseWorktreePath:
     def test_returns_none_for_none(self) -> None:
         assert parse_worktree_path(None) is None
 
-    def test_returns_none_for_a_worktree_subdir_path_with_no_terminal_segment(self) -> None:
-        # `.cao/worktrees` itself, or a nested extra path segment past the
-        # terminal_id -- neither is a valid single terminal_id leaf.
+    def test_returns_none_for_the_worktrees_dir_itself_with_no_terminal_segment(self) -> None:
         assert parse_worktree_path("/home/user/myrepo/.cao/worktrees/") is None
-        assert parse_worktree_path("/home/user/myrepo/.cao/worktrees/term_x/extra") is None
+
+    def test_accepts_a_subdirectory_of_the_worktree(self) -> None:
+        # tmux reports the pane's CURRENT directory (pane_current_path); a
+        # worker that `cd`s into a subdirectory of its own worktree (very
+        # likely) must still be recognized as worktree-backed at teardown,
+        # or the worktree/branch leaks silently.
+        assert parse_worktree_path("/home/user/myrepo/.cao/worktrees/term_x/extra") == (
+            "/home/user/myrepo",
+            "term_x",
+        )
+        assert parse_worktree_path("/home/user/myrepo/.cao/worktrees/term_x/deeply/nested/dir") == (
+            "/home/user/myrepo",
+            "term_x",
+        )
+
+    def test_resolves_the_innermost_worktree_under_nesting(self) -> None:
+        # A worktree-backed supervisor (terminal A) spawning a worktree-backed
+        # worker (terminal B) nests B's worktree under A's:
+        # <repo_root>/.cao/worktrees/A/.cao/worktrees/B. `rfind` (last
+        # marker occurrence) must resolve to B's own (repo_root, terminal_id)
+        # -- repo_root being A's worktree root -- not fail to parse (`find`,
+        # first occurrence, would yield terminal_id "A/.cao/worktrees/B",
+        # rejected for containing a path separator, leaking B).
+        nested = "/home/user/myrepo/.cao/worktrees/term_a/.cao/worktrees/term_b"
+        assert parse_worktree_path(nested) == (
+            "/home/user/myrepo/.cao/worktrees/term_a",
+            "term_b",
+        )


### PR DESCRIPTION
Closes the Phase 1 slice of #100, per your own 2026-03-12 comment there suggesting exactly this phased breakdown:

> Phase 1: `worktree_service.py` + integration with `handoff`/`assign` via `use_worktree` field
> Phase 2: `--enable-worktrees` global flag on `cao launch`
> Phase 3: `cao worktrees clean` CLI command

That comment sat unanswered for a while, so — belatedly — here's a concrete Phase 1 implementation. Deliberately scoped to *only* that: no `--enable-worktrees` flag, no `cao worktrees clean` command, kept out on purpose to keep this reviewable-sized. Happy to follow up with Phase 2/3 as separate PRs if this shape looks right to you.

## What this does

When a supervisor spawns a worker via `handoff` or `assign` with `use_worktree=true`, the worker gets an isolated `git worktree` checkout on its own branch (from the resolved repo's current `HEAD`) instead of sharing the caller's working directory — closing the "all workers share the same Git branch and working directory" race the issue describes.

- **New `worktree_service.py`**: `find_repo_root`, `create_worktree`, `remove_worktree`, `list_worktrees` — plain `git` subprocess calls, no new dependencies.
- **No new CAO-side persistence.** A worktree's path (`<repo_root>/.cao/worktrees/<terminal_id>`) and branch (`cao/<terminal_id>`) are both derived deterministically from the `terminal_id` CAO already generates fresh per terminal, so `create_terminal`/`delete_terminal` can locate a worktree at teardown time from the terminal_id alone — git's own `.git/worktrees` bookkeeping is the single source of truth, no schema/DB change.
- **`terminal_service.create_terminal()`** provisions the worktree before the tmux session/window is created, and overrides `working_directory` to it. If a later step in the same call fails, the existing failure-cleanup path rolls the worktree back too. **`delete_terminal()`** reuses the live pane cwd it already reads for its snapshot feature to recognize a worktree-backed terminal and remove it — again, no schema change.
- **`handoff`** (`RunStepRequest`/`/terminals/run-step`) and **`assign`** (`create_terminal_in_session`, as a query param) both thread `use_worktree` through. A new `WorktreeError` maps to `400`, matching how `ValueError` already maps to `404` in the same handlers.
- **`docs/api.md`** updated alongside the existing `defer_init` entry for the same endpoint.

## Testing

- New `test/services/test_worktree_service.py` runs against **real local git repos** (no subprocess mocking), matching this repo's own `test_project_identity.py` precedent for real-git tests.
- Wiring tests added across `terminal_service`, `agent_step`, `api/main.py`, and both `mcp_server` tool layers.
- Full suite: `5147 passed`. There are 61 pre-existing failures on `main` unrelated to this change (missing optional `ag_ui` dependency in this dev environment — `test/services/agui/`, `test/telemetry/`) — verified the exact same 61 test names fail identically with and without this diff.
- `worktree_service.py` itself: 98% coverage.
- `black`/`isort`/`mypy` all clean on every touched file.

## A note on process, since you might wonder about the shape of the diff

This went through an internal adversarial review pass before I opened it (not just my own read of the diff) — that pass found and I fixed two real bugs: `remove_worktree`'s "never raises" contract and `find_repo_root`'s "always raises `WorktreeError`" contract were both false for an unreadable/nonexistent directory (a raw `OSError`/`FileNotFoundError` from `subprocess.run`'s own `cwd` resolution escaped uncaught in both). Both shared one root cause, fixed once in `_run_git`, with regression tests reproducing each failure mode directly rather than just asserting the fix exists.

## Open questions for you

- Default worktree location (`<repo_root>/.cao/worktrees/<terminal_id>`) matches the issue's own stated default. A couple of commenters on #100 mentioned preferring worktrees stored outside the repo (avoiding parent-repo file-watcher noise) — that's naturally what `--worktree-path` (Phase 2) would control; happy to adjust the Phase 1 default too if you'd rather not wait for Phase 2 to land.
- Cleanup today only happens via the worker's own terminal teardown (`delete_terminal`) — if a worker's terminal is somehow never deleted, its worktree leaks until `cao worktrees clean` (Phase 3) exists. Worth flagging explicitly since Phase 3 isn't in this PR.