### PR TITLE
fix(antigravity): reliably submit orchestrated/flow tasks on Gemini 3.x agy

### DIFF
--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -216,6 +216,26 @@ class AntigravityCliProvider(BaseProvider):
         """
         return True
 
+    @property
+    def paste_submit_delay(self) -> float:
+        """Gemini 3.x ``agy`` needs longer than the 0.3s base default to settle
+        the bracketed-paste end marker. An Enter sent that soon is consumed as a
+        literal newline inside the input box, so the pasted task is left
+        UNSUBMITTED and the agent sits at "ready for my first task" forever --
+        silently breaking scheduled flows and supervisor assign/handoff on the
+        antigravity provider. 1.5s lets the paste settle so the Enter submits
+        (tune 1.2-2.0 empirically).
+        """
+        return 1.5
+
+    @property
+    def paste_enter_count(self) -> int:
+        """``agy`` submits on a single Enter once the bracketed paste has settled
+        (see ``paste_submit_delay``). The base default of 2 is tuned for Claude
+        Code's multi-line input mode and does not apply here.
+        """
+        return 1
+
     # ------------------------------------------------------------------ #
     # Launch
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Problem
On the `antigravity_cli` provider, a task delivered via `send_input` (scheduled flows, supervisor `assign`/`handoff`) is pasted but never submitted. The agent boots, acknowledges its role, then sits at "ready for my first task" while the task shows as `[Pasted text +N lines]`, unsubmitted. This silently breaks all orchestrated delivery on antigravity — the flow fires and the agent does nothing.

## Root cause
`BaseProvider.paste_submit_delay` is `0.3s`. The current Gemini `agy` CLI is still processing the bracketed-paste end marker at 0.3s, so the submit Enter is consumed as a literal newline inside the input box rather than "send." Pressing Enter manually a few seconds later — after the paste settles — submits correctly, confirming it is a timing issue. Separately, `paste_enter_count` defaults to `2` (Claude Code multi-line mode); `agy` submits on a **single** Enter once settled.

## Fix
Override two properties in `AntigravityCliProvider`:
- `paste_submit_delay` → `1.5` (let the bracketed paste settle before the Enter)
- `paste_enter_count` → `1`

Scoped to the antigravity provider; no other provider is affected. (These same values are already in use in a downstream fork.)

## Verify
1. Create an antigravity session and POST a concrete task to `/terminals/{id}/input`; confirm the agent **acts** instead of sitting idle.
2. `cao schedule run <flow>` with an antigravity conductor → it starts working rather than stalling at "ready for my first task."

🤖 Generated with [Claude Code](https://claude.com/claude-code)