### PR TITLE
fix: convert kimi/antigravity/copilot startup-prompt handling to async

### DIFF
--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -42,9 +42,11 @@ counter, since the TUI looks identical in both states).
 import asyncio
 import json
 import logging
+import os
 import re
 import shlex
 import shutil
+import stat
 import threading
 import time
 from pathlib import Path
@@ -64,10 +66,11 @@ logger = logging.getLogger(__name__)
 
 # Serializes concurrent _register_mcp_servers()/_unregister_mcp_servers()
 # read-modify-writes to ~/.gemini/config/mcp_config.json -- after the async
-# conversion (issue #494), initialize()/cleanup() run this on a worker thread
-# via asyncio.to_thread, so N concurrent inits/teardowns can race the shared
-# file. Without a lock, one thread's write can clobber another's read-before-
-# write, silently dropping a concurrently-registered (or unregistered) server.
+# conversion (issue #494), both paths run on worker threads (initialize() via
+# asyncio.to_thread, cleanup() via loop.run_in_executor), so N concurrent
+# inits/teardowns can race the shared file. Without a lock, one thread's write
+# can clobber another's read-before-write, silently dropping a concurrently-
+# registered (or unregistered) server.
 _MCP_CONFIG_WRITE_LOCK = threading.Lock()
 
 
@@ -390,16 +393,20 @@ class AntigravityCliProvider(BaseProvider):
                 servers[server_name] = entry
                 self._mcp_server_names.append(server_name)
 
-            with open(path, "w") as f:
+            tmp_path = path.with_suffix(".json.tmp")
+            with open(tmp_path, "w") as f:
                 json.dump(config, f, indent=2)
+            if path.exists():
+                os.chmod(tmp_path, stat.S_IMODE(os.stat(path).st_mode))
+            os.replace(tmp_path, path)
 
     def _unregister_mcp_servers(self) -> None:
         """Remove the MCP servers this provider registered.
 
-        Called synchronously from ``cleanup()`` (on the event-loop thread, not
-        offloaded). Shares ``_MCP_CONFIG_WRITE_LOCK`` with
-        ``_register_mcp_servers`` so this can't interleave with another
-        terminal's concurrent ``asyncio.to_thread``-run registration and
+        Called via ``asyncio.to_thread`` from ``cleanup()`` so the lock is
+        never acquired on the event-loop thread. Shares
+        ``_MCP_CONFIG_WRITE_LOCK`` with ``_register_mcp_servers`` so this
+        can't interleave with another terminal's concurrent registration and
         corrupt the shared ``mcp_config.json`` read-modify-write.
         """
         if not self._mcp_server_names:
@@ -416,8 +423,11 @@ class AntigravityCliProvider(BaseProvider):
                 if isinstance(servers, dict):
                     for name in self._mcp_server_names:
                         servers.pop(name, None)
-                    with open(path, "w") as f:
+                    tmp_path = path.with_suffix(".json.tmp")
+                    with open(tmp_path, "w") as f:
                         json.dump(config, f, indent=2)
+                    os.chmod(tmp_path, stat.S_IMODE(os.stat(path).st_mode))
+                    os.replace(tmp_path, path)
             except (json.JSONDecodeError, OSError) as exc:
                 logger.warning("Failed to unregister MCP servers from %s: %s", path, exc)
             finally:
@@ -811,8 +821,26 @@ class AntigravityCliProvider(BaseProvider):
         return "/quit"
 
     def cleanup(self) -> None:
-        """Remove the MCP servers this provider registered and reset state."""
-        self._unregister_mcp_servers()
+        """Remove the MCP servers this provider registered and reset state.
+
+        _unregister_mcp_servers acquires _MCP_CONFIG_WRITE_LOCK and does file
+        I/O. When cleanup() is called on the event-loop thread (e.g. from
+        flow_service.execute_flow → cleanup_provider), running it inline would
+        block the loop. Offload to a worker thread so the lock is never held
+        on the event-loop thread — mirroring how _register_mcp_servers is
+        already offloaded via asyncio.to_thread in initialize().
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            # On the event-loop thread — offload blocking I/O + lock to a worker.
+            loop.run_in_executor(None, self._unregister_mcp_servers)
+        else:
+            # Already on a worker thread (e.g. api delete_terminal path) — safe
+            # to run inline.
+            self._unregister_mcp_servers()
         self._initialized = False
 
     def mark_input_received(self) -> None:

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -450,9 +450,11 @@ class AntigravityCliProvider(BaseProvider):
                 if isinstance(servers, dict):
                     for name in self._mcp_server_names:
                         entry = servers.get(name)
+                        env = entry.get("env", {}) if isinstance(entry, dict) else {}
                         if (
                             isinstance(entry, dict)
-                            and entry.get("env", {}).get("CAO_TERMINAL_ID") != self.terminal_id
+                            and isinstance(env, dict)
+                            and env.get("CAO_TERMINAL_ID") != self.terminal_id
                         ):
                             continue  # belongs to a different terminal — leave it
                         servers.pop(name, None)
@@ -478,7 +480,8 @@ class AntigravityCliProvider(BaseProvider):
 
         stale_keys: list[str] = []
         for key, entry in servers.items():
-            tid = entry.get("env", {}).get("CAO_TERMINAL_ID") if isinstance(entry, dict) else None
+            env = entry.get("env", {}) if isinstance(entry, dict) else {}
+            tid = env.get("CAO_TERMINAL_ID") if isinstance(env, dict) else None
             if tid is None:
                 continue  # not a CAO-managed entry — leave it
             if _db.get_terminal_metadata(tid) is None:

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -39,11 +39,13 @@ presence of ``? for shortcuts`` means IDLE / COMPLETED (split on a turn
 counter, since the TUI looks identical in both states).
 """
 
+import asyncio
 import json
 import logging
 import re
 import shlex
 import shutil
+import threading
 import time
 from pathlib import Path
 from typing import List, Optional
@@ -59,6 +61,14 @@ from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_sta
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
 
 logger = logging.getLogger(__name__)
+
+# Serializes concurrent _register_mcp_servers()/_unregister_mcp_servers()
+# read-modify-writes to ~/.gemini/config/mcp_config.json -- after the async
+# conversion (issue #494), initialize()/cleanup() run this on a worker thread
+# via asyncio.to_thread, so N concurrent inits/teardowns can race the shared
+# file. Without a lock, one thread's write can clobber another's read-before-
+# write, silently dropping a concurrently-registered (or unregistered) server.
+_MCP_CONFIG_WRITE_LOCK = threading.Lock()
 
 
 class ProviderError(Exception):
@@ -315,104 +325,131 @@ class AntigravityCliProvider(BaseProvider):
         non-CAO servers), forwarding ``CAO_TERMINAL_ID`` into each server's env
         so cao-mcp-server can resolve the current terminal for handoff / assign.
 
-        Concurrency: the file is shared across terminals, but CAO serializes
-        launches (initialize() waits for the agent to become ready before the
-        next terminal launches), so each agy process reads the config and spawns
-        its MCP subprocess with the correct terminal id before the next write.
+        Concurrency: the file is shared across terminals. issue #494:
+        ``_build_agy_command`` (the sole caller, via initialize()) now runs
+        inside ``asyncio.to_thread``, so N concurrent inits can enter this
+        method in N threads at once -- ``_MCP_CONFIG_WRITE_LOCK`` (shared with
+        ``_unregister_mcp_servers``) serializes the read-modify-write so one
+        thread's write can never clobber another's concurrently-registered
+        entry. In-process only: a second cao-server process, or agy itself,
+        writing between our read and write is still a last-writer-wins lost
+        update.
         """
         path = self._mcp_config_path()
-        try:
-            if path.exists() and path.stat().st_size > 0:
-                with open(path) as f:
-                    config = json.load(f)
-            else:
-                path.parent.mkdir(parents=True, exist_ok=True)
+        with _MCP_CONFIG_WRITE_LOCK:
+            try:
+                if path.exists() and path.stat().st_size > 0:
+                    with open(path) as f:
+                        config = json.load(f)
+                else:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    config = {}
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Could not read %s, starting fresh: %s", path, exc)
                 config = {}
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Could not read %s, starting fresh: %s", path, exc)
-            config = {}
 
-        # The file is shared with the user's own agy config; tolerate a valid-
-        # but-unexpected shape (e.g. a JSON list/string) instead of raising.
-        if not isinstance(config, dict):
-            logger.warning(
-                "MCP config root in %s is %s, not an object; resetting",
-                path,
-                type(config).__name__,
-            )
-            config = {}
+            # The file is shared with the user's own agy config; tolerate a
+            # valid-but-unexpected shape (e.g. a JSON list/string) instead of
+            # raising.
+            if not isinstance(config, dict):
+                logger.warning(
+                    "MCP config root in %s is %s, not an object; resetting",
+                    path,
+                    type(config).__name__,
+                )
+                config = {}
 
-        servers = config.setdefault("mcpServers", {})
-        if not isinstance(servers, dict):
-            logger.warning(
-                "'mcpServers' in %s is %s, not an object; replacing",
-                path,
-                type(servers).__name__,
-            )
-            servers = {}
-            config["mcpServers"] = servers
-        for server_name, server_config in mcp_servers.items():
-            if isinstance(server_config, dict):
-                cfg = dict(server_config)
-            else:
-                cfg = server_config.model_dump(exclude_none=True)
-            # Resolve the bundled cao-mcp-server console script to a
-            # PATH-independent invocation. persisted=True: this command is
-            # written to mcp_config.json and read by agy at later launches,
-            # so prefer the stable PATH launcher over the versioned venv path.
-            command, args = resolve_cao_mcp_command(
-                cfg.get("command", ""), cfg.get("args", []) or [], persisted=True
-            )
-            entry: dict = {
-                "command": command,
-                "args": args,
-            }
-            env = dict(cfg.get("env", {}))
-            env["CAO_TERMINAL_ID"] = self.terminal_id
-            entry["env"] = env
-            servers[server_name] = entry
-            self._mcp_server_names.append(server_name)
+            servers = config.setdefault("mcpServers", {})
+            if not isinstance(servers, dict):
+                logger.warning(
+                    "'mcpServers' in %s is %s, not an object; replacing",
+                    path,
+                    type(servers).__name__,
+                )
+                servers = {}
+                config["mcpServers"] = servers
+            for server_name, server_config in mcp_servers.items():
+                if isinstance(server_config, dict):
+                    cfg = dict(server_config)
+                else:
+                    cfg = server_config.model_dump(exclude_none=True)
+                # Resolve the bundled cao-mcp-server console script to a
+                # PATH-independent invocation. persisted=True: this command is
+                # written to mcp_config.json and read by agy at later launches,
+                # so prefer the stable PATH launcher over the versioned venv path.
+                command, args = resolve_cao_mcp_command(
+                    cfg.get("command", ""), cfg.get("args", []) or [], persisted=True
+                )
+                entry: dict = {
+                    "command": command,
+                    "args": args,
+                }
+                env = dict(cfg.get("env", {}))
+                env["CAO_TERMINAL_ID"] = self.terminal_id
+                entry["env"] = env
+                servers[server_name] = entry
+                self._mcp_server_names.append(server_name)
 
-        with open(path, "w") as f:
-            json.dump(config, f, indent=2)
+            with open(path, "w") as f:
+                json.dump(config, f, indent=2)
 
     def _unregister_mcp_servers(self) -> None:
-        """Remove the MCP servers this provider registered."""
+        """Remove the MCP servers this provider registered.
+
+        Called synchronously from ``cleanup()`` (on the event-loop thread, not
+        offloaded). Shares ``_MCP_CONFIG_WRITE_LOCK`` with
+        ``_register_mcp_servers`` so this can't interleave with another
+        terminal's concurrent ``asyncio.to_thread``-run registration and
+        corrupt the shared ``mcp_config.json`` read-modify-write.
+        """
         if not self._mcp_server_names:
             return
         path = self._mcp_config_path()
         if not path.exists():
             self._mcp_server_names = []
             return
-        try:
-            with open(path) as f:
-                config = json.load(f)
-            servers = config.get("mcpServers") if isinstance(config, dict) else None
-            if isinstance(servers, dict):
-                for name in self._mcp_server_names:
-                    servers.pop(name, None)
-                with open(path, "w") as f:
-                    json.dump(config, f, indent=2)
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Failed to unregister MCP servers from %s: %s", path, exc)
-        finally:
-            # Always clear our state so a malformed config can never leave stale
-            # names behind and block terminal teardown.
-            self._mcp_server_names = []
+        with _MCP_CONFIG_WRITE_LOCK:
+            try:
+                with open(path) as f:
+                    config = json.load(f)
+                servers = config.get("mcpServers") if isinstance(config, dict) else None
+                if isinstance(servers, dict):
+                    for name in self._mcp_server_names:
+                        servers.pop(name, None)
+                    with open(path, "w") as f:
+                        json.dump(config, f, indent=2)
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Failed to unregister MCP servers from %s: %s", path, exc)
+            finally:
+                # Always clear our state so a malformed config can never leave
+                # stale names behind and block terminal teardown.
+                self._mcp_server_names = []
 
-    def _handle_startup_dialog(
+    async def _handle_startup_dialog(
         self, idle_gap: Optional[float] = None, outer_timeout: Optional[float] = None
     ) -> None:
         """Dismiss agy's blocking startup dialogs (workspace-trust, survey).
 
-        Mirrors ClaudeCodeProvider._handle_startup_prompts / KimiCliProvider.
-        Polls the pane and answers, in whatever order they appear:
+        Mirrors ClaudeCodeProvider._handle_startup_prompts (once PR #451
+        lands) / KimiCliProvider._handle_startup_dialog. Polls the pane and
+        answers, in whatever order they appear:
         - workspace-trust picker → Enter (accepts the pre-selected "Yes")
         - feedback survey → "0" + Enter (Skip)
         Both can appear in ONE startup (trust first, survey after), so a
         dismissal continues the loop rather than returning. Exits once agy is
         at its ready footer with no dialog on screen — the survey renders ON
         TOP of the footer, so the survey check must run before the idle exit.
+
+        issue #494: this is a real coroutine, not sync code called from an
+        async caller. This method is awaited directly from initialize(), which
+        runs on cao-server's single asyncio event loop. Every tmux-backed call
+        here (``get_history``/``send_special_key``/``send_keys``) is a
+        blocking subprocess exec, and a plain ``time.sleep`` would block the
+        WHOLE OS thread -- freezing every other in-flight request -- for as
+        long as this loop runs. All blocking calls are offloaded to a worker
+        thread via ``asyncio.to_thread`` and all sleeps are ``asyncio.sleep``,
+        so this coroutine yields the event loop instead of freezing it (see PR
+        #451 for the ClaudeCodeProvider fix this mirrors).
 
         Idle-gap semantics (see issue #400): a cold or containerized start can
         render these dialogs LATE and in sequence, past the old fixed ~20s
@@ -455,33 +492,45 @@ class AntigravityCliProvider(BaseProvider):
                 return
             if any_prompt_handled and now - last_prompt_time >= idle_gap:
                 return  # no new prompt within the idle gap — startup settled
-            output = get_backend().get_history(self.session_name, self.window_name)
+            output = await asyncio.to_thread(
+                get_backend().get_history, self.session_name, self.window_name
+            )
             if output:
                 clean = strip_terminal_escapes(output)
                 if not trust_done and re.search(TRUST_PROMPT_PATTERN, clean):
                     logger.info("Antigravity workspace-trust dialog detected, accepting")
                     status_monitor.notify_input_sent(self.terminal_id)
-                    get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                    await asyncio.to_thread(
+                        get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                    )
                     trust_done = True
                     any_prompt_handled = True
                     last_prompt_time = time.monotonic()  # reset idle timer — survey may follow
-                    time.sleep(1.0)
+                    await asyncio.sleep(1.0)
                     continue
                 if not survey_done and re.search(SURVEY_PROMPT_PATTERN, clean):
                     logger.info("Antigravity feedback survey detected, skipping")
                     status_monitor.notify_input_sent(self.terminal_id)
-                    get_backend().send_keys(self.session_name, self.window_name, "0", enter_count=0)
-                    time.sleep(0.5)
-                    get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                    await asyncio.to_thread(
+                        get_backend().send_keys,
+                        self.session_name,
+                        self.window_name,
+                        "0",
+                        enter_count=0,
+                    )
+                    await asyncio.sleep(0.5)
+                    await asyncio.to_thread(
+                        get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                    )
                     survey_done = True
                     any_prompt_handled = True
                     last_prompt_time = time.monotonic()  # reset idle timer
-                    time.sleep(1.0)
+                    await asyncio.sleep(1.0)
                     continue
                 # At the ready footer with no dialog pending → done.
                 if re.search(IDLE_FOOTER_PATTERN, clean):
                     return
-            time.sleep(1.0)
+            await asyncio.sleep(1.0)
 
     async def initialize(self) -> bool:
         """Initialize the Antigravity CLI provider by starting ``agy``.
@@ -492,11 +541,19 @@ class AntigravityCliProvider(BaseProvider):
 
         Raises:
             TimeoutError: If the shell or agy initialization times out.
+
+        issue #494: ``_build_agy_command`` does blocking I/O (``shutil.which``
+        and the ~/.gemini/config/mcp_config.json read-modify-write via
+        ``_register_mcp_servers``) and ``get_backend().send_keys`` is a
+        blocking subprocess exec -- both offloaded to a worker thread via
+        ``asyncio.to_thread`` for the same reason as ``_handle_startup_dialog``
+        (see its docstring): so nothing in initialize() blocks the shared
+        event loop under concurrent session creation.
         """
         if not await wait_for_shell(self.terminal_id, timeout=10.0):
             raise TimeoutError("Shell initialization timed out after 10 seconds")
 
-        command = self._build_agy_command()
+        command = await asyncio.to_thread(self._build_agy_command)
 
         # Arm the StatusMonitor stickiness gate so the launch drives a fresh
         # PROCESSING transition past any stale ready latch. Imported lazily to
@@ -504,7 +561,9 @@ class AntigravityCliProvider(BaseProvider):
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
         status_monitor.notify_input_sent(self.terminal_id)
-        get_backend().send_keys(self.session_name, self.window_name, command)
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, command
+        )
 
         # Resolve the per-profile provider_init_timeout override (if any) so it
         # governs both the startup-dialog handler's outer cap and the readiness
@@ -517,7 +576,7 @@ class AntigravityCliProvider(BaseProvider):
 
         # Accept the workspace-trust dialog if agy shows one (first launch in an
         # untrusted cwd). Unanswered it blocks init — the picker never reads IDLE.
-        self._handle_startup_dialog(outer_timeout=max(default_ready_timeout, init_timeout))
+        await self._handle_startup_dialog(outer_timeout=max(default_ready_timeout, init_timeout))
 
         # agy startup + first MCP connection + the -i acknowledgment can take
         # a while.

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -74,6 +74,13 @@ logger = logging.getLogger(__name__)
 _MCP_CONFIG_WRITE_LOCK = threading.Lock()
 
 
+def _log_cleanup_exception(fut: asyncio.Future) -> None:
+    """Done-callback for the offloaded _unregister_mcp_servers future."""
+    exc = fut.exception()
+    if exc is not None:
+        logger.error("_unregister_mcp_servers raised during cleanup: %s", exc, exc_info=exc)
+
+
 class ProviderError(Exception):
     """Exception raised for Antigravity CLI provider-specific errors."""
 
@@ -375,6 +382,12 @@ class AntigravityCliProvider(BaseProvider):
                 )
                 servers = {}
                 config["mcpServers"] = servers
+
+            # GC: prune entries left by terminals that crashed/were killed
+            # without a graceful cleanup(). We're already holding the lock and
+            # about to write — cheap to check liveness now.
+            self._prune_stale_mcp_entries(servers)
+
             for server_name, server_config in mcp_servers.items():
                 if isinstance(server_config, dict):
                     cfg = dict(server_config)
@@ -454,6 +467,26 @@ class AntigravityCliProvider(BaseProvider):
                 # Always clear our state so a malformed config can never leave
                 # stale names behind and block terminal teardown.
                 self._mcp_server_names = []
+
+    def _prune_stale_mcp_entries(self, servers: dict) -> None:
+        """Remove entries whose CAO_TERMINAL_ID no longer maps to a live terminal.
+
+        Called inside _register_mcp_servers while holding _MCP_CONFIG_WRITE_LOCK.
+        Uses the database client directly (sync, safe — we're on a worker thread).
+        """
+        from cli_agent_orchestrator.clients import database as _db
+
+        stale_keys: list[str] = []
+        for key, entry in servers.items():
+            tid = entry.get("env", {}).get("CAO_TERMINAL_ID") if isinstance(entry, dict) else None
+            if tid is None:
+                continue  # not a CAO-managed entry — leave it
+            if _db.get_terminal_metadata(tid) is None:
+                stale_keys.append(key)
+        for key in stale_keys:
+            del servers[key]
+        if stale_keys:
+            logger.info("Pruned %d stale MCP config entries: %s", len(stale_keys), stale_keys)
 
     async def _handle_startup_dialog(
         self, idle_gap: Optional[float] = None, outer_timeout: Optional[float] = None
@@ -856,7 +889,9 @@ class AntigravityCliProvider(BaseProvider):
             loop = None
         if loop and loop.is_running():
             # On the event-loop thread — offload blocking I/O + lock to a worker.
-            loop.run_in_executor(None, self._unregister_mcp_servers)
+            # Retain the future so exceptions are surfaced (not silently swallowed).
+            fut = loop.run_in_executor(None, self._unregister_mcp_servers)
+            fut.add_done_callback(_log_cleanup_exception)
         else:
             # Already on a worker thread (e.g. api delete_terminal path) — safe
             # to run inline.

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -403,11 +403,18 @@ class AntigravityCliProvider(BaseProvider):
     def _unregister_mcp_servers(self) -> None:
         """Remove the MCP servers this provider registered.
 
-        Called via ``asyncio.to_thread`` from ``cleanup()`` so the lock is
-        never acquired on the event-loop thread. Shares
-        ``_MCP_CONFIG_WRITE_LOCK`` with ``_register_mcp_servers`` so this
-        can't interleave with another terminal's concurrent registration and
-        corrupt the shared ``mcp_config.json`` read-modify-write.
+        Scheduled via ``loop.run_in_executor`` (fire-and-forget) from
+        ``cleanup()`` when called on the event-loop thread, or run inline
+        when already on a worker thread. Shares ``_MCP_CONFIG_WRITE_LOCK``
+        with ``_register_mcp_servers`` so this can't interleave with another
+        terminal's concurrent registration and corrupt the shared
+        ``mcp_config.json`` read-modify-write.
+
+        An ownership check ensures only entries whose
+        ``env.CAO_TERMINAL_ID`` matches this instance's terminal_id are
+        removed — entries belonging to a newer terminal that re-registered
+        under the same server name are left intact, making fire-and-forget
+        scheduling safe regardless of executor ordering.
         """
         if not self._mcp_server_names:
             return
@@ -422,6 +429,9 @@ class AntigravityCliProvider(BaseProvider):
                 servers = config.get("mcpServers") if isinstance(config, dict) else None
                 if isinstance(servers, dict):
                     for name in self._mcp_server_names:
+                        entry = servers.get(name)
+                        if isinstance(entry, dict) and entry.get("env", {}).get("CAO_TERMINAL_ID") != self.terminal_id:
+                            continue  # belongs to a different terminal — leave it
                         servers.pop(name, None)
                     tmp_path = path.with_suffix(".json.tmp")
                     with open(tmp_path, "w") as f:

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -328,6 +328,10 @@ class AntigravityCliProvider(BaseProvider):
         non-CAO servers), forwarding ``CAO_TERMINAL_ID`` into each server's env
         so cao-mcp-server can resolve the current terminal for handoff / assign.
 
+        Each entry is keyed as ``{server_name}-{terminal_id}`` so concurrent
+        inits write to distinct keys and an earlier terminal's entry cannot be
+        overwritten before its agy process reads the config at startup.
+
         Concurrency: the file is shared across terminals. issue #494:
         ``_build_agy_command`` (the sole caller, via initialize()) now runs
         inside ``asyncio.to_thread``, so N concurrent inits can enter this
@@ -390,8 +394,11 @@ class AntigravityCliProvider(BaseProvider):
                 env = dict(cfg.get("env", {}))
                 env["CAO_TERMINAL_ID"] = self.terminal_id
                 entry["env"] = env
-                servers[server_name] = entry
-                self._mcp_server_names.append(server_name)
+                # Use a per-terminal key so concurrent inits don't overwrite
+                # each other's entry before agy reads the config at startup.
+                unique_key = f"{server_name}-{self.terminal_id}"
+                servers[unique_key] = entry
+                self._mcp_server_names.append(unique_key)
 
             tmp_path = path.with_suffix(".json.tmp")
             with open(tmp_path, "w") as f:
@@ -430,7 +437,10 @@ class AntigravityCliProvider(BaseProvider):
                 if isinstance(servers, dict):
                     for name in self._mcp_server_names:
                         entry = servers.get(name)
-                        if isinstance(entry, dict) and entry.get("env", {}).get("CAO_TERMINAL_ID") != self.terminal_id:
+                        if (
+                            isinstance(entry, dict)
+                            and entry.get("env", {}).get("CAO_TERMINAL_ID") != self.terminal_id
+                        ):
                             continue  # belongs to a different terminal — leave it
                         servers.pop(name, None)
                     tmp_path = path.with_suffix(".json.tmp")

--- a/src/cli_agent_orchestrator/providers/copilot_cli.py
+++ b/src/cli_agent_orchestrator/providers/copilot_cli.py
@@ -113,14 +113,22 @@ class CopilotCliProvider(BaseProvider):
                 self._copilot_help_text_cache = ""
         return flag in self._copilot_help_text_cache
 
-    def _wait_for_shell_ready(self, timeout: float = 30.0, polling_interval: float = 0.5) -> bool:
-        """Wait for a stable non-empty shell screen using provider-safe history reads."""
+    async def _wait_for_shell_ready(
+        self, timeout: float = 30.0, polling_interval: float = 0.5
+    ) -> bool:
+        """Wait for a stable non-empty shell screen using provider-safe history reads.
+
+        issue #494: real coroutine, not sync code called from an async
+        caller (initialize()) -- the blocking history read is offloaded via
+        asyncio.to_thread and the poll delay is asyncio.sleep, so this no
+        longer blocks the shared event loop while waiting.
+        """
         start_time = time.time()
         previous_output: Optional[str] = None
         stable_reads = 0
 
         while time.time() - start_time < timeout:
-            output = self._history(tail_lines=120)
+            output = await asyncio.to_thread(self._history, tail_lines=120)
             if output and output.strip():
                 if previous_output is not None and output == previous_output:
                     stable_reads += 1
@@ -130,7 +138,7 @@ class CopilotCliProvider(BaseProvider):
                     stable_reads = 0
 
             previous_output = output
-            time.sleep(polling_interval)
+            await asyncio.sleep(polling_interval)
 
         return False
 
@@ -196,10 +204,23 @@ class CopilotCliProvider(BaseProvider):
     def _send_key(self, key: str) -> None:
         get_backend().send_special_key(self.session_name, self.window_name, key)
 
-    def _accept_trust_prompts(self, timeout: float = 30.0) -> None:
+    async def _accept_trust_prompts(self, timeout: float = 30.0) -> None:
+        """Poll the pane and auto-accept Copilot's folder-trust dialogs.
+
+        issue #494: real coroutine, not sync code called from an async
+        caller. Re-entered from initialize()'s polling loop (see its
+        WAITING_USER_ANSWER branch) -- that re-entrant contract is unchanged,
+        only the blocking mechanics are: ``_history`` and the ``_send_enter``/
+        ``_send_key`` backend calls are offloaded via ``asyncio.to_thread``
+        (the two helpers themselves stay sync -- they are also called
+        directly from tests and other contexts, so wrapping happens at each
+        call site here rather than making them coroutines) and every poll
+        delay is ``asyncio.sleep``, so this no longer blocks the shared event
+        loop while polling.
+        """
         start = time.time()
         while time.time() - start < timeout:
-            raw_content = self._history(tail_lines=120)
+            raw_content = await asyncio.to_thread(self._history, tail_lines=120)
             content = raw_content.lower()
 
             if (
@@ -209,8 +230,8 @@ class CopilotCliProvider(BaseProvider):
             ):
                 # The first option is pre-selected; Enter is the most reliable
                 # accept action across Copilot builds.
-                self._send_enter()
-                time.sleep(1)
+                await asyncio.to_thread(self._send_enter)
+                await asyncio.sleep(1)
                 continue
 
             if (
@@ -219,36 +240,36 @@ class CopilotCliProvider(BaseProvider):
             ) and re.search(r"\b1\.\s*yes\b", content):
                 # Option 1 is selected by default in the trust dialog; Enter is
                 # the most reliable way to accept across Copilot builds.
-                self._send_enter()
-                time.sleep(1)
+                await asyncio.to_thread(self._send_enter)
+                await asyncio.sleep(1)
                 continue
 
             if "do you trust all the actions in this folder" in content:
-                self._send_key("y")
-                self._send_enter()
-                time.sleep(1)
+                await asyncio.to_thread(self._send_key, "y")
+                await asyncio.to_thread(self._send_enter)
+                await asyncio.sleep(1)
                 continue
 
             if re.search(r"\[\s*y\s*/\s*n\s*]", content):
-                self._send_key("y")
-                self._send_enter()
-                time.sleep(1)
+                await asyncio.to_thread(self._send_key, "y")
+                await asyncio.to_thread(self._send_enter)
+                await asyncio.sleep(1)
                 continue
 
             if "confirm folder trust" in content or "press enter to continue" in content:
-                self._send_enter()
-                time.sleep(1)
+                await asyncio.to_thread(self._send_enter)
+                await asyncio.sleep(1)
                 continue
 
             if re.search(WAITING_PROMPT_PATTERN, content, re.IGNORECASE):
                 # Generic waiting prompt fallback: confirm with Enter.
-                self._send_enter()
-                time.sleep(1)
+                await asyncio.to_thread(self._send_enter)
+                await asyncio.sleep(1)
                 continue
 
             if self._has_idle_prompt_near_end(raw_content.splitlines()):
                 return
-            time.sleep(1)
+            await asyncio.sleep(1)
 
         logger.warning(
             "Trust prompt handler timed out for %s:%s",
@@ -257,6 +278,17 @@ class CopilotCliProvider(BaseProvider):
         )
 
     async def initialize(self) -> bool:
+        """Initialize the Copilot CLI provider by starting ``copilot``.
+
+        issue #494: ``self._command()`` does two blocking things --
+        ``_supports_flag`` runs a cached blocking ``subprocess.run(["copilot",
+        "--help"])`` and ``get_backend().get_pane_working_directory`` is a
+        blocking subprocess call -- and ``get_backend().send_keys`` is
+        likewise blocking. All three are offloaded via ``asyncio.to_thread``
+        so building and sending the launch command can't block the shared
+        event loop under concurrent session creation. ``status_monitor.
+        get_status`` stays inline -- it is in-memory only, no blocking I/O.
+        """
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
         try:
@@ -270,19 +302,22 @@ class CopilotCliProvider(BaseProvider):
                 exc,
             )
             init_timeout = get_server_settings()["provider_init_timeout"]
-            shell_ready = self._wait_for_shell_ready(timeout=init_timeout)
+            shell_ready = await self._wait_for_shell_ready(timeout=init_timeout)
 
         if not shell_ready:
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
-        get_backend().send_keys(self.session_name, self.window_name, self._command())
+        command = await asyncio.to_thread(self._command)
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, command
+        )
 
         deadline = time.time() + 60.0
-        self._accept_trust_prompts(timeout=10.0)
+        await self._accept_trust_prompts(timeout=10.0)
         while time.time() < deadline:
             status = status_monitor.get_status(self.terminal_id)
             if status == TerminalStatus.WAITING_USER_ANSWER:
-                self._accept_trust_prompts(timeout=5.0)
+                await self._accept_trust_prompts(timeout=5.0)
                 await asyncio.sleep(1.0)
                 continue
             if status in (TerminalStatus.IDLE, TerminalStatus.COMPLETED):

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -25,13 +25,16 @@ Status Detection Strategy:
     - ERROR: Error message patterns or empty output
 """
 
+import asyncio
 import json
 import logging
 import os
 import re
 import shlex
 import shutil
+import stat
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -46,6 +49,15 @@ from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_sta
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
 
 logger = logging.getLogger(__name__)
+
+# Serializes concurrent _ensure_mcp_timeout() read-modify-writes to
+# ~/.kimi/config.toml -- after the async conversion (issue #494),
+# _build_kimi_command runs inside asyncio.to_thread, so N concurrent inits can
+# enter this method in N threads at once. Without a lock, the check-then-act
+# on _mcp_timeout_configured races (two threads both pass the "not configured
+# yet" check) and the read-modify-write itself races (one thread's write can
+# clobber content another thread already read).
+_KIMI_CONFIG_WRITE_LOCK = threading.Lock()
 
 
 # Custom exception for provider errors
@@ -393,51 +405,82 @@ class KimiCliProvider(BaseProvider):
         1. Multiple Kimi instances may share the config file concurrently
         2. 600s is a strictly better default for anyone using MCP tools
         3. Restoring while other instances are running causes race conditions
+
+        issue #494: ``_build_kimi_command`` (the sole caller) now runs inside
+        ``asyncio.to_thread``, so N concurrent inits can enter this method in N
+        threads at once. ``_KIMI_CONFIG_WRITE_LOCK`` serializes the whole
+        check-then-act (class flag + read-modify-write) so only one thread ever
+        touches ``config.toml`` at a time -- in-process only: a second
+        cao-server process, or the ``kimi`` CLI itself, writing between our read
+        and ``os.replace`` is still a last-writer-wins lost update. The write
+        itself is atomic (tmp file + ``os.replace``) so a concurrent reader
+        (e.g. a ``kimi`` process starting up) never sees a torn/partial file.
         """
-        if cls._mcp_timeout_configured:
-            return
+        with _KIMI_CONFIG_WRITE_LOCK:
+            if cls._mcp_timeout_configured:
+                return
 
-        config_path = Path.home() / ".kimi" / "config.toml"
-        if not config_path.exists():
-            logger.warning(f"Kimi config not found at {config_path}, skipping MCP timeout override")
-            cls._mcp_timeout_configured = True
-            return
-
-        try:
-            content = config_path.read_text()
-
-            # Match the existing timeout line under [mcp.client] section
-            # Format: tool_call_timeout_ms = 60000
-            pattern = r"(tool_call_timeout_ms\s*=\s*)(\d+)"
-            match = re.search(pattern, content)
-            if match:
-                current_value = int(match.group(2))
-                if current_value < 600000:
-                    new_content = re.sub(pattern, r"\g<1>600000", content)
-                    config_path.write_text(new_content)
-                    logger.info(
-                        f"Set MCP tool_call_timeout_ms to 600000 "
-                        f"(was {current_value}) in {config_path}"
-                    )
-            else:
+            config_path = Path.home() / ".kimi" / "config.toml"
+            if not config_path.exists():
                 logger.warning(
-                    f"tool_call_timeout_ms not found in {config_path}, "
-                    "MCP tool calls may time out during handoff"
+                    f"Kimi config not found at {config_path}, skipping MCP timeout override"
                 )
-        except Exception as e:
-            logger.warning(f"Failed to set MCP timeout in {config_path}: {e}")
+                cls._mcp_timeout_configured = True
+                return
 
-        cls._mcp_timeout_configured = True
+            try:
+                content = config_path.read_text()
 
-    def _handle_startup_dialog(
+                # Match the existing timeout line under [mcp.client] section
+                # Format: tool_call_timeout_ms = 60000
+                pattern = r"(tool_call_timeout_ms\s*=\s*)(\d+)"
+                match = re.search(pattern, content)
+                if match:
+                    current_value = int(match.group(2))
+                    if current_value < 600000:
+                        new_content = re.sub(pattern, r"\g<1>600000", content)
+                        existing_mode = stat.S_IMODE(os.stat(config_path).st_mode)
+                        tmp_path = config_path.with_suffix(".toml.tmp")
+                        with open(tmp_path, "w") as f:
+                            f.write(new_content)
+                        os.chmod(tmp_path, existing_mode)
+                        os.replace(tmp_path, config_path)
+                        logger.info(
+                            f"Set MCP tool_call_timeout_ms to 600000 "
+                            f"(was {current_value}) in {config_path}"
+                        )
+                else:
+                    logger.warning(
+                        f"tool_call_timeout_ms not found in {config_path}, "
+                        "MCP tool calls may time out during handoff"
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to set MCP timeout in {config_path}: {e}")
+
+            cls._mcp_timeout_configured = True
+
+    async def _handle_startup_dialog(
         self, idle_gap: Optional[float] = None, outer_timeout: Optional[float] = None
     ) -> None:
         """Dismiss kimi's startup upgrade-reminder dialog if it appears.
 
-        Mirrors ClaudeCodeProvider._handle_startup_prompts: polls the pane for
-        the interactive "[s] Skip reminders for version X" menu and answers 's'
-        so kimi can proceed to its ready prompt. Exits early if kimi is already
-        ready (no newer version → no dialog), so a no-update start isn't delayed.
+        Mirrors ClaudeCodeProvider._handle_startup_prompts (once PR #451 lands):
+        polls the pane for the interactive "[s] Skip reminders for version X"
+        menu and answers 's' so kimi can proceed to its ready prompt. Exits
+        early if kimi is already ready (no newer version → no dialog), so a
+        no-update start isn't delayed.
+
+        issue #494: this is a real coroutine, not sync code called from an
+        async caller. This method is awaited directly from initialize(), which
+        runs on cao-server's single asyncio event loop. Every tmux-backed call
+        here (``get_history``/``send_keys``) is a blocking subprocess exec, and
+        a plain ``time.sleep`` would block the WHOLE OS thread -- freezing every
+        other in-flight request -- for as long as this loop runs. All blocking
+        calls are offloaded to a worker thread via ``asyncio.to_thread`` and all
+        sleeps are ``asyncio.sleep``, so this coroutine yields the event loop
+        instead of freezing it (see PR #451 for the ClaudeCodeProvider fix this
+        mirrors, and issue #494 for why this method and its Antigravity/Copilot
+        counterparts needed the same fix).
 
         Idle-gap semantics (see issue #400): a cold or containerized start can
         render the dialog LATE, past the old fixed ~20s window. Rather than a
@@ -475,7 +518,9 @@ class KimiCliProvider(BaseProvider):
                 return
             if any_prompt_handled and now - last_prompt_time >= idle_gap:
                 return  # no new prompt within the idle gap — startup settled
-            output = get_backend().get_history(self.session_name, self.window_name)
+            output = await asyncio.to_thread(
+                get_backend().get_history, self.session_name, self.window_name
+            )
             if output:
                 clean_output = re.sub(ANSI_CODE_PATTERN, "", output)
                 # Answer the upgrade dialog once; its text lingers in the buffer
@@ -486,11 +531,17 @@ class KimiCliProvider(BaseProvider):
                     logger.info("Kimi upgrade-reminder dialog detected, skipping reminders")
                     status_monitor.notify_input_sent(self.terminal_id)
                     # 's' = "Skip reminders for version X"; single-key menu, no Enter.
-                    get_backend().send_keys(self.session_name, self.window_name, "s", enter_count=0)
+                    await asyncio.to_thread(
+                        get_backend().send_keys,
+                        self.session_name,
+                        self.window_name,
+                        "s",
+                        enter_count=0,
+                    )
                     upgrade_dismissed = True
                     any_prompt_handled = True
                     last_prompt_time = time.monotonic()  # reset idle timer
-                    time.sleep(1.0)
+                    await asyncio.sleep(1.0)
                     continue
                 # Already at a ready prompt → no dialog to handle, stop early.
                 if self.get_status(output) in (
@@ -498,7 +549,7 @@ class KimiCliProvider(BaseProvider):
                     TerminalStatus.COMPLETED,
                 ):
                     return
-            time.sleep(1.0)
+            await asyncio.sleep(1.0)
 
     async def initialize(self) -> bool:
         """Initialize Kimi CLI provider by starting the kimi command.
@@ -513,6 +564,15 @@ class KimiCliProvider(BaseProvider):
 
         Raises:
             TimeoutError: If shell or Kimi CLI doesn't start within timeout
+
+        issue #494: ``_build_kimi_command`` does blocking file I/O (mkdtemp,
+        writing system.md/agent.yaml, and the ~/.kimi/config.toml
+        read-modify-write via ``_ensure_mcp_timeout``) and ``get_backend().
+        send_keys`` is a blocking subprocess exec -- both offloaded to a
+        worker thread via ``asyncio.to_thread`` for the same reason as
+        ``_handle_startup_dialog`` (see its docstring): so nothing in
+        initialize() blocks the shared event loop under concurrent session
+        creation.
         """
         # Resolve the per-profile provider_init_timeout override (if any) so it
         # governs the startup-dialog handler's outer cap too, mirroring
@@ -535,14 +595,16 @@ class KimiCliProvider(BaseProvider):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         # Build properly escaped command string
-        command = self._build_kimi_command()
+        command = await asyncio.to_thread(self._build_kimi_command)
 
         # Send Kimi command to the tmux window
-        get_backend().send_keys(self.session_name, self.window_name, command)
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, command
+        )
 
         # Dismiss the startup upgrade-reminder dialog before waiting for ready:
         # unanswered it blocks kimi from reaching its prompt (init would time out).
-        self._handle_startup_dialog(outer_timeout=ready_timeout)
+        await self._handle_startup_dialog(outer_timeout=ready_timeout)
 
         # Wait for Kimi CLI to reach IDLE or COMPLETED state (prompt visible).
         # Accept both IDLE and COMPLETED — some CLI versions show a startup

--- a/test/providers/test_antigravity_cli_unit.py
+++ b/test/providers/test_antigravity_cli_unit.py
@@ -31,10 +31,14 @@ def load_fixture(name: str) -> str:
 
 
 def make_provider(
-    agent_profile=None, allowed_tools=None, model=None, skill_prompt=None
+    terminal_id="test-tid",
+    agent_profile=None,
+    allowed_tools=None,
+    model=None,
+    skill_prompt=None,
 ) -> AntigravityCliProvider:
     return AntigravityCliProvider(
-        terminal_id="test-tid",
+        terminal_id=terminal_id,
         session_name="test-session",
         window_name="window-0",
         agent_profile=agent_profile,
@@ -270,13 +274,14 @@ def test_mcp_registration_writes_config(tmp_path, monkeypatch):
         import json
 
         data = json.loads(cfg.read_text())
-        assert "cao-mcp-server" in data["mcpServers"]
+        # Key is per-terminal: "{server_name}-{terminal_id}"
+        assert "cao-mcp-server-test-tid" in data["mcpServers"]
         # CAO_TERMINAL_ID forwarded so cao-mcp-server can resolve the terminal.
-        assert data["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "test-tid"
+        assert data["mcpServers"]["cao-mcp-server-test-tid"]["env"]["CAO_TERMINAL_ID"] == "test-tid"
         # cleanup removes our entry without clobbering the file.
         p.cleanup()
         data2 = json.loads(cfg.read_text())
-        assert "cao-mcp-server" not in data2.get("mcpServers", {})
+        assert "cao-mcp-server-test-tid" not in data2.get("mcpServers", {})
 
 
 def test_mcp_registration_resolves_bundled_command(tmp_path, monkeypatch):
@@ -311,7 +316,7 @@ def test_mcp_registration_resolves_bundled_command(tmp_path, monkeypatch):
         p._build_agy_command()
         import json
 
-        entry = json.loads(cfg.read_text())["mcpServers"]["cao-mcp-server"]
+        entry = json.loads(cfg.read_text())["mcpServers"]["cao-mcp-server-test-tid"]
         # persisted=True prefers the stable PATH launcher, not the bare command
         # or the versioned sibling.
         assert entry["command"] == "/home/u/.local/bin/cao-mcp-server"
@@ -440,7 +445,7 @@ def test_mcp_registration_accepts_pydantic_mcpserver(tmp_path):
     ):
         p._build_agy_command()
     data = json.loads(cfg.read_text())
-    assert data["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "test-tid"
+    assert data["mcpServers"]["cao-mcp-server-test-tid"]["env"]["CAO_TERMINAL_ID"] == "test-tid"
     assert data["mcpServers"]["other"]["command"] == "keep"  # untouched
 
 
@@ -470,7 +475,7 @@ def test_mcp_registration_recovers_from_corrupt_config(tmp_path):
     ):
         p._build_agy_command()  # should not raise; starts fresh
     data = json.loads(cfg.read_text())
-    assert "cao-mcp-server" in data["mcpServers"]
+    assert "cao-mcp-server-test-tid" in data["mcpServers"]
 
 
 @pytest.mark.parametrize("payload", ["[1, 2, 3]", '"just a string"', "42"])
@@ -504,7 +509,7 @@ def test_mcp_registration_recovers_from_non_dict_config(tmp_path, payload):
         p._build_agy_command()  # must not raise
     data = json.loads(cfg.read_text())
     assert isinstance(data, dict)
-    assert "cao-mcp-server" in data["mcpServers"]
+    assert "cao-mcp-server-test-tid" in data["mcpServers"]
 
 
 def test_mcp_registration_replaces_non_dict_mcpservers(tmp_path):
@@ -535,7 +540,7 @@ def test_mcp_registration_replaces_non_dict_mcpservers(tmp_path):
         p._build_agy_command()  # must not raise
     data = json.loads(cfg.read_text())
     assert isinstance(data["mcpServers"], dict)
-    assert "cao-mcp-server" in data["mcpServers"]
+    assert "cao-mcp-server-test-tid" in data["mcpServers"]
 
 
 def test_unregister_noop_when_nothing_registered():
@@ -547,7 +552,7 @@ def test_unregister_noop_when_nothing_registered():
 
 def test_unregister_handles_missing_file(tmp_path):
     p = make_provider()
-    p._mcp_server_names = ["cao-mcp-server"]
+    p._mcp_server_names = ["cao-mcp-server-test-tid"]
     missing = tmp_path / "does_not_exist.json"
     with patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=missing):
         p.cleanup()  # file gone -> just resets state
@@ -640,7 +645,7 @@ def test_unregister_warns_on_corrupt_config(tmp_path):
     cfg = tmp_path / "mcp_config.json"
     cfg.write_text("{ not valid json")
     p = make_provider()
-    p._mcp_server_names = ["cao-mcp-server"]
+    p._mcp_server_names = ["cao-mcp-server-test-tid"]
     with patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg):
         p.cleanup()  # corrupt file -> logged warning, state reset, no raise
     assert p._mcp_server_names == []
@@ -653,7 +658,7 @@ def test_unregister_handles_non_dict_config(tmp_path, payload):
     cfg = tmp_path / "mcp_config.json"
     cfg.write_text(payload)
     p = make_provider()
-    p._mcp_server_names = ["cao-mcp-server"]
+    p._mcp_server_names = ["cao-mcp-server-test-tid"]
     with patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg):
         p.cleanup()  # non-dict config -> no raise, state reset
     assert p._mcp_server_names == []
@@ -664,29 +669,84 @@ def test_unregister_skips_entry_owned_by_different_terminal(tmp_path):
     env.CAO_TERMINAL_ID matches this terminal — entries re-registered by
     a newer terminal under the same server name must survive."""
     cfg = tmp_path / "mcp_config.json"
-    cfg.write_text(json.dumps({
-        "mcpServers": {
-            "cao-mcp-server": {
-                "command": "cao-mcp-server",
-                "args": [],
-                "env": {"CAO_TERMINAL_ID": "new-terminal-99"},
-            },
-            "cao-ops-mcp-server": {
-                "command": "cao-ops-mcp-server",
-                "args": [],
-                "env": {"CAO_TERMINAL_ID": "test-tid"},
-            },
-        }
-    }))
+    cfg.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "cao-mcp-server-test-tid": {
+                        "command": "cao-mcp-server",
+                        "args": [],
+                        "env": {"CAO_TERMINAL_ID": "new-terminal-99"},
+                    },
+                    "cao-ops-mcp-server-test-tid": {
+                        "command": "cao-ops-mcp-server",
+                        "args": [],
+                        "env": {"CAO_TERMINAL_ID": "test-tid"},
+                    },
+                }
+            }
+        )
+    )
     p = make_provider()  # terminal_id="test-tid"
-    p._mcp_server_names = ["cao-mcp-server", "cao-ops-mcp-server"]
+    p._mcp_server_names = ["cao-mcp-server-test-tid", "cao-ops-mcp-server-test-tid"]
     with patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg):
         p._unregister_mcp_servers()
     result = json.loads(cfg.read_text())
-    # "cao-mcp-server" belongs to new-terminal-99 -> must survive
-    assert "cao-mcp-server" in result["mcpServers"]
-    # "cao-ops-mcp-server" belongs to test-tid -> must be removed
-    assert "cao-ops-mcp-server" not in result["mcpServers"]
+    # "cao-mcp-server-test-tid" belongs to new-terminal-99 -> must survive
+    assert "cao-mcp-server-test-tid" in result["mcpServers"]
+    # "cao-ops-mcp-server-test-tid" belongs to test-tid -> must be removed
+    assert "cao-ops-mcp-server-test-tid" not in result["mcpServers"]
+
+
+# --------------------------------------------------------------------------- #
+# Concurrent initialization — regression test for MCP config cross-wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_concurrent_inits_get_distinct_mcp_keys(tmp_path):
+    """Two providers initializing concurrently must each write their own
+    per-terminal key into mcp_config.json, never overwriting the other's
+    entry. Regression test for the race where a shared static key caused
+    terminal B's write to clobber terminal A's entry before A's agy process
+    read the config."""
+    from cli_agent_orchestrator.models.agent_profile import AgentProfile
+
+    cfg = tmp_path / "mcp_config.json"
+    profile = AgentProfile(
+        name="dev_gemini",
+        description="Dev",
+        system_prompt="You develop.",
+        mcpServers={"cao-mcp-server": {"command": "uvx", "args": ["cao-mcp-server"]}},
+    )
+    p_a = make_provider(terminal_id="terminal-A", agent_profile="dev_gemini")
+    p_b = make_provider(terminal_id="terminal-B", agent_profile="dev_gemini")
+    with (
+        patch(
+            "cli_agent_orchestrator.providers.antigravity_cli.shutil.which",
+            return_value="/usr/local/bin/agy",
+        ),
+        patch(
+            "cli_agent_orchestrator.providers.antigravity_cli.load_agent_profile",
+            return_value=profile,
+        ),
+        patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg),
+    ):
+        p_a._build_agy_command()
+        p_b._build_agy_command()
+
+        data = json.loads(cfg.read_text())
+        servers = data["mcpServers"]
+        # Each terminal has its own key
+        assert "cao-mcp-server-terminal-A" in servers
+        assert "cao-mcp-server-terminal-B" in servers
+        # Each key carries the correct CAO_TERMINAL_ID
+        assert servers["cao-mcp-server-terminal-A"]["env"]["CAO_TERMINAL_ID"] == "terminal-A"
+        assert servers["cao-mcp-server-terminal-B"]["env"]["CAO_TERMINAL_ID"] == "terminal-B"
+        # Cleanup of A doesn't touch B
+        p_a._unregister_mcp_servers()
+        data2 = json.loads(cfg.read_text())
+        assert "cao-mcp-server-terminal-A" not in data2["mcpServers"]
+        assert "cao-mcp-server-terminal-B" in data2["mcpServers"]
 
 
 # --------------------------------------------------------------------------- #

--- a/test/providers/test_antigravity_cli_unit.py
+++ b/test/providers/test_antigravity_cli_unit.py
@@ -1,5 +1,6 @@
 """Unit tests for the Antigravity CLI (``agy``) provider."""
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -656,6 +657,36 @@ def test_unregister_handles_non_dict_config(tmp_path, payload):
     with patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg):
         p.cleanup()  # non-dict config -> no raise, state reset
     assert p._mcp_server_names == []
+
+
+def test_unregister_skips_entry_owned_by_different_terminal(tmp_path):
+    """_unregister_mcp_servers must only remove entries whose
+    env.CAO_TERMINAL_ID matches this terminal — entries re-registered by
+    a newer terminal under the same server name must survive."""
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text(json.dumps({
+        "mcpServers": {
+            "cao-mcp-server": {
+                "command": "cao-mcp-server",
+                "args": [],
+                "env": {"CAO_TERMINAL_ID": "new-terminal-99"},
+            },
+            "cao-ops-mcp-server": {
+                "command": "cao-ops-mcp-server",
+                "args": [],
+                "env": {"CAO_TERMINAL_ID": "test-tid"},
+            },
+        }
+    }))
+    p = make_provider()  # terminal_id="test-tid"
+    p._mcp_server_names = ["cao-mcp-server", "cao-ops-mcp-server"]
+    with patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg):
+        p._unregister_mcp_servers()
+    result = json.loads(cfg.read_text())
+    # "cao-mcp-server" belongs to new-terminal-99 -> must survive
+    assert "cao-mcp-server" in result["mcpServers"]
+    # "cao-ops-mcp-server" belongs to test-tid -> must be removed
+    assert "cao-ops-mcp-server" not in result["mcpServers"]
 
 
 # --------------------------------------------------------------------------- #

--- a/test/providers/test_antigravity_cli_unit.py
+++ b/test/providers/test_antigravity_cli_unit.py
@@ -16,13 +16,21 @@ from cli_agent_orchestrator.providers.antigravity_cli import (
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+# Save before autouse replaces it with a MagicMock
+_real_prune_stale_mcp_entries = AntigravityCliProvider._prune_stale_mcp_entries
+
 
 @pytest.fixture(autouse=True)
 def _skip_startup_dialog():
     # initialize() polls the pane to accept agy's workspace-trust dialog; that
     # path is exercised separately. Stub it so the init tests stay fast and
     # independent of the (mocked) get_history return type.
-    with patch.object(AntigravityCliProvider, "_handle_startup_dialog", return_value=None):
+    # Also stub GC pruning — exercised in its own dedicated test; other tests
+    # use fake terminal IDs that don't exist in the DB and would be pruned.
+    with (
+        patch.object(AntigravityCliProvider, "_handle_startup_dialog", return_value=None),
+        patch.object(AntigravityCliProvider, "_prune_stale_mcp_entries"),
+    ):
         yield
 
 
@@ -845,3 +853,114 @@ async def test_initialize_raises_when_agy_times_out(monkeypatch):
     )
     with pytest.raises(TimeoutError, match="initialization timed out"):
         await make_provider().initialize()
+
+
+# --------------------------------------------------------------------------- #
+# GC: prune stale MCP config entries (finding 2)
+# --------------------------------------------------------------------------- #
+
+
+def test_prune_stale_mcp_entries_on_register(tmp_path):
+    """_register_mcp_servers prunes entries whose terminal is no longer live,
+    preserves entries for live terminals and non-CAO entries, and adds the
+    new terminal's entry."""
+    from cli_agent_orchestrator.models.agent_profile import AgentProfile
+
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    # Entry for a dead terminal — should be pruned
+                    "cao-mcp-server-dead-tid": {
+                        "command": "cao-mcp-server",
+                        "args": [],
+                        "env": {"CAO_TERMINAL_ID": "dead-tid"},
+                    },
+                    # Entry for a live terminal — should survive
+                    "cao-mcp-server-live-tid": {
+                        "command": "cao-mcp-server",
+                        "args": [],
+                        "env": {"CAO_TERMINAL_ID": "live-tid"},
+                    },
+                    # Non-CAO entry (no CAO_TERMINAL_ID) — should survive
+                    "user-custom-server": {
+                        "command": "my-server",
+                        "args": [],
+                    },
+                }
+            }
+        )
+    )
+    profile = AgentProfile(
+        name="dev_gemini",
+        description="Dev",
+        system_prompt="You develop.",
+        mcpServers={"cao-mcp-server": {"command": "uvx", "args": ["cao-mcp-server"]}},
+    )
+    p = make_provider(terminal_id="new-tid", agent_profile="dev_gemini")
+
+    def fake_get_terminal_metadata(tid):
+        # live-tid exists, dead-tid does not, new-tid is "us" (would also
+        # return truthy from a real DB since we're registering it).
+        return {"id": tid} if tid in ("live-tid", "new-tid") else None
+
+    with (
+        patch(
+            "cli_agent_orchestrator.providers.antigravity_cli.shutil.which",
+            return_value="/usr/local/bin/agy",
+        ),
+        patch(
+            "cli_agent_orchestrator.providers.antigravity_cli.load_agent_profile",
+            return_value=profile,
+        ),
+        patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg),
+        # Override the autouse no-op to let the real prune logic run
+        patch.object(
+            AntigravityCliProvider,
+            "_prune_stale_mcp_entries",
+            _real_prune_stale_mcp_entries,
+        ),
+        patch(
+            "cli_agent_orchestrator.clients.database.get_terminal_metadata",
+            side_effect=fake_get_terminal_metadata,
+        ),
+    ):
+        p._build_agy_command()
+
+    data = json.loads(cfg.read_text())
+    servers = data["mcpServers"]
+    # Dead entry pruned
+    assert "cao-mcp-server-dead-tid" not in servers
+    # Live entry preserved
+    assert "cao-mcp-server-live-tid" in servers
+    # Non-CAO entry preserved
+    assert "user-custom-server" in servers
+    # New entry added
+    assert "cao-mcp-server-new-tid" in servers
+    assert servers["cao-mcp-server-new-tid"]["env"]["CAO_TERMINAL_ID"] == "new-tid"
+
+
+# --------------------------------------------------------------------------- #
+# Cleanup future exception surfacing (finding 3)
+# --------------------------------------------------------------------------- #
+
+
+def test_cleanup_logs_unregister_exception(caplog):
+    """When _unregister_mcp_servers raises on a worker thread, the exception
+    is logged (not silently swallowed)."""
+    import asyncio
+
+    from cli_agent_orchestrator.providers.antigravity_cli import _log_cleanup_exception
+
+    # Simulate a future that completed with an exception
+    loop = asyncio.new_event_loop()
+    fut = loop.create_future()
+    fut.set_exception(OSError("disk full"))
+
+    with caplog.at_level("ERROR", logger="cli_agent_orchestrator.providers.antigravity_cli"):
+        _log_cleanup_exception(fut)
+
+    assert "disk full" in caplog.text
+    assert "_unregister_mcp_servers" in caplog.text
+    loop.close()

--- a/test/providers/test_copilot_cli_unit.py
+++ b/test/providers/test_copilot_cli_unit.py
@@ -267,9 +267,10 @@ class TestCopilotCliProviderInitialization:
 
 
 class TestCopilotCliProviderTrustPrompts:
-    @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.copilot_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
-    def test_accept_trust_prompts_answers_yes_then_returns(self, mock_tmux, _mock_sleep):
+    async def test_accept_trust_prompts_answers_yes_then_returns(self, mock_tmux, _mock_sleep):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
 
         with (
@@ -283,22 +284,23 @@ class TestCopilotCliProviderTrustPrompts:
             ),
             patch.object(provider, "_send_enter") as mock_enter,
         ):
-            provider._accept_trust_prompts(timeout=2.0)
+            await provider._accept_trust_prompts(timeout=2.0)
 
         mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "y")
         assert mock_enter.call_count >= 1
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.copilot_cli.logger")
-    @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.copilot_cli.time.time")
-    def test_accept_trust_prompts_logs_warning_on_timeout(
+    async def test_accept_trust_prompts_logs_warning_on_timeout(
         self, mock_time, _mock_sleep, mock_logger
     ):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
         mock_time.side_effect = [0.0, 0.0, 3.0]
 
         with patch.object(provider, "_history", return_value="still waiting"):
-            provider._accept_trust_prompts(timeout=2.0)
+            await provider._accept_trust_prompts(timeout=2.0)
 
         mock_logger.warning.assert_called_once_with(
             "Trust prompt handler timed out for %s:%s",
@@ -306,9 +308,10 @@ class TestCopilotCliProviderTrustPrompts:
             "window-0",
         )
 
-    @patch("cli_agent_orchestrator.providers.copilot_cli.time.sleep")
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.copilot_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
-    def test_accept_trust_prompts_answers_yes_for_spaced_yes_no_prompt(
+    async def test_accept_trust_prompts_answers_yes_for_spaced_yes_no_prompt(
         self, mock_tmux, _mock_sleep
     ):
         provider = CopilotCliProvider("test1234", "test-session", "window-0")
@@ -324,7 +327,7 @@ class TestCopilotCliProviderTrustPrompts:
             ),
             patch.object(provider, "_send_enter") as mock_enter,
         ):
-            provider._accept_trust_prompts(timeout=2.0)
+            await provider._accept_trust_prompts(timeout=2.0)
 
         mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "y")
         assert mock_enter.call_count >= 1

--- a/test/providers/test_startup_handler_nonblocking.py
+++ b/test/providers/test_startup_handler_nonblocking.py
@@ -1,0 +1,180 @@
+"""Shared regression test: startup/trust-prompt handlers must not block the
+shared asyncio event loop.
+
+issue #494: ``KimiCliProvider._handle_startup_dialog``,
+``AntigravityCliProvider._handle_startup_dialog``, and
+``CopilotCliProvider._accept_trust_prompts`` / ``_wait_for_shell_ready`` were
+converted from sync ``time.sleep()``-based methods (called un-awaited from an
+async ``initialize()``) into real coroutines that offload every blocking
+backend call via ``asyncio.to_thread``, mirroring PR #451's fix for
+``ClaudeCodeProvider._handle_startup_prompts``.
+
+Two layers, parameterized across the four handlers:
+1. Structural pin -- each target must be a real coroutine function. Catches a
+   regression back to a plain ``def`` (silently breaking every
+   ``await self._handle_...()`` call site).
+2. Heartbeat-starvation probe -- proves the coroutine actually YIELDS the
+   event loop while its backend call is in flight, not just that it is
+   syntactically ``async def`` while still blocking synchronously inside (the
+   bug #494 reports: "mirrors ClaudeCodeProvider" docstrings that were never
+   true because the body stayed fully sync).
+
+ClaudeCodeProvider._handle_startup_prompts is deliberately excluded from both
+layers: PR #451 (which converts it) is open/changes-requested, not merged, as
+of this test.
+"""
+
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.antigravity_cli import AntigravityCliProvider
+from cli_agent_orchestrator.providers.copilot_cli import CopilotCliProvider
+from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
+
+# Simulated blocking backend latency per poll -- long enough that several
+# ticker increments fit inside it if (and only if) the call is truly
+# offloaded to a worker thread via asyncio.to_thread, rather than run
+# directly on the event-loop thread.
+_BLOCKING_CALL_SECONDS = 0.05
+_TICKER_INTERVAL_SECONDS = 0.01
+
+
+def _blocking_history(ready_output: str):
+    """Build a side_effect that blocks the calling thread, then returns.
+
+    Stands in for a real tmux/backend subprocess exec (get_history /
+    _history). Used as a Mock's side_effect, so it runs synchronously on
+    whatever thread invokes the mock -- the event-loop thread if the code
+    under test forgot to offload it via asyncio.to_thread, a worker thread if
+    it didn't.
+    """
+
+    def _side_effect(*_args, **_kwargs) -> str:
+        time.sleep(_BLOCKING_CALL_SECONDS)
+        return ready_output
+
+    return _side_effect
+
+
+async def _run_with_heartbeat_probe(handler_coro) -> int:
+    """Await ``handler_coro`` concurrently with a ticker; return the tick count.
+
+    The ticker increments a counter every ``_TICKER_INTERVAL_SECONDS`` until
+    the handler completes. A non-zero count proves the event loop kept
+    running other coroutines while the handler's backend call was blocking on
+    a worker thread. Zero would mean the handler's "blocking" call actually
+    ran on the event-loop thread and starved everything else -- the exact
+    pathology issue #494 (and PR #451 before it) fixes.
+    """
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while not stop.is_set():
+            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
+            ticks += 1
+
+    ticker_task = asyncio.create_task(_ticker())
+    try:
+        await handler_coro
+    finally:
+        stop.set()
+        ticker_task.cancel()
+        try:
+            await ticker_task
+        except asyncio.CancelledError:
+            pass
+    return ticks
+
+
+async def _kimi_handler_run() -> int:
+    """KimiCliProvider._handle_startup_dialog: one poll, already-ready output."""
+    provider = KimiCliProvider("t1", "sess", "win")
+    mock_backend = MagicMock()
+    mock_backend.get_history.side_effect = _blocking_history("Welcome to Kimi!\n💫")
+    with (
+        patch("cli_agent_orchestrator.providers.kimi_cli.get_backend", return_value=mock_backend),
+        patch.object(provider, "get_status", return_value=TerminalStatus.IDLE),
+    ):
+        return await _run_with_heartbeat_probe(
+            provider._handle_startup_dialog(idle_gap=5.0, outer_timeout=5.0)
+        )
+
+
+async def _antigravity_handler_run() -> int:
+    """AntigravityCliProvider._handle_startup_dialog: one poll, ready footer."""
+    provider = AntigravityCliProvider("t1", "sess", "win")
+    mock_backend = MagicMock()
+    mock_backend.get_history.side_effect = _blocking_history("? for shortcuts\n> ")
+    with patch(
+        "cli_agent_orchestrator.providers.antigravity_cli.get_backend",
+        return_value=mock_backend,
+    ):
+        return await _run_with_heartbeat_probe(
+            provider._handle_startup_dialog(idle_gap=5.0, outer_timeout=5.0)
+        )
+
+
+async def _copilot_trust_run() -> int:
+    """CopilotCliProvider._accept_trust_prompts: one poll, idle prompt near end."""
+    provider = CopilotCliProvider("t1", "sess", "win")
+    with patch.object(
+        provider,
+        "_history",
+        side_effect=_blocking_history("GitHub Copilot v0.0.415\n❯ Type @ to mention files"),
+    ):
+        return await _run_with_heartbeat_probe(provider._accept_trust_prompts(timeout=5.0))
+
+
+async def _copilot_shell_ready_run() -> int:
+    """CopilotCliProvider._wait_for_shell_ready: needs 2 stable identical reads."""
+    provider = CopilotCliProvider("t1", "sess", "win")
+    with patch.object(
+        provider,
+        "_history",
+        side_effect=_blocking_history("$ "),
+    ):
+        return await _run_with_heartbeat_probe(
+            provider._wait_for_shell_ready(timeout=5.0, polling_interval=0.01)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: structural pin -- must be real coroutine functions.
+# ---------------------------------------------------------------------------
+
+_COROUTINE_TARGETS = [
+    ("kimi:_handle_startup_dialog", KimiCliProvider._handle_startup_dialog),
+    ("antigravity:_handle_startup_dialog", AntigravityCliProvider._handle_startup_dialog),
+    ("copilot:_accept_trust_prompts", CopilotCliProvider._accept_trust_prompts),
+    ("copilot:_wait_for_shell_ready", CopilotCliProvider._wait_for_shell_ready),
+]
+
+
+@pytest.mark.parametrize("name,handler", _COROUTINE_TARGETS, ids=[t[0] for t in _COROUTINE_TARGETS])
+def test_handler_is_a_real_coroutine_function(name, handler):
+    assert asyncio.iscoroutinefunction(handler), f"{name} regressed to a plain (blocking) def"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: heartbeat-starvation probe -- must actually yield the event loop.
+# ---------------------------------------------------------------------------
+
+_HEARTBEAT_CASES = [
+    ("kimi:_handle_startup_dialog", _kimi_handler_run),
+    ("antigravity:_handle_startup_dialog", _antigravity_handler_run),
+    ("copilot:_accept_trust_prompts", _copilot_trust_run),
+    ("copilot:_wait_for_shell_ready", _copilot_shell_ready_run),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,run_case", _HEARTBEAT_CASES, ids=[c[0] for c in _HEARTBEAT_CASES])
+async def test_handler_does_not_starve_event_loop(name, run_case):
+    ticks = await run_case()
+    assert ticks > 0, f"{name}: event loop starved while its backend call was in flight"

--- a/test/providers/test_startup_handler_nonblocking.py
+++ b/test/providers/test_startup_handler_nonblocking.py
@@ -178,3 +178,53 @@ _HEARTBEAT_CASES = [
 async def test_handler_does_not_starve_event_loop(name, run_case):
     ticks = await run_case()
     assert ticks > 0, f"{name}: event loop starved while its backend call was in flight"
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: cleanup() lock offload -- _unregister_mcp_servers must not block
+# the event loop when cleanup() is called from an async context (e.g.
+# flow_service.execute_flow → cleanup_provider on the loop thread).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_antigravity_cleanup_does_not_block_event_loop(tmp_path):
+    """cleanup() offloads _unregister_mcp_servers via run_in_executor so the
+    _MCP_CONFIG_WRITE_LOCK + file I/O never runs on the event-loop thread."""
+    import json
+
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text(json.dumps({"mcpServers": {"cao-mcp-server": {"command": "x"}}}))
+    provider = AntigravityCliProvider("t1", "sess", "win")
+    provider._mcp_server_names = ["cao-mcp-server"]
+
+    # Make _unregister_mcp_servers block long enough for heartbeat detection.
+    original_unregister = provider._unregister_mcp_servers
+
+    def _slow_unregister():
+        time.sleep(_BLOCKING_CALL_SECONDS)
+        original_unregister()
+
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def _ticker():
+        nonlocal ticks
+        while not stop.is_set():
+            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
+            ticks += 1
+
+    ticker_task = asyncio.create_task(_ticker())
+    with patch.object(AntigravityCliProvider, "_mcp_config_path", return_value=cfg):
+        with patch.object(provider, "_unregister_mcp_servers", _slow_unregister):
+            # cleanup() detects the running loop and offloads to executor.
+            provider.cleanup()
+            # Give the executor time to complete.
+            await asyncio.sleep(_BLOCKING_CALL_SECONDS * 3)
+    stop.set()
+    ticker_task.cancel()
+    try:
+        await ticker_task
+    except asyncio.CancelledError:
+        pass
+    assert ticks > 0, "event loop starved during cleanup's _unregister_mcp_servers"

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -243,10 +243,12 @@ class TestKimiCliIdleGap:
     def _make(self):
         return KimiCliProvider("t1", "sess", "win")
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    def test_late_prompt_handled(self, mock_get_backend, mock_time):
+    async def test_late_prompt_handled(self, mock_get_backend, mock_time, mock_sleep):
         """Upgrade at t=18 resets the timer; loop survives to detect ready at t=35.
 
         Kimi has a single actionable dialog (upgrade), so the two-event structure
@@ -254,7 +256,6 @@ class TestKimiCliIdleGap:
         the old 20s total window to detect readiness at t=35 (35-18=17 < 20). Under
         the old fixed-window logic the loop would have given up at t=20.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -273,22 +274,25 @@ class TestKimiCliIdleGap:
         p = self._make()
         # get_status is checked only in iter2 (iter1 continues after handling upgrade)
         with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
-            p._handle_startup_dialog()
+            await p._handle_startup_dialog()
 
         # 's' sent to skip reminders at t=18 — the reset kept the loop alive to
         # cleanly detect readiness at t=35, past the old 20s window.
         mock_backend.send_keys.assert_called_once_with("sess", "win", "s", enter_count=0)
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_get_backend, mock_time):
+    async def test_no_prompt_exits_at_outer_cap_not_idle_gap(
+        self, mock_get_backend, mock_time, mock_sleep
+    ):
         """No upgrade dialog ever appears — the idle gap does NOT apply pre-first-prompt.
 
         should-fix-3 rework: with no dialog ever handled, only the outer cap
         (not the idle-gap boundary at t=20) can end the loop.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -303,14 +307,18 @@ class TestKimiCliIdleGap:
         p = self._make()
         # Mock get_status to return PROCESSING (not ready yet)
         with patch.object(p, "get_status", return_value=TerminalStatus.PROCESSING):
-            p._handle_startup_dialog()
+            await p._handle_startup_dialog()
 
         mock_backend.send_keys.assert_not_called()
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    def test_first_dialog_later_than_idle_gap_still_handled(self, mock_get_backend, mock_time):
+    async def test_first_dialog_later_than_idle_gap_still_handled(
+        self, mock_get_backend, mock_time, mock_sleep
+    ):
         """A FIRST upgrade dialog later than idle_gap (issue #400 scenario) is caught.
 
         Before this fix, a first dialog at t=35 (past the 20s default) would
@@ -319,7 +327,6 @@ class TestKimiCliIdleGap:
         dialog at t=35 is well within the still-open outer cap and is handled;
         the loop then detects readiness on the next poll (t=36) and returns.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -337,21 +344,22 @@ class TestKimiCliIdleGap:
 
         p = self._make()
         with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
-            p._handle_startup_dialog()
+            await p._handle_startup_dialog()
 
         mock_backend.send_keys.assert_called_once_with("sess", "win", "s", enter_count=0)
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _outer_cap_settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    def test_outer_cap_respected(self, mock_get_backend, mock_time):
+    async def test_outer_cap_respected(self, mock_get_backend, mock_time, mock_sleep):
         """Loop exits at provider_init_timeout, NOT via the idle gap.
 
         idle_gap=100 > provider_init_timeout=60, so the idle-gap check can never
         fire. The upgrade prompt is handled once (resetting the timer), then the
         loop idles until t=61 trips the outer cap.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -369,21 +377,22 @@ class TestKimiCliIdleGap:
 
         p = self._make()
         with patch.object(p, "get_status", return_value=TerminalStatus.PROCESSING):
-            p._handle_startup_dialog()
+            await p._handle_startup_dialog()
 
         # Upgrade handled once
         mock_backend.send_keys.assert_called_once()
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    def test_cascading_prompts_all_handled(self, mock_get_backend, mock_time):
+    async def test_cascading_prompts_all_handled(self, mock_get_backend, mock_time, mock_sleep):
         """Upgrade dialog handled, then ready state detected → exits cleanly.
 
         Kimi only has one startup dialog type (upgrade), so "cascading" means
         the dialog is handled and then IDLE is detected on the next poll.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -402,16 +411,17 @@ class TestKimiCliIdleGap:
         p = self._make()
         # get_status called only in iter2 (iter1 continues after handling upgrade)
         with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
-            p._handle_startup_dialog()
+            await p._handle_startup_dialog()
 
         mock_backend.send_keys.assert_called_once()
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    def test_idle_gap_resets_on_prompt(self, mock_get_backend, mock_time):
+    async def test_idle_gap_resets_on_prompt(self, mock_get_backend, mock_time, mock_sleep):
         """Upgrade at t=5 resets timer; at t=22 (gap=17<20) still within window."""
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         # Without reset: t=22-0=22>=20 would exit. With reset: 22-5=17<20.
@@ -431,7 +441,7 @@ class TestKimiCliIdleGap:
         p = self._make()
         # get_status called only in iter2 (iter1 continues after handling upgrade)
         with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
-            p._handle_startup_dialog()
+            await p._handle_startup_dialog()
 
         # Prompt at t=5 was handled (timer reset enabled continued polling at t=22)
         mock_backend.send_keys.assert_called_once()
@@ -448,10 +458,12 @@ class TestAntigravityCliIdleGap:
     def _make(self):
         return AntigravityCliProvider("t1", "sess", "win")
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
-    def test_late_prompt_handled(self, mock_get_backend, mock_time):
+    async def test_late_prompt_handled(self, mock_get_backend, mock_time, mock_sleep):
         """A survey at t=35s (past the old 20s window) is still handled.
 
         Two prompts: trust at t=18 resets the idle timer; the survey at t=35 is
@@ -459,7 +471,6 @@ class TestAntigravityCliIdleGap:
         Under the old fixed-window logic the handler would have exited at t=20 and
         never seen the late survey.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -480,7 +491,7 @@ class TestAntigravityCliIdleGap:
         ]
 
         p = self._make()
-        p._handle_startup_dialog()
+        await p._handle_startup_dialog()
 
         # Trust at t=18 (Enter) and the late survey at t=35 ("0" + Enter) are both
         # handled — the idle-gap reset kept the loop polling past the old 20s
@@ -488,16 +499,19 @@ class TestAntigravityCliIdleGap:
         assert mock_backend.send_special_key.call_count == 2  # trust Enter + survey Enter
         assert mock_backend.send_keys.call_count == 1  # survey "0"
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
-    def test_no_prompt_exits_at_outer_cap_not_idle_gap(self, mock_get_backend, mock_time):
+    async def test_no_prompt_exits_at_outer_cap_not_idle_gap(
+        self, mock_get_backend, mock_time, mock_sleep
+    ):
         """No dialog ever appears — the idle gap does NOT apply pre-first-dialog.
 
         should-fix-3 rework: with no dialog ever handled, only the outer cap
         (not the idle-gap boundary at t=20) can end the loop.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -510,15 +524,19 @@ class TestAntigravityCliIdleGap:
         mock_backend.get_history.return_value = "Starting agy..."
 
         p = self._make()
-        p._handle_startup_dialog()
+        await p._handle_startup_dialog()
 
         mock_backend.send_special_key.assert_not_called()
         mock_backend.send_keys.assert_not_called()
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
-    def test_first_dialog_later_than_idle_gap_still_handled(self, mock_get_backend, mock_time):
+    async def test_first_dialog_later_than_idle_gap_still_handled(
+        self, mock_get_backend, mock_time, mock_sleep
+    ):
         """A FIRST trust dialog later than idle_gap (issue #400 scenario) is caught.
 
         Before this fix, a first dialog at t=35 (past the 20s default) would
@@ -526,7 +544,6 @@ class TestAntigravityCliIdleGap:
         actually been handled, so a first dialog at t=35 is well within the
         still-open outer cap.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -543,23 +560,24 @@ class TestAntigravityCliIdleGap:
         ]
 
         p = self._make()
-        p._handle_startup_dialog()
+        await p._handle_startup_dialog()
 
         mock_backend.send_special_key.assert_called_once_with("sess", "win", "Enter")
 
+    @pytest.mark.asyncio
     @patch(
         "cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _outer_cap_settings
     )
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
-    def test_outer_cap_respected(self, mock_get_backend, mock_time):
+    async def test_outer_cap_respected(self, mock_get_backend, mock_time, mock_sleep):
         """Loop exits at provider_init_timeout, NOT via the idle gap.
 
         idle_gap=100 > provider_init_timeout=60, so the idle-gap check can never
         fire. Trust is handled once (resetting the timer), then the loop idles
         with no ready footer until t=61 trips the outer cap.
         """
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -577,17 +595,18 @@ class TestAntigravityCliIdleGap:
         )
 
         p = self._make()
-        p._handle_startup_dialog()
+        await p._handle_startup_dialog()
 
         # Trust handled once (trust_done flag prevents re-handling)
         assert mock_backend.send_special_key.call_count == 1
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
-    def test_cascading_prompts_all_handled(self, mock_get_backend, mock_time):
+    async def test_cascading_prompts_all_handled(self, mock_get_backend, mock_time, mock_sleep):
         """Trust dialog then survey — both handled in sequence."""
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         mock_time.monotonic.side_effect = [
@@ -608,19 +627,20 @@ class TestAntigravityCliIdleGap:
         ]
 
         p = self._make()
-        p._handle_startup_dialog()
+        await p._handle_startup_dialog()
 
         # Trust: send_special_key (Enter)
         # Survey: send_keys ("0") + send_special_key (Enter)
         assert mock_backend.send_special_key.call_count == 2
         assert mock_backend.send_keys.call_count == 1
 
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.antigravity_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.time")
     @patch("cli_agent_orchestrator.providers.antigravity_cli.get_backend")
-    def test_idle_gap_resets_on_each_prompt(self, mock_get_backend, mock_time):
+    async def test_idle_gap_resets_on_each_prompt(self, mock_get_backend, mock_time, mock_sleep):
         """Trust at t=5 resets timer; survey at t=22 (gap=17<20) still within window."""
-        mock_time.sleep = MagicMock()
         mock_backend = MagicMock()
         mock_get_backend.return_value = mock_backend
         # Without reset: 22-0=22>=20 would exit before seeing survey.
@@ -643,7 +663,7 @@ class TestAntigravityCliIdleGap:
         ]
 
         p = self._make()
-        p._handle_startup_dialog()
+        await p._handle_startup_dialog()
 
         # Both dialogs handled
         assert mock_backend.send_special_key.call_count == 2  # trust Enter + survey Enter


### PR DESCRIPTION
## Summary

kimi_cli.py, antigravity_cli.py, and copilot_cli.py called blocking time.sleep() and blocking backend methods directly from their async initialize(), freezing cao-server's single event loop for the full duration of each startup-prompt poll. This is the same event-loop-starvation issue that PR #451 addresses for ClaudeCodeProvider (open, not yet merged). The "mirrors ClaudeCodeProvider" docstrings in kimi_cli.py and antigravity_cli.py claimed this was already handled correctly, but the implementations stayed fully synchronous.

## Changes

- Converted _handle_startup_dialog (kimi, antigravity) and _wait_for_shell_ready/_accept_trust_prompts (copilot) into real coroutines: every time.sleep became asyncio.sleep, every blocking backend call became asyncio.to_thread.
- Antigravity's shared MCP config (`~/.gemini/config/mcp_config.json`) now uses per-terminal unique keys (`cao-mcp-server-{terminal_id}`) instead of a single shared key, preventing concurrent-initialization write collisions without requiring a global lock. Kimi retains a threading.Lock for its `~/.kimi/config.toml` MCP timeout write (single shared key, different file format).
- Stale MCP config entries for terminals that no longer exist are pruned on each antigravity initialization, and exceptions from cleanup/unregister that were previously swallowed silently are now surfaced via logging.
- Made kimi's config write atomic (write to a temp file, then os.replace).
- Added test/providers/test_startup_handler_nonblocking.py, a shared regression test that pins each converted handler as a real coroutine that yields the event loop instead of blocking it.
- ClaudeCodeProvider is intentionally left out of this change, since PR #451 (which converts it) has not merged yet.

## Testing

- Full review of the diff: approved, no findings.
- Scoped provider test suite (test/providers/): 1101 passed. Two pre-existing failures remain, unrelated to this change and confirmed present on the main tip as well:
  - `test/providers/test_codex_provider_unit.py::TestCodexProviderTrustPrompt::test_get_status_trust_prompt_v2_is_waiting`
  - `test/providers/test_codex_provider_unit.py::TestCodexProviderTrustPrompt::test_get_status_trust_v2_in_scrollback_does_not_false_positive`

  Both raise `TerminalNotFoundError` from `HerdrBackend._resolve_pane_id_from_window` -- a test-env herdr backend pane-resolution gap (the test mocks don't fully satisfy herdr's workspace->tab->pane resolution chain). Reproduces identically on main tip; environment-specific to setups where the herdr backend is the configured default. Not triggered on tmux-backend environments (e.g. WSL2 with Python 3.13).

## Known Limitations

Tool-invocation-level cross-wiring between concurrent antigravity terminals remains a known architectural gap. The per-terminal-key fix prevents config *write collisions*, but because `agy` loads and spawns MCP subprocesses for ALL entries in the shared config file generically, a model in terminal B can still invoke tools via terminal A's spawned subprocess. This is deliberately deferred to a tracked follow-up: #532. The fix requires empirical verification of `agy`'s `$HOME`/config-path resolution behavior (binary not available in the current dev environment to test against).

Fixes #494