### PR TITLE
fix(tmux): skip bracketed-paste wrap when the pane is a bare shell

### DIFF
--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -58,6 +58,7 @@ _HERDR_ALLOWED_FLAGS = frozenset(
         "--format",
         "--label",
         "--lines",
+        "--pane",
         "--source",
         "--workspace",
     }
@@ -577,17 +578,32 @@ class HerdrBackend(TerminalBackend):
             return None
 
     def get_pane_current_command(self, session_name: str, window_name: str) -> Optional[str]:
-        """Get foreground process via herdr pane get."""
+        """Get the pane's live foreground process name via ``herdr pane
+        process-info``.
+
+        NOT ``herdr pane get``: that command's ``foreground_process`` field
+        is null/absent across all pane states on herdr 0.7.5 (confirmed
+        live against a running herdr server), so this callable would always
+        return ``None`` and every caller that branches on it (this class's
+        own ``_pane_is_bracketed_paste_incompatible``, plus
+        ``codex``/``kiro_cli``'s ``shell_baseline`` TUI-exit detection) would
+        silently never fire on herdr. ``pane process-info`` instead reports
+        real process names (``"bash"``, ``"claude"``, etc.) via
+        ``foreground_processes``.
+        """
         pane_id = self._resolve_pane_id_from_window(session_name, window_name)
 
-        result = self._run_herdr(["pane", "get", pane_id], check=False)
+        result = self._run_herdr(["pane", "process-info", "--pane", pane_id], check=False)
         if result.returncode != 0:
             return None
         try:
             data = self._parse_herdr_json(result.stdout)
-            pane_info = data.get("pane", data) if isinstance(data, dict) else data
-            return cast(Optional[str], pane_info.get("foreground_process"))
-        except (json.JSONDecodeError, AttributeError):
+            info = data.get("pane", data) if isinstance(data, dict) else data
+            processes = info.get("foreground_processes")
+            if not processes:
+                return None
+            return cast(Optional[str], processes[0].get("name"))
+        except (json.JSONDecodeError, AttributeError, IndexError, TypeError):
             return None
 
     # --- Attach ---

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -24,6 +24,7 @@ from cli_agent_orchestrator.backends.base import (
     TerminalBackendError,
     TerminalNotFoundError,
 )
+from cli_agent_orchestrator.constants import BRACKETED_PASTE_INCOMPATIBLE_SHELLS
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 
 logger = logging.getLogger(__name__)
@@ -439,6 +440,17 @@ class HerdrBackend(TerminalBackend):
 
     # --- Input ---
 
+    def _pane_is_bracketed_paste_incompatible(self, session_name: str, window_name: str) -> bool:
+        """Whether the pane's live foreground command is a known shell.
+
+        Mirrors ``TmuxClient._pane_is_bracketed_paste_incompatible`` (clients/
+        tmux.py) -- see that method's own docstring for the failure mode this
+        guards against. Fails closed to "compatible" (returns False) on any
+        lookup failure or unrecognized command name.
+        """
+        command = self.get_pane_current_command(session_name, window_name)
+        return command is not None and command in BRACKETED_PASTE_INCOMPATIBLE_SHELLS
+
     def send_keys(
         self,
         session_name: str,
@@ -465,10 +477,23 @@ class HerdrBackend(TerminalBackend):
         # which maps to a terminal in the DB. We'll resolve via the pane list.
         pane_id = self._resolve_pane_id_from_window(session_name, window_name)
 
-        # Wrap in bracketed paste sequences when requested.
-        # herdr pane send-text writes raw bytes to the pty, so escape sequences
-        # pass through to the running process unchanged — same behavior as tmux.
-        if force_bracketed_paste:
+        # Wrap in bracketed paste sequences when requested -- UNLESS the pane's
+        # live foreground process is a known shell (see
+        # BRACKETED_PASTE_INCOMPATIBLE_SHELLS' own docstring in constants.py):
+        # a bare shell doesn't understand the escape sequences and glues them
+        # onto the first token of whatever's sent, corrupting it. Same
+        # tmux-backend fix (clients/tmux.py's
+        # _pane_is_bracketed_paste_incompatible), mirrored here since herdr's
+        # ``pane send-text`` writes raw bytes to the pty just like tmux's
+        # paste-buffer -- the same corruption is equally possible here, and
+        # herdr already exposes the same get_pane_current_command primitive.
+        # Fails closed to "compatible" (wraps, existing behavior) on a lookup
+        # failure or unrecognized command name. Only probed when
+        # force_bracketed_paste is actually requested -- an extra herdr
+        # round-trip whose result would otherwise be discarded.
+        if force_bracketed_paste and not self._pane_is_bracketed_paste_incompatible(
+            session_name, window_name
+        ):
             text = "\x1b[200~" + keys + "\x1b[201~"
         else:
             text = keys

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -10,7 +10,10 @@ from typing import Dict, List, Optional
 
 import libtmux
 
-from cli_agent_orchestrator.constants import TMUX_HISTORY_LINES
+from cli_agent_orchestrator.constants import (
+    BRACKETED_PASTE_INCOMPATIBLE_SHELLS,
+    TMUX_HISTORY_LINES,
+)
 from cli_agent_orchestrator.utils.path_validation import (
     BLOCKED_SYSTEM_DIRECTORIES,
     resolve_and_validate_path,
@@ -273,6 +276,27 @@ class TmuxClient:
                 cls._paste_buffer_sanitizes = True
         return cls._paste_buffer_sanitizes
 
+    def _pane_is_bracketed_paste_incompatible(self, session_name: str, window_name: str) -> bool:
+        """Whether the pane's live foreground command is a known shell.
+
+        Used by ``send_keys(force_bracketed_paste=True)`` to avoid gluing
+        bracketed-paste escape sequences onto a bare shell prompt that
+        doesn't understand them (see BRACKETED_PASTE_INCOMPATIBLE_SHELLS'
+        own docstring for the failure mode). Reuses the same
+        ``#{pane_current_command}`` probe already trusted elsewhere in this
+        codebase for an equivalent "has the TUI exited back to a shell?"
+        check (``codex.py``/``kiro_cli.py``'s own ``shell_baseline``
+        comparison in ``get_status()``).
+
+        Fails closed to "compatible" (returns False) on any lookup failure
+        or an unrecognized command name -- an unknown foreground process is
+        assumed to be a real TUI expecting bracketed paste, preserving the
+        existing behavior for every case this function can't positively
+        rule out.
+        """
+        command = self.get_pane_current_command(session_name, window_name)
+        return command is not None and command in BRACKETED_PASTE_INCOMPATIBLE_SHELLS
+
     def send_keys(
         self,
         session_name: str,
@@ -298,27 +322,42 @@ class TmuxClient:
                 Some TUIs enter multi-line mode after bracketed paste,
                 requiring 2 Enters to submit.
             force_bracketed_paste: If True, guarantee bracketed-paste framing
-                for message delivery to TUIs. On tmux < 3.7 this wraps the
-                buffer in hand-crafted \x1b[200~...\x1b[201~ markers and
-                pastes with -r (no LF->CR conversion) — required because
-                paste-buffer -p only emits markers when the pane enabled
-                DECSET 2004, and some TUIs (e.g. kiro-cli) never do, so under
-                -p their multi-line messages would submit per-line (#230). On
-                tmux >= 3.7 the wrap is impossible: pasted buffer content
-                passes through vis(3) sanitization (hardening against
-                bracket-end injection), turning each raw ESC into the literal
-                two characters "^[" — hand-crafted markers render as visible
-                "^[[200~" garbage in the receiving TUI (issue #413). There we
-                paste raw content with -p, which emits genuine 0x1b markers
-                conditionally on the pane's DECSET 2004 state; non-2004 panes
-                receive raw text and multi-line content submits per-line
-                (tmux-sanctioned paste semantics — nothing better exists on
-                >= 3.7 without -S, which is deliberately NOT used because it
-                bypasses the vis(3) hardening and would let worker-authored
-                message bytes smuggle control sequences into a receiving
-                TUI). Do NOT set for shell commands sent to bash during
-                initialization (bash 4.x would receive the literal escape
-                sequences on tmux < 3.7).
+                for message delivery to TUIs -- UNLESS the pane's live
+                foreground command (per #{pane_current_command}) is a known
+                shell (see BRACKETED_PASTE_INCOMPATIBLE_SHELLS), in which
+                case the wrap is skipped entirely and the content is
+                delivered as plain keystrokes instead. A bare shell doesn't
+                understand the escape sequences and glues them onto the
+                first token of the command, corrupting it -- the caller
+                asking for bracketed delivery does not always know the
+                target TUI has already exited (e.g. via its own `/exit`)
+                and left the pane at a shell prompt, so this is checked
+                fresh on every call rather than trusted from the caller's
+                own intent.
+
+                For a pane that IS running a real TUI, how the wrap is
+                applied depends on the tmux version: on tmux < 3.7 this
+                wraps the buffer in hand-crafted \x1b[200~...\x1b[201~
+                markers and pastes with -r (no LF->CR conversion) —
+                required because paste-buffer -p only emits markers when
+                the pane enabled DECSET 2004, and some TUIs (e.g. kiro-cli)
+                never do, so under -p their multi-line messages would
+                submit per-line (#230). On tmux >= 3.7 the hand-crafted wrap
+                is impossible: pasted buffer content passes through vis(3)
+                sanitization (hardening against bracket-end injection),
+                turning each raw ESC into the literal two characters "^["
+                — hand-crafted markers render as visible "^[[200~" garbage
+                in the receiving TUI (issue #413). There we paste raw
+                content with -p, which emits genuine 0x1b markers
+                conditionally on the pane's DECSET 2004 state; non-2004
+                panes receive raw text and multi-line content submits
+                per-line (tmux-sanctioned paste semantics — nothing better
+                exists on >= 3.7 without -S, which is deliberately NOT used
+                because it bypasses the vis(3) hardening and would let
+                worker-authored message bytes smuggle control sequences
+                into a receiving TUI). Do NOT set for shell commands sent
+                to bash during initialization (bash 4.x would receive the
+                literal escape sequences on tmux < 3.7).
         """
         # Defence-in-depth: re-validate at the sink even though callers
         # validate at the API/MCP boundary. Both halves flow into a
@@ -339,33 +378,54 @@ class TmuxClient:
             # available here at DEBUG for local delivery troubleshooting.
             logger.info(f"send_keys: {target} - keys length: {len(keys)}")
             logger.debug(f"send_keys: {target} - keys: {keys}")
-            if force_bracketed_paste and not self._tmux_sanitizes_paste_buffers():
-                # tmux < 3.7: buffer bytes pass through paste-buffer
-                # unmodified, so keep the legacy unconditional wrap + -r
-                # (no LF->CR conversion). paste-buffer -p only emits markers
-                # when the pane enabled DECSET 2004, and some TUIs (e.g.
-                # kiro-cli) never do — under -p their multi-line messages
-                # would submit per-line (#230). No pane-level bracketed-paste
-                # state format exists on these versions (verified empirically
-                # on 3.4), so the wrap stays unconditional here.
-                buf_content = b"\x1b[200~" + keys.encode() + b"\x1b[201~"
-                paste_flag = "-r"
-            else:
-                # tmux >= 3.7 vis(3)-sanitizes pasted buffer content: raw ESC
-                # bytes in the buffer would render as literal "^[[200~" in the
-                # receiving TUI (issue #413). Load ONLY the raw message bytes
-                # and let tmux emit genuine markers via -p, conditionally on
-                # the pane's DECSET 2004 state. -S is deliberately NOT used:
-                # it bypasses the vis(3) hardening.
+            if force_bracketed_paste and self._pane_is_bracketed_paste_incompatible(
+                validated_session, validated_window
+            ):
+                # The pane's live foreground command is a known shell (see
+                # BRACKETED_PASTE_INCOMPATIBLE_SHELLS) -- it won't reliably
+                # understand bracketed-paste escapes, so don't ask tmux to
+                # add them, on ANY tmux version. Deliberately omitting -p
+                # here too, not just the manual \x1b[200~ wrap used below
+                # for a real TUI on tmux < 3.7: -p's own bracket-emitting
+                # decision is driven by tmux's per-pane ?2004h tracking,
+                # which can itself be stale (the very TUI that used to run
+                # in this pane can leave it "on" without ever sending
+                # ?2004l on exit) -- so -p is not a safe fallback here
+                # either. Sending with no paste flag at all never adds
+                # escape sequences regardless of that tracked state; \n
+                # still becomes Enter (no -r), the correct behavior for a
+                # plain shell prompt.
                 buf_content = keys.encode()
-                paste_flag = "-p"
+                paste_args = []
+            elif force_bracketed_paste and not self._tmux_sanitizes_paste_buffers():
+                # A real TUI, tmux < 3.7: buffer bytes pass through
+                # paste-buffer unmodified, so keep the legacy unconditional
+                # wrap + -r (no LF->CR conversion). paste-buffer -p only
+                # emits markers when the pane enabled DECSET 2004, and some
+                # TUIs (e.g. kiro-cli) never do — under -p their multi-line
+                # messages would submit per-line (#230). No pane-level
+                # bracketed-paste state format exists on these versions
+                # (verified empirically on 3.4), so the wrap stays
+                # unconditional here.
+                buf_content = b"\x1b[200~" + keys.encode() + b"\x1b[201~"
+                paste_args = ["-r"]
+            else:
+                # Either force_bracketed_paste=False, or a real TUI on
+                # tmux >= 3.7 which vis(3)-sanitizes pasted buffer content:
+                # raw ESC bytes in the buffer would render as literal
+                # "^[[200~" in the receiving TUI (issue #413). Load ONLY the
+                # raw message bytes and let tmux emit genuine markers via
+                # -p, conditionally on the pane's DECSET 2004 state. -S is
+                # deliberately NOT used: it bypasses the vis(3) hardening.
+                buf_content = keys.encode()
+                paste_args = ["-p"]
             subprocess.run(
                 ["tmux", "load-buffer", "-b", buf_name, "-"],
                 input=buf_content,
                 check=True,
             )
             subprocess.run(
-                ["tmux", "paste-buffer", paste_flag, "-b", buf_name, "-t", target],
+                ["tmux", "paste-buffer", *paste_args, "-b", buf_name, "-t", target],
                 check=True,
             )
             # Delay to let the TUI process the bracketed paste end sequence before

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -68,6 +68,18 @@ DEFAULT_PROVIDER = ProviderType.KIRO_CLI.value
 # Higher values provide more context but increase memory usage
 TMUX_HISTORY_LINES = 200
 
+# Foreground commands that do NOT understand bracketed-paste escape sequences
+# (\x1b[200~...\x1b[201~). send_keys(force_bracketed_paste=True) checks the
+# pane's live #{pane_current_command} against this set before wrapping, so a
+# terminal whose provider process has already exited back to a bare shell
+# (e.g. after a TUI's own `/exit`) doesn't get the escape bytes glued onto
+# the first token of the next command. Bash is included deliberately: bash
+# itself does not interpret bracketed-paste sequences at its own prompt
+# either (see send_keys' own docstring) -- only the TUIs CAO drives do.
+BRACKETED_PASTE_INCOMPATIBLE_SHELLS = frozenset(
+    {"sh", "dash", "bash", "zsh", "ksh", "mksh", "csh", "tcsh", "fish", "ash"}
+)
+
 # =============================================================================
 # Application Directory Structure
 # =============================================================================

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -68,14 +68,19 @@ DEFAULT_PROVIDER = ProviderType.KIRO_CLI.value
 # Higher values provide more context but increase memory usage
 TMUX_HISTORY_LINES = 200
 
-# Foreground commands that do NOT understand bracketed-paste escape sequences
+# Foreground commands to treat as bracketed-paste INCOMPATIBLE.
 # (\x1b[200~...\x1b[201~). send_keys(force_bracketed_paste=True) checks the
 # pane's live #{pane_current_command} against this set before wrapping, so a
 # terminal whose provider process has already exited back to a bare shell
 # (e.g. after a TUI's own `/exit`) doesn't get the escape bytes glued onto
-# the first token of the next command. Bash is included deliberately: bash
-# itself does not interpret bracketed-paste sequences at its own prompt
-# either (see send_keys' own docstring) -- only the TUIs CAO drives do.
+# the first token of the next command. Bash is included deliberately even
+# though it CAN understand bracketed paste: readline's support is
+# version/config-dependent (default-off before readline 8.1/bash 5.1,
+# default-on after, and always overridable via `set enable-bracketed-paste`
+# in .inputrc) and there's no reliable way to detect from here whether it's
+# active in a given pane -- so the safe default is to skip wrapping rather
+# than risk the pasted markers leaking into the command on a
+# bracketed-paste-off bash.
 BRACKETED_PASTE_INCOMPATIBLE_SHELLS = frozenset(
     {"sh", "dash", "bash", "zsh", "ksh", "mksh", "csh", "tcsh", "fish", "ash"}
 )

--- a/src/cli_agent_orchestrator/services/flow_service.py
+++ b/src/cli_agent_orchestrator/services/flow_service.py
@@ -1,5 +1,6 @@
 """Flow service for scheduled agent sessions."""
 
+import asyncio
 import json
 import logging
 import re
@@ -266,8 +267,14 @@ async def execute_flow(name: str) -> bool:
             new_session=True,
         )
 
-        # Send rendered prompt to terminal
-        send_input(terminal.id, rendered_prompt)
+        # Send rendered prompt to terminal. send_input is blocking tmux I/O
+        # (now additionally a pane-foreground-command probe on top of the
+        # existing bracketed-paste delivery, see clients/tmux.py's
+        # _pane_is_bracketed_paste_incompatible) -- run it off the event loop
+        # so a slow tmux call can't freeze every other request (same hazard
+        # class as issue #382, already fixed for POST /terminals/{id}/input
+        # in api/main.py's send_terminal_input; this call site was missed).
+        await asyncio.to_thread(send_input, terminal.id, rendered_prompt)
 
         logger.info(f"Flow {name}: launched session {session_name}")
         return True

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -382,6 +382,69 @@ class TestHerdrBackendCommands:
         assert "Enter" in calls[-1]
 
     @patch("subprocess.run")
+    def test_send_keys_force_bracketed_wraps_when_pane_runs_a_real_tui(self, mock_run, backend):
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(),  # send-text
+            _completed(),  # send-keys Enter
+        ]
+
+        with patch.object(backend, "get_pane_current_command", return_value="node"):
+            backend.send_keys("cao-test", "window-0", "hello world", force_bracketed_paste=True)
+
+        send_text_call = mock_run.call_args_list[-2][0][0]
+        text_arg = send_text_call[send_text_call.index("send-text") + 2]
+        assert text_arg == "\x1b[200~hello world\x1b[201~"
+
+    @patch("subprocess.run")
+    def test_send_keys_force_bracketed_skips_wrap_for_bare_shell(self, mock_run, backend):
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(),  # send-text
+            _completed(),  # send-keys Enter
+        ]
+
+        with patch.object(backend, "get_pane_current_command", return_value="bash"):
+            backend.send_keys("cao-test", "window-0", "claude --continue", force_bracketed_paste=True)
+
+        send_text_call = mock_run.call_args_list[-2][0][0]
+        text_arg = send_text_call[send_text_call.index("send-text") + 2]
+        assert text_arg == "claude --continue"
+
+    @patch("subprocess.run")
+    def test_send_keys_non_forced_skips_the_pane_command_probe(self, mock_run, backend):
+        """force_bracketed_paste=False (the default) never calls
+        get_pane_current_command at all -- no wasted herdr round-trip."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(),  # send-text
+            _completed(),  # send-keys Enter
+        ]
+
+        with patch.object(backend, "get_pane_current_command") as mock_get:
+            backend.send_keys("cao-test", "window-0", "hello world")
+
+        mock_get.assert_not_called()
+
+    @patch("subprocess.run")
     def test_send_special_key_enter(self, mock_run, backend):
         """send_special_key with empty string sends Enter."""
         ws = [{"label": "cao-test", "workspace_id": "w1"}]

--- a/test/backends/test_herdr_backend.py
+++ b/test/backends/test_herdr_backend.py
@@ -417,7 +417,9 @@ class TestHerdrBackendCommands:
         ]
 
         with patch.object(backend, "get_pane_current_command", return_value="bash"):
-            backend.send_keys("cao-test", "window-0", "claude --continue", force_bracketed_paste=True)
+            backend.send_keys(
+                "cao-test", "window-0", "claude --continue", force_bracketed_paste=True
+            )
 
         send_text_call = mock_run.call_args_list[-2][0][0]
         text_arg = send_text_call[send_text_call.index("send-text") + 2]
@@ -548,6 +550,74 @@ class TestHerdrBackendCommands:
 
         result = backend.get_pane_working_directory("cao-test", "window-0")
         assert result == "/home/user/project"
+
+    @patch("subprocess.run")
+    def test_get_pane_current_command_parses_a_realistic_process_info_payload(
+        self, mock_run, backend
+    ):
+        """Regression: must-fix from PR #500 review -- `herdr pane get`'s
+        `foreground_process` field is null/absent across all pane states on
+        herdr 0.7.5 (confirmed live), so get_pane_current_command must call
+        `herdr pane process-info --pane <id>` and read
+        `foreground_processes[0].name` instead. This feeds a realistic
+        process-info-shaped payload through the real subprocess/JSON-parsing
+        path (not a mock of get_pane_current_command itself, which would
+        hide exactly this kind of field-name bug)."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
+        process_info = json.dumps(
+            {
+                "id": "cli:pane:process-info",
+                "result": {
+                    "pane": {"foreground_processes": [{"name": "bash", "pid": 4242}]},
+                    "type": "pane_process_info",
+                },
+            }
+        )
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(stdout=process_info),  # pane process-info
+        ]
+
+        result = backend.get_pane_current_command("cao-test", "window-0")
+
+        assert result == "bash"
+        process_info_call = mock_run.call_args_list[-1][0][0]
+        assert "process-info" in process_info_call
+        assert "--pane" in process_info_call
+
+    @patch("subprocess.run")
+    def test_get_pane_current_command_returns_none_for_empty_foreground_processes(
+        self, mock_run, backend
+    ):
+        """An idle pane with no foreground process (or the old, broken
+        `herdr pane get` shape with a null `foreground_process`) must
+        degrade to None, not raise -- this feeds the caller's fail-closed
+        `_pane_is_bracketed_paste_incompatible` behavior."""
+        ws = [{"label": "cao-test", "workspace_id": "w1"}]
+        tabs = [{"tab_id": "tab-0", "workspace_id": "w1", "label": "window-0"}]
+        panes = [{"tab_id": "tab-0", "pane_id": "w1-1", "workspace_id": "w1"}]
+        process_info = json.dumps(
+            {
+                "id": "cli:pane:process-info",
+                "result": {"pane": {"foreground_processes": []}, "type": "pane_process_info"},
+            }
+        )
+
+        mock_run.side_effect = [
+            _completed(_make_workspace_list_response(ws)),
+            _completed(_make_tab_list_response(tabs)),
+            _completed(_make_pane_list_response(panes)),
+            _completed(stdout=process_info),  # pane process-info
+        ]
+
+        result = backend.get_pane_current_command("cao-test", "window-0")
+
+        assert result is None
 
     @patch("subprocess.run")
     def test_pipe_pane_is_noop(self, mock_run, backend):
@@ -1162,6 +1232,14 @@ class TestSanitizeHerdrArgs:
 
         result = _sanitize_herdr_args(["pane", "list"])
         assert result == ["pane", "list"]
+
+    def test_happy_path_pane_process_info(self):
+        """get_pane_current_command's `pane process-info --pane <id>` call
+        (PR #500 review must-fix) needs `--pane` in the flag allowlist."""
+        from cli_agent_orchestrator.backends.herdr_backend import _sanitize_herdr_args
+
+        result = _sanitize_herdr_args(["pane", "process-info", "--pane", "w1-1"])
+        assert result == ["pane", "process-info", "--pane", "w1-1"]
 
     def test_happy_path_with_path_containing_parens(self):
         from cli_agent_orchestrator.backends.herdr_backend import _sanitize_herdr_args

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -740,3 +740,23 @@ class TestGetPaneCurrentCommand:
         result = tmux.get_pane_current_command("ses", "win")
 
         assert result is None
+
+
+class TestPaneIsBracketedPasteIncompatible:
+    @pytest.mark.parametrize(
+        "shell", ["sh", "dash", "bash", "zsh", "ksh", "mksh", "csh", "tcsh", "fish", "ash"]
+    )
+    def test_every_known_shell_is_incompatible(self, tmux, shell):
+        with patch.object(tmux, "get_pane_current_command", return_value=shell):
+            assert tmux._pane_is_bracketed_paste_incompatible("ses", "win") is True
+
+    @pytest.mark.parametrize("program", ["node", "claude", "kiro-cli", "python3", "codex"])
+    def test_known_tui_programs_are_compatible(self, tmux, program):
+        with patch.object(tmux, "get_pane_current_command", return_value=program):
+            assert tmux._pane_is_bracketed_paste_incompatible("ses", "win") is False
+
+    def test_lookup_failure_is_treated_as_compatible(self, tmux):
+        """Fails closed to the existing (pre-fix) behavior on an
+        unresolvable pane command -- see send_keys' own docstring."""
+        with patch.object(tmux, "get_pane_current_command", return_value=None):
+            assert tmux._pane_is_bracketed_paste_incompatible("ses", "win") is False

--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -270,6 +270,129 @@ class TestSendKeysLegacyWrapOnOldTmux:
         )
 
 
+class TestSendKeysForcedBracketedPasteShellDetection:
+    """force_bracketed_paste=True skips bracket-wrapping (and the -p flag)
+    when the pane's live foreground command is a known shell -- issue: a
+    resumed/woken terminal whose original TUI already exited via its own
+    quit command left the pane at a bare shell prompt that doesn't
+    understand \\x1b[200~/\\x1b[201~, corrupting the first token of
+    whatever's sent next."""
+
+    def test_wraps_when_pane_runs_a_real_tui(
+        self, client, mock_subprocess, mock_uuid, legacy_tmux
+    ):
+        """Baseline: an actual TUI (e.g. Claude Code, running as `node`) on
+        tmux < 3.7 still gets the existing unconditional bracket-wrap + -r
+        delivery (the manual wrap is only valid pre-#413; see
+        TestSendKeysNoHandCraftedMarkersOnModernTmux for the >= 3.7 case,
+        which this class's shell-detection check takes priority over)."""
+        with patch.object(client, "get_pane_current_command", return_value="node"):
+            client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
+
+        paste_call = mock_subprocess.run.call_args_list[1]
+        assert paste_call == call(
+            ["tmux", "paste-buffer", "-r", "-b", "cao_abcd1234", "-t", "sess:win"],
+            check=True,
+        )
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call[1]["input"] == b"\x1b[200~claude --continue\x1b[201~"
+
+    @pytest.mark.parametrize("shell", ["sh", "dash", "bash", "zsh", "fish"])
+    def test_skips_bracket_wrap_when_pane_is_a_bare_shell(
+        self, client, mock_subprocess, mock_uuid, shell
+    ):
+        """A bare shell prompt gets the plain command, with NEITHER the
+        manual \\x1b[200~ wrap NOR the -p flag (the latter's own bracket
+        decision depends on tmux's per-pane ?2004h tracking, which can be
+        stale from a TUI that used to run in this exact pane -- so it's not
+        a safe fallback either)."""
+        with patch.object(client, "get_pane_current_command", return_value=shell):
+            client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
+
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call[1]["input"] == b"claude --continue"
+        paste_call = mock_subprocess.run.call_args_list[1]
+        assert paste_call == call(
+            ["tmux", "paste-buffer", "-b", "cao_abcd1234", "-t", "sess:win"],
+            check=True,
+        )
+
+    def test_fails_closed_to_wrapped_when_pane_command_lookup_fails(
+        self, client, mock_subprocess, mock_uuid, legacy_tmux
+    ):
+        """An unresolvable pane command (tmux error, race with window
+        teardown, ...) preserves the existing wrap-unconditionally behavior
+        rather than guessing -- an unknown foreground process might still be
+        a real TUI expecting bracketed paste. Pinned to tmux < 3.7: on
+        >= 3.7 the "wrapped" fallback is -p with no manual markers (#413),
+        covered by TestSendKeysNoHandCraftedMarkersOnModernTmux."""
+        with patch.object(client, "get_pane_current_command", return_value=None):
+            client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
+
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call[1]["input"] == b"\x1b[200~claude --continue\x1b[201~"
+
+    def test_non_forced_calls_are_unaffected_by_shell_detection(
+        self, client, mock_subprocess, mock_uuid
+    ):
+        """force_bracketed_paste=False (the default, used for shell-command
+        delivery during provider initialization) keeps its existing -p
+        behavior regardless of what the pane is running -- this fix is
+        scoped to the force_bracketed_paste=True path only."""
+        with patch.object(client, "get_pane_current_command", return_value="bash") as mock_get:
+            client.send_keys("sess", "win", "echo ready")
+
+        mock_get.assert_not_called()
+        paste_call = mock_subprocess.run.call_args_list[1]
+        assert paste_call == call(
+            ["tmux", "paste-buffer", "-p", "-b", "cao_abcd1234", "-t", "sess:win"],
+            check=True,
+        )
+
+
+class TestSendKeysShellDetectionCrossedWithTmuxVersion:
+    """The bare-shell check and the tmux-version check are two independent
+    axes of the same `if/elif/else` in send_keys -- both interactions need
+    direct coverage, not just each axis tested in isolation with the other
+    implicitly defaulted."""
+
+    def test_bare_shell_skips_wrap_on_modern_tmux_too(
+        self, client, mock_subprocess, mock_uuid, sanitizing_tmux
+    ):
+        """A bare shell must never get bracketed-paste markers or -p,
+        regardless of tmux version -- the shell-detection check takes
+        priority over the tmux-version branch, not the other way around."""
+        with patch.object(client, "get_pane_current_command", return_value="bash"):
+            client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
+
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call[1]["input"] == b"claude --continue"
+        paste_call = mock_subprocess.run.call_args_list[1]
+        assert paste_call == call(
+            ["tmux", "paste-buffer", "-b", "cao_abcd1234", "-t", "sess:win"],
+            check=True,
+        )
+
+    def test_real_tui_on_modern_tmux_gets_p_flag_not_manual_wrap(
+        self, client, mock_subprocess, mock_uuid, sanitizing_tmux
+    ):
+        """A real TUI on tmux >= 3.7 must still get the #413 fix (-p, no
+        hand-crafted markers) even when force_bracketed_paste=True -- the
+        shell-detection feature must not regress the vis(3)-sanitization
+        fix for the non-shell case."""
+        with patch.object(client, "get_pane_current_command", return_value="node"):
+            client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
+
+        load_call = mock_subprocess.run.call_args_list[0]
+        assert load_call[1]["input"] == b"claude --continue"
+        assert b"\x1b" not in load_call[1]["input"]
+        paste_call = mock_subprocess.run.call_args_list[1]
+        assert paste_call == call(
+            ["tmux", "paste-buffer", "-p", "-b", "cao_abcd1234", "-t", "sess:win"],
+            check=True,
+        )
+
+
 class TestTmuxSanitizationDetection:
     """Version probe behind the tmux >= 3.7 vis(3) gate."""
 

--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -278,9 +278,7 @@ class TestSendKeysForcedBracketedPasteShellDetection:
     understand \\x1b[200~/\\x1b[201~, corrupting the first token of
     whatever's sent next."""
 
-    def test_wraps_when_pane_runs_a_real_tui(
-        self, client, mock_subprocess, mock_uuid, legacy_tmux
-    ):
+    def test_wraps_when_pane_runs_a_real_tui(self, client, mock_subprocess, mock_uuid, legacy_tmux):
         """Baseline: an actual TUI (e.g. Claude Code, running as `node`) on
         tmux < 3.7 still gets the existing unconditional bracket-wrap + -r
         delivery (the manual wrap is only valid pre-#413; see


### PR DESCRIPTION
## Problem

`send_keys(force_bracketed_paste=True)` -- the delivery path behind every `POST /terminals/{id}/input` call, used both for ordinary TUI messaging and for a resume/continue command sent to a hibernated terminal -- always wraps its content in `\x1b[200~...\x1b[201~` bracketed-paste escape sequences and sends it via `paste-buffer -r`, regardless of what's actually running in the pane.

When the TUI that used to occupy a pane exits (e.g. Claude Code's own `/exit`) leaving a bare POSIX shell behind, a subsequent `send_keys` call still gets wrapped -- but a bare shell doesn't understand bracketed-paste escapes, so they glue onto the front of the first token, corrupting the command **deterministically**, not as a timing race:

```
$ printf '\033[200~claude --version\033[201~\n' | sh
sh: 1: [200~claude: not found
$ printf 'claude --version\n' | sh     # confirms --version genuinely resolves normally
2.1.197 (Claude Code)
```

This was root-caused live against a real production deployment (a downstream consumer, harness-control) via `tmux capture-pane` on the actual affected session: a hibernated Claude Code terminal repeatedly failed to wake with `claude: not found`, byte-for-byte matching the corruption above -- not a `RESUME_SETTLE_SECONDS`/PATH-not-ready race, which was the working hypothesis before the pane's raw scrollback was inspected.

Falling back to the existing `paste-buffer -p` path isn't safe either: `-p`'s own bracket-emitting decision is driven by tmux's per-pane `?2004h` tracking, which the same exited TUI can leave "on" indefinitely without ever sending `?2004l` first -- so a stale pane can get corrupted through *either* delivery path.

## Fix

Check the pane's live `#{pane_current_command}` (the same primitive `codex.py`/`kiro_cli.py` already trust for their own "has the TUI exited back to a shell?" `shell_baseline` comparison in `get_status()`) against a new `BRACKETED_PASTE_INCOMPATIBLE_SHELLS` set before wrapping. A known shell gets the plain content with **no** paste flags at all -- never bracketed, never subject to tmux's own stale tracking -- while `\n` still becomes Enter (confirmed against `man tmux`: LF->CR replacement is the default whenever `-r` is absent, independent of `-p`), so a multi-line command still executes line-by-line. Fails closed to the existing wrap-unconditionally behavior on an unresolvable or unrecognized foreground command, so every case this can't positively rule out keeps today's exact behavior.

Mirrored in `HerdrBackend.send_keys`, which implements the identical unconditional-wrap-when-requested behavior over a different transport and already exposes the same `get_pane_current_command` primitive -- an independent self-ROAST pass on this PR caught that the tmux-only fix would have left herdr with the identical bug.

## Self-ROAST fix: an adjacent, pre-existing async-offload gap this change would have made worse

An independent review of this branch also caught: `flow_service.py`'s `execute_flow` (an `async def`) called `send_input` directly on the event loop, un-offloaded -- the exact hazard class issue #382 was fixed for elsewhere (`api/main.py`'s `POST /terminals/{id}/input` already wraps the same call in `asyncio.to_thread`, and `status_monitor.py`'s own comments document a prior real incident where an inline `get_pane_current_command`-class call froze the whole server for ~120s). This PR's own new pane-command probe adds a small amount of synchronous subprocess work to that same call path, so the missed offload is fixed alongside it in this PR rather than left to surface as its own separate report later.

## Test plan

- New/updated tests in `test/clients/test_tmux_send_keys.py`, `test/clients/test_tmux_client.py`, and `test/backends/test_herdr_backend.py` covering: a real TUI (wraps as before, byte-identical subprocess calls), a bare shell x5 shell names (skips the wrap, no `-p` either), an unresolvable pane command (fails closed to the old wrap behavior), and confirming the non-forced (`force_bracketed_paste=False`) path is completely untouched (`get_pane_current_command` never even called, byte-identical `-p` subprocess call).
- Full suite: `uv run pytest test/ -q --no-cov` -> 5233 passed, 0 failed (32 skipped/1 xfailed pre-existing/unrelated to this change; a handful of `test_agui_*`/telemetry failures reproduce identically against unmodified `main` -- confirmed by running the same files against a clean checkout -- and are pre-existing/environmental, not caused by this branch).
- Reproduced the bug and the fix directly against a real host shell (see the `printf`/`sh` snippets above), not just via unit mocks.

Happy to adjust the shell-name set, the herdr mirroring, or the `flow_service.py` offload fix scope to match your preferences -- flagging the latter explicitly since it's adjacent-but-motivated rather than the headline change.