### PR TITLE
feat(mcp): add an explicit model override to handoff/assign

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -242,6 +242,15 @@ class RunStepRequest(BaseModel):
             "values are validated but never echoed in error bodies."
         ),
     )
+    model: Optional[str] = Field(
+        default=None,
+        description=(
+            "Explicit per-call model override for a freshly created terminal "
+            "(ignored when reusing a terminal), applied ahead of the agent "
+            "profile's own static model field. Lets a caller pin a specific "
+            "model for one worker without a dedicated agent profile."
+        ),
+    )
 
     @field_validator("env_vars")
     @classmethod
@@ -1783,6 +1792,7 @@ async def create_terminal_in_session(
     allowed_tools: Optional[str] = None,
     caller_id: Optional[TerminalId] = None,
     defer_init: bool = False,
+    model: Optional[str] = None,
     body: Optional[CreateTerminalBody] = None,
     _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
 ) -> Terminal:
@@ -1801,6 +1811,12 @@ async def create_terminal_in_session(
     ``initial_message_orchestration_type``) rather than query params so prompt
     content isn't exposed in HTTP access logs and isn't subject to URL-length
     limits.
+
+    ``model``: optional explicit override, applied ahead of the agent
+    profile's own static ``model`` field (where the resolved provider
+    supports it -- see ``terminal_service.create_terminal``'s own docstring).
+    Lets a caller pin a specific model for one worker without needing a
+    dedicated agent profile.
     """
     try:
         validate_tmux_name(session_name, "session_name")
@@ -1864,6 +1880,7 @@ async def create_terminal_in_session(
             defer_init=defer_init,
             initial_message=initial_message,
             initial_message_orchestration_type=orch_type,
+            model=model,
         )
         return result
     except HTTPException:
@@ -2173,6 +2190,7 @@ async def run_step(
             registry=get_plugin_registry(request),
             env_vars=body.env_vars,
             on_terminal_created=on_terminal_created,
+            model=body.model,
         )
         # Success -> transition the script step RUNNING->COMPLETED (no-op for
         # non-script callers). Before building the response so a settle failure

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -54,6 +54,8 @@ from cli_agent_orchestrator.constants import (
     DEFAULT_PROVIDER,
     INBOX_POLLING_INTERVAL,
     INBOX_RECONCILE_INTERVAL,
+    MODEL_ID_MAX_LEN,
+    MODEL_ID_RE,
     OTEL_SERVICE_NAME,
     SERVER_HOST,
     SERVER_PORT,
@@ -205,6 +207,27 @@ class CreateTerminalBody(BaseModel):
     initial_message_orchestration_type: Optional[str] = None
 
 
+def _validate_model_id(value: str) -> None:
+    """Validate a ``model`` override at the request boundary (PR #501 review).
+
+    Shared by ``RunStepRequest.model`` (field_validator below) and the
+    ``/sessions/{session_name}/terminals`` ``model`` query param, so both
+    entry points into ``terminal_service.create_terminal`` apply the same
+    rule. Raises ``ValueError``; callers translate that into the transport
+    -appropriate error (FastAPI 422 for a Pydantic field_validator, an
+    explicit 400 for the query-param call site — see that endpoint).
+
+    Raises:
+        ValueError: ``value`` exceeds MODEL_ID_MAX_LEN or contains a
+            character outside MODEL_ID_RE (whitespace, control characters,
+            and shell/quoting metacharacters are all rejected).
+    """
+    if len(value) > MODEL_ID_MAX_LEN:
+        raise ValueError(f"model exceeds the {MODEL_ID_MAX_LEN}-char cap")
+    if not re.fullmatch(MODEL_ID_RE, value):
+        raise ValueError(f"model {value!r} is invalid (must match {MODEL_ID_RE!r})")
+
+
 class RunStepRequest(BaseModel):
     """Request body for the combined step-execution endpoint (N0, #312)."""
 
@@ -294,6 +317,20 @@ class RunStepRequest(BaseModel):
                     f"value for '{key}' is invalid (must be a 1-64 char "
                     "[A-Za-z0-9_-] identifier)"
                 ) from None
+        return v
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, v: Optional[str]) -> Optional[str]:
+        """See ``_validate_model_id`` -- the boundary check the model
+        override needs (PR #501 review): the value reaches a provider's
+        launch-command builder, shlex-quoted before delivery (so classic
+        word-splitting is not reachable) but a control character or newline
+        surviving quoting into the command string is still a delivery
+        hazard this codebase already guards against elsewhere."""
+        if v is None:
+            return v
+        _validate_model_id(v)
         return v
 
     @model_validator(mode="after")
@@ -1820,6 +1857,8 @@ async def create_terminal_in_session(
     """
     try:
         validate_tmux_name(session_name, "session_name")
+        if model is not None:
+            _validate_model_id(model)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     try:

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -583,6 +583,21 @@ WORKFLOW_ENV_ALLOWLIST = frozenset(
 # accepted length is 64 via WORKFLOW_NAME_RE; this cap is the outer fence).
 WORKFLOW_ENV_VALUE_MAX_LEN = 256
 
+# Model-ID validation for the explicit per-call ``model`` override on
+# handoff/assign (issue reported via PR #501 review). The override reaches a
+# provider's own launch-command builder (e.g. Codex/Kimi's ``--model
+# <value>``) which is shlex-quoted before delivery, so classic word-splitting
+# injection is not reachable -- but a control character or newline surviving
+# quoting into the command string is still a delivery hazard (this codebase
+# already treats that class of input as one: claude_code.py escapes newlines
+# in system_prompt to prevent tmux paste-buffer chunking, and bash's own
+# bracketed-paste-safety is called out in tmux.py). No allowlist is needed
+# (unlike WORKFLOW_ENV_ALLOWLIST's fixed key set) since a model id is
+# free-form per-provider, but a conservative charset covers every real model
+# id across all nine providers, including OpenCode's "vendor/model" form.
+MODEL_ID_RE = r"^[A-Za-z0-9._:/-]+$"
+MODEL_ID_MAX_LEN = 128
+
 # Script-runner subprocess lifecycle (Bolt 3, U4/C1). Wall-clock bound + grace,
 # output ring-buffer cap, engine-owned scratch root for resume materialization.
 WORKFLOW_SCRIPT_TERM_GRACE = 5.0  # SIGTERM->SIGKILL grace (BR-10/11, NFR-REL-1)

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -173,6 +173,7 @@ def _create_terminal(
     defer_init: bool = False,
     initial_message: Optional[str] = None,
     initial_message_orchestration_type: Optional[OrchestrationType] = None,
+    model: Optional[str] = None,
 ) -> Tuple[str, str]:
     """Create a new terminal with the specified agent profile.
 
@@ -191,6 +192,16 @@ def _create_terminal(
             initializing. Ignored otherwise.
         initial_message_orchestration_type: Passed through to send_input for
             plugin event emission (assign/handoff).
+        model: Explicit per-call model override for the new terminal, applied
+            ahead of the agent profile's own static model field (where the
+            resolved provider supports it). Only honored on the
+            existing-session branch below (``POST /sessions/{name}/
+            terminals``) -- the new-session branch (``POST /sessions``, used
+            only when this tool is called with no current CAO_TERMINAL_ID)
+            goes through a different server-side route that does not accept
+            it; handoff/assign both already require an existing terminal
+            (see their own CAO_TERMINAL_ID checks), so this branch is the one
+            that matters for both callers in practice.
 
     Returns:
         Tuple of (terminal_id, provider)
@@ -248,6 +259,8 @@ def _create_terminal(
             params["working_directory"] = working_directory
         if child_allowed_tools:
             params["allowed_tools"] = child_allowed_tools
+        if model:
+            params["model"] = model
         # The message payload goes in the JSON body, not the query string, so
         # prompt content isn't exposed in HTTP access logs and isn't subject to
         # URL-length limits. Only routing flags stay in params.
@@ -670,7 +683,11 @@ def _load_skill_impl(name: str) -> Union[str, Dict[str, Any]]:
 
 # Implementation functions
 async def _handoff_impl(
-    agent_profile: str, message: str, timeout: int = 600, working_directory: Optional[str] = None
+    agent_profile: str,
+    message: str,
+    timeout: int = 600,
+    working_directory: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> HandoffResult:
     """Implementation of handoff logic.
 
@@ -742,6 +759,8 @@ async def _handoff_impl(
             payload["allowed_tools"] = ctx.allowed_tools
         if working_directory:
             payload["working_directory"] = working_directory
+        if model:
+            payload["model"] = model
 
         # Allow the full step time plus the server-side ready-wait (up to 120s)
         # plus headroom; the server enforces the per-step timeout internally.
@@ -810,6 +829,17 @@ async def _handoff_impl(
         )
 
 
+# Shared by both handoff and assign's tool signatures below.
+_model_field_desc = (
+    "Optional model override for the worker agent (e.g. a concrete model name/id "
+    "accepted by the resolved provider's own --model flag). Takes precedence over "
+    "the agent profile's own configured model, if any, for this one call only -- "
+    "no dedicated profile is needed just to pin a specific model. Not honored by "
+    "every provider (see the target provider's own docs); omit to use the agent "
+    "profile's configured model as before."
+)
+
+
 # Conditional tool registration based on environment variable
 if ENABLE_WORKING_DIRECTORY:
 
@@ -829,6 +859,7 @@ if ENABLE_WORKING_DIRECTORY:
             default=None,
             description='Optional working directory where the agent should execute (e.g., "/path/to/workspace/src/Package")',
         ),
+        model: Optional[str] = Field(default=None, description=_model_field_desc),
     ) -> HandoffResult:
         """Hand off a task to another agent via CAO terminal and wait for completion.
 
@@ -852,6 +883,12 @@ if ENABLE_WORKING_DIRECTORY:
         - You can specify a custom directory via working_directory parameter
         - Directory must exist and be accessible
 
+        ## Model
+
+        - By default, the agent uses whatever model its profile is configured with
+        - You can pin a specific model via the model parameter, without needing a
+          dedicated agent profile -- not honored by every provider
+
         ## Requirements
 
         - Must be called from within a CAO terminal (CAO_TERMINAL_ID environment variable)
@@ -863,11 +900,12 @@ if ENABLE_WORKING_DIRECTORY:
             message: The task/message to send
             timeout: Maximum wait time in seconds
             working_directory: Optional directory path where agent should execute
+            model: Optional model override (not honored by every provider)
 
         Returns:
             HandoffResult with success status, message, and agent output
         """
-        return await _handoff_impl(agent_profile, message, timeout, working_directory)
+        return await _handoff_impl(agent_profile, message, timeout, working_directory, model)
 
 else:
 
@@ -883,6 +921,7 @@ else:
             ge=1,
             le=3600,
         ),
+        model: Optional[str] = Field(default=None, description=_model_field_desc),
     ) -> HandoffResult:
         """Hand off a task to another agent via CAO terminal and wait for completion.
 
@@ -899,6 +938,12 @@ else:
         4. Return the agent's response
         5. Clean up the terminal with /exit
 
+        ## Model
+
+        - By default, the agent uses whatever model its profile is configured with
+        - You can pin a specific model via the model parameter, without needing a
+          dedicated agent profile -- not honored by every provider
+
         ## Requirements
 
         - Must be called from within a CAO terminal (CAO_TERMINAL_ID environment variable)
@@ -908,16 +953,20 @@ else:
             agent_profile: The agent profile for the new terminal
             message: The task/message to send
             timeout: Maximum wait time in seconds
+            model: Optional model override (not honored by every provider)
 
         Returns:
             HandoffResult with success status, message, and agent output
         """
-        return await _handoff_impl(agent_profile, message, timeout, None)
+        return await _handoff_impl(agent_profile, message, timeout, None, model)
 
 
 # Implementation function for assign
 def _assign_impl(
-    agent_profile: str, message: str, working_directory: Optional[str] = None
+    agent_profile: str,
+    message: str,
+    working_directory: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Implementation of assign logic.
 
@@ -976,6 +1025,7 @@ def _assign_impl(
             defer_init=True,
             initial_message=worker_message,
             initial_message_orchestration_type=OrchestrationType.ASSIGN,
+            model=model,
         )
 
         return {
@@ -1031,6 +1081,12 @@ Example message: "Analyze the logs. When done, send results back to terminal ee3
 
     desc += """
 
+## Model
+
+- By default, the worker uses whatever model its agent profile is configured with
+- You can pin a specific model for this one worker via the model parameter, without
+  needing a dedicated agent profile -- not honored by every provider
+
 ## Cleanup
 
 When you are done with an assigned terminal (received results or no longer need it),
@@ -1045,6 +1101,7 @@ Args:
     working_directory: Optional working directory where the agent should execute"""
 
     desc += """
+    model: Optional model override for the worker (not honored by every provider)
 
 Returns:
     Dict with success status, worker terminal_id, and message"""
@@ -1072,8 +1129,9 @@ if ENABLE_WORKING_DIRECTORY:
         working_directory: Optional[str] = Field(
             default=None, description="Optional working directory where the agent should execute"
         ),
+        model: Optional[str] = Field(default=None, description=_model_field_desc),
     ) -> Dict[str, Any]:
-        return _assign_impl(agent_profile, message, working_directory)
+        return _assign_impl(agent_profile, message, working_directory, model)
 
 else:
 
@@ -1083,8 +1141,9 @@ else:
             description='The agent profile for the worker agent (e.g., "developer", "analyst")'
         ),
         message: str = Field(description=_assign_message_field_desc),
+        model: Optional[str] = Field(default=None, description=_model_field_desc),
     ) -> Dict[str, Any]:
-        return _assign_impl(agent_profile, message, None)
+        return _assign_impl(agent_profile, message, None, model)
 
 
 # Implementation function for send_message

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -216,11 +216,16 @@ class ClaudeCodeProvider(BaseProvider):
         agent_profile: Optional[str] = None,
         allowed_tools: Optional[list] = None,
         skill_prompt: Optional[str] = None,
+        model: Optional[str] = None,
     ):
         """Initialize provider state."""
         super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
         self._initialized = False
         self._agent_profile = agent_profile
+        # Explicit per-call override for profile.model (see launch()'s own
+        # --model resolution below) -- e.g. a handoff/assign caller pinning a
+        # specific model for one worker without needing a dedicated profile.
+        self._model = model
         # Native-status dispatch tracking (_task_dispatched + flush-wait timers)
         # lives on BaseProvider and is consumed by _resolve_native_status().
         self._input_generation: int = 0
@@ -331,7 +336,16 @@ class ClaudeCodeProvider(BaseProvider):
         native = getattr(profile, "native_agent", None) if profile else None
         if profile is not None and isinstance(native, str) and native:
             # Thin wrapper: CAO profile maps to a native Claude Code agent.
-            # Let Claude Code handle all config (MCP servers, hooks, tools, model).
+            # Let Claude Code handle all config (MCP servers, hooks, tools, model)
+            # -- self._model (whether sourced from an explicit per-call override
+            # or from this same profile's own model field, see
+            # terminal_service.create_terminal's own precedence resolution) is
+            # deliberately NOT applied here, same as it was never applied for
+            # profile.model alone before this parameter existed. Not warned on:
+            # by the time this runs, self._model can no longer be distinguished
+            # from "this profile's own model field, nothing to do with a caller
+            # override at all" -- warning here would misattribute ordinary
+            # profile config as an ignored explicit request.
             # CAO_TERMINAL_ID propagates via tmux pane env inheritance.
             command_parts.extend(["--agent", native])
         elif self._agent_profile is not None and profile is None:
@@ -339,10 +353,18 @@ class ClaudeCodeProvider(BaseProvider):
             # native agent store (~/.claude/agents/). Same thin-orchestrator
             # pattern as the Kiro CLI provider.
             command_parts.extend(["--agent", self._agent_profile])
+            if self._model:
+                command_parts.extend(["--model", self._model])
         elif profile is not None:
-            # Full CAO profile with config decomposition
-            if profile.model:
-                command_parts.extend(["--model", profile.model])
+            # Full CAO profile with config decomposition. self._model is an
+            # explicit per-call override (handoff/assign's own `model`
+            # parameter) and wins over the profile's own static model field
+            # when both are given -- a caller pinning a one-off model for a
+            # single worker shouldn't need a dedicated agent profile just to
+            # do it.
+            resolved_model = self._model or profile.model
+            if resolved_model:
+                command_parts.extend(["--model", resolved_model])
 
             # Add system prompt - escape newlines to prevent tmux chunking issues
             system_prompt = profile.system_prompt if profile.system_prompt is not None else ""

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -273,11 +273,14 @@ class CodexProvider(BaseProvider):
         agent_profile: Optional[str] = None,
         allowed_tools: Optional[list] = None,
         skill_prompt: Optional[str] = None,
+        model: Optional[str] = None,
     ):
         """Initialize provider state."""
         super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
         self._initialized = False
         self._agent_profile = agent_profile
+        # Explicit per-call override for profile.model, see _build_codex_command.
+        self._model = model
 
     def _build_codex_command(self) -> str:
         """Build Codex command with agent profile if provided.
@@ -307,10 +310,14 @@ class CodexProvider(BaseProvider):
             command_parts = ["codex", "--yolo"]
         command_parts.extend(["--no-alt-screen", "--disable", "shell_snapshot"])
 
-        if profile is not None:
-            if profile.model:
-                command_parts.extend(["--model", profile.model])
+        # self._model is an explicit per-call override (handoff/assign's own
+        # `model` parameter) and wins over the profile's own static model
+        # field when both are given; applies even with no profile at all.
+        resolved_model = self._model or (profile.model if profile else None)
+        if resolved_model:
+            command_parts.extend(["--model", resolved_model])
 
+        if profile is not None:
             system_prompt = profile.system_prompt if profile.system_prompt is not None else ""
             system_prompt = self._apply_skill_prompt(system_prompt)
 

--- a/src/cli_agent_orchestrator/providers/hermes.py
+++ b/src/cli_agent_orchestrator/providers/hermes.py
@@ -120,10 +120,13 @@ class HermesProvider(BaseProvider):
         agent_profile: Optional[str] = None,
         allowed_tools: Optional[list] = None,
         skill_prompt: Optional[str] = None,
+        model: Optional[str] = None,
     ):
         super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
         self._initialized = False
         self._agent_profile = agent_profile
+        # Explicit per-call override for profile.model, see _build_hermes_command.
+        self._model = model
         self._last_idle_timer: Optional[str] = None
         self._stable_idle_timer_count = 0
 
@@ -157,8 +160,12 @@ class HermesProvider(BaseProvider):
             "cao",
         ]
 
-        if profile and profile.model:
-            command_parts.extend(["--model", profile.model])
+        # self._model is an explicit per-call override (handoff/assign's own
+        # `model` parameter) and wins over the profile's own static model
+        # field when both are given.
+        resolved_model = self._model or (profile.model if profile else None)
+        if resolved_model:
+            command_parts.extend(["--model", resolved_model])
 
         if self._skill_prompt:
             logger.warning(

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -208,11 +208,14 @@ class KimiCliProvider(BaseProvider):
         agent_profile: Optional[str] = None,
         allowed_tools: Optional[list] = None,
         skill_prompt: Optional[str] = None,
+        model: Optional[str] = None,
     ):
         """Initialize provider state."""
         super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
         self._initialized = False
         self._agent_profile = agent_profile
+        # Explicit per-call override for profile.model, see initialize().
+        self._model = model
         # Track temp directory for cleanup (created when agent profile needs temp files)
         self._temp_dir: Optional[str] = None
         # Latching flag: set True when user input box (╭─) is detected in ANY
@@ -300,8 +303,12 @@ class KimiCliProvider(BaseProvider):
             try:
                 profile = load_agent_profile(self._agent_profile)
 
-                if profile.model:
-                    command_parts.extend(["--model", profile.model])
+                # self._model is an explicit per-call override (handoff/assign's
+                # own `model` parameter) and wins over the profile's own static
+                # model field when both are given.
+                resolved_model = self._model or profile.model
+                if resolved_model:
+                    command_parts.extend(["--model", resolved_model])
 
                 # Build agent file from profile's system prompt.
                 # Kimi uses YAML agent files with a system_prompt_path pointing

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -299,17 +299,23 @@ class KimiCliProvider(BaseProvider):
         if not self._temp_dir:
             self._temp_dir = tempfile.mkdtemp(prefix="cao_kimi_")
 
+        profile = None
         if self._agent_profile is not None:
             try:
                 profile = load_agent_profile(self._agent_profile)
+            except Exception as e:
+                raise ProviderError(f"Failed to load agent profile '{self._agent_profile}': {e}")
 
-                # self._model is an explicit per-call override (handoff/assign's
-                # own `model` parameter) and wins over the profile's own static
-                # model field when both are given.
-                resolved_model = self._model or profile.model
-                if resolved_model:
-                    command_parts.extend(["--model", resolved_model])
+        # self._model is an explicit per-call override (handoff/assign's own
+        # `model` parameter) and wins over the profile's own static model
+        # field when both are given; applies even with no profile at all
+        # (matches codex.py/hermes.py's own resolution shape).
+        resolved_model = self._model or (profile.model if profile else None)
+        if resolved_model:
+            command_parts.extend(["--model", resolved_model])
 
+        if profile is not None:
+            try:
                 # Build agent file from profile's system prompt.
                 # Kimi uses YAML agent files with a system_prompt_path pointing
                 # to a markdown file. We create both in the temp directory.
@@ -380,7 +386,10 @@ class KimiCliProvider(BaseProvider):
                     command_parts.extend(["--mcp-config", json.dumps(mcp_config)])
 
             except Exception as e:
-                raise ProviderError(f"Failed to load agent profile '{self._agent_profile}': {e}")
+                raise ProviderError(
+                    f"Failed to build kimi command from agent profile "
+                    f"'{self._agent_profile}': {e}"
+                )
 
         # cd to unique temp dir (per-directory lock) + set TERM for tmux compatibility
         kimi_cmd = shlex.join(command_parts)

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -160,6 +160,7 @@ class KiroCliProvider(BaseProvider):
         window_name: str,
         agent_profile: str,
         allowed_tools: Optional[list] = None,
+        model: Optional[str] = None,
     ):
         """Initialize Kiro CLI provider with terminal context.
 
@@ -169,11 +170,15 @@ class KiroCliProvider(BaseProvider):
             window_name: Name of the tmux window
             agent_profile: Name of the Kiro agent profile to use (e.g., "developer")
             allowed_tools: Optional list of CAO tool names the agent is allowed to use
+            model: Explicit per-call override for profile.model (see
+                _get_profile_model), e.g. a handoff/assign caller pinning a
+                specific model for one worker without a dedicated profile.
         """
         super().__init__(terminal_id, session_name, window_name, allowed_tools)
         self._initialized = False
         self._input_received = False
         self._agent_profile = agent_profile
+        self._model = model
 
         # Build dynamic prompt pattern based on agent profile
         # This pattern matches various Kiro prompt formats after ANSI stripping:
@@ -224,12 +229,15 @@ class KiroCliProvider(BaseProvider):
         return 2000
 
     def _get_profile_model(self) -> Optional[str]:
-        """Return profile.model if the agent profile can be loaded, else None.
+        """Return the explicit per-call model override if given, else
+        profile.model if the agent profile can be loaded, else None.
 
         Best-effort: historically the Kiro CLI provider has not required the
         CAO agent profile to be loadable at runtime (kiro-cli has its own
         agent store). A missing or unparseable profile must not block launch.
         """
+        if self._model:
+            return self._model
         try:
             profile = load_agent_profile(self._agent_profile)
         except (FileNotFoundError, RuntimeError) as exc:

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -49,6 +49,7 @@ class ProviderManager:
                     tmux_window,
                     agent_profile,
                     allowed_tools,
+                    model=model,
                 )
             elif provider_type == ProviderType.CLAUDE_CODE.value:
                 provider = ClaudeCodeProvider(
@@ -58,6 +59,7 @@ class ProviderManager:
                     agent_profile,
                     allowed_tools,
                     skill_prompt=skill_prompt,
+                    model=model,
                 )
             elif provider_type == ProviderType.CODEX.value:
                 provider = CodexProvider(
@@ -67,6 +69,7 @@ class ProviderManager:
                     agent_profile,
                     allowed_tools,
                     skill_prompt=skill_prompt,
+                    model=model,
                 )
             elif provider_type == ProviderType.COPILOT_CLI.value:
                 provider = CopilotCliProvider(
@@ -85,6 +88,7 @@ class ProviderManager:
                     agent_profile,
                     allowed_tools,
                     skill_prompt=skill_prompt,
+                    model=model,
                 )
             elif provider_type == ProviderType.OPENCODE_CLI.value:
                 provider = OpenCodeCliProvider(
@@ -103,6 +107,7 @@ class ProviderManager:
                     agent_profile,
                     allowed_tools,
                     skill_prompt=skill_prompt,
+                    model=model,
                 )
             elif provider_type == ProviderType.CURSOR_CLI.value:
                 provider = CursorCliProvider(

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -213,6 +213,7 @@ async def run_agent_step(
     env_vars: Optional[dict[str, str]] = None,
     on_terminal_created: Optional[Callable[[str], None]] = None,
     cancel_event: Optional[asyncio.Event] = None,
+    model: Optional[str] = None,
 ) -> AgentStepResult:
     """Run one agent step and return its result (success only).
 
@@ -288,6 +289,12 @@ async def run_agent_step(
             provider never emits a completion signal is exactly the run that could
             not otherwise be killed. Default None = no cancellation seam (the
             handoff caller passes nothing) — behavior unchanged.
+        model: Explicit per-call model override for a freshly created
+            terminal (ignored when reusing a terminal), forwarded to
+            ``terminal_service.create_terminal``. Lets a handoff caller pin
+            a specific model for this one worker without a dedicated agent
+            profile. Default None = behavior unchanged (profile.model, if
+            any, still applies).
 
     Returns:
         ``AgentStepResult`` with status COMPLETED — ONLY on success.
@@ -354,6 +361,7 @@ async def run_agent_step(
             allowed_tools=allowed_tools,
             caller_id=caller_id,
             env_vars=env_vars,
+            model=model,
         )
         terminal_id = terminal.id
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -159,6 +159,7 @@ async def create_terminal(
     defer_init: bool = False,
     initial_message: Optional[str] = None,
     initial_message_orchestration_type: Optional[OrchestrationType] = None,
+    model: Optional[str] = None,
 ) -> Terminal:
     """Create a new terminal with an initialized CLI agent.
 
@@ -187,6 +188,12 @@ async def create_terminal(
             via handoff/assign. Recorded so send_message can route callbacks
             structurally instead of parsing IDs out of message text (issue #284).
             None for operator-launched terminals.
+        model: Explicit per-call model override, forwarded to the provider
+            (where supported -- see each provider's own __init__) ahead of
+            the agent profile's own static `model` field. Lets a caller
+            (e.g. MCP handoff/assign's own `model` parameter) pin a specific
+            model for one worker without needing a dedicated agent profile.
+            None = behavior unchanged (profile.model, if any, still applies).
 
     Returns:
         Terminal object with all metadata populated
@@ -357,7 +364,7 @@ async def create_terminal(
             agent_profile,
             allowed_tools,
             skill_prompt=skill_prompt,
-            model=profile.model if profile else None,
+            model=model or (profile.model if profile else None),
         )
 
         # Deferred-init path: return fast so callers (e.g. MCP assign) do not

--- a/test/api/test_run_step.py
+++ b/test/api/test_run_step.py
@@ -41,6 +41,17 @@ class TestRunStepEndpoint:
         assert kwargs["provider"] == "kiro_cli"
         assert kwargs["agent"] == "developer"
         assert kwargs["prompt"] == "do it"
+        assert kwargs["model"] is None
+
+    def test_model_forwarded_to_substrate(self, client):
+        result = AgentStepResult(
+            terminal_id="abc12345", last_message="all done", status=TerminalStatus.COMPLETED
+        )
+        with patch(_RUN_STEP, new=AsyncMock(return_value=result)) as m_run:
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(model="fable-5"))
+
+        assert resp.status_code == 200
+        assert m_run.await_args.kwargs["model"] == "fable-5"
 
     def test_timeout_maps_to_504_with_structured_terminal_id(self, client):
         with patch(

--- a/test/api/test_run_step.py
+++ b/test/api/test_run_step.py
@@ -53,6 +53,40 @@ class TestRunStepEndpoint:
         assert resp.status_code == 200
         assert m_run.await_args.kwargs["model"] == "fable-5"
 
+    @pytest.mark.parametrize(
+        "bad_model",
+        [
+            "fable-5\nrm -rf /",  # newline -- delivery hazard, not word-splitting
+            "fable\x00-5",  # NUL
+            "fable 5",  # whitespace
+            "fable;5",  # shell metacharacter
+            "x" * 129,  # exceeds MODEL_ID_MAX_LEN (128)
+        ],
+    )
+    def test_invalid_model_returns_422_and_never_reaches_the_substrate(self, client, bad_model):
+        """PR #501 review: a control character/newline/metacharacter in
+        model must be rejected at the request boundary, not merely arrive
+        shlex-quoted at a provider's launch command."""
+        with patch(_RUN_STEP, new=AsyncMock()) as m_run:
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(model=bad_model))
+
+        assert resp.status_code == 422
+        m_run.assert_not_awaited()
+
+    def test_valid_model_with_slash_and_dots_is_accepted(self, client):
+        """OpenCode's "vendor/model" form, and dotted version suffixes, must
+        not be rejected by the boundary check."""
+        result = AgentStepResult(
+            terminal_id="abc12345", last_message="all done", status=TerminalStatus.COMPLETED
+        )
+        with patch(_RUN_STEP, new=AsyncMock(return_value=result)) as m_run:
+            resp = client.post(
+                TERMINALS_RUN_STEP_ROUTE, json=_body(model="anthropic/claude-3.5-sonnet")
+            )
+
+        assert resp.status_code == 200
+        assert m_run.await_args.kwargs["model"] == "anthropic/claude-3.5-sonnet"
+
     def test_timeout_maps_to_504_with_structured_terminal_id(self, client):
         with patch(
             _RUN_STEP,

--- a/test/api/test_run_step.py
+++ b/test/api/test_run_step.py
@@ -87,6 +87,22 @@ class TestRunStepEndpoint:
         assert resp.status_code == 200
         assert m_run.await_args.kwargs["model"] == "anthropic/claude-3.5-sonnet"
 
+    def test_explicit_model_null_is_accepted_same_as_omitted(self, client):
+        """Regression: Pydantic v2 does not run field_validators on a field
+        that falls back to its default (validate_default=False, the
+        default) -- so `model` omitted entirely never exercises
+        validate_model's `if v is None` branch. An explicit `"model": null`
+        in the request body does exercise it, and must be accepted exactly
+        like omitting the field."""
+        result = AgentStepResult(
+            terminal_id="abc12345", last_message="all done", status=TerminalStatus.COMPLETED
+        )
+        with patch(_RUN_STEP, new=AsyncMock(return_value=result)) as m_run:
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(model=None))
+
+        assert resp.status_code == 200
+        assert m_run.await_args.kwargs["model"] is None
+
     def test_timeout_maps_to_504_with_structured_terminal_id(self, client):
         with patch(
             _RUN_STEP,

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -193,6 +193,66 @@ class TestTerminalCreationWithWorkingDirectory:
             assert call_kwargs.get("caller_id") == "dcba8765"
             assert response.json()["caller_id"] == "dcba8765"
 
+    def test_create_terminal_passes_model(self, client):
+        """model query param threads through to the service -- explicit
+        per-call model override for MCP handoff/assign."""
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            mock_svc.create_terminal = AsyncMock(
+                return_value=Terminal(
+                    id="abcd5678",
+                    name="test-window",
+                    session_name="test-session",
+                    provider="claude_code",
+                    agent_profile="analyst",
+                )
+            )
+
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={
+                    "provider": "claude_code",
+                    "agent_profile": "analyst",
+                    "model": "fable-5",
+                },
+            )
+
+            assert response.status_code == 201
+            call_kwargs = mock_svc.create_terminal.call_args.kwargs
+            assert call_kwargs.get("model") == "fable-5"
+
+    def test_create_terminal_omitted_model_forwards_none(self, client):
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            mock_svc.create_terminal = AsyncMock(
+                return_value=Terminal(
+                    id="abcd5678",
+                    name="test-window",
+                    session_name="test-session",
+                    provider="kiro_cli",
+                    agent_profile="analyst",
+                )
+            )
+
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={"provider": "kiro_cli", "agent_profile": "analyst"},
+            )
+
+            assert response.status_code == 201
+            call_kwargs = mock_svc.create_terminal.call_args.kwargs
+            assert call_kwargs.get("model") is None
+
     def test_create_terminal_rejects_malformed_caller_id(self, client):
         """caller_id is validated against the TerminalId pattern — IDs arrive
         from agent input and must not be persisted unvalidated."""

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -253,6 +253,31 @@ class TestTerminalCreationWithWorkingDirectory:
             call_kwargs = mock_svc.create_terminal.call_args.kwargs
             assert call_kwargs.get("model") is None
 
+    def test_create_terminal_rejects_malformed_model(self, client):
+        """PR #501 review: a malformed model (control char/newline/shell
+        metacharacter) must 400 at the request boundary rather than either
+        reaching terminal_service unvalidated or -- if it later raised
+        ValueError there -- being mismapped to a misleading 404 (this
+        endpoint's ValueError handler means "session/window not found")."""
+        with (
+            patch(
+                "cli_agent_orchestrator.api.main.resolve_provider",
+                side_effect=lambda _, fallback_provider: fallback_provider,
+            ),
+            patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc,
+        ):
+            response = client.post(
+                "/sessions/test-session/terminals",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "analyst",
+                    "model": "fable-5\nrm -rf /",
+                },
+            )
+
+            assert response.status_code == 400
+            mock_svc.create_terminal.assert_not_called()
+
     def test_create_terminal_rejects_malformed_caller_id(self, client):
         """caller_id is validated against the TerminalId pattern — IDs arrive
         from agent input and must not be persisted unvalidated."""

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -164,6 +164,73 @@ class TestCreateTerminalProviderResolution:
         mock_requests.post.assert_not_called()
 
 
+class TestCreateTerminalModelOverride:
+    """_create_terminal's own `model` parameter -- an explicit per-call model
+    override for the new terminal, forwarded to the existing-session POST as
+    a params entry (see terminal_service.create_terminal's own docstring for
+    how it wins over the profile's own static model field)."""
+
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
+    )
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="claude_code")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_model_is_forwarded_as_a_param(
+        self, mock_requests, mock_resolve_provider, mock_allowed_tools
+    ):
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        metadata_response = MagicMock()
+        metadata_response.json.return_value = {
+            "provider": "kiro_cli",
+            "session_name": "cao-session",
+            "allowed_tools": None,
+        }
+        metadata_response.raise_for_status.return_value = None
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-1", "provider": "claude_code"}
+        post_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = metadata_response
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "a1b2c3d4"}):
+            _create_terminal("reviewer", "/repo", model="fable-5")
+
+        _, kwargs = mock_requests.post.call_args
+        assert kwargs["params"]["model"] == "fable-5"
+
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
+    )
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="claude_code")
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_omitted_model_leaves_params_unchanged(
+        self, mock_requests, mock_resolve_provider, mock_allowed_tools
+    ):
+        """No model given -> params dict is byte-for-byte the pre-fix shape
+        (no 'model' key at all) -- existing callers see zero behavior change."""
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        metadata_response = MagicMock()
+        metadata_response.json.return_value = {
+            "provider": "kiro_cli",
+            "session_name": "cao-session",
+            "allowed_tools": None,
+        }
+        metadata_response.raise_for_status.return_value = None
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-1", "provider": "claude_code"}
+        post_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = metadata_response
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "a1b2c3d4"}):
+            _create_terminal("reviewer", "/repo")
+
+        _, kwargs = mock_requests.post.call_args
+        assert "model" not in kwargs["params"]
+
+
 class TestAssignSenderIdInjection:
     """Tests for sender ID injection in _assign_impl.
 
@@ -299,6 +366,36 @@ class TestAssignSenderIdInjection:
         # falsely conclude the worker has already received the task.
         assert "initializing" in result["message"].lower()
 
+    @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
+    @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
+    def test_assign_forwards_model_to_create_terminal(self, mock_create):
+        from cli_agent_orchestrator.mcp_server.server import _assign_impl
+
+        mock_create.return_value = ("worker-1", "claude_code")
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "a1b2c3d4"}):
+            result = _assign_impl("developer", "Do work", model="fable-5")
+
+        assert result["success"] is True
+        _, kwargs = mock_create.call_args
+        assert kwargs["model"] == "fable-5"
+
+    @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
+    @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
+    def test_assign_omitted_model_passes_none(self, mock_create):
+        """No model given -> _create_terminal's own model=None default kicks
+        in (profile.model, if any, still applies) -- existing callers see
+        zero behavior change."""
+        from cli_agent_orchestrator.mcp_server.server import _assign_impl
+
+        mock_create.return_value = ("worker-1", "claude_code")
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": "a1b2c3d4"}):
+            _assign_impl("developer", "Do work")
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["model"] is None
+
 
 class TestBuildAssignDescription:
     """Tests for the _build_assign_description helper.
@@ -385,6 +482,19 @@ class TestBuildAssignDescription:
         """When workdir is off, working_directory does not appear in Args."""
         desc = _build_assign_description(enable_sender_id=False, enable_workdir=False)
         assert "working_directory:" not in desc
+
+    # ------------------------------------------------------------------
+    # Model section (unconditional -- not gated on any flag)
+    # ------------------------------------------------------------------
+
+    def test_model_section_and_arg_always_present(self):
+        """Unlike working_directory, the Model section/arg isn't feature-
+        flagged -- present in all four combinations."""
+        for sender_id in (True, False):
+            for workdir in (True, False):
+                desc = _build_assign_description(sender_id, workdir)
+                assert "## Model" in desc
+                assert "model:" in desc
 
     # ------------------------------------------------------------------
     # All four flag combinations

--- a/test/mcp_server/test_handoff.py
+++ b/test/mcp_server/test_handoff.py
@@ -366,6 +366,42 @@ class TestHandoffContextPropagation:
         assert "allowed_tools" not in payload
 
 
+class TestHandoffModelOverride:
+    """handoff's own `model` parameter -- an explicit per-call model override
+    for the worker, threaded through to the run-step payload."""
+
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
+    @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
+    def test_model_is_forwarded_in_payload(self, mock_provider, _nudge):
+        mock_provider.return_value = _ctx("claude_code")
+
+        with patch("cli_agent_orchestrator.mcp_server.server.requests") as mock_requests:
+            mock_requests.post.return_value = _ok_run_step_response()
+            mock_requests.Timeout = Exception
+            result = asyncio.run(_handoff_impl("developer", "Do task", model="fable-5"))
+
+        assert result.success is True
+        payload = mock_requests.post.call_args[1]["json"]
+        assert payload["model"] == "fable-5"
+
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
+    @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
+    def test_omitted_model_is_absent_from_payload(self, mock_provider, _nudge):
+        """No model given -> no 'model' key at all (not None), matching the
+        existing convention for every other optional field on this payload
+        (session_name/caller_id/allowed_tools/working_directory above)."""
+        mock_provider.return_value = _ctx("claude_code")
+
+        with patch("cli_agent_orchestrator.mcp_server.server.requests") as mock_requests:
+            mock_requests.post.return_value = _ok_run_step_response()
+            mock_requests.Timeout = Exception
+            result = asyncio.run(_handoff_impl("developer", "Do task"))
+
+        assert result.success is True
+        payload = mock_requests.post.call_args[1]["json"]
+        assert "model" not in payload
+
+
 class TestResolveHandoffProvider:
     """_resolve_handoff_provider extracts the full supervisor context (not just
     the provider) from the supervisor terminal metadata."""

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1613,6 +1613,69 @@ class TestClaudeCodeProviderModelFlag:
 
         assert "--model" not in command
 
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_explicit_model_override_wins_over_profile_model(self, mock_load):
+        """An explicit per-call model (handoff/assign's own `model` param)
+        takes precedence over the profile's own static model field."""
+        mock_profile = MagicMock()
+        mock_profile.model = "sonnet"
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.permissionMode = None
+        mock_load.return_value = mock_profile
+
+        provider = ClaudeCodeProvider("tid", "sess", "win", "agent", model="fable-5")
+        command = provider._build_claude_command()
+
+        assert "--model fable-5" in command
+        assert "--model sonnet" not in command
+
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_explicit_model_override_applies_with_no_profile_model(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.permissionMode = None
+        mock_load.return_value = mock_profile
+
+        provider = ClaudeCodeProvider("tid", "sess", "win", "agent", model="fable-5")
+        command = provider._build_claude_command()
+
+        assert "--model fable-5" in command
+
+    @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
+    def test_model_override_ignored_for_native_agent_profile(self, mock_load):
+        """A profile that maps to a native Claude Code agent handles its own
+        model config -- an explicit override is not applied there (by
+        design, see the provider's own comment), and does not appear in the
+        launch command at all."""
+        mock_profile = MagicMock()
+        mock_profile.native_agent = "my-claude-agent"
+        mock_profile.permissionMode = None
+        mock_load.return_value = mock_profile
+
+        provider = ClaudeCodeProvider("tid", "sess", "win", "agent", model="fable-5")
+        command = provider._build_claude_command()
+
+        assert "--agent my-claude-agent" in command
+        assert "--model" not in command
+
+    def test_no_agent_profile_still_honors_explicit_model(self):
+        """No CAO profile exists (agent_profile passed straight through to
+        Claude Code's own native agent store) -- an explicit model override
+        still applies since there's no profile.model to conflict with."""
+        provider = ClaudeCodeProvider("tid", "sess", "win", "agent", model="fable-5")
+        # profile is None on this path (agent_profile has no CAO profile file).
+        with patch(
+            "cli_agent_orchestrator.providers.claude_code.load_agent_profile",
+            side_effect=FileNotFoundError,
+        ):
+            command = provider._build_claude_command()
+
+        assert "--agent agent" in command
+        assert "--model fable-5" in command
+
 
 class TestClaudeCodeProviderPermissionMode:
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -444,6 +444,27 @@ class TestCodexProviderModelFlag:
 
         assert "--model" not in command
 
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_explicit_model_override_wins_over_profile_model(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = "gpt-5"
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent", model="fable-5")
+        command = provider._build_codex_command()
+
+        assert "--model fable-5" in command
+        assert "--model gpt-5" not in command
+
+    def test_explicit_model_override_applies_with_no_agent_profile(self):
+        provider = CodexProvider("tid", "sess", "win", None, model="fable-5")
+        command = provider._build_codex_command()
+
+        assert "--model fable-5" in command
+
 
 class TestCodexBuildCommandExtra:
     """Coverage for branches inside ``_build_codex_command`` that the

--- a/test/providers/test_hermes_provider_unit.py
+++ b/test/providers/test_hermes_provider_unit.py
@@ -242,6 +242,24 @@ class TestHermesBuildCommand:
         assert "--model deepseek-v4-flash-free" in command
 
     @patch("cli_agent_orchestrator.providers.hermes.load_agent_profile")
+    def test_explicit_model_override_wins_over_profile_model(self, mock_load):
+        mock_profile = self._profile("test-worker")
+        mock_profile.model = "deepseek-v4-flash-free"
+        mock_load.return_value = mock_profile
+
+        provider = HermesProvider("tid", "sess", "win", "developer", model="fable-5")
+        command = provider._build_hermes_command()
+
+        assert "--model fable-5" in command
+        assert "--model deepseek-v4-flash-free" not in command
+
+    def test_explicit_model_override_applies_with_no_agent_profile(self):
+        provider = HermesProvider("tid", "sess", "win", None, model="fable-5")
+        command = provider._build_hermes_command()
+
+        assert "--model fable-5" in command
+
+    @patch("cli_agent_orchestrator.providers.hermes.load_agent_profile")
     def test_build_command_quotes_profile_with_spaces_or_shell_metacharacters(self, mock_load):
         mock_load.return_value = self._profile("test worker; rm -rf /")
 

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -946,6 +946,20 @@ class TestKimiCliProviderModelFlag:
 
         assert "--model" not in command
 
+    @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
+    def test_explicit_model_override_wins_over_profile_model(self, mock_load):
+        mock_profile = MagicMock()
+        mock_profile.model = "kimi-k2-turbo"
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_load.return_value = mock_profile
+
+        provider = KimiCliProvider("term-1", "sess", "win", "agent", model="fable-5")
+        command = provider._build_kimi_command()
+
+        assert "--model fable-5" in command
+        assert "--model kimi-k2-turbo" not in command
+
 
 class TestKimiCliProviderMisc:
     """Tests for miscellaneous KimiCliProvider methods and lifecycle."""

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -960,6 +960,18 @@ class TestKimiCliProviderModelFlag:
         assert "--model fable-5" in command
         assert "--model kimi-k2-turbo" not in command
 
+    def test_explicit_model_override_applies_with_no_agent_profile(self):
+        """Regression: PR #501 review -- model resolution used to live
+        entirely inside `if self._agent_profile is not None:`, so an
+        override passed with agent_profile=None (unreachable through
+        handoff/assign today, but inconsistent with codex/hermes's own
+        no-profile-still-applies shape) was silently dropped."""
+        provider = KimiCliProvider("term-1", "sess", "win", None, model="fable-5")
+        command = provider._build_kimi_command()
+
+        assert "--model fable-5" in command
+        provider.cleanup()
+
 
 class TestKimiCliProviderMisc:
     """Tests for miscellaneous KimiCliProvider methods and lifecycle."""

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -160,6 +160,27 @@ class TestKiroCliProviderInitialization:
             "kiro-cli chat --trust-all-tools --model claude-opus-4-6 --agent developer",
         )
 
+    @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
+    def test_get_profile_model_explicit_override_wins_over_profile_model(self, mock_load_profile):
+        profile = Mock()
+        profile.model = "claude-opus-4-6"
+        mock_load_profile.return_value = profile
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer", model="fable-5")
+
+        assert provider._get_profile_model() == "fable-5"
+
+    def test_get_profile_model_explicit_override_applies_without_loading_profile(self):
+        """An explicit override short-circuits before even attempting to
+        load the CAO agent profile from disk."""
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer", model="fable-5")
+
+        with patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile") as mock_load:
+            result = provider._get_profile_model()
+
+        assert result == "fable-5"
+        mock_load.assert_not_called()
+
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -166,14 +166,18 @@ class TestKiroCliProviderInitialization:
         profile.model = "claude-opus-4-6"
         mock_load_profile.return_value = profile
 
-        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer", model="fable-5")
+        provider = KiroCliProvider(
+            "test1234", "test-session", "window-0", "developer", model="fable-5"
+        )
 
         assert provider._get_profile_model() == "fable-5"
 
     def test_get_profile_model_explicit_override_applies_without_loading_profile(self):
         """An explicit override short-circuits before even attempting to
         load the CAO agent profile from disk."""
-        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer", model="fable-5")
+        provider = KiroCliProvider(
+            "test1234", "test-session", "window-0", "developer", model="fable-5"
+        )
 
         with patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile") as mock_load:
             result = provider._get_profile_model()

--- a/test/services/test_agent_step.py
+++ b/test/services/test_agent_step.py
@@ -124,6 +124,31 @@ class TestHappyPath:
             asyncio.run(run_agent_step("kiro_cli", "dev", "x", working_directory="/tmp/wd"))
         assert m_create.await_args.kwargs["working_directory"] == "/tmp/wd"
 
+    def test_model_forwarded_to_create(self):
+        """handoff's own `model` parameter reaches terminal_service.create_terminal
+        for a freshly created terminal."""
+        create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer()
+        with create as m_create, send, delete, get_output, exit_cli, wait, status:
+            asyncio.run(run_agent_step("kiro_cli", "dev", "x", model="fable-5"))
+        assert m_create.await_args.kwargs["model"] == "fable-5"
+
+    def test_omitted_model_forwards_none_to_create(self):
+        create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer()
+        with create as m_create, send, delete, get_output, exit_cli, wait, status:
+            asyncio.run(run_agent_step("kiro_cli", "dev", "x"))
+        assert m_create.await_args.kwargs["model"] is None
+
+    def test_reused_terminal_never_passes_model_to_create(self):
+        """Reusing a terminal skips create_terminal entirely -- model has
+        nothing to apply to and must not be silently expected to retarget an
+        already-running provider."""
+        create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer()
+        with create as m_create, send, delete, get_output, exit_cli, wait, status:
+            asyncio.run(
+                run_agent_step("kiro_cli", "dev", "x", reuse_terminal_id="reuse99", model="fable-5")
+            )
+        m_create.assert_not_awaited()
+
     def test_no_session_name_creates_new_session(self):
         """Regression: session_name=None must create a NEW tmux session
         (new_session=True). Otherwise create_terminal auto-generates a name and

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -131,6 +131,106 @@ class TestCreateTerminal:
     @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
     @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
     @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_create_terminal_explicit_model_overrides_profile_model(
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        """Regression: PR #501 review -- `model=model or (profile.model if
+        profile else None)` in create_terminal is the line the entire
+        model-override feature hangs on, and every other test mocks around
+        this exact seam (API tests mock terminal_service.create_terminal
+        itself, agent_step tests patch the terminal layer, MCP tests mock
+        requests, provider tests construct providers directly). This is the
+        one test that calls the REAL create_terminal with an explicit
+        override AND a profile carrying its own (different) model, so a
+        revert to the pre-PR `model=profile.model if profile else None`
+        would fail this test even though the rest of the suite stays green."""
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.return_value = AgentProfile(
+            name="developer", description="Developer", model="profile-default-model"
+        )
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        await create_terminal(
+            "kiro_cli", "developer", new_session=True, model="explicit-override-model"
+        )
+
+        assert mock_provider_manager.create_provider.call_args.kwargs["model"] == (
+            "explicit-override-model"
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_create_terminal_falls_back_to_profile_model_when_no_override(
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+    ):
+        """The other half of the same precedence line: with no explicit
+        override, the profile's own model still reaches provider creation
+        (unchanged pre-PR behavior)."""
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.return_value = AgentProfile(
+            name="developer", description="Developer", model="profile-default-model"
+        )
+        mock_provider = AsyncMock()
+        mock_provider.initialize.return_value = True
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        await create_terminal("kiro_cli", "developer", new_session=True)
+
+        assert (
+            mock_provider_manager.create_provider.call_args.kwargs["model"]
+            == "profile-default-model"
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
     async def test_create_terminal_persists_caller_id(
         self,
         mock_load_profile,


### PR DESCRIPTION
## Problem

`handoff`/`assign` -- the documented, intended way to spawn a child/worker agent -- had no way to specify which model the worker should use. Model selection only ever came from a static `model` field baked into a named agent profile file; a caller who wanted to pin a specific model for one worker had no lever short of authoring a dedicated profile first.

Found live by a downstream consumer (harness-control), investigating a real production incident: an agent supervisor, asked by its operator to spawn a child review agent on a specific model, found its own tool surface had no parameter for it. Rather than reporting this as impossible, it fell back to reverse-engineering CAO's raw REST API -- repeated large `/openapi.json` dumps, a 40-iteration polling loop -- and created a terminal via a raw `POST /sessions/{name}/terminals` call that bypassed all of CAO's own bookkeeping. That bypass is what actually caused the downstream crashes under investigation (the terminal's `account_id` was never recorded, since gateway-side bookkeeping only runs for terminals created through the normal path) -- the missing `model` parameter was the root trigger of the whole cascade, not merely a side note.

## Fix

Adds an optional `model: Optional[str] = None` parameter, threaded end-to-end through both `handoff`'s and `assign`'s distinct server-side paths:

- **assign**: MCP tool -> `_create_terminal` (HTTP client) -> `POST /sessions/{name}/terminals` -> `terminal_service.create_terminal` -> `provider_manager.create_provider` -> the resolved provider.
- **handoff**: MCP tool -> `POST /terminals/run-step` (`RunStepRequest`) -> `run_agent_step` -> the same `terminal_service.create_terminal` -> same downstream.

At the provider layer, this extends an *existing* per-call `model` kwarg pattern -- already implemented by `copilot_cli`/`opencode_cli`/`cursor_cli`/`antigravity_cli` -- to the remaining five providers (`claude_code`, `codex`, `kiro_cli`, `kimi_cli`, `hermes`), each of which previously read `model` only from a static profile field via its own `--model <name>` CLI flag construction. `terminal_service.create_terminal` resolves precedence once (an explicit override wins over `profile.model`) before constructing the provider -- matching `copilot_cli`/`opencode_cli`'s existing shape of trusting `self._model` as already-resolved, rather than re-deriving it. The newly-updated providers' own internal `profile.model` fallback stays load-bearing (not dead code) for the separate `provider_manager.get_provider()` on-demand-resurrection path -- e.g. reconnecting to a terminal after a server restart -- which never passes `model` at all and relies on each provider re-reading its own profile.

**Deliberately out of scope**: `_create_terminal`'s new-session branch (used only when there's no current `CAO_TERMINAL_ID`) does not get `model` support -- `assign` fails fast before ever reaching it (its own `CAO_TERMINAL_ID` guard), and `handoff` never calls `_create_terminal` at all (it uses the entirely separate run-step path) -- so this branch is unreachable from either MCP tool in practice, verified by reading both call sites.

## Self-ROAST fix: a real false-positive this PR would otherwise have shipped

An independent review of this branch caught a real regression before it ever ran against a live profile: `claude_code.py`'s `native_agent` branch (a profile that thin-wraps a native Claude Code agent, which owns its own model config by design -- `--model` is never applied there, deliberately, same as MCP servers/hooks/tools) originally logged a warning whenever `self._model` was truthy. But by the time `self._model` reaches the provider, it's already been resolved to `override-or-profile.model` one layer up (`terminal_service.create_terminal`'s own precedence resolution) -- so the warning fired on an ordinary, previously-silent, entirely schema-legal profile shape (`native_agent` + a `model` field, no caller override at all involved), misattributing routine profile config as an ignored explicit request. Removed rather than left in; the underlying behavior (never applying `--model` on that branch) is unchanged and correct.

## Test plan

- New/updated tests across `test/providers/` (all 5 newly-updated providers, including the override-wins-over-profile.model and no-profile-still-applies cases), `test/mcp_server/test_assign.py` and `test_handoff.py` (parameter forwarding + payload/params shape when given vs. omitted), `test/api/test_run_step.py` and `test_terminals.py` (REST-layer forwarding), `test/services/test_agent_step.py` (the handoff-path substrate, including that `model` is never forwarded when reusing an existing terminal).
- `uv run pytest test/providers/ test/mcp_server/ test/api/ test/services/test_terminal_service*.py test/services/test_agent_step*.py -q --no-cov` -> 1872 passed, 0 failed (15 pre-existing `test_agui_*` failures reproduce identically against unmodified `main` -- confirmed against a clean checkout -- and are unrelated to this change).
- Backward compatibility: every touched function's new `model` parameter defaults to `None`; every dict/payload insertion is `if model:`-guarded; confirmed no unconditional shape change in any touched request/params dict when `model` is omitted (new tests assert `"model" not in params`/`payload`, not merely `is None`).

Happy to extend `model` support to the remaining providers (`hermes`'s own gaps, kiro_cli's `_get_profile_model` shape, etc.) or reconsider the new-session-branch scoping if you'd prefer a wider surface.