### PR TITLE
fix(assign): prevent deferred-init retry loop from re-pasting into working OpenCode workers

### DIFF
--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -157,6 +157,13 @@ class BaseProvider(ABC):
     # depends on raw \r) whose detectors are tuned for the raw stream.
     supports_screen_detection: bool = False
 
+    # Opt-in for the deferred-init direct status probe (capture-pane bypass).
+    # Set True on providers whose get_status() detector is line-oriented and
+    # works correctly on a rendered capture-pane snapshot. Providers whose
+    # get_status() relies on dispatch bookkeeping (e.g. kiro_cli) must leave
+    # this False — their COMPLETED/IDLE split is not screen-detectable.
+    supports_direct_status_probe: bool = False
+
     def get_status_from_screen(self, screen_lines: List[str]) -> TerminalStatus:
         """Detect status from a pyte-rendered screen (composited viewport).
 

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -104,6 +104,13 @@ class OpenCodeCliProvider(BaseProvider):
         return 1
 
     @property
+    def paste_submit_delay(self) -> float:
+        """OpenCode's Ink-based input widget can swallow an Enter sent too soon after
+        the bracketed-paste end marker. 1.0s (matching kiro_cli) is conservative and
+        avoids the deferred-init "never started processing" race (see #479)."""
+        return 1.0
+
+    @property
     def extraction_tail_lines(self) -> int:
         """Capture extra scrollback for extraction (belt-and-braces).
 

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -105,10 +105,17 @@ class OpenCodeCliProvider(BaseProvider):
 
     @property
     def paste_submit_delay(self) -> float:
-        """OpenCode's Ink-based input widget can swallow an Enter sent too soon after
-        the bracketed-paste end marker. 1.0s (matching kiro_cli) is conservative and
-        avoids the deferred-init "never started processing" race (see #479)."""
+        """OpenCode's TUI can swallow an Enter sent too soon after the bracketed-paste
+        end marker. 1.0s (matching kiro_cli) is conservative and avoids the
+        deferred-init "never started processing" race (see #479)."""
         return 1.0
+
+    # Opt-in for the deferred-init direct status probe (capture-pane bypass).
+    # OpenCode's get_status() detector is line-oriented and works correctly on a
+    # rendered capture-pane snapshot. Providers whose get_status() relies on
+    # dispatch bookkeeping (e.g. kiro_cli, antigravity_cli, cursor_cli) must NOT
+    # set this flag — their COMPLETED/IDLE split is not screen-detectable.
+    supports_direct_status_probe = True
 
     @property
     def extraction_tail_lines(self) -> int:

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -578,6 +578,12 @@ def _worker_is_started_direct(terminal_id: str, provider) -> bool:
     (not the 8 KB rolling buffer, which is too small to reliably hold the
     footer) and calls ``provider.get_status()`` directly, catching the real
     state so the retry loop doesn't re-deliver into a working terminal.
+
+    Only providers that set ``supports_direct_status_probe = True`` should
+    be passed to this function; the ``get_status()`` contract for other
+    providers (e.g. kiro_cli, antigravity_cli, cursor_cli) relies on
+    dispatch bookkeeping and cannot distinguish IDLE from COMPLETED on a
+    rendered capture-pane snapshot.
     """
     try:
         metadata = get_terminal_metadata(terminal_id)
@@ -588,9 +594,14 @@ def _worker_is_started_direct(terminal_id: str, provider) -> bool:
         if not session_name or not window_name:
             return False
         output = get_backend().get_history(session_name, window_name, tail_lines=200)
+        status = provider.get_status(output)
     except Exception:
+        logger.debug(
+            "Direct status probe for %s failed (falling through to cached path)",
+            terminal_id,
+            exc_info=True,
+        )
         return False
-    status = provider.get_status(output)
     return status in _DEFERRED_STARTED_STATUSES
 
 
@@ -641,12 +652,14 @@ async def _confirm_worker_started_or_resubmit(
     for attempt in range(1, _DEFERRED_SUBMIT_MAX_RESUBMITS + 1):
         # The cached status_monitor status is event-driven (pyte screener at
         # rising-edge/quiescence only) and can lag behind reality. Before
-        # re-delivering, do a direct raw-buffer check via the provider to
-        # catch cases where the worker IS processing but the cached status
-        # hasn't caught up yet (e.g. OpenCode's ``esc interrupt`` footer
-        # appearing between pyte detection edges).
-        if provider is not None and _worker_is_started_direct(terminal_id, provider):
-            return True
+        # re-delivering, do a direct capture-pane / visible-screen check via
+        # the provider to catch cases where the worker IS processing but the
+        # cached status hasn't caught up yet (e.g. OpenCode's ``esc interrupt``
+        # footer appearing between pyte detection edges). Only providers that
+        # opt in via ``supports_direct_status_probe = True`` take this path.
+        if provider is not None and getattr(provider, "supports_direct_status_probe", False):
+            if await asyncio.to_thread(_worker_is_started_direct, terminal_id, provider):
+                return True
 
         if await asyncio.to_thread(_message_visible_in_box, terminal_id, message):
             logger.warning(

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -565,6 +565,35 @@ _DEFERRED_STARTED_STATUSES = {
 }
 
 
+def _worker_is_started_direct(terminal_id: str, provider) -> bool:
+    """Direct visible-screen status check bypassing the event-driven status cache.
+
+    The deferred-init retry loop polls ``status_monitor.get_status()`` which
+    returns the **cached** status updated only by the event-driven pipeline
+    (pyte screener at rising-edge/quiescence edges). When that lags behind
+    reality the cached status stays IDLE even though the worker already
+    transitioned to PROCESSING.
+
+    This function does a live ``capture-pane`` to grab the visible screen
+    (not the 8 KB rolling buffer, which is too small to reliably hold the
+    footer) and calls ``provider.get_status()`` directly, catching the real
+    state so the retry loop doesn't re-deliver into a working terminal.
+    """
+    try:
+        metadata = get_terminal_metadata(terminal_id)
+        if not metadata:
+            return False
+        session_name = metadata.get("tmux_session")
+        window_name = metadata.get("tmux_window")
+        if not session_name or not window_name:
+            return False
+        output = get_backend().get_history(session_name, window_name, tail_lines=200)
+    except Exception:
+        return False
+    status = provider.get_status(output)
+    return status in _DEFERRED_STARTED_STATUSES
+
+
 def _message_visible_in_box(terminal_id: str, message: str) -> bool:
     """True when the delivered message is still sitting in the input box.
 
@@ -593,6 +622,7 @@ async def _confirm_worker_started_or_resubmit(
     registry: "PluginRegistry | None",
     sender_id: Optional[str],
     orchestration_type: Optional[OrchestrationType],
+    provider=None,
 ) -> bool:
     """Confirm a deferred-init worker began processing; re-submit if not.
 
@@ -609,6 +639,15 @@ async def _confirm_worker_started_or_resubmit(
         return True
 
     for attempt in range(1, _DEFERRED_SUBMIT_MAX_RESUBMITS + 1):
+        # The cached status_monitor status is event-driven (pyte screener at
+        # rising-edge/quiescence only) and can lag behind reality. Before
+        # re-delivering, do a direct raw-buffer check via the provider to
+        # catch cases where the worker IS processing but the cached status
+        # hasn't caught up yet (e.g. OpenCode's ``esc interrupt`` footer
+        # appearing between pyte detection edges).
+        if provider is not None and _worker_is_started_direct(terminal_id, provider):
+            return True
+
         if await asyncio.to_thread(_message_visible_in_box, terminal_id, message):
             logger.warning(
                 "Deferred assign to %s unsubmitted (Enter swallowed); "
@@ -702,6 +741,7 @@ def _schedule_deferred_init(
                     registry,
                     caller_id,
                     orchestration_type,
+                    provider=provider_instance,
                 )
                 if not started:
                     logger.error(

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -535,6 +535,16 @@ class TestMiscInterface:
         """extraction_tail_lines must be large enough for long-response agents."""
         assert make_provider().extraction_tail_lines == 2000
 
+    def test_paste_submit_delay_is_1_0(self):
+        """paste_submit_delay must exceed BaseProvider's 0.3s default to reduce
+        Enter-swallowing after bracketed paste (see #479 and #496)."""
+        assert make_provider().paste_submit_delay == 1.0
+
+    def test_supports_direct_status_probe_is_true(self):
+        """The deferred-init retry loop uses this opt-in flag to gate the
+        capture-pane direct status probe; only OpenCode currently sets it."""
+        assert make_provider().supports_direct_status_probe is True
+
 
 # ---------------------------------------------------------------------------
 # Provider manager registration

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -98,3 +98,132 @@ class TestConfirmWorkerStartedOrResubmit:
                 "t1", "Analyze the logs", None, "sup", None
             )
         assert ok is False
+
+    async def test_direct_probe_short_circuits_when_worker_started(self):
+        # Provider with supports_direct_status_probe=True + direct probe True →
+        # returns True without calling send_input or send_special_key.
+        provider = MagicMock(supports_direct_status_probe=True)
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
+            patch.object(ts, "_worker_is_started_direct", return_value=True),
+            patch.object(ts, "send_special_key") as key,
+            patch.object(ts, "send_input") as send,
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", None, "sup", None, provider=provider,
+            )
+        assert ok is True
+        key.assert_not_called()
+        send.assert_not_called()
+
+    async def test_direct_probe_falls_through_when_worker_not_started(self):
+        # Direct probe returns False → continues to existing resubmit logic.
+        provider = MagicMock(supports_direct_status_probe=True)
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(ts, "_worker_is_started_direct", return_value=False),
+            patch.object(ts, "_message_visible_in_box", return_value=True),
+            patch.object(ts, "send_special_key") as key,
+            patch.object(ts, "send_input") as send,
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", None, "sup", None, provider=provider,
+            )
+        assert ok is True
+        key.assert_called_once()
+        send.assert_not_called()
+
+    async def test_direct_probe_skipped_when_provider_not_opted_in(self):
+        # Provider without supports_direct_status_probe → direct probe never
+        # invoked; falls through to existing resubmit logic.
+        provider = MagicMock(supports_direct_status_probe=False)
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(ts, "_worker_is_started_direct") as probe,
+            patch.object(ts, "_message_visible_in_box", return_value=True),
+            patch.object(ts, "send_special_key"),
+            patch.object(ts, "send_input"),
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", None, "sup", None, provider=provider,
+            )
+        assert ok is True
+        probe.assert_not_called()
+
+    async def test_provider_none_skips_direct_probe(self):
+        # The existing None-provider path still works unchanged.
+        with (
+            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(ts, "_worker_is_started_direct") as probe,
+            patch.object(ts, "_message_visible_in_box", return_value=True),
+            patch.object(ts, "send_special_key"),
+            patch.object(ts, "send_input"),
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", "Analyze the logs", None, "sup", None, provider=None,
+            )
+        assert ok is True
+        probe.assert_not_called()
+
+
+class TestWorkerIsStartedDirect:
+    """Unit tests for the capture-pane direct status probe."""
+
+    def test_returns_false_when_metadata_is_none(self):
+        with patch.object(ts, "get_terminal_metadata", return_value=None):
+            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+
+    def test_returns_false_when_session_key_missing(self):
+        with patch.object(ts, "get_terminal_metadata", return_value={"tmux_window": "w1"}):
+            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+
+    def test_returns_false_when_window_key_missing(self):
+        with patch.object(ts, "get_terminal_metadata", return_value={"tmux_session": "s1"}):
+            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+
+    def test_returns_false_when_get_history_raises(self):
+        with (
+            patch.object(ts, "get_terminal_metadata", return_value={
+                "tmux_session": "s1", "tmux_window": "w1",
+            }),
+            patch.object(ts, "get_backend") as mock_be,
+        ):
+            mock_be.return_value.get_history.side_effect = Exception("capture failed")
+            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+
+    def test_returns_false_when_get_status_raises(self):
+        provider = MagicMock()
+        provider.get_status.side_effect = Exception("parse failure")
+        with (
+            patch.object(ts, "get_terminal_metadata", return_value={
+                "tmux_session": "s1", "tmux_window": "w1",
+            }),
+            patch.object(ts, "get_backend") as mock_be,
+        ):
+            assert ts._worker_is_started_direct("t1", provider) is False
+
+    def test_returns_true_when_status_is_processing(self):
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+        provider = MagicMock()
+        provider.get_status.return_value = TerminalStatus.PROCESSING
+        with (
+            patch.object(ts, "get_terminal_metadata", return_value={
+                "tmux_session": "s1", "tmux_window": "w1",
+            }),
+            patch.object(ts, "get_backend") as mock_be,
+        ):
+            assert ts._worker_is_started_direct("t1", provider) is True
+
+    def test_returns_false_when_status_is_idle(self):
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+        provider = MagicMock()
+        provider.get_status.return_value = TerminalStatus.IDLE
+        with (
+            patch.object(ts, "get_terminal_metadata", return_value={
+                "tmux_session": "s1", "tmux_window": "w1",
+            }),
+            patch.object(ts, "get_backend") as mock_be,
+        ):
+            assert ts._worker_is_started_direct("t1", provider) is False

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -110,7 +110,12 @@ class TestConfirmWorkerStartedOrResubmit:
             patch.object(ts, "send_input") as send,
         ):
             ok = await ts._confirm_worker_started_or_resubmit(
-                "t1", "Analyze the logs", None, "sup", None, provider=provider,
+                "t1",
+                "Analyze the logs",
+                None,
+                "sup",
+                None,
+                provider=provider,
             )
         assert ok is True
         key.assert_not_called()
@@ -127,7 +132,12 @@ class TestConfirmWorkerStartedOrResubmit:
             patch.object(ts, "send_input") as send,
         ):
             ok = await ts._confirm_worker_started_or_resubmit(
-                "t1", "Analyze the logs", None, "sup", None, provider=provider,
+                "t1",
+                "Analyze the logs",
+                None,
+                "sup",
+                None,
+                provider=provider,
             )
         assert ok is True
         key.assert_called_once()
@@ -145,7 +155,12 @@ class TestConfirmWorkerStartedOrResubmit:
             patch.object(ts, "send_input"),
         ):
             ok = await ts._confirm_worker_started_or_resubmit(
-                "t1", "Analyze the logs", None, "sup", None, provider=provider,
+                "t1",
+                "Analyze the logs",
+                None,
+                "sup",
+                None,
+                provider=provider,
             )
         assert ok is True
         probe.assert_not_called()
@@ -160,7 +175,12 @@ class TestConfirmWorkerStartedOrResubmit:
             patch.object(ts, "send_input"),
         ):
             ok = await ts._confirm_worker_started_or_resubmit(
-                "t1", "Analyze the logs", None, "sup", None, provider=None,
+                "t1",
+                "Analyze the logs",
+                None,
+                "sup",
+                None,
+                provider=None,
             )
         assert ok is True
         probe.assert_not_called()
@@ -183,9 +203,14 @@ class TestWorkerIsStartedDirect:
 
     def test_returns_false_when_get_history_raises(self):
         with (
-            patch.object(ts, "get_terminal_metadata", return_value={
-                "tmux_session": "s1", "tmux_window": "w1",
-            }),
+            patch.object(
+                ts,
+                "get_terminal_metadata",
+                return_value={
+                    "tmux_session": "s1",
+                    "tmux_window": "w1",
+                },
+            ),
             patch.object(ts, "get_backend") as mock_be,
         ):
             mock_be.return_value.get_history.side_effect = Exception("capture failed")
@@ -195,9 +220,14 @@ class TestWorkerIsStartedDirect:
         provider = MagicMock()
         provider.get_status.side_effect = Exception("parse failure")
         with (
-            patch.object(ts, "get_terminal_metadata", return_value={
-                "tmux_session": "s1", "tmux_window": "w1",
-            }),
+            patch.object(
+                ts,
+                "get_terminal_metadata",
+                return_value={
+                    "tmux_session": "s1",
+                    "tmux_window": "w1",
+                },
+            ),
             patch.object(ts, "get_backend") as mock_be,
         ):
             assert ts._worker_is_started_direct("t1", provider) is False
@@ -208,9 +238,14 @@ class TestWorkerIsStartedDirect:
         provider = MagicMock()
         provider.get_status.return_value = TerminalStatus.PROCESSING
         with (
-            patch.object(ts, "get_terminal_metadata", return_value={
-                "tmux_session": "s1", "tmux_window": "w1",
-            }),
+            patch.object(
+                ts,
+                "get_terminal_metadata",
+                return_value={
+                    "tmux_session": "s1",
+                    "tmux_window": "w1",
+                },
+            ),
             patch.object(ts, "get_backend") as mock_be,
         ):
             assert ts._worker_is_started_direct("t1", provider) is True
@@ -221,9 +256,14 @@ class TestWorkerIsStartedDirect:
         provider = MagicMock()
         provider.get_status.return_value = TerminalStatus.IDLE
         with (
-            patch.object(ts, "get_terminal_metadata", return_value={
-                "tmux_session": "s1", "tmux_window": "w1",
-            }),
+            patch.object(
+                ts,
+                "get_terminal_metadata",
+                return_value={
+                    "tmux_session": "s1",
+                    "tmux_window": "w1",
+                },
+            ),
             patch.object(ts, "get_backend") as mock_be,
         ):
             assert ts._worker_is_started_direct("t1", provider) is False


### PR DESCRIPTION
### Issue
When a deferred-init worker (assign) is created, the retry loop from #479
repeatedly re-pastes the task message into the terminal because
`status_monitor.get_status()` returns a cached value that lags behind
reality. The pyte screener only detects status at rising-edge and quiescence
edges — never mid-burst — so the IDLE→PROCESSING transition for OpenCode's
`esc interrupt` footer is often missed. The loop then re-delivers the full
message into a worker that is already processing, corrupting the session.

### Root cause
Two issues compound:
1. **Detection gap**: `status_monitor.get_status()` returns the cached
   event-driven status. When pyte misses a transition edge, the cached
   value stays IDLE even though the worker's TUI shows `esc interrupt`.
2. **Tight submit delay**: `opencode_cli` inherits `paste_submit_delay=0.3s`
   from BaseProvider — the shortest of any provider (kiro_cli: 1.0s,
   claude_code: 2.0s) — which increases the chance of the Enter being
   swallowed in the first place.

### Changes
1. **`opencode_cli.py`**: Override `paste_submit_delay` to 1.0s (matching
   kiro_cli), giving OpenCode's Ink-based input widget time to process the
   bracketed-paste end marker before Enter fires.

2. **`terminal_service.py`**: Add `_worker_is_started_direct()` which
   performs a live `capture-pane` and calls `provider.get_status()` directly
   on the visible screen content, bypassing the cached `status_monitor`
   value. Called before each resubmit decision in
   `_confirm_worker_started_or_resubmit()`.

### Testing
Reproduced the issue with OpenCode workers on `cao launch` + `assign`.
The retry loop no longer re-pastes into working terminals, and the
`paste_submit_delay` bump reduces Enter-swallowing on initial delivery.