### PR TITLE
feat(ops-mcp): pass model and initial message when launching sessions

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -207,6 +207,17 @@ class CreateTerminalBody(BaseModel):
     initial_message_orchestration_type: Optional[str] = None
 
 
+class CreateSessionBody(CreateTerminalBody):
+    """Optional JSON body for POST /sessions.
+
+    Reuses the terminal-creation message payload and keeps operator-forwarded
+    environment variables in the request body, preserving the existing
+    ``{"env_vars": {...}}`` wire shape.
+    """
+
+    env_vars: Optional[Dict[str, str]] = None
+
+
 def _validate_model_id(value: str) -> None:
     """Validate a ``model`` override at the request boundary (PR #501 review).
 
@@ -1679,7 +1690,8 @@ async def create_session(
     working_directory: Optional[str] = None,
     allowed_tools: Optional[str] = None,
     memory_manager: Optional[str] = None,
-    env_vars: Optional[Dict[str, str]] = Body(default=None, embed=True),
+    model: Optional[str] = None,
+    body: Optional[CreateSessionBody] = None,
     _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
 ) -> Terminal:
     """Create a new session with exactly one terminal.
@@ -1691,11 +1703,24 @@ async def create_session(
     the curator reaches IDLE; ``get_curated_memory_context`` falls back to
     Phase 1 in that window.
 
-    ``env_vars`` (request body, optional) is the operator-forwarded env map
+    ``body.env_vars`` is the optional operator-forwarded env map
     from ``cao launch --env``. It travels in the JSON body — not the query
     string — so values potentially containing secrets do not land in
     cao-server's HTTP access log. See issue #248.
+
+    When ``body.initial_message`` is present, session creation reuses the
+    existing deferred terminal-initialization path: the response is returned
+    after the session and terminal record are created, then provider
+    initialization and message delivery continue in the background. This
+    narrows the create-then-send window but is not a transactional operation;
+    deferred failures follow terminal_service's existing logging and best-
+    effort cleanup behavior.
+
+    ``model`` is an optional per-launch override. It uses the same validation
+    and provider handoff as the existing terminal-creation endpoint.
     """
+    initial_message = body.initial_message if body else None
+    initial_message_orchestration_type = None
     try:
         if session_name is not None:
             # terminal_service.create_terminal prepends SESSION_PREFIX
@@ -1711,6 +1736,22 @@ async def create_session(
                 else f"{SESSION_PREFIX}{session_name}"
             )
             validate_tmux_name(effective, "session_name")
+        if model is not None:
+            _validate_model_id(model)
+        if initial_message == "":
+            raise ValueError("initial_message must not be empty")
+        if body and body.initial_message_orchestration_type:
+            if initial_message is None:
+                raise ValueError("initial_message_orchestration_type requires initial_message")
+            try:
+                initial_message_orchestration_type = OrchestrationType(
+                    body.initial_message_orchestration_type
+                )
+            except ValueError:
+                raise ValueError(
+                    "invalid initial_message_orchestration_type: "
+                    f"{body.initial_message_orchestration_type!r}"
+                )
         # Parse comma-separated allowed_tools string into list
         allowed_tools_list = allowed_tools.split(",") if allowed_tools else None
 
@@ -1721,7 +1762,10 @@ async def create_session(
             working_directory=working_directory,
             allowed_tools=allowed_tools_list,
             registry=get_plugin_registry(request),
-            env_vars=env_vars,
+            env_vars=body.env_vars if body else None,
+            initial_message=initial_message,
+            initial_message_orchestration_type=initial_message_orchestration_type,
+            model=model,
         )
 
         if memory_manager and str(memory_manager).lower() in ("true", "1", "yes"):

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -187,9 +187,10 @@ def _create_terminal(
             runs as a background task on cao-server. The tool-call round-trip
             drops from tens of seconds to <2s, keeping it well under
             kiro-cli 2.11's ~60s per-tool client timeout.
-        initial_message: If ``defer_init=True``, this message is delivered
-            to the newly created worker once its provider finishes
-            initializing. Ignored otherwise.
+        initial_message: This message is delivered to the newly created worker
+            once its provider finishes initializing. For a new session, the
+            message selects deferred initialization automatically; for an
+            existing session, ``defer_init=True`` is required.
         initial_message_orchestration_type: Passed through to send_input for
             plugin event emission (assign/handoff).
         model: Explicit per-call model override for the new terminal, applied
@@ -303,8 +304,7 @@ def _create_terminal(
             params["model"] = model
 
         json_body = None
-        if defer_init:
-            assert initial_message is not None  # guarded above for new sessions
+        if initial_message is not None:
             json_body = {"initial_message": initial_message}
             if initial_message_orchestration_type is not None:
                 json_body["initial_message_orchestration_type"] = (

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -180,7 +180,7 @@ def _create_terminal(
     Args:
         agent_profile: Agent profile for the terminal
         working_directory: Optional working directory for the terminal
-        defer_init: If True and creating within an existing session, tell
+        defer_init: If True, tell
             cao-server to skip the ``provider.initialize()`` wait and return
             as soon as the tmux window and DB record exist. Provider init
             (and, when ``initial_message`` is set, delivery of that message)
@@ -194,14 +194,8 @@ def _create_terminal(
             plugin event emission (assign/handoff).
         model: Explicit per-call model override for the new terminal, applied
             ahead of the agent profile's own static model field (where the
-            resolved provider supports it). Only honored on the
-            existing-session branch below (``POST /sessions/{name}/
-            terminals``) -- the new-session branch (``POST /sessions``, used
-            only when this tool is called with no current CAO_TERMINAL_ID)
-            goes through a different server-side route that does not accept
-            it; handoff/assign both already require an existing terminal
-            (see their own CAO_TERMINAL_ID checks), so this branch is the one
-            that matters for both callers in practice.
+            resolved provider supports it). Honored by both the existing-
+            session and new-session branches.
 
     Returns:
         Tuple of (terminal_id, provider)
@@ -259,7 +253,7 @@ def _create_terminal(
             params["working_directory"] = working_directory
         if child_allowed_tools:
             params["allowed_tools"] = child_allowed_tools
-        if model:
+        if model is not None:
             params["model"] = model
         # The message payload goes in the JSON body, not the query string, so
         # prompt content isn't exposed in HTTP access logs and isn't subject to
@@ -287,16 +281,14 @@ def _create_terminal(
         terminal = response.json()
     else:
         # Create new session with terminal.
-        # The new-session endpoint (POST /sessions) has no deferred-init support,
-        # so defer_init/initial_message CANNOT be honored here. Raise rather than
-        # silently create a worker and drop the task (the caller — _assign_impl —
-        # already fails fast when CAO_TERMINAL_ID is unset, so this is a
-        # belt-and-suspenders guard the docstring promised).
-        if defer_init:
+        # POST /sessions automatically uses deferred init when an initial
+        # message is present. A bare defer_init flag still cannot be represented
+        # on that endpoint, so reject that narrower shape rather than silently
+        # changing it to synchronous initialization.
+        if defer_init and initial_message is None:
             raise ValueError(
-                "defer_init/initial_message is not supported when creating a new "
-                "session (no current CAO_TERMINAL_ID); refusing to create a worker "
-                "whose task would never be delivered."
+                "defer_init requires initial_message when creating a new session "
+                "(no current CAO_TERMINAL_ID)"
             )
         session_name = generate_session_name()
         provider = resolve_provider(agent_profile, fallback_provider=provider)
@@ -307,8 +299,26 @@ def _create_terminal(
         }
         if working_directory:
             params["working_directory"] = working_directory
+        if model is not None:
+            params["model"] = model
 
-        response = requests.post(f"{API_BASE_URL}/sessions", params=params, timeout=_mcp_timeout())
+        json_body = None
+        if defer_init:
+            assert initial_message is not None  # guarded above for new sessions
+            json_body = {"initial_message": initial_message}
+            if initial_message_orchestration_type is not None:
+                json_body["initial_message_orchestration_type"] = (
+                    initial_message_orchestration_type.value
+                    if isinstance(initial_message_orchestration_type, OrchestrationType)
+                    else str(initial_message_orchestration_type)
+                )
+
+        response = requests.post(
+            f"{API_BASE_URL}/sessions",
+            params=params,
+            json=json_body,
+            timeout=_mcp_timeout(),
+        )
         response.raise_for_status()
         terminal = response.json()
 

--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -30,8 +30,8 @@ mcp = FastMCP(
     1. list_profiles to inspect available profiles
     2. get_profile_details to review a profile's full prompt and metadata
     3. install_profile to install a profile for a target provider
-    4. launch_session to start a new CAO session
-    5. send_session_message to deliver a prompt to a running terminal
+    4. launch_session to start a new CAO session, optionally with its first task
+    5. send_session_message to deliver later prompts to a running terminal
     6. get_terminal_status to poll a worker until it finishes a task
     7. get_terminal_output to read a worker's result (or review its files/git diff)
     8. read_session_output to read a terminal's captured output by session name
@@ -99,6 +99,8 @@ async def _launch_session_impl(
     session_name: Optional[str] = None,
     working_directory: Optional[str] = None,
     allowed_tools: Optional[List[str]] = None,
+    model: Optional[str] = None,
+    initial_message: Optional[str] = None,
 ) -> LaunchResult:
     """Create a new CAO session and return the session identifiers."""
     resolved_session_name = session_name or generate_session_name()
@@ -110,13 +112,16 @@ async def _launch_session_impl(
         params["provider"] = provider
     if working_directory:
         params["working_directory"] = working_directory
+    if model is not None:
+        params["model"] = model
 
     serialized_allowed_tools = _serialize_allowed_tools(allowed_tools)
     if serialized_allowed_tools:
         params["allowed_tools"] = serialized_allowed_tools
 
+    body = {"initial_message": initial_message} if initial_message is not None else None
     session_data, error = _request_json(
-        "post", "/sessions", params=params, operation="Launch session"
+        "post", "/sessions", params=params, json=body, operation="Launch session"
     )
     if error:
         return LaunchResult(
@@ -135,9 +140,14 @@ async def _launch_session_impl(
         )
 
     terminal_id = str(session_data["id"])
+    message = (
+        f"Session '{resolved_session_name}' launched; initial message delivery is in progress"
+        if initial_message is not None
+        else f"Session '{resolved_session_name}' launched successfully"
+    )
     return LaunchResult(
         success=True,
-        message=f"Session '{resolved_session_name}' launched successfully",
+        message=message,
         session_name=resolved_session_name,
         terminal_id=terminal_id,
     )
@@ -275,12 +285,32 @@ async def launch_session(
         Optional[List[str]],
         Field(description="Optional list of allowed tool restrictions"),
     ] = None,
+    model: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional per-launch model override accepted by the resolved provider; "
+                "takes precedence over the profile model"
+            )
+        ),
+    ] = None,
+    initial_message: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional first task to deliver after provider initialization; "
+                "sent in the JSON request body"
+            )
+        ),
+    ] = None,
 ) -> LaunchResult:
     """Create a new CAO session with the given provider and agent profile.
 
-    Returns immediately with session_name and terminal_id. Use
-    send_session_message to deliver an initial prompt once the session is
-    running, and get_session_info or list_sessions to monitor progress.
+    Returns immediately with session_name and terminal_id. When
+    ``initial_message`` is provided, provider initialization and delivery
+    continue in the background; use get_terminal_status or get_session_info to
+    observe the result. Without it, use send_session_message to deliver work
+    later.
 
     Args:
         agent_profile: Agent profile for the new session
@@ -288,6 +318,8 @@ async def launch_session(
         session_name: Optional custom session name (auto-generated if omitted)
         working_directory: Optional working directory for the session
         allowed_tools: Optional list of tool restrictions
+        model: Optional per-launch model override
+        initial_message: Optional first task, carried in the JSON request body
 
     Returns:
         LaunchResult with success status, session_name, and terminal_id
@@ -298,6 +330,8 @@ async def launch_session(
         session_name=session_name,
         working_directory=working_directory,
         allowed_tools=allowed_tools,
+        model=model,
+        initial_message=initial_message,
     )
 
 

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -25,6 +25,7 @@ from typing import Dict, List
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import list_terminals_by_session
 from cli_agent_orchestrator.constants import SESSION_PREFIX
+from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import Terminal
 from cli_agent_orchestrator.plugins import (
     PluginRegistry,
@@ -47,13 +48,26 @@ async def create_session(
     allowed_tools: list[str] | None = None,
     registry: PluginRegistry | None = None,
     env_vars: dict[str, str] | None = None,
+    initial_message: str | None = None,
+    initial_message_orchestration_type: OrchestrationType | None = None,
+    model: str | None = None,
 ) -> Terminal:
     """Create a new session by creating its initial terminal.
 
     ``env_vars`` are operator-forwarded env vars from ``cao launch --env``.
     They are persisted on the session record so every worker spawned later
     in the same session inherits them. See issue #248.
+
+    When ``initial_message`` is provided, the initial terminal uses the
+    existing deferred-init path so provider initialization and delivery can
+    continue after the session response. Omitting it preserves the synchronous
+    initialization behavior used by existing callers.
     """
+    if initial_message == "":
+        raise ValueError("initial_message must not be empty")
+    if initial_message is None and initial_message_orchestration_type is not None:
+        raise ValueError("initial_message_orchestration_type requires initial_message")
+
     if provider is None:
         resolved_provider = resolve_provider(agent_profile, fallback_provider="kiro_cli")
     else:
@@ -68,6 +82,10 @@ async def create_session(
         allowed_tools=allowed_tools,
         registry=registry,
         env_vars=env_vars,
+        defer_init=initial_message is not None,
+        initial_message=initial_message,
+        initial_message_orchestration_type=initial_message_orchestration_type,
+        model=model,
     )
     dispatch_plugin_event(
         registry,

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -62,6 +62,8 @@ async def create_session(
     existing deferred-init path so provider initialization and delivery can
     continue after the session response. Omitting it preserves the synchronous
     initialization behavior used by existing callers.
+    On the deferred path, the ``post_create_session`` plugin event is dispatched
+    before provider initialization and message delivery finish.
     """
     if initial_message == "":
         raise ValueError("initial_message must not be empty")

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -17,6 +17,7 @@ from cli_agent_orchestrator.api.main import (
     inbox_reconciliation_daemon,
     opencode_inbox_delivery_daemon,
 )
+from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import Terminal
 from cli_agent_orchestrator.services.inbox_service import inbox_service
 from cli_agent_orchestrator.utils.skills import SkillNameError
@@ -291,7 +292,93 @@ class TestCreateSession:
             allowed_tools=None,
             registry=ANY,
             env_vars=None,
+            initial_message=None,
+            initial_message_orchestration_type=None,
+            model=None,
         )
+
+    def test_create_session_passes_model_and_initial_message(self, client):
+        """The launch override and first task reach the session service, while
+        the task remains in the JSON body rather than the request URL."""
+        mock_terminal = Terminal(
+            id="abcd1234",
+            name="test-window",
+            session_name="test-session",
+            provider="codex",
+            agent_profile="developer",
+        )
+        initial_message = "Review the current change"
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            mock_svc.create_session = AsyncMock(return_value=mock_terminal)
+
+            response = client.post(
+                "/sessions",
+                params={
+                    "provider": "codex",
+                    "agent_profile": "developer",
+                    "model": "gpt-5.1-codex",
+                },
+                json={
+                    "initial_message": initial_message,
+                    "initial_message_orchestration_type": "send_message",
+                },
+            )
+
+        assert response.status_code == 201
+        assert initial_message not in str(response.request.url)
+        call_kwargs = mock_svc.create_session.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-5.1-codex"
+        assert call_kwargs["initial_message"] == initial_message
+        assert call_kwargs["initial_message_orchestration_type"] == OrchestrationType.SEND_MESSAGE
+
+    def test_create_session_preserves_env_vars_body_shape(self, client):
+        """Existing cao launch --env callers keep using {"env_vars": {...}}."""
+        mock_terminal = Terminal(
+            id="abcd1234",
+            name="test-window",
+            session_name="test-session",
+            provider="kiro_cli",
+            agent_profile="developer",
+        )
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            mock_svc.create_session = AsyncMock(return_value=mock_terminal)
+
+            response = client.post(
+                "/sessions",
+                params={"agent_profile": "developer"},
+                json={"env_vars": {"FEATURE_MODE": "enabled"}},
+            )
+
+        assert response.status_code == 201
+        assert mock_svc.create_session.call_args.kwargs["env_vars"] == {"FEATURE_MODE": "enabled"}
+
+    def test_create_session_rejects_malformed_model(self, client):
+        """Malformed model IDs fail before any session is created."""
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            response = client.post(
+                "/sessions",
+                params={
+                    "agent_profile": "developer",
+                    "model": "invalid;model",
+                },
+            )
+
+        assert response.status_code == 400
+        assert "model" in response.json()["detail"]
+        mock_svc.create_session.assert_not_called()
+
+    def test_create_session_rejects_empty_initial_message(self, client):
+        """An explicitly supplied but undeliverable empty task is not ignored."""
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            response = client.post(
+                "/sessions",
+                params={"agent_profile": "developer"},
+                json={"initial_message": ""},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "initial_message must not be empty"
+        mock_svc.create_session.assert_not_called()
 
     def test_create_session_with_session_name(self, client):
         """POST /sessions with explicit session_name."""

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -380,6 +380,37 @@ class TestCreateSession:
         assert response.json()["detail"] == "initial_message must not be empty"
         mock_svc.create_session.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("payload", "expected_detail"),
+        [
+            (
+                {"initial_message_orchestration_type": "send_message"},
+                "initial_message_orchestration_type requires initial_message",
+            ),
+            (
+                {
+                    "initial_message": "Review the current change",
+                    "initial_message_orchestration_type": "invalid",
+                },
+                "invalid initial_message_orchestration_type: 'invalid'",
+            ),
+        ],
+    )
+    def test_create_session_rejects_invalid_initial_message_orchestration(
+        self, client, payload, expected_detail
+    ):
+        """Invalid initial-message orchestration fails at the API boundary."""
+        with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
+            response = client.post(
+                "/sessions",
+                params={"agent_profile": "developer"},
+                json=payload,
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == expected_detail
+        mock_svc.create_session.assert_not_called()
+
     def test_create_session_with_session_name(self, client):
         """POST /sessions with explicit session_name."""
         mock_terminal = Terminal(

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -134,33 +134,74 @@ class TestCreateTerminalProviderResolution:
                 defer_init=True,
                 initial_message="Analyze the sensitive logs at /secret/path",
                 initial_message_orchestration_type=OrchestrationType.ASSIGN,
+                model="",
             )
 
         _, kwargs = mock_requests.post.call_args
         # Routing flag stays in params; message payload is in the body.
         assert kwargs["params"].get("defer_init") == "true"
+        # Even an invalid empty override reaches the API validation boundary.
+        assert kwargs["params"]["model"] == ""
         assert "initial_message" not in kwargs["params"]
         assert kwargs["json"]["initial_message"] == "Analyze the sensitive logs at /secret/path"
         assert kwargs["json"]["initial_message_orchestration_type"] == "assign"
 
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server.generate_session_name",
+        return_value="cao-new-session",
+    )
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server.resolve_provider",
+        return_value="codex",
+    )
     @patch("cli_agent_orchestrator.mcp_server.server.requests")
-    def test_defer_init_on_new_session_branch_raises(self, mock_requests):
-        """PR #390 must-fix #2: the new-session branch can't honor defer_init
-        (POST /sessions has no deferred-init support), so _create_terminal must
-        raise rather than silently create a worker whose task is never
-        delivered. This is the branch taken when CAO_TERMINAL_ID is unset."""
+    def test_new_session_forwards_model_and_initial_message(
+        self, mock_requests, mock_resolve_provider, mock_generate_session_name
+    ):
+        """The no-current-terminal branch no longer drops either launch field."""
         from cli_agent_orchestrator.mcp_server.server import _create_terminal
         from cli_agent_orchestrator.models.inbox import OrchestrationType
 
-        with patch.dict(os.environ, {}, clear=True):  # no CAO_TERMINAL_ID
-            with pytest.raises(ValueError, match="not supported when creating a new session"):
-                _create_terminal(
-                    "reviewer",
-                    defer_init=True,
-                    initial_message="do work",
-                    initial_message_orchestration_type=OrchestrationType.ASSIGN,
-                )
-        # Must raise BEFORE creating anything.
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-1", "provider": "codex"}
+        post_response.raise_for_status.return_value = None
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": ""}):
+            terminal_id, provider = _create_terminal(
+                "reviewer",
+                defer_init=True,
+                initial_message="Review the current change",
+                initial_message_orchestration_type=OrchestrationType.ASSIGN,
+                model="gpt-5.1-codex",
+            )
+
+        assert terminal_id == "worker-1"
+        assert provider == "codex"
+        mock_requests.post.assert_called_once_with(
+            f"{API_BASE_URL}/sessions",
+            params={
+                "provider": "codex",
+                "agent_profile": "reviewer",
+                "session_name": "cao-new-session",
+                "model": "gpt-5.1-codex",
+            },
+            json={
+                "initial_message": "Review the current change",
+                "initial_message_orchestration_type": "assign",
+            },
+            timeout=_mcp_timeout(),
+        )
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_defer_init_without_message_on_new_session_raises(self, mock_requests):
+        """A bare defer flag still fails rather than changing semantics silently."""
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": ""}):
+            with pytest.raises(ValueError, match="defer_init requires initial_message"):
+                _create_terminal("reviewer", defer_init=True)
+
         mock_requests.post.assert_not_called()
 
 

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -193,6 +193,43 @@ class TestCreateTerminalProviderResolution:
             timeout=_mcp_timeout(),
         )
 
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server.generate_session_name",
+        return_value="cao-new-session",
+    )
+    @patch(
+        "cli_agent_orchestrator.mcp_server.server.resolve_provider",
+        return_value="codex",
+    )
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_new_session_initial_message_is_forwarded_without_defer_flag(
+        self, mock_requests, mock_resolve_provider, mock_generate_session_name
+    ):
+        """An initial message cannot be dropped when defer_init keeps its default."""
+        from cli_agent_orchestrator.mcp_server.server import _create_terminal
+
+        post_response = MagicMock()
+        post_response.json.return_value = {"id": "worker-1", "provider": "codex"}
+        post_response.raise_for_status.return_value = None
+        mock_requests.post.return_value = post_response
+
+        with patch.dict(os.environ, {"CAO_TERMINAL_ID": ""}):
+            _create_terminal(
+                "reviewer",
+                initial_message="Review the current change",
+            )
+
+        mock_requests.post.assert_called_once_with(
+            f"{API_BASE_URL}/sessions",
+            params={
+                "provider": "codex",
+                "agent_profile": "reviewer",
+                "session_name": "cao-new-session",
+            },
+            json={"initial_message": "Review the current change"},
+            timeout=_mcp_timeout(),
+        )
+
     @patch("cli_agent_orchestrator.mcp_server.server.requests")
     def test_defer_init_without_message_on_new_session_raises(self, mock_requests):
         """A bare defer flag still fails rather than changing semantics silently."""

--- a/test/ops_mcp_server/test_server.py
+++ b/test/ops_mcp_server/test_server.py
@@ -346,6 +346,63 @@ class TestSessionLifecycleTools:
             json=None,
         )
 
+    async def test_launch_session_passes_model_and_initial_message(self) -> None:
+        """The model stays in routing params and the first task stays in JSON."""
+        initial_message = "Review the current change"
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(json_data={"id": "term-789"}),
+        ) as mock_request:
+            result = await launch_session(
+                agent_profile="developer",
+                provider="codex",
+                session_name="model-session",
+                model="gpt-5.1-codex",
+                initial_message=initial_message,
+            )
+
+        assert result == LaunchResult(
+            success=True,
+            message=(
+                "Session 'model-session' launched; " "initial message delivery is in progress"
+            ),
+            session_name="model-session",
+            terminal_id="term-789",
+        )
+        mock_request.assert_called_once_with(
+            "post",
+            "http://127.0.0.1:9889/sessions",
+            params={
+                "provider": "codex",
+                "agent_profile": "developer",
+                "session_name": "model-session",
+                "model": "gpt-5.1-codex",
+            },
+            json={"initial_message": initial_message},
+        )
+        request_url = mock_request.call_args.args[1]
+        request_params = mock_request.call_args.kwargs["params"]
+        assert initial_message not in request_url
+        assert initial_message not in str(request_params)
+
+    async def test_launch_session_returns_invalid_model_error(self) -> None:
+        """Request-boundary model errors are returned instead of ignored."""
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(
+                status_code=400,
+                json_data={"detail": "model 'invalid;model' is invalid"},
+            ),
+        ):
+            result = await launch_session(
+                agent_profile="developer",
+                model="invalid;model",
+            )
+
+        assert result.success is False
+        assert result.message == ("Launch session failed: model 'invalid;model' is invalid")
+        assert result.terminal_id is None
+
     async def test_launch_session_returns_failure_on_api_error(self) -> None:
         """Session API errors should return failed LaunchResults."""
         with patch(

--- a/test/services/test_session_service.py
+++ b/test/services/test_session_service.py
@@ -100,6 +100,19 @@ class TestCreateSession:
 
         mock_create_terminal.assert_not_called()
 
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.session_service.create_terminal")
+    async def test_create_session_rejects_empty_initial_message(self, mock_create_terminal):
+        """Direct callers cannot turn an empty first task into deferred initialization."""
+        with pytest.raises(ValueError, match="initial_message must not be empty"):
+            await create_session(
+                provider="codex",
+                agent_profile="my_agent",
+                initial_message="",
+            )
+
+        mock_create_terminal.assert_not_called()
+
 
 class TestListSessions:
     """Tests for list_sessions function."""

--- a/test/services/test_session_service.py
+++ b/test/services/test_session_service.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.services.session_service import (
     create_session,
     delete_session,
@@ -31,7 +32,11 @@ class TestCreateSession:
         await create_session(provider=None, agent_profile="my_agent")
 
         mock_resolve.assert_called_once_with("my_agent", fallback_provider="kiro_cli")
-        assert mock_create_terminal.call_args.kwargs["provider"] == "claude_code"
+        call_kwargs = mock_create_terminal.call_args.kwargs
+        assert call_kwargs["provider"] == "claude_code"
+        assert call_kwargs["defer_init"] is False
+        assert call_kwargs["initial_message"] is None
+        assert call_kwargs["model"] is None
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.session_service.dispatch_plugin_event")
@@ -49,6 +54,51 @@ class TestCreateSession:
 
         mock_resolve.assert_not_called()
         assert mock_create_terminal.call_args.kwargs["provider"] == "kiro_cli"
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.session_service.dispatch_plugin_event")
+    @patch("cli_agent_orchestrator.services.session_service.create_terminal")
+    async def test_create_session_forwards_launch_payload(
+        self, mock_create_terminal, mock_dispatch
+    ):
+        """A first task selects the existing deferred-init path and reaches
+        terminal creation alongside the model override."""
+        mock_terminal = MagicMock()
+        mock_terminal.session_name = "cao-test"
+        mock_create_terminal.return_value = mock_terminal
+
+        await create_session(
+            provider="codex",
+            agent_profile="my_agent",
+            session_name="cao-test",
+            initial_message="Review the current change",
+            initial_message_orchestration_type=OrchestrationType.SEND_MESSAGE,
+            model="gpt-5.1-codex",
+        )
+
+        call_kwargs = mock_create_terminal.call_args.kwargs
+        assert call_kwargs["new_session"] is True
+        assert call_kwargs["defer_init"] is True
+        assert call_kwargs["initial_message"] == "Review the current change"
+        assert call_kwargs["initial_message_orchestration_type"] == OrchestrationType.SEND_MESSAGE
+        assert call_kwargs["model"] == "gpt-5.1-codex"
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.session_service.create_terminal")
+    async def test_create_session_rejects_orchestration_type_without_message(
+        self, mock_create_terminal
+    ):
+        """An incomplete initial-message payload fails instead of being dropped."""
+        with pytest.raises(
+            ValueError, match="initial_message_orchestration_type requires initial_message"
+        ):
+            await create_session(
+                provider="codex",
+                agent_profile="my_agent",
+                initial_message_orchestration_type=OrchestrationType.SEND_MESSAGE,
+            )
+
+        mock_create_terminal.assert_not_called()
 
 
 class TestListSessions:

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -65,6 +65,68 @@ class TestCreateTerminal:
         mock_provider.initialize.assert_called_once()
 
     @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service._schedule_deferred_init")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+    @patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+    @patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+    async def test_create_terminal_forwards_deferred_launch_payload(
+        self,
+        mock_load_profile,
+        mock_gen_id,
+        mock_gen_session,
+        mock_gen_window,
+        mock_tmux,
+        mock_db_create,
+        mock_provider_manager,
+        mock_fifo_dir,
+        mock_fifo_manager,
+        mock_status_monitor,
+        mock_schedule_deferred_init,
+    ):
+        """The real terminal layer sends the model to provider construction and
+        the first task to the established deferred-init scheduler."""
+        mock_gen_id.return_value = "test1234"
+        mock_gen_session.return_value = "cao-session"
+        mock_gen_window.return_value = "developer-abcd"
+        mock_tmux.session_exists.return_value = False
+        mock_load_profile.return_value = AgentProfile(
+            name="developer",
+            description="Developer",
+            model="profile-default-model",
+        )
+        mock_provider = AsyncMock()
+        mock_provider_manager.create_provider.return_value = mock_provider
+        mock_fifo_dir.__truediv__ = MagicMock(return_value="fake.fifo")
+
+        result = await create_terminal(
+            "codex",
+            "developer",
+            new_session=True,
+            defer_init=True,
+            initial_message="Review the current change",
+            initial_message_orchestration_type=OrchestrationType.SEND_MESSAGE,
+            model="gpt-5.1-codex",
+        )
+
+        assert result.status == TerminalStatus.UNKNOWN
+        assert mock_provider_manager.create_provider.call_args.kwargs["model"] == ("gpt-5.1-codex")
+        mock_provider.initialize.assert_not_awaited()
+        mock_schedule_deferred_init.assert_called_once_with(
+            mock_provider,
+            "test1234",
+            "Review the current change",
+            OrchestrationType.SEND_MESSAGE,
+            None,
+        )
+
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.utils.tool_mapping.resolve_allowed_tools")
     @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
     @patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")


### PR DESCRIPTION
## Summary

This is a small API consistency change for new session creation.

CAO already supports model overrides in terminal creation and handoff/assign, and it already supports an initial message in terminal creation and `cao launch`. This change carries those existing capabilities through `POST /sessions` and `cao-ops-mcp.launch_session`.

- Add optional `model` and `initial_message` arguments to `launch_session`.
- Forward `model` through the existing validation and provider creation path.
- Carry `initial_message` in the JSON request body, never in the URL or query string.
- Reuse the existing deferred initialization, delivery confirmation, retry, and cleanup path when an initial message is present.
- Fix the internal MCP new-session branch so it does not silently drop `model` or the initial message.
- Keep all new parameters optional, preserving existing callers and synchronous initialization when no initial message is supplied.

This lets an external supervisor create a session and bind its first task in one structured call. It removes the extra launch-then-send round trip, narrows the window where a session exists without its task, and permits an optional per-launch model override beyond the profile default. Invalid model identifiers fail explicitly at the existing API validation boundary.

## Delivery semantics

The operation is not fully atomic. A successful HTTP response confirms that the session and terminal were created; provider initialization and initial-message delivery continue in the background. Existing deferred-init behavior logs failures and performs best-effort terminal cleanup. Callers should continue polling terminal or session status.

## Non-goals

This does not add model discovery, provider routing, health checks, failover, circuit breaking, or provider-specific gateway behavior. It does not claim provider availability or automatic fallback.

## Tests

- `uv run pytest test/api/test_api_endpoints.py test/mcp_server/test_assign.py test/ops_mcp_server/test_server.py test/services/test_session_service.py test/services/test_terminal_service_full.py test/providers/test_codex_provider_unit.py test/providers/test_claude_code_unit.py test/providers/test_claude_code_coverage.py test/providers/test_hermes_provider_unit.py -q --no-cov`
  - `581 passed, 3 skipped, 1 xfailed`
- `CAO_MEMORY_ENABLED=true uv run pytest test/ --ignore=test/e2e -m "not integration" -k "not test_returns_false_when_explicitly_disabled and not test_set_memory_setting_enabled_roundtrip" -q --no-cov`
  - `5350 passed, 27 skipped, 39 deselected, 1 xfailed`
- `uv run pytest test/services/test_memory_enabled_flag.py::TestIsMemoryEnabledFlag::test_returns_false_when_explicitly_disabled test/services/test_memory_enabled_flag.py::TestIsMemoryEnabledFlag::test_set_memory_setting_enabled_roundtrip -q --no-cov`
  - `2 passed`
- `uv run black --check src/ test/`
  - Passed (`488 files would be left unchanged`)
- `uv run isort --check-only src/ test/`
  - Passed
- `git diff --check`
  - Passed
- `uv run mypy src/`
  - Reports the same pre-existing `88 errors in 8 files` as an unmodified `upstream/main` worktree; this change adds no mypy errors.
- `scripts/security-scan.sh gitleaks`
  - Skipped by the repository script because `gitleaks` is not installed locally; the GitHub secret-scan workflow remains authoritative.
