### PR TITLE
fix(mcp): mock cleanup-nudge lookup in assign tests to stop live-server leakage

### DIFF
--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -174,9 +174,10 @@ class TestAssignSenderIdInjection:
     The tool-call itself returns as soon as the tmux window/DB row exist.
     """
 
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_appends_sender_id_when_injection_enabled(self, mock_create):
+    def test_assign_appends_sender_id_when_injection_enabled(self, mock_create, _nudge):
         """When injection is enabled, assign should pass a message with the
         sender ID suffix as ``initial_message`` to _create_terminal."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
@@ -199,9 +200,10 @@ class TestAssignSenderIdInjection:
 
         assert kwargs["initial_message_orchestration_type"] == OrchestrationType.ASSIGN
 
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", False)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_no_suffix_when_injection_disabled(self, mock_create):
+    def test_assign_no_suffix_when_injection_disabled(self, mock_create, _nudge):
         """When injection is disabled, assign should pass the message unchanged."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
 
@@ -264,9 +266,10 @@ class TestAssignSenderIdInjection:
         assert result["terminal_id"] is None
         assert "Assignment failed" in result["message"]
 
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_suffix_is_appended_not_prepended(self, mock_create):
+    def test_assign_suffix_is_appended_not_prepended(self, mock_create, _nudge):
         """The sender ID should be a suffix, not a prefix."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl
 
@@ -281,9 +284,10 @@ class TestAssignSenderIdInjection:
         assert sent_message.startswith(original)
         assert sent_message.index("[Assigned by terminal") > len(original)
 
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
     @patch("cli_agent_orchestrator.mcp_server.server.ENABLE_SENDER_ID_INJECTION", True)
     @patch("cli_agent_orchestrator.mcp_server.server._create_terminal")
-    def test_assign_returns_fast_success_message(self, mock_create):
+    def test_assign_returns_fast_success_message(self, mock_create, _nudge):
         """Regression: assign() should tell the LLM the worker is initializing
         in the background, not claim the message has been delivered."""
         from cli_agent_orchestrator.mcp_server.server import _assign_impl


### PR DESCRIPTION
Fixes #503

## What was broken

Several tests in `test/mcp_server/test_assign.py` mocked terminal creation and delivery but did not mock `_get_cleanup_nudge()`. That function performs a real `GET {API_BASE_URL}/terminals/{current_terminal_id}` call. Once PR #475 changed the test fixtures' `CAO_TERMINAL_ID` values to valid 8-character hex strings (`a1b2c3d4`, `deadbeef`), those IDs started passing validation, so the tests began contacting a real local `cao-server` and leaking 404 log noise for terminals that never existed. The tests kept passing throughout because `_get_cleanup_nudge()` swallows non-200 responses and request failures into an empty string, which is what masked the leak.

## Fix

Patch `_get_cleanup_nudge()` with `return_value=""` on the 4 affected success-path tests in `TestAssignSenderIdInjection`, matching the real no-nudge fallback behavior. No production code changes.

PR #475's terminal-ID validation coverage is untouched — the same valid hex fixture IDs are still used, so that regression coverage still exercises the validation path. This change only stops the downstream nudge lookup from reaching a live server.

## Test plan

- `uv run pytest --no-cov test/mcp_server/` — 167 passed, 167 total
