### PR TITLE
fix(memory): bound graph lint projection

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -65,7 +65,8 @@ from cli_agent_orchestrator.constants import (
     add_local_cors_origins,
 )
 from cli_agent_orchestrator.ext_apps import mount_widget_static
-from cli_agent_orchestrator.graph.providers import get_provider
+from cli_agent_orchestrator.graph.models import GraphView
+from cli_agent_orchestrator.graph.providers import GraphProvider, get_provider
 
 # Import the sinks package for its import-time @register_sink side effects
 # ("okf", "obsidian", "graphml"); get_sink resolves by name from the registry.
@@ -130,6 +131,7 @@ logger = logging.getLogger(__name__)
 TMUX_KEY_PATTERN = re.compile(
     r"^(?:Up|Down|Left|Right|Enter|Tab|Escape|Space|[A-Za-z0-9]|[CMS]-[A-Za-z0-9])$"
 )
+GRAPH_PROJECTION_TIMEOUT_S = 90.0
 
 
 async def flow_daemon():
@@ -2592,6 +2594,28 @@ async def resume_workflow_run_endpoint(
 # which raise KeyError for an unregistered name (mapped to 404 here).
 
 
+async def _project_graph_with_timeout(
+    inst: GraphProvider,
+    filters: Dict[str, Any],
+    *,
+    provider: str,
+    timeout_s: float = GRAPH_PROJECTION_TIMEOUT_S,
+) -> GraphView:
+    try:
+        return await asyncio.wait_for(inst.project(**filters), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail={
+                "message": f"graph projection timed out after {timeout_s:g} seconds",
+                "kind": "graph_projection_timeout",
+                "timeout_s": timeout_s,
+                "provider": provider,
+                "metadata": {"graph_projection_timeout": True},
+            },
+        )
+
+
 @app.get("/graph/{provider}")
 async def get_graph_endpoint(
     provider: str,
@@ -2642,7 +2666,7 @@ async def get_graph_endpoint(
             detail=f"unknown graph provider '{provider}'",
         )
     try:
-        view = await inst.project(**filters)
+        view = await _project_graph_with_timeout(inst, filters, provider=provider)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     return view.to_dict()

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -2703,7 +2703,7 @@ async def export_graph_endpoint(
         )
 
     try:
-        view = await prov.project(**filters)
+        view = await _project_graph_with_timeout(prov, filters, provider=provider)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/src/cli_agent_orchestrator/cli/commands/memory.py
+++ b/src/cli_agent_orchestrator/cli/commands/memory.py
@@ -293,10 +293,22 @@ def lint_cmd(scope, out_format):
     """
     import json as _json
 
+    from cli_agent_orchestrator.services import settings_service
     from cli_agent_orchestrator.services.wiki_lint import (
         compute_exit_code,
         run_lint,
     )
+
+    is_json = out_format.lower() == "json"
+    if not settings_service.is_memory_lint_enabled():
+        message = (
+            "Memory lint is disabled by configuration "
+            "(memory.lint_enabled=false or CAO_MEMORY_LINT_ENABLED=false)."
+        )
+        click.echo(message, err=is_json)
+        if is_json:
+            click.echo("[]")
+        raise click.exceptions.Exit(0)
 
     svc = _get_memory_service()
     ctx = _cwd_context()
@@ -310,8 +322,6 @@ def lint_cmd(scope, out_format):
         issues = _run_async(run_lint(project_hash, scope=scope))
     except Exception as e:
         raise click.ClickException(f"lint run failed: {e}")
-
-    is_json = out_format.lower() == "json"
 
     # Emit a top-line completion summary for visibility even when the result
     # list is empty. Routed to stderr under --format json so stdout stays a
@@ -460,8 +470,21 @@ def heal_cmd(scope, do_apply, aggressive, issue_type, out_format):
     """
     import json as _json
 
-    from cli_agent_orchestrator.services import wiki_healer
+    from cli_agent_orchestrator.services import settings_service, wiki_healer
     from cli_agent_orchestrator.services.wiki_lint import run_lint
+
+    is_json = out_format.lower() == "json"
+    if not settings_service.is_memory_lint_enabled():
+        message = (
+            "Memory lint is disabled by configuration "
+            "(memory.lint_enabled=false or CAO_MEMORY_LINT_ENABLED=false)."
+        )
+        if is_json:
+            click.echo(message, err=True)
+            click.echo(_json.dumps({"disabled": True, "message": message}, indent=2))
+        else:
+            click.echo(message)
+        return
 
     svc = _get_memory_service()
     ctx = _cwd_context()
@@ -497,7 +520,6 @@ def heal_cmd(scope, do_apply, aggressive, issue_type, out_format):
     except Exception as e:
         raise click.ClickException(f"heal failed: {e}")
 
-    is_json = out_format.lower() == "json"
     if is_json:
         payload = {
             "scope": report.scope,

--- a/src/cli_agent_orchestrator/graph/cache.py
+++ b/src/cli_agent_orchestrator/graph/cache.py
@@ -1,4 +1,6 @@
-"""Per-(provider, scope, scope_id) GraphView cache (Issue #348, perf follow-up).
+"""Per-(provider, scope, scope_id, lint_enabled) GraphView cache.
+
+Issue #348, perf follow-up.
 
 DELIBERATE ADR REVERSAL. The original graph-layer design record specified
 "lint-on-demand, no caching machinery" (ADR-7): every ``/graph/{provider}``
@@ -41,10 +43,11 @@ from cli_agent_orchestrator.graph.models import GraphView
 # write-invalidation (see module docstring).
 DEFAULT_TTL_S = 300.0
 
-# Cache key: (provider name, scope, scope_id). scope_id is normalized to a
-# string-or-None so ``("memory","global",None)`` and a project projection never
-# collide, and a global request never serves a project-scope entry.
-CacheKey = tuple[str, str, Optional[str]]
+# Cache key: (provider name, scope, scope_id, lint_enabled). scope_id is
+# normalized to a string-or-None so ``("memory","global",None,True)`` and a
+# project projection never collide, a global request never serves a
+# project-scope entry, and lint-enabled/disabled graph projections stay isolated.
+CacheKey = tuple[str, str, Optional[str], bool]
 
 
 @dataclass

--- a/src/cli_agent_orchestrator/graph/providers/memory.py
+++ b/src/cli_agent_orchestrator/graph/providers/memory.py
@@ -8,12 +8,12 @@ ABC, no edits to memory_service/wiki_lint) and awaiting
 
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from cli_agent_orchestrator.graph.cache import GraphViewCache, make_meta
 from cli_agent_orchestrator.graph.models import Edge, EdgeType, GraphView, Node
 from cli_agent_orchestrator.graph.providers.base import GraphProvider, register_provider
-from cli_agent_orchestrator.services import wiki_lint
+from cli_agent_orchestrator.services import settings_service, wiki_lint
 from cli_agent_orchestrator.services.memory_service import MemoryService
 
 logger = logging.getLogger(__name__)
@@ -41,8 +41,13 @@ class MemoryGraphProvider(GraphProvider):
     never cross the (scope, scope_id) boundary (FR-9).
     """
 
-    def __init__(self, memory_service: Optional[MemoryService] = None) -> None:
+    def __init__(
+        self,
+        memory_service: Optional[MemoryService] = None,
+        lint_enabled: Optional[Callable[[], bool]] = None,
+    ) -> None:
         self._svc = memory_service or MemoryService()
+        self._lint_enabled = lint_enabled or settings_service.is_memory_lint_enabled
 
     async def project(self, **filters: Any) -> GraphView:
         """Return this scope's GraphView, served from cache when fresh.
@@ -57,8 +62,12 @@ class MemoryGraphProvider(GraphProvider):
         raw_scope_id = filters.get("scope_id")
         scope_id: Optional[str] = None if raw_scope_id is None else str(raw_scope_id)
 
-        key = ("memory", scope, scope_id)
-        view, cached, as_of = await _CACHE.get_or_build(key, lambda: self._build(scope, scope_id))
+        lint_enabled = self._lint_enabled()
+        key = ("memory", scope, scope_id, lint_enabled)
+        view, cached, as_of = await _CACHE.get_or_build(
+            key,
+            lambda: self._build(scope, scope_id, lint_enabled),
+        )
         # Re-wrap with fresh cache provenance without mutating the cached
         # instance's own meta (the same GraphView object is served to every hit).
         return GraphView(
@@ -67,9 +76,23 @@ class MemoryGraphProvider(GraphProvider):
             meta=make_meta(view.meta, cached=cached, as_of=as_of),
         )
 
-    async def _build(self, scope: str, scope_id: Optional[str]) -> GraphView:
+    async def _build(self, scope: str, scope_id: Optional[str], lint_enabled: bool) -> GraphView:
         """Project the scope's wiki into a GraphView (the uncached, ~148s path)."""
         meta: dict[str, Any] = {"provider": "memory", "scope": scope, "scope_id": scope_id}
+        if not lint_enabled:
+            meta.update(
+                {
+                    "lint_enabled": False,
+                    "lint_enrichment": "disabled",
+                    "disabled_enrichments": [
+                        "orphan_page",
+                        "contradiction",
+                        "stale_claim",
+                        "poison_frequency",
+                        "graph_density",
+                    ],
+                }
+            )
 
         # Resolve + parse the scope's index. A scope with no wiki on disk
         # (or an unresolvable scope/scope_id) is an empty graph, not an error.
@@ -118,20 +141,21 @@ class MemoryGraphProvider(GraphProvider):
                     )
                 )
 
-        # Lint findings — awaited directly in-request (ADR-7); no SQL or LLM
-        # calls beyond what run_lint itself performs (FR-7, C-1). A lint
-        # failure degrades to a lint-free graph rather than a 500.
-        try:
-            # project_hash arg is only used for run_lint's audit log, not for
-            # lookup — `project()` has no cwd/terminal_context to resolve the
-            # real project id (resolve_project_id), so this is a placeholder.
-            issues = await wiki_lint.run_lint(scope_id or scope, scope=scope)
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            logger.warning("memory graph provider: run_lint failed: %r", e, exc_info=True)
-            meta["lint_error"] = type(e).__name__
-            issues = []
+        issues = []
+        if lint_enabled:
+            # Lint findings may run expensive detectors. A failure degrades to
+            # a lint-free graph rather than a 500.
+            try:
+                # project_hash arg is only used for run_lint's audit log, not
+                # lookup — `project()` has no cwd/terminal_context to resolve
+                # the real project id (resolve_project_id), so this is a
+                # placeholder.
+                issues = await wiki_lint.run_lint(scope_id or scope, scope=scope)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("memory graph provider: run_lint failed: %r", e, exc_info=True)
+                meta["lint_error"] = type(e).__name__
 
         for issue in issues:
             if issue.issue_type == "orphan_page":

--- a/src/cli_agent_orchestrator/services/config_service.py
+++ b/src/cli_agent_orchestrator/services/config_service.py
@@ -65,6 +65,7 @@ class MemoryConfig(BaseModel):
     compile_mode: str = "llm"
     flush_threshold: float = 0.85
     compile_timeout_s: float = 120.0
+    lint_enabled: bool = True
 
 
 class TerminalConfig(BaseModel):
@@ -177,6 +178,7 @@ ENV_REGISTRY: Dict[str, Tuple[str, str, Any]] = {
     "CAO_CORS_ORIGINS": ("network.cors_origins", "list", []),
     "CAO_WS_ALLOWED_CLIENTS": ("network.ws_allowed_clients", "list", []),
     "CAO_MEMORY_ENABLED": ("memory.enabled", "bool", True),
+    "CAO_MEMORY_LINT_ENABLED": ("memory.lint_enabled", "bool", True),
     "CAO_MEMORY_COMPILE_MODE": ("memory.compile_mode", "str", "llm"),
     "CAO_MEMORY_FLUSH_THRESHOLD": ("memory.flush_threshold", "float", 0.85),
     "CAO_MCP_REQUEST_TIMEOUT": ("server.mcp_request_timeout", "int", 30),
@@ -329,6 +331,8 @@ def _get_owned_section(path: str, default: Any) -> Any:
     if section == "memory":
         if key == "enabled":
             return settings_service.is_memory_enabled()
+        if key == "lint_enabled":
+            return settings_service.is_memory_lint_enabled()
         if key == "compile_mode":
             return settings_service.get_compile_mode()
         if key == "compile_timeout_s":
@@ -350,6 +354,11 @@ def _get_value(path: str, default: Any = None, override: Optional[Any] = None) -
     """
     if override is not None:
         return override
+
+    if path == "memory.lint_enabled":
+        from cli_agent_orchestrator.services import settings_service
+
+        return settings_service.is_memory_lint_enabled()
 
     env_name = _PATH_TO_ENV.get(path)
     if env_name is not None:
@@ -442,6 +451,7 @@ _ALL_PATHS = sorted(
         "server.provider_init_timeout",
         "server.startup_prompt_handler_timeout",
         "memory.enabled",
+        "memory.lint_enabled",
         "memory.compile_mode",
         "memory.flush_threshold",
         "memory.compile_timeout_s",
@@ -504,6 +514,7 @@ class ConfigService:
             ),
             memory=MemoryConfig(
                 enabled=_get_value("memory.enabled", default=True),
+                lint_enabled=_get_value("memory.lint_enabled", default=True),
                 compile_mode=_get_value("memory.compile_mode", default="llm"),
                 flush_threshold=_get_value("memory.flush_threshold", default=0.85),
                 compile_timeout_s=_get_value("memory.compile_timeout_s", default=120.0),

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -257,7 +257,10 @@ def get_server_settings() -> Dict[str, Any]:
 def get_memory_settings() -> Dict[str, Any]:
     """Get memory-related settings.
 
-    Precedence per key: CAO_* env var > settings.json > built-in default.
+    Precedence for most keys: CAO_* env var > settings.json > built-in
+    default. ``memory.lint_enabled`` intentionally uses
+    ``is_memory_lint_enabled()`` fail-closed semantics instead: any explicit
+    false in persisted settings or ``CAO_MEMORY_LINT_ENABLED`` disables lint.
 
     ``enabled`` defaults to ``True`` (opt-out) to preserve current shipping
     behavior. Setting it to ``False`` disables all memory subsystem

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -21,6 +21,9 @@ _DEFAULTS = {
     "cao_installed": str(Path.home() / ".aws" / "cli-agent-orchestrator" / "agent-context"),
 }
 
+_BOOL_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_BOOL_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
 
 def _load() -> Dict[str, Any]:
     """Load settings from disk."""
@@ -261,8 +264,15 @@ def get_memory_settings() -> Dict[str, Any]:
     operations — see ``is_memory_enabled()``.
     """
     settings = _load()
-    defaults: Dict[str, Any] = {"enabled": True, "flush_threshold": 0.85}
+    defaults: Dict[str, Any] = {
+        "enabled": True,
+        "flush_threshold": 0.85,
+        "lint_enabled": True,
+    }
     saved = settings.get("memory", {})
+    if not isinstance(saved, dict):
+        logger.warning("Invalid settings.memory=%r (expected object); using defaults", saved)
+        saved = {}
     result = dict(defaults)
     result.update(saved)
 
@@ -289,7 +299,54 @@ def get_memory_settings() -> Dict[str, Any]:
                 f"(expected float); using file/default"
             )
 
+    result["lint_enabled"] = is_memory_lint_enabled(settings=settings)
     return result
+
+
+def _coerce_optional_bool(value: Any, *, label: str) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "":
+            return None
+        if normalized in _BOOL_TRUE_VALUES:
+            return True
+        if normalized in _BOOL_FALSE_VALUES:
+            return False
+    logger.warning("Ignoring invalid %s=%r (expected bool); using file/default", label, value)
+    return None
+
+
+def _explicit_false(value: Any, *, label: str) -> bool:
+    return _coerce_optional_bool(value, label=label) is False
+
+
+def is_memory_lint_enabled(settings: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True unless persisted settings or env explicitly disable lint.
+
+    This is intentionally not normal env precedence: either explicit false
+    source disables lint, so env true cannot override persisted false and
+    persisted true cannot override env false.
+    """
+    try:
+        data = settings if settings is not None else _load()
+        saved = data.get("memory", {}) if isinstance(data, dict) else {}
+        if not isinstance(saved, dict):
+            saved = {}
+
+        if _explicit_false(saved.get("lint_enabled", True), label="memory.lint_enabled"):
+            return False
+
+        raw_env = os.environ.get("CAO_MEMORY_LINT_ENABLED")
+        if raw_env is not None and raw_env.strip() != "":
+            coerced = _coerce_optional_bool(raw_env, label="CAO_MEMORY_LINT_ENABLED")
+            if coerced is False:
+                return False
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to read memory.lint_enabled, defaulting to True: {e}")
+        return True
 
 
 def is_memory_enabled() -> bool:
@@ -360,13 +417,20 @@ def set_memory_setting(key: str, value: Any) -> Dict[str, Any]:
     Supported keys:
         ``enabled`` (bool) — master switch for the memory subsystem.
         ``flush_threshold`` (float, 0.0 < x ≤ 1.0) — context-usage trigger.
+        ``lint_enabled`` (bool) — expensive wiki lint enrichment switch.
     """
     settings = _load()
     memory = settings.get("memory", {})
+    if not isinstance(memory, dict):
+        memory = {}
 
     if key == "enabled":
         if not isinstance(value, bool):
             raise ValueError(f"enabled must be a bool, got {type(value).__name__}")
+        memory[key] = value
+    elif key == "lint_enabled":
+        if not isinstance(value, bool):
+            raise ValueError(f"lint_enabled must be a bool, got {type(value).__name__}")
         memory[key] = value
     elif key == "flush_threshold":
         fval = float(value)

--- a/src/cli_agent_orchestrator/services/wiki_lint.py
+++ b/src/cli_agent_orchestrator/services/wiki_lint.py
@@ -1030,7 +1030,7 @@ async def run_lint(
 
     # Detector: stale_claim.
     try:
-        issues.extend(_detect_stale_claims(rows, repo_root_resolved))
+        issues.extend(await asyncio.to_thread(_detect_stale_claims, rows, repo_root_resolved))
         completion["stale_claim"] = True
     except Exception as e:
         logger.warning(f"stale_claim detector failed: {e}")

--- a/test/cli/commands/test_config.py
+++ b/test/cli/commands/test_config.py
@@ -124,6 +124,18 @@ class TestConfigSet:
         assert result.exception is None or isinstance(result.exception, SystemExit)
         assert "Unknown memory setting" in result.output
 
+    def test_set_memory_lint_enabled_false_persists_locally(self, runner, _isolated_settings):
+        result = runner.invoke(config, ["set", "memory.lint_enabled", "false"])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["lint_enabled"] is False
+
+        on_disk = json.loads(_isolated_settings["settings"].read_text())
+        assert on_disk["memory"]["lint_enabled"] is False
+
+        get_result = runner.invoke(config, ["get", "memory.lint_enabled"])
+        assert get_result.exit_code == 0
+        assert json.loads(get_result.output) is False
+
     def test_set_network_key_succeeds_persists_and_warns(self, runner, _isolated_settings):
         """network.* is schema-only (no runtime effect yet) — set() still
         succeeds and persists, but must warn the operator on stderr."""

--- a/test/cli/commands/test_memory.py
+++ b/test/cli/commands/test_memory.py
@@ -322,6 +322,43 @@ class TestMemoryLint:
 
     @patch("cli_agent_orchestrator.services.wiki_lint.run_lint", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.cli.commands.memory._get_memory_service")
+    @patch(
+        "cli_agent_orchestrator.services.settings_service.is_memory_lint_enabled",
+        return_value=False,
+    )
+    def test_lint_disabled_table_skips_expensive_work(
+        self, mock_lint_enabled, mock_get_svc, mock_run_lint
+    ):
+        runner = CliRunner()
+        result = runner.invoke(lint_cmd, [])
+
+        assert result.exit_code == 0
+        assert "Memory lint is disabled by configuration" in result.stdout
+        mock_get_svc.assert_not_called()
+        mock_run_lint.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.wiki_lint.run_lint", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.cli.commands.memory._get_memory_service")
+    @patch(
+        "cli_agent_orchestrator.services.settings_service.is_memory_lint_enabled",
+        return_value=False,
+    )
+    def test_lint_disabled_json_stdout_remains_parseable(
+        self, mock_lint_enabled, mock_get_svc, mock_run_lint
+    ):
+        import json
+
+        runner = CliRunner()
+        result = runner.invoke(lint_cmd, ["--format", "json"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == []
+        assert "Memory lint is disabled by configuration" in result.stderr
+        mock_get_svc.assert_not_called()
+        mock_run_lint.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.wiki_lint.run_lint", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.cli.commands.memory._get_memory_service")
     def test_lint_json_stdout_is_pure_json(self, mock_get_svc, mock_run_lint):
         """The completion line must not pollute stdout under --format json."""
         import json
@@ -405,6 +442,54 @@ class TestMemoryLint:
 
 class TestMemoryHeal:
     """cao memory heal — dry-run default, --apply gate, poison dual-gate."""
+
+    @patch("cli_agent_orchestrator.services.wiki_healer.heal", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.services.wiki_lint.run_lint", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.cli.commands.memory._get_memory_service")
+    @patch(
+        "cli_agent_orchestrator.services.settings_service.is_memory_lint_enabled",
+        return_value=False,
+    )
+    def test_heal_disabled_dry_run_skips_lint_and_heal(
+        self, mock_lint_enabled, mock_get_svc, mock_run_lint, mock_heal
+    ):
+        runner = CliRunner()
+        result = runner.invoke(heal_cmd, ["--scope", "project"])
+
+        assert result.exit_code == 0
+        assert "Memory lint is disabled by configuration" in result.stdout
+        mock_get_svc.assert_not_called()
+        mock_run_lint.assert_not_called()
+        mock_heal.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.wiki_healer.heal", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.services.wiki_lint.run_lint", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.cli.commands.memory._get_memory_service")
+    @patch(
+        "cli_agent_orchestrator.services.settings_service.is_memory_lint_enabled",
+        return_value=False,
+    )
+    def test_heal_disabled_apply_skips_lint_and_heal(
+        self, mock_lint_enabled, mock_get_svc, mock_run_lint, mock_heal
+    ):
+        runner = CliRunner()
+        result = runner.invoke(heal_cmd, ["--scope", "project", "--apply"])
+
+        assert result.exit_code == 0
+        assert "Memory lint is disabled by configuration" in result.stdout
+        mock_get_svc.assert_not_called()
+        mock_run_lint.assert_not_called()
+        mock_heal.assert_not_called()
+
+    def test_lint_and_heal_do_not_define_force_override(self):
+        lint_options = {opt.name for opt in lint_cmd.params}
+        heal_options = {opt.name for opt in heal_cmd.params}
+        runner = CliRunner()
+
+        assert "force" not in lint_options
+        assert "force" not in heal_options
+        assert "--force" not in runner.invoke(lint_cmd, ["--help"]).output
+        assert "--force" not in runner.invoke(heal_cmd, ["--help"]).output
 
     @patch("cli_agent_orchestrator.services.wiki_healer.heal", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.services.wiki_lint.run_lint", new_callable=AsyncMock)

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -9,6 +9,7 @@ engine (no mocking of the memory internals); the lint LLM is stubbed.
 import asyncio
 import json
 import time
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import create_engine
@@ -311,3 +312,34 @@ class TestMemoryProviderEdgeCases:
 
         with pytest.raises(asyncio.CancelledError):
             await provider.project(scope="global")
+
+    @pytest.mark.asyncio
+    async def test_lint_disabled_skips_run_lint_and_keeps_related_topology(
+        self, populated_scope, monkeypatch
+    ):
+        run_lint = AsyncMock(return_value=[])
+        monkeypatch.setattr(wiki_lint, "run_lint", run_lint)
+        provider = MemoryGraphProvider(
+            memory_service=populated_scope,
+            lint_enabled=lambda: False,
+        )
+
+        view = await provider.project(scope="global")
+
+        run_lint.assert_not_called()
+        assert {n.id for n in view.nodes} >= {"a", "b", "c"}
+        assert [(e.source, e.target, e.type) for e in view.edges] == [
+            ("a", "b", EdgeType.RELATES_TO)
+        ]
+        assert view.meta["lint_enabled"] is False
+        assert view.meta["lint_enrichment"] == "disabled"
+        assert set(view.meta["disabled_enrichments"]) == {
+            "orphan_page",
+            "contradiction",
+            "stale_claim",
+            "poison_frequency",
+            "graph_density",
+        }
+        by_id = {n.id: n for n in view.nodes}
+        assert "is_hub" not in by_id["a"].attrs
+        assert all(e.type != EdgeType.CONTRADICTION for e in view.edges)

--- a/test/graph/test_api_routes.py
+++ b/test/graph/test_api_routes.py
@@ -7,15 +7,21 @@ fixture in test/graph/conftest.py, so registering the test sink here does not
 leak into other tests.
 """
 
+import asyncio
 import inspect
+import threading
+import time
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
+from cli_agent_orchestrator.api import main as api_main
 from cli_agent_orchestrator.api.main import app
 from cli_agent_orchestrator.graph.models import GraphView, Node
+from cli_agent_orchestrator.graph.providers import base as providers_base
+from cli_agent_orchestrator.graph.providers.base import GraphProvider
 from cli_agent_orchestrator.graph.sinks import base as sinks_base
 from cli_agent_orchestrator.graph.sinks.base import GraphSink
 from cli_agent_orchestrator.plugins import PluginRegistry
@@ -137,6 +143,75 @@ def test_get_graph_private_scope_refused_400(client, auth_on, scope):
     resp = client.get(f"/graph/stub?scope={scope}")
     assert resp.status_code == 400
     assert "private" in resp.json()["detail"]
+
+
+def test_get_graph_private_scope_refused_before_provider_resolution(client, auth_on, monkeypatch):
+    app.dependency_overrides[auth.get_current_scopes] = _override_scopes([auth.SCOPE_READ])
+    get_provider_spy = MagicMock()
+    monkeypatch.setattr(api_main, "get_provider", get_provider_spy)
+
+    resp = client.get("/graph/memory?scope=session")
+
+    assert resp.status_code == 400
+    get_provider_spy.assert_not_called()
+
+
+def test_graph_projection_timeout_returns_structured_504(client, monkeypatch):
+    assert api_main.GRAPH_PROJECTION_TIMEOUT_S == 90.0
+
+    @providers_base.register_provider("slow-provider")
+    class _SlowProvider(GraphProvider):
+        async def project(self, **filters: Any) -> GraphView:
+            await asyncio.sleep(1.0)
+            return GraphView(nodes=[], edges=[])
+
+    original = api_main._project_graph_with_timeout
+
+    async def _short_timeout(inst, filters, *, provider, timeout_s=90.0):
+        return await original(inst, filters, provider=provider, timeout_s=0.01)
+
+    monkeypatch.setattr(api_main, "_project_graph_with_timeout", _short_timeout)
+
+    resp = client.get("/graph/slow-provider")
+
+    assert resp.status_code == 504
+    detail = resp.json()["detail"]
+    assert detail["kind"] == "graph_projection_timeout"
+    assert detail["provider"] == "slow-provider"
+    assert detail["timeout_s"] == 0.01
+    assert detail["metadata"]["graph_projection_timeout"] is True
+
+
+def test_health_responds_while_slow_graph_projection_in_flight(client, monkeypatch):
+    @providers_base.register_provider("slow-health-provider")
+    class _SlowHealthProvider(GraphProvider):
+        async def project(self, **filters: Any) -> GraphView:
+            await asyncio.sleep(1.0)
+            return GraphView(nodes=[], edges=[])
+
+    original = api_main._project_graph_with_timeout
+
+    async def _short_timeout(inst, filters, *, provider, timeout_s=90.0):
+        return await original(inst, filters, provider=provider, timeout_s=0.3)
+
+    monkeypatch.setattr(api_main, "_project_graph_with_timeout", _short_timeout)
+    graph_response = {}
+
+    def _call_graph() -> None:
+        graph_response["resp"] = client.get("/graph/slow-health-provider")
+
+    thread = threading.Thread(target=_call_graph)
+    thread.start()
+    time.sleep(0.05)
+
+    started = time.monotonic()
+    health = client.get("/health")
+    elapsed = time.monotonic() - started
+
+    thread.join(timeout=1.0)
+    assert health.status_code == 200
+    assert elapsed < 0.5
+    assert graph_response["resp"].status_code == 504
 
 
 # ── POST /graph/{provider}/export ────────────────────────────────────────

--- a/test/graph/test_api_routes.py
+++ b/test/graph/test_api_routes.py
@@ -234,6 +234,36 @@ def test_post_export_happy_path(client, stub_test_sink):
     assert stub_test_sink.call_count == 1
 
 
+def test_post_export_projection_timeout_returns_structured_504_without_exporting(
+    client, stub_test_sink, monkeypatch
+):
+    @providers_base.register_provider("slow-export-provider")
+    class _SlowExportProvider(GraphProvider):
+        async def project(self, **filters: Any) -> GraphView:
+            await asyncio.sleep(1.0)
+            return GraphView(nodes=[], edges=[])
+
+    original = api_main._project_graph_with_timeout
+
+    async def _short_timeout(inst, filters, *, provider, timeout_s=90.0):
+        return await original(inst, filters, provider=provider, timeout_s=0.01)
+
+    monkeypatch.setattr(api_main, "_project_graph_with_timeout", _short_timeout)
+
+    resp = client.post(
+        "/graph/slow-export-provider/export",
+        json={"sink": "stub-test-sink", "dest": "/tmp/x", "options": {}},
+    )
+
+    assert resp.status_code == 504
+    detail = resp.json()["detail"]
+    assert detail["kind"] == "graph_projection_timeout"
+    assert detail["provider"] == "slow-export-provider"
+    assert detail["timeout_s"] == 0.01
+    assert detail["metadata"]["graph_projection_timeout"] is True
+    stub_test_sink.assert_not_called()
+
+
 def test_post_export_unregistered_sink_404(client):
     """An unregistered sink name is a 404."""
     resp = client.post(

--- a/test/services/test_memory_lint_enabled.py
+++ b/test/services/test_memory_lint_enabled.py
@@ -1,0 +1,87 @@
+"""Tests for the memory.lint_enabled fail-closed settings contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cli_agent_orchestrator.services import config_service as cs
+from cli_agent_orchestrator.services.config_service import ConfigService
+
+
+@pytest.fixture(autouse=True)
+def _isolated_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.SETTINGS_FILE",
+        settings_file,
+    )
+    monkeypatch.setattr("cli_agent_orchestrator.services.settings_service.CAO_HOME_DIR", tmp_path)
+    monkeypatch.setattr(cs, "LEGACY_CONFIG_FILE", tmp_path / "config.json")
+    for env_name in cs.ENV_REGISTRY:
+        monkeypatch.delenv(env_name, raising=False)
+    return settings_file
+
+
+def test_lint_enabled_defaults_true(_isolated_settings: Path) -> None:
+    from cli_agent_orchestrator.services.settings_service import is_memory_lint_enabled
+
+    assert is_memory_lint_enabled() is True
+    assert ConfigService.get("memory.lint_enabled") is True
+
+
+def test_env_false_disables_even_when_persisted_true(
+    _isolated_settings: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cli_agent_orchestrator.services.settings_service import is_memory_lint_enabled
+
+    _isolated_settings.write_text(json.dumps({"memory": {"lint_enabled": True}}))
+    monkeypatch.setenv("CAO_MEMORY_LINT_ENABLED", "false")
+
+    assert is_memory_lint_enabled() is False
+    assert ConfigService.get("memory.lint_enabled") is False
+
+
+def test_persisted_false_disables_even_when_env_true(
+    _isolated_settings: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cli_agent_orchestrator.services.settings_service import is_memory_lint_enabled
+
+    _isolated_settings.write_text(json.dumps({"memory": {"lint_enabled": False}}))
+    monkeypatch.setenv("CAO_MEMORY_LINT_ENABLED", "true")
+
+    assert is_memory_lint_enabled() is False
+    assert ConfigService.get("memory.lint_enabled") is False
+
+
+def test_invalid_env_value_falls_back_to_file_default(
+    _isolated_settings: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cli_agent_orchestrator.services.settings_service import is_memory_lint_enabled
+
+    monkeypatch.setenv("CAO_MEMORY_LINT_ENABLED", "definitely")
+
+    assert is_memory_lint_enabled() is True
+
+
+def test_config_list_and_set_preserve_unknown_keys(_isolated_settings: Path) -> None:
+    _isolated_settings.write_text(
+        json.dumps({"memory": {"unknown_future_key": "keep-me"}, "other": {"x": 1}})
+    )
+
+    assert ConfigService.list_all()["memory.lint_enabled"] is True
+    ConfigService.set("memory.lint_enabled", False)
+
+    on_disk = json.loads(_isolated_settings.read_text())
+    assert on_disk["memory"]["lint_enabled"] is False
+    assert on_disk["memory"]["unknown_future_key"] == "keep-me"
+    assert on_disk["other"] == {"x": 1}
+    assert ConfigService.get("memory.lint_enabled") is False
+    assert ConfigService.list_all()["memory.lint_enabled"] is False
+
+
+def test_config_set_rejects_non_bool(_isolated_settings: Path) -> None:
+    with pytest.raises(ValueError, match="lint_enabled must be a bool"):
+        ConfigService.set("memory.lint_enabled", "false")

--- a/test/services/test_wiki_lint_offload.py
+++ b/test/services/test_wiki_lint_offload.py
@@ -1,0 +1,63 @@
+"""Regression tests for wiki_lint event-loop responsiveness."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+
+from cli_agent_orchestrator.clients.database import Base
+from cli_agent_orchestrator.services import settings_service, wiki_lint
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Any:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'lint-offload.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_stale_claim_detector_does_not_block_event_loop(
+    tmp_path: Path, db_engine: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _slow_detector(rows: list, repo_root_resolved: str) -> list:
+        time.sleep(1.0)
+        return []
+
+    async def _no_audit(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(settings_service, "is_memory_enabled", lambda: True)
+    monkeypatch.setattr(wiki_lint, "_detect_stale_claims", _slow_detector)
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.audit_log.write_audit",
+        _no_audit,
+    )
+
+    async def _marker() -> float:
+        await asyncio.sleep(0.1)
+        return time.monotonic()
+
+    start = time.monotonic()
+    lint_task = asyncio.create_task(
+        wiki_lint.run_lint(
+            "test-project",
+            repo_root=str(tmp_path),
+            base_dir=tmp_path / "memory",
+            db_engine=db_engine,
+        )
+    )
+    marker_task = asyncio.create_task(_marker())
+
+    marker_done_at = await asyncio.wait_for(marker_task, timeout=0.5)
+    assert marker_done_at - start < 0.5
+
+    await lint_task

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -10,6 +10,8 @@ const BASE = ''  // Vite proxy handles routing to backend
 export interface ApiError extends Error {
   status?: number
   detail?: string
+  kind?: string
+  detailMeta?: Record<string, unknown>
 }
 
 async function fetchJSON<T>(url: string, opts?: RequestInit & { timeoutMs?: number }): Promise<T> {
@@ -22,13 +24,22 @@ async function fetchJSON<T>(url: string, opts?: RequestInit & { timeoutMs?: numb
       // `detail` without leaking a full response. A non-JSON body is fine —
       // detail just stays undefined.
       let detail: string | undefined
+      let kind: string | undefined
+      let detailMeta: Record<string, unknown> | undefined
       try {
         const body = await res.json()
         if (body && typeof body.detail === 'string') detail = body.detail
+        if (body && body.detail && typeof body.detail === 'object') {
+          detailMeta = body.detail as Record<string, unknown>
+          if (typeof detailMeta.message === 'string') detail = detailMeta.message
+          if (typeof detailMeta.kind === 'string') kind = detailMeta.kind
+        }
       } catch { /* non-JSON error body */ }
       const err: ApiError = new Error(`${res.status} ${res.statusText}`)
       err.status = res.status
       err.detail = detail
+      err.kind = kind
+      err.detailMeta = detailMeta
       throw err
     }
     return res.json()

--- a/web/src/components/MemoryGraphView.tsx
+++ b/web/src/components/MemoryGraphView.tsx
@@ -145,6 +145,10 @@ export function MemoryGraphView({ scope, scopeId }: MemoryGraphViewProps) {
         setError(err.detail || 'This scope cannot be viewed as a graph.')
       } else if (err.status === 404) {
         setError(err.detail || 'Graph provider not found (is memory enabled?).')
+      } else if (err.status === 504 && err.kind === 'graph_projection_timeout') {
+        const timeout = err.detailMeta?.timeout_s
+        const timeoutText = typeof timeout === 'number' ? `${timeout}s` : 'the server limit'
+        setError(`Graph projection timed out on the server after ${timeoutText}. The CAO server stayed responsive; refresh to retry or disable memory lint enrichment.`)
       } else if (err.name === 'AbortError') {
         // The AbortController in api.ts fired after the 120s graph budget. The
         // wiki-lint projection is ~30s typical / up to ~148s under load, so a
@@ -312,6 +316,7 @@ export function MemoryGraphView({ scope, scopeId }: MemoryGraphViewProps) {
   }
 
   const hasGraph = !!view && view.nodes.length > 0
+  const lintDisabled = view?.meta?.lint_enabled === false || view?.meta?.lint_enrichment === 'disabled'
 
   // Friendly guard: don't fire a doomed request for '' / session / agent.
   if (!graphable) {
@@ -354,6 +359,11 @@ export function MemoryGraphView({ scope, scopeId }: MemoryGraphViewProps) {
           </button>
         </div>
       </div>
+      {lintDisabled ? (
+        <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          Memory lint enrichment is disabled; this graph shows related-key topology only.
+        </div>
+      ) : null}
 
       {/* Graph + side panel */}
       <div className="flex gap-4 h-[600px]">

--- a/web/src/test/api.test.ts
+++ b/web/src/test/api.test.ts
@@ -183,6 +183,51 @@ describe('API wrapper', () => {
     await expect(api.listSessions()).rejects.toThrow('500 Internal Server Error')
   })
 
+  it('preserves string error detail on non-OK response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ detail: 'bad graph scope' }),
+    })
+
+    try {
+      await api.getGraph('memory', 'session')
+      throw new Error('expected rejection')
+    } catch (err: any) {
+      expect(err.status).toBe(400)
+      expect(err.detail).toBe('bad graph scope')
+      expect(err.kind).toBeUndefined()
+    }
+  })
+
+  it('preserves object error detail metadata on non-OK response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 504,
+      statusText: 'Gateway Timeout',
+      json: () => Promise.resolve({
+        detail: {
+          message: 'graph projection timed out after 90 seconds',
+          kind: 'graph_projection_timeout',
+          timeout_s: 90,
+          metadata: { graph_projection_timeout: true },
+        },
+      }),
+    })
+
+    try {
+      await api.getGraph('memory', 'global')
+      throw new Error('expected rejection')
+    } catch (err: any) {
+      expect(err.status).toBe(504)
+      expect(err.detail).toBe('graph projection timed out after 90 seconds')
+      expect(err.kind).toBe('graph_projection_timeout')
+      expect(err.detailMeta.timeout_s).toBe(90)
+      expect(err.detailMeta.metadata.graph_projection_timeout).toBe(true)
+    }
+  })
+
   it('exitTerminal sends POST', async () => {
     mockResponse({ success: true })
     await api.exitTerminal('t1')

--- a/web/src/test/memory-graph.test.tsx
+++ b/web/src/test/memory-graph.test.tsx
@@ -102,6 +102,15 @@ const GRAPH = {
   meta: {},
 }
 
+const LINT_DISABLED_GRAPH = {
+  ...GRAPH,
+  meta: {
+    lint_enabled: false,
+    lint_enrichment: 'disabled',
+    disabled_enrichments: ['orphan_page', 'contradiction'],
+  },
+}
+
 describe('MemoryPanel — List⇄Graph toggle & graph view', () => {
   const mockFetch = vi.fn()
 
@@ -200,6 +209,23 @@ describe('MemoryPanel — List⇄Graph toggle & graph view', () => {
       expect(Number.isFinite(graph.getNodeAttribute(n, 'x'))).toBe(true)
       expect(Number.isFinite(graph.getNodeAttribute(n, 'y'))).toBe(true)
     })
+  })
+
+  it('renders disabled-lint metadata while still showing graph topology', async () => {
+    routeFetch(url => {
+      if (url.startsWith('/graph/')) return { status: 200, body: LINT_DISABLED_GRAPH }
+      return { status: 200, body: [] }
+    })
+    render(<MemoryPanel />)
+    await screen.findByText('No memories stored.')
+    fireEvent.click(screen.getByRole('tab', { name: /graph/i }))
+    selectGlobalScope()
+
+    expect(await screen.findByText(/Memory lint enrichment is disabled/i)).toBeInTheDocument()
+    await waitFor(() => expect(getLastSigma()).toBeDefined())
+    const graph = getLastSigma()!.graph as import('graphology').default
+    expect(graph.hasNode('hub1')).toBe(true)
+    expect(graph.hasEdge('hub1', 'n3')).toBe(true)
   })
 
   it('clicking a node calls api.getMemory and shows its content as plain text', async () => {
@@ -434,6 +460,34 @@ describe('MemoryPanel — List⇄Graph toggle & graph view', () => {
     expect(errBox.textContent).toMatch(/timed out/i)
     expect(errBox.textContent).toMatch(/:9889/)
     expect(errBox.textContent).not.toMatch(/9894/)
+  })
+
+  it('a server-side graph projection timeout renders 504-specific copy', async () => {
+    routeFetch(url => {
+      if (url.startsWith('/graph/')) {
+        return {
+          status: 504,
+          body: {
+            detail: {
+              message: 'graph projection timed out after 90 seconds',
+              kind: 'graph_projection_timeout',
+              timeout_s: 90,
+              metadata: { graph_projection_timeout: true },
+            },
+          },
+        }
+      }
+      return { status: 200, body: [] }
+    })
+    render(<MemoryPanel />)
+    await screen.findByText('No memories stored.')
+    fireEvent.click(screen.getByRole('tab', { name: /graph/i }))
+    selectGlobalScope()
+
+    const errBox = await screen.findByTestId('graph-error')
+    expect(errBox.textContent).toMatch(/timed out on the server/i)
+    expect(errBox.textContent).toMatch(/90s/)
+    expect(errBox.textContent).not.toMatch(/waited 120s/)
   })
 
   it('a stale graph fetch (scope switched mid-flight) does NOT overwrite the current view', async () => {


### PR DESCRIPTION
## Summary
- Add `memory.lint_enabled` config/env support with default-on behavior and fail-closed explicit-false semantics.
- Offload stale-claim wiki lint work from the API event loop.
- Bound GET graph projection with a 90s timeout and structured HTTP 504 metadata.
- Preserve graph topology when lint enrichment is disabled and surface disabled/timeout states in CLI and web UI.
- Add focused backend and frontend regression coverage.

## Verification
- Architecture review approved after re-review; security review approved with no P1/P2 blockers.
- Clean merge-candidate CI audit passed for Python 3.11/3.12 backend unit tests, backend coverage JSON, web type-check/tests/build, MCP Apps checks, Playwright E2E, AG-UI recordings, gitleaks, Trivy, workflow YAML, black, isort, and markdown links.
- Python 3.10 local Docker image with CPython 3.10.19 segfaults in an unrelated deep AST stress test; recent GitHub `main` runs use CPython 3.10.20 and pass the same test.
- Full repo mypy remains non-blocking in CI and has pre-existing errors; no diff-introduced mypy errors remain.
- Post-rebase sanity: `git diff --check origin/main...HEAD`, isolated focused backend suite (`134 passed`), and focused web tests (`54 passed`) passed.

## Residual Risk
- P3: offloaded stale-claim work already running in a thread may continue briefly after the HTTP timeout returns.
- The original live operator disconnect was not reproduced; mitigation is covered by isolated regression tests.