### PR TITLE
feat(web): add agent-profile management to the Web UI

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Optional, Tuple, cast
 
+import frontmatter
 from fastapi import (
     BackgroundTasks,
     Body,
@@ -40,6 +41,7 @@ from cli_agent_orchestrator.backends import TerminalBackendError, TerminalNotFou
 from cli_agent_orchestrator.backends.herdr_backend import HerdrBackend
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.cli.commands.init import seed_default_skills
+from cli_agent_orchestrator.cli.commands.profile import _validate_frontmatter
 from cli_agent_orchestrator.clients.database import (
     create_inbox_message,
     get_inbox_messages,
@@ -54,6 +56,7 @@ from cli_agent_orchestrator.constants import (
     DEFAULT_PROVIDER,
     INBOX_POLLING_INTERVAL,
     INBOX_RECONCILE_INTERVAL,
+    LOCAL_AGENT_STORE_DIR,
     MODEL_ID_MAX_LEN,
     MODEL_ID_RE,
     OTEL_SERVICE_NAME,
@@ -101,6 +104,11 @@ from cli_agent_orchestrator.services import (
     session_service,
     terminal_service,
 )
+from cli_agent_orchestrator.services.agent_scaffold import (
+    get_template_schema,
+    list_templates,
+    render_template,
+)
 from cli_agent_orchestrator.services.agent_step import StepExecutionError, run_agent_step
 from cli_agent_orchestrator.services.cleanup_service import (
     cleanup_expired_memories,
@@ -116,11 +124,17 @@ from cli_agent_orchestrator.services.herdr_inbox_service import HerdrInboxServic
 from cli_agent_orchestrator.services.inbox_service import inbox_service
 from cli_agent_orchestrator.services.install_service import InstallResult, install_agent
 from cli_agent_orchestrator.services.log_writer import log_writer
+from cli_agent_orchestrator.services.profile_search import DEFAULT_LIMIT, search_profiles
 from cli_agent_orchestrator.services.status_monitor import status_monitor
 from cli_agent_orchestrator.services.step_output_store import _validate_key_part
 from cli_agent_orchestrator.services.terminal_service import OutputMode, TerminalInputBlockedError
 from cli_agent_orchestrator.telemetry import init_telemetry, shutdown_telemetry
-from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile, resolve_provider
+from cli_agent_orchestrator.utils.agent_profiles import (
+    _safe_join,
+    _validate_agent_name,
+    load_agent_profile,
+    resolve_provider,
+)
 from cli_agent_orchestrator.utils.logging import install_access_log_redaction, setup_logging
 from cli_agent_orchestrator.utils.skills import (
     SkillNameError,
@@ -460,6 +474,137 @@ class InstallAgentProfileRequest(BaseModel):
     source: str
     provider: Optional[str] = None
     env_vars: Optional[Dict[str, str]] = None
+
+
+# --- U1 profile-management DTOs (#510) -----------------------------------
+#
+# HTTP request/response models for the additive ``/agents/profiles/*`` routes
+# (search, templates, template schema, validate, create, edit). These are pure
+# serialization shapes over existing profile/template data — no new persistent
+# entity is introduced. See the U1 functional-design (business-logic-model
+# R1-R6, domain-entities). All ranking/validation/containment logic lives in the
+# reused services; these models only carry data across the HTTP boundary.
+
+
+class ProfileSearchResult(BaseModel):
+    """One search hit — mirrors the ``search_profiles`` result shape verbatim.
+
+    Serialization only; the list order is service-provided (coverage DESC →
+    BM25Plus DESC → name ASC) and MUST NOT be re-sorted by the route.
+    """
+
+    name: str
+    description: str
+    capabilities: List[str]
+    tags: List[str]
+    role: Optional[str] = None
+    source: str
+    coverage: int
+    score: float
+
+
+class TemplateInfo(BaseModel):
+    """One scaffolding template descriptor — mirrors ``list_templates()``."""
+
+    name: str
+    description: str
+    path: str
+
+
+class ValidateProfileRequest(BaseModel):
+    """Request to validate a profile.
+
+    Accepts either raw ``content`` (markdown + YAML frontmatter) or a parsed
+    ``metadata`` frontmatter dict. Exactly one is required; ``content`` takes
+    precedence when both are supplied. Validation is identical either way
+    (parse-then-``_validate_frontmatter``).
+    """
+
+    content: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="after")
+    def _require_one_input(self) -> "ValidateProfileRequest":
+        if self.content is None and self.metadata is None:
+            raise ValueError("Provide either 'content' or 'metadata'.")
+        return self
+
+
+class ValidateProfileResponse(BaseModel):
+    """Validation outcome. ``valid`` is true iff there are zero ``[error]``s;
+    ``[warn]`` messages never make a profile invalid (mirrors the CLI)."""
+
+    valid: bool
+    errors: List[str]
+    warnings: List[str]
+
+
+class CreateProfileRequest(BaseModel):
+    """Request to create a profile from a template (R5).
+
+    ``provider`` and ``model`` are REQUIRED explicit inputs (ADR-006); they are
+    set as top-level frontmatter fields on the RENDERED profile, never merged
+    into the template ``config`` (the template schemas are
+    ``additionalProperties:false``, so a config merge would fail validation).
+    """
+
+    template_name: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+    provider: str
+    model: str
+
+
+class UpdateProfileRequest(BaseModel):
+    """Request to edit an existing local-store profile (R6).
+
+    The client submits the full edited profile ``content`` (frontmatter +
+    body). ``provider`` and ``model`` are REQUIRED explicit inputs (ADR-006);
+    they are already embedded in the submitted frontmatter, and the server
+    re-asserts their presence on the request body.
+    """
+
+    content: str
+    provider: str
+    model: str
+
+
+class ProfileWriteResult(BaseModel):
+    """Response for a create/edit write — the persisted local profile."""
+
+    name: str
+    source: str = "local"
+    path: str
+
+
+class PreviewProfileResponse(BaseModel):
+    """Response for the render-only preview (R5-preview).
+
+    Carries the rendered profile ``text`` (frontmatter patched with
+    provider/model, exactly as create would write it) plus the C-BE-3 validation
+    split. NON-MUTATING: nothing is written. ``valid``/``errors``/``warnings``
+    mirror ``ValidateProfileResponse`` so the wizard can block Save on any
+    ``[error]`` before the create call (BR-8/BR-9)."""
+
+    text: str
+    valid: bool
+    errors: List[str]
+    warnings: List[str]
+
+
+class CreateFromContentRequest(BaseModel):
+    """Request to create a NEW local profile from raw ``content`` (R6-clone).
+
+    This is the content-mode create used by clone-to-customize: the client
+    submits a built-in's (edited) content under a NEW local ``name``. Unlike the
+    template create, there is no ``render_template`` step — the ``content`` is
+    the finished profile. ``provider`` and ``model`` are REQUIRED explicit inputs
+    (ADR-006); F-1 does NOT apply here because they arrive INSIDE ``content``'s
+    frontmatter (no post-render patch), exactly as the edit (PUT) path works."""
+
+    name: str
+    content: str
+    provider: str
+    model: str
 
 
 class MemorySummary(BaseModel):
@@ -1477,6 +1622,390 @@ async def list_agent_profiles_endpoint() -> List[Dict]:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list agent profiles: {str(e)}",
         )
+
+
+# --- U1 profile-management helpers (#510) --------------------------------
+#
+# Thin glue over the reused services. No ranking, scaffolding, schema, or
+# containment logic is reimplemented here (ADR-003): the helpers parse input,
+# call an existing service, and shape the result. See the U1 functional-design
+# (business-logic-model R1-R6, business-rules BR-1..BR-18).
+
+
+def _parse_profile_metadata(
+    content: Optional[str], metadata: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Resolve the frontmatter dict to validate from raw ``content`` or a parsed
+    ``metadata`` dict. ``content`` wins when both are supplied.
+
+    Raises ``ValueError`` if raw ``content`` cannot be parsed as frontmatter, so
+    the caller can map it to a 400 (bad input) rather than a silent pass.
+    """
+    if content is not None:
+        try:
+            post = frontmatter.loads(content)
+        except Exception as e:
+            raise ValueError(f"Could not parse profile content: {e}")
+        return dict(post.metadata)
+    return dict(metadata or {})
+
+
+def validate_profile(
+    content: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None
+) -> ValidateProfileResponse:
+    """Validate a profile's frontmatter and split messages into errors/warnings.
+
+    Reuses the CLI's ``_validate_frontmatter`` (schema + CAO conventions) — no
+    validation rule is reimplemented (C-BE-3, ADR-003). ``valid`` is true iff
+    there are zero ``[error]`` messages; ``[warn]`` messages never make a profile
+    invalid, mirroring the CLI's "exit 1 only on ``[error]``" (BR-8). Schema
+    errors are already emitted sorted by path by ``_validate_frontmatter`` (BR-6).
+    """
+    meta = _parse_profile_metadata(content, metadata)
+    messages = _validate_frontmatter(meta)
+    errors = [m for m in messages if m.startswith("[error]")]
+    warnings = [m for m in messages if m.startswith("[warn]")]
+    return ValidateProfileResponse(valid=(len(errors) == 0), errors=errors, warnings=warnings)
+
+
+def set_frontmatter_fields(rendered: str, provider: str, model: str) -> str:
+    """Patch the RENDERED profile's YAML frontmatter with explicit top-level
+    ``provider`` and ``model`` fields, then re-serialize.
+
+    ``provider`` and ``model`` are declared properties of
+    ``agent_profile.schema.json``, so patching them onto the rendered output
+    keeps it schema-valid. This is U1's only new glue (business-logic-model R5,
+    F-1 fix): the fields are set on the RENDERED profile, NEVER merged into the
+    template ``config`` (the template schemas are ``additionalProperties:false``,
+    so a config merge would fail ``validate_config`` inside ``render_template``).
+    """
+    post = frontmatter.loads(rendered)
+    post["provider"] = provider
+    post["model"] = model
+    return cast("str", frontmatter.dumps(post))
+
+
+def write_local_profile(name: str, text: str) -> Path:
+    """Write ``text`` to ``<local-store>/<name>.md`` and return the resolved path.
+
+    Reuses the existing containment guards (``_validate_agent_name`` +
+    ``_safe_join``): a name containing ``/``, ``\\`` or ``..`` raises
+    ``ValueError``, and any path that would escape ``LOCAL_AGENT_STORE_DIR``
+    (absolute component, symlink escape) is refused. Writes ONLY under the local
+    store, so a built-in/packaged profile is never mutated in place
+    (ADR-005, BR-12/13).
+    """
+    _validate_agent_name(name)
+    target = _safe_join(LOCAL_AGENT_STORE_DIR, f"{name}.md")
+    if target is None:
+        raise ValueError(f"Invalid profile name '{name}': resolved path escapes the local store.")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+# --- U1 profile-management routes (#510) ---------------------------------
+#
+# GET sub-paths (search, templates, template schema) are declared BEFORE the
+# existing GET ``/agents/profiles/{name}`` so a request to e.g.
+# ``/agents/profiles/search`` resolves to the search handler, not ``{name}``
+# with ``name="search"`` (ADR-001, BR-16). POST/PUT sub-paths are method-distinct
+# from GET ``{name}`` and carry no shadowing risk. All new routes precede the
+# StaticFiles mount.
+
+
+@app.get("/agents/profiles/search")
+async def search_agent_profiles_endpoint(
+    q: str = Query(..., description="Free-text keywords (e.g. 'monitor sqs')."),
+    limit: int = Query(DEFAULT_LIMIT, description="Maximum number of results."),
+) -> List[ProfileSearchResult]:
+    """Search agent profiles by keyword (R1).
+
+    Pure pass-through to ``search_profiles``: the service owns tokenization, the
+    coverage → BM25Plus → name-ascending ordering, the score formula, the
+    unloadable filter, and the empty/``limit<=0`` → ``[]`` guard. The route MUST
+    NOT sort, slice, re-score, or re-filter — it surfaces the service order
+    verbatim (BR-1..BR-5, ADR-004).
+    """
+    try:
+        results = search_profiles(q, limit=limit)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Profile search failed: {str(e)}",
+        )
+    return [ProfileSearchResult(**r) for r in results]
+
+
+@app.get("/agents/profiles/templates")
+async def list_profile_templates_endpoint() -> List[TemplateInfo]:
+    """List available scaffolding templates (R2) — wraps ``list_templates()``,
+    which never raises and returns ``[]`` when the templates root is absent."""
+    try:
+        return [TemplateInfo(**t) for t in list_templates()]
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list templates: {str(e)}",
+        )
+
+
+@app.get("/agents/profiles/templates/{template_name:path}/schema")
+async def get_profile_template_schema_endpoint(template_name: str) -> Dict:
+    """Return a template's JSON-Schema (R3) — wraps ``get_template_schema``.
+
+    The ``:path`` convertor captures the ``category/name`` template id (e.g.
+    ``aws/stepfunction``). A missing schema (``None``) or a containment escape
+    (``FileNotFoundError``) both map to 404.
+    """
+    try:
+        schema = get_template_schema(template_name)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to load template schema: {str(e)}",
+        )
+    if schema is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No schema found for template '{template_name}'",
+        )
+    return schema
+
+
+@app.post("/agents/profiles/validate")
+async def validate_agent_profile_endpoint(
+    request: ValidateProfileRequest,
+) -> ValidateProfileResponse:
+    """Validate a profile's frontmatter (R4). Non-mutating: a schema-invalid
+    profile is a normal 200 body with ``valid:false`` (not an exception); only
+    unparseable ``content`` is a 400 (BR-8, BR-18)."""
+    try:
+        return validate_profile(content=request.content, metadata=request.metadata)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Validation failed: {str(e)}",
+        )
+
+
+@app.post("/agents/profiles/preview")
+async def preview_agent_profile_endpoint(
+    request: CreateProfileRequest,
+) -> PreviewProfileResponse:
+    """Render-only preview of a create (R5-preview, FR4/AC4.2). NON-MUTATING.
+
+    Runs the SAME render pipeline as create — ``render_template(config)`` →
+    ``set_frontmatter_fields`` (provider/model patched onto the RENDERED output,
+    NEVER merged into ``config`` — F-1/BR-10) → ``validate_profile`` — but calls
+    NO ``write_local_profile`` on any path (including errors): nothing is ever
+    written. Returns the rendered ``text`` plus the validation split so the
+    create wizard can show the preview and block Save on any ``[error]`` before
+    the actual create call.
+
+    Open-read (non-mutating), like ``/validate``: no scope dependency. Invalid
+    config surfaces ``validate_config``'s messages as 400 (via
+    ``render_template`` → ``ValueError``); a template-path escape is 404 (BR-18).
+    A schema-invalid RENDERED profile is a normal 200 body with ``valid:false``
+    (the wizard blocks Save on it) — not an exception, matching ``/validate``.
+    """
+    if not request.provider or not request.model:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Both 'provider' and 'model' are required.",
+        )
+    try:
+        rendered = render_template(request.template_name, request.config)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    text = set_frontmatter_fields(rendered, provider=request.provider, model=request.model)
+    result = validate_profile(content=text)
+    # No write on any path — this route only renders + validates.
+    return PreviewProfileResponse(
+        text=text,
+        valid=result.valid,
+        errors=result.errors,
+        warnings=result.warnings,
+    )
+
+
+@app.post("/agents/profiles", status_code=status.HTTP_201_CREATED)
+async def create_agent_profile_endpoint(
+    request: CreateProfileRequest,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+) -> ProfileWriteResult:
+    """Create a profile from a template (R5).
+
+    Flow: require provider+model → ``render_template(config)`` (which runs
+    ``validate_config`` against the template schema and containment-checks the
+    template path) → ``set_frontmatter_fields`` patches provider/model onto the
+    RENDERED profile → ``validate_profile`` (pre-write, blocks on any ``[error]``,
+    BR-9/F-2) → ``write_local_profile`` (containment-guarded local write) → 201.
+
+    ``provider``/``model`` are NEVER merged into ``config`` — the template
+    schemas are ``additionalProperties:false`` (BR-10/F-1).
+    """
+    if not request.provider or not request.model:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Both 'provider' and 'model' are required.",
+        )
+    try:
+        rendered = render_template(request.template_name, request.config)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    text = set_frontmatter_fields(rendered, provider=request.provider, model=request.model)
+
+    result = validate_profile(content=text)
+    if result.errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "Profile validation failed", "errors": result.errors},
+        )
+
+    # Derive the local-store name from the rendered profile's own validated
+    # identity (its `name` frontmatter field is schema-guaranteed present and
+    # filesystem-safe post-validation). For the shipped templates this equals
+    # the CLI's `<basename>-agent`; falling back to that if `name` is absent.
+    post = frontmatter.loads(text)
+    name = str(post.metadata.get("name") or f"{request.template_name.split('/')[-1]}-agent")
+    try:
+        path = write_local_profile(name, text)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return ProfileWriteResult(name=name, source="local", path=str(path))
+
+
+@app.post("/agents/profiles/from-content", status_code=status.HTTP_201_CREATED)
+async def create_profile_from_content_endpoint(
+    request: CreateFromContentRequest,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+) -> ProfileWriteResult:
+    """Create a NEW local profile from raw ``content`` (R6-clone).
+
+    The content-mode create that clone-to-customize needs: the built-ins are not
+    template-derived (5 built-ins, 7 unrelated AWS templates — zero overlap), so
+    clone cannot go through the template ``create`` path, and ``PUT`` refuses a
+    non-existent target. This route writes a NEW local-store profile from the
+    submitted (edited) content under a NEW ``name``.
+
+    Flow: require provider+model → refuse-overwrite (a ``name`` that already
+    exists in the local store → 400, no clobber) → ``validate_profile(content)``
+    (any ``[error]`` → 400, nothing written; same F-2 shape as create) →
+    ``write_local_profile`` (containment-guarded via ``_validate_agent_name`` +
+    ``_safe_join``; a ``../evil`` name is refused). Scope-gated WRITE|ADMIN — this
+    genuinely writes, so it is NOT in the read-only ``_EXEMPT`` set.
+
+    F-1 does NOT apply: ``provider``/``model`` arrive INSIDE ``content``'s
+    frontmatter (the client embeds them, as the edit/PUT path does), not via a
+    post-render patch — there is no ``render_template`` step to keep them out of.
+    The server re-asserts their presence on the request body (ADR-006).
+    """
+    if not request.provider or not request.model:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Both 'provider' and 'model' are required.",
+        )
+    try:
+        _validate_agent_name(request.name)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    target = _safe_join(LOCAL_AGENT_STORE_DIR, f"{request.name}.md")
+    if target is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid profile name '{request.name}'.",
+        )
+    # Refuse overwrite: a clone must never silently clobber an existing local
+    # profile. The caller picks a different new name (or edits the existing one
+    # via PUT).
+    if target.exists():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"A local profile named '{request.name}' already exists. "
+                f"Choose a different name (clone must not overwrite)."
+            ),
+        )
+
+    result = validate_profile(content=request.content)
+    if result.errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "Profile validation failed", "errors": result.errors},
+        )
+    try:
+        path = write_local_profile(request.name, request.content)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return ProfileWriteResult(name=request.name, source="local", path=str(path))
+
+
+@app.put("/agents/profiles/{name}")
+async def update_agent_profile_endpoint(
+    name: str,
+    request: UpdateProfileRequest,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+) -> ProfileWriteResult:
+    """Edit an existing local-store profile (R6).
+
+    The target MUST be a local-store profile: a built-in/packaged-only name has
+    no local file and is refused with 400 (built-ins are read-only — clone them
+    to a new local profile via create instead; FR6, BR-12/13). The submitted
+    ``content`` already carries provider/model in its frontmatter (no post-render
+    patch — the R5/R6 asymmetry); the server re-asserts them on the request body
+    (ADR-006) and re-validates before writing (BR-9).
+    """
+    if not request.provider or not request.model:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Both 'provider' and 'model' are required.",
+        )
+    try:
+        _validate_agent_name(name)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    target = _safe_join(LOCAL_AGENT_STORE_DIR, f"{name}.md")
+    if target is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid profile name '{name}'.",
+        )
+    if not target.exists():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Profile '{name}' is not a local-store profile. Built-in/packaged "
+                f"profiles are read-only; clone to a new local profile instead."
+            ),
+        )
+
+    result = validate_profile(content=request.content)
+    if result.errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "Profile validation failed", "errors": result.errors},
+        )
+    try:
+        path = write_local_profile(name, request.content)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return ProfileWriteResult(name=name, source="local", path=str(path))
 
 
 @app.get("/agents/profiles/{name}")

--- a/test/api/test_api_profiles_management.py
+++ b/test/api/test_api_profiles_management.py
@@ -1,0 +1,738 @@
+"""Tests for the U1 profile-management API endpoints (#510).
+
+Covers the additive ``/agents/profiles/*`` routes: search (R1), templates (R2),
+template schema (R3), validate (R4), create (R5), edit/clone (R6). The reused
+services (``search_profiles``, ``agent_scaffold``, the CLI's
+``_validate_frontmatter``, and the containment path helpers) are proven correct
+by their own suites; these tests prove the ROUTES surface that behavior
+faithfully — parity, not reimplementation.
+
+Fixture/patch conventions mirror the sibling ``test_api_profiles.py`` (the shared
+``client`` fixture from ``conftest.py`` + ``patch``/``monkeypatch``).
+"""
+
+import importlib.resources as resources
+from unittest.mock import MagicMock
+
+import frontmatter
+import pytest
+
+import cli_agent_orchestrator.api.main as main_mod
+from cli_agent_orchestrator.cli.commands.profile import _validate_frontmatter
+from cli_agent_orchestrator.security import auth
+from cli_agent_orchestrator.services.agent_scaffold import get_template_schema, list_templates
+from cli_agent_orchestrator.services.profile_search import search_profiles
+
+_LIST_PROFILES = "cli_agent_orchestrator.utils.agent_profiles.list_agent_profiles"
+
+
+def _profile(
+    name,
+    description="",
+    *,
+    tags=None,
+    capabilities=None,
+    role="developer",
+    source="local",
+    loadable=True,
+):
+    """Build a profile-catalog row the way ``list_agent_profiles`` emits it."""
+    return {
+        "name": name,
+        "description": description,
+        "tags": tags or [],
+        "capabilities": capabilities or [],
+        "role": role,
+        "source": source,
+        "loadable": loadable,
+    }
+
+
+# --- A valid config + valid rendered profile for create tests -----------------
+
+_VALID_SQS_CONFIG = {
+    "profile": "myprofile",
+    "region": "us-east-1",
+    "queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/myqueue",
+}
+
+
+@pytest.fixture
+def local_store(tmp_path, monkeypatch):
+    """Redirect the local agent store to a temp dir for write-path tests."""
+    store = tmp_path / "agent-store"
+    store.mkdir()
+    monkeypatch.setattr(main_mod, "LOCAL_AGENT_STORE_DIR", store)
+    return store
+
+
+# =============================================================================
+# R1 — search (ranking parity, FR1)
+# =============================================================================
+
+
+class TestSearchRankingParity:
+    """The search route is a pure pass-through to ``search_profiles``; these
+    tests prove it surfaces the service order verbatim (no re-sort/slice/
+    re-filter/re-map)."""
+
+    def test_endpoint_equals_service_output_exactly(self, client, monkeypatch):
+        """Order- AND membership-sensitive parity: the endpoint returns exactly
+        ``search_profiles(q, limit)``. This single deep-equality assertion
+        catches ANY route-level drift (reorder, re-filter, slice, re-map)."""
+        corpus = [
+            _profile("aaa-partial", "sqs"),
+            _profile("zzz-full", "sqs monitoring queue"),
+            _profile("mmm-mid", "sqs monitoring"),
+            _profile("no-match", "unrelated dynamodb thing"),
+        ]
+        monkeypatch.setattr(_LIST_PROFILES, lambda: corpus)
+
+        expected = search_profiles("sqs monitoring", limit=10)
+        assert expected  # sanity: fixture actually matches something
+
+        resp = client.get("/agents/profiles/search", params={"q": "sqs monitoring", "limit": 10})
+        assert resp.status_code == 200
+        assert resp.json() == expected
+
+    def test_name_ascending_tie_break_preserved(self, client, monkeypatch):
+        """Two profiles that tie on coverage AND BM25 (identical searchable text)
+        are returned name-ascending — surfaced from the service order verbatim."""
+        corpus = [
+            _profile("zebra-agent", "sqs monitoring"),
+            _profile("apple-agent", "sqs monitoring"),
+        ]
+        monkeypatch.setattr(_LIST_PROFILES, lambda: corpus)
+
+        resp = client.get("/agents/profiles/search", params={"q": "sqs monitoring"})
+        assert resp.status_code == 200
+        names = [r["name"] for r in resp.json()]
+        # Fixture is inserted zebra-first; the service (and thus the route) must
+        # order them apple, zebra by the name tie-break.
+        assert names == ["apple-agent", "zebra-agent"]
+
+    def test_unloadable_profiles_excluded(self, client, monkeypatch):
+        """Unloadable profiles are excluded by the service; the route surfaces
+        the filtered set (BR-3)."""
+        corpus = [
+            _profile("good-monitor", "sqs monitoring", loadable=True),
+            _profile("broken-monitor", "sqs monitoring", loadable=False),
+        ]
+        monkeypatch.setattr(_LIST_PROFILES, lambda: corpus)
+
+        resp = client.get("/agents/profiles/search", params={"q": "sqs monitoring"})
+        assert resp.status_code == 200
+        assert [r["name"] for r in resp.json()] == ["good-monitor"]
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"q": ""},  # empty query
+            {"q": "   "},  # whitespace-only
+            {"q": "--- !!!"},  # all-punctuation (tokenizes empty)
+            {"q": "sqs", "limit": 0},  # limit == 0
+            {"q": "sqs", "limit": -3},  # limit < 0
+        ],
+    )
+    def test_empty_and_zero_limit_return_empty(self, client, monkeypatch, params):
+        """Empty/whitespace/punctuation query or limit<=0 → [] (BR-4)."""
+        monkeypatch.setattr(_LIST_PROFILES, lambda: [_profile("sqs-a", "sqs monitoring")])
+        resp = client.get("/agents/profiles/search", params=params)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# =============================================================================
+# R2 / R3 — templates & schema (FR4)
+# =============================================================================
+
+
+class TestTemplatesAndSchema:
+    def test_list_templates_matches_service(self, client):
+        resp = client.get("/agents/profiles/templates")
+        assert resp.status_code == 200
+        expected = list_templates()
+        assert resp.json() == expected
+        # Contract: every item carries name/description/path.
+        for item in resp.json():
+            assert set(item.keys()) == {"name", "description", "path"}
+
+    def test_template_schema_found(self, client):
+        resp = client.get("/agents/profiles/templates/aws/sqs-monitor/schema")
+        assert resp.status_code == 200
+        assert resp.json() == get_template_schema("aws/sqs-monitor")
+
+    def test_template_schema_missing_returns_404(self, client):
+        resp = client.get("/agents/profiles/templates/aws/does-not-exist/schema")
+        assert resp.status_code == 404
+
+
+# =============================================================================
+# R4 — validate (validation parity, FR2)
+# =============================================================================
+
+
+class TestValidateParity:
+    def test_schema_invalid_profile_reports_errors(self, client):
+        """A schema-invalid profile → valid:false with the same [error]s the CLI
+        emits (sorted by path). Non-mutating: still a 200 body."""
+        content = "---\nname: has spaces\n---\nbody\n"
+        resp = client.post("/agents/profiles/validate", json={"content": content})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is False
+        cli_errors = [
+            m for m in _validate_frontmatter({"name": "has spaces"}) if m.startswith("[error]")
+        ]
+        assert cli_errors  # sanity
+        assert body["errors"] == cli_errors
+
+    def test_warnings_only_profile_is_valid(self, client):
+        """A profile with only [warn]s (e.g. a non-built-in role) is valid:true —
+        warnings never block, mirroring the CLI's 'exit 1 only on [error]'."""
+        metadata = {"name": "ok-agent", "role": "totally-made-up-role"}
+        resp = client.post("/agents/profiles/validate", json={"metadata": metadata})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is True
+        assert body["errors"] == []
+        assert body["warnings"]  # at least the custom-role warning
+
+    def test_missing_both_inputs_is_422(self, client):
+        resp = client.post("/agents/profiles/validate", json={})
+        assert resp.status_code == 422
+
+
+# =============================================================================
+# R5 — create + F-1 / F-2 (FR4, supervisor-mandated)
+# =============================================================================
+
+
+class TestCreateProfile:
+    def test_f1_provider_model_are_frontmatter_not_config(self, client, local_store, monkeypatch):
+        """F-1: provider/model are set as top-level frontmatter on the RENDERED
+        profile and are NEVER merged into the template config passed to
+        render_template."""
+        captured = {}
+        real_render = main_mod.render_template
+
+        def capturing_render(template_name, config):
+            captured["config"] = config
+            return real_render(template_name, config)
+
+        monkeypatch.setattr(main_mod, "render_template", capturing_render)
+
+        resp = client.post(
+            "/agents/profiles",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": _VALID_SQS_CONFIG,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+
+        # (A) render_template's config must be untouched by provider/model.
+        assert "provider" not in captured["config"]
+        assert "model" not in captured["config"]
+        # (B) create succeeded and the SAVED profile carries them as frontmatter.
+        assert resp.status_code == 201
+        result = resp.json()
+        assert result["source"] == "local"
+        saved = frontmatter.loads((local_store / f"{result['name']}.md").read_text())
+        assert saved["provider"] == "claude_code"
+        assert saved["model"] == "opus"
+
+    def test_f2_rendered_invalid_profile_400_writes_nothing(self, client, local_store, monkeypatch):
+        """F-2: a create whose RENDERED profile is schema-invalid returns 400
+        (not 201) and writes nothing — proving validate_profile runs before the
+        write."""
+
+        def bad_render(template_name, config):
+            # Schema-invalid: name violates ^[A-Za-z0-9_-]{1,64}$.
+            return "---\nname: bad name\ndescription: x\n---\nbody\n"
+
+        monkeypatch.setattr(main_mod, "render_template", bad_render)
+
+        resp = client.post(
+            "/agents/profiles",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": {},
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 400
+        assert list(local_store.glob("*.md")) == []
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"template_name": "aws/sqs-monitor", "config": _VALID_SQS_CONFIG, "model": "opus"},
+            {
+                "template_name": "aws/sqs-monitor",
+                "config": _VALID_SQS_CONFIG,
+                "provider": "claude_code",
+            },
+        ],
+    )
+    def test_create_requires_provider_and_model(self, client, local_store, body):
+        """Omitting provider or model is rejected before any write (ADR-006)."""
+        resp = client.post("/agents/profiles", json=body)
+        assert resp.status_code == 422  # Pydantic required-field rejection
+        assert list(local_store.glob("*.md")) == []
+
+    def test_create_bad_config_400(self, client, local_store):
+        """An invalid template config is a 400 (via render_template's
+        validate_config → ValueError), with nothing written."""
+        resp = client.post(
+            "/agents/profiles",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": {"profile": "p"},  # missing required region/queue_url
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 400
+        assert list(local_store.glob("*.md")) == []
+
+    def test_create_containment_refuses_escaping_name(self, client, local_store, monkeypatch):
+        """A rendered profile whose derived name escapes the local store is
+        refused with no write (validation/containment guard)."""
+
+        def escaping_render(template_name, config):
+            return "---\nname: ../evil\ndescription: x\n---\nbody\n"
+
+        monkeypatch.setattr(main_mod, "render_template", escaping_render)
+        resp = client.post(
+            "/agents/profiles",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": {},
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 400
+        assert list(local_store.rglob("*.md")) == []
+
+
+# =============================================================================
+# R5-preview — render-only preview (FR4/AC4.2, additive U1 addendum)
+# =============================================================================
+
+
+class TestPreviewProfile:
+    def test_preview_returns_rendered_text_and_valid(self, client, local_store):
+        """A valid config renders the profile text and reports valid:true, with
+        provider/model present as frontmatter — and writes NOTHING."""
+        resp = client.post(
+            "/agents/profiles/preview",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": _VALID_SQS_CONFIG,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is True
+        assert body["errors"] == []
+        # Rendered text carries the patched provider/model frontmatter (F-1).
+        rendered = frontmatter.loads(body["text"])
+        assert rendered["provider"] == "claude_code"
+        assert rendered["model"] == "opus"
+        # NON-MUTATING: nothing written to the local store.
+        assert list(local_store.rglob("*.md")) == []
+
+    def test_preview_never_writes_even_when_valid(self, client, local_store):
+        """Explicit non-mutation guard: a fully valid preview leaves the store
+        empty. Pins the 'preview never writes' property (fail-before-pass:
+        inserting a write into the handler makes this fail)."""
+        resp = client.post(
+            "/agents/profiles/preview",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": _VALID_SQS_CONFIG,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 200
+        assert list(local_store.rglob("*")) == []
+
+    def test_preview_f1_provider_model_not_in_render_config(self, client, local_store, monkeypatch):
+        """F-1 for the preview path: provider/model are patched onto the RENDERED
+        output, never merged into the config passed to render_template."""
+        captured = {}
+        real_render = main_mod.render_template
+
+        def capturing_render(template_name, config):
+            captured["config"] = config
+            return real_render(template_name, config)
+
+        monkeypatch.setattr(main_mod, "render_template", capturing_render)
+        resp = client.post(
+            "/agents/profiles/preview",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": _VALID_SQS_CONFIG,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 200
+        assert "provider" not in captured["config"]
+        assert "model" not in captured["config"]
+
+    def test_preview_invalid_rendered_profile_reports_errors_no_write(
+        self, client, local_store, monkeypatch
+    ):
+        """A schema-invalid RENDERED profile is a normal 200 body with
+        valid:false (not an exception, matching /validate) and writes nothing."""
+
+        def bad_render(template_name, config):
+            return "---\nname: bad name\ndescription: x\n---\nbody\n"
+
+        monkeypatch.setattr(main_mod, "render_template", bad_render)
+        resp = client.post(
+            "/agents/profiles/preview",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": {},
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is False
+        assert body["errors"]
+        assert list(local_store.rglob("*.md")) == []
+
+    def test_preview_bad_config_400_no_write(self, client, local_store):
+        """An invalid template config is a 400 (render_template's validate_config
+        → ValueError), with nothing written."""
+        resp = client.post(
+            "/agents/profiles/preview",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": {"profile": "p"},  # missing required region/queue_url
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 400
+        assert list(local_store.rglob("*.md")) == []
+
+    def test_preview_requires_provider_and_model(self, client, local_store):
+        """provider and model are required (ADR-006); omission → 422 before any
+        render/write."""
+        resp = client.post(
+            "/agents/profiles/preview",
+            json={"template_name": "aws/sqs-monitor", "config": _VALID_SQS_CONFIG},
+        )
+        assert resp.status_code == 422
+        assert list(local_store.rglob("*.md")) == []
+
+
+# =============================================================================
+# R6 — edit + clone (FR5, FR6)
+# =============================================================================
+
+
+class TestEditProfile:
+    def _valid_profile_text(self, name="my-agent"):
+        return f"---\nname: {name}\ndescription: an edited agent\nprovider: claude_code\nmodel: opus\n---\n\nBody.\n"
+
+    def test_edit_updates_local_profile_and_revalidates(self, client, local_store):
+        target = local_store / "my-agent.md"
+        target.write_text(self._valid_profile_text(), encoding="utf-8")
+
+        updated = self._valid_profile_text().replace("an edited agent", "updated description")
+        resp = client.put(
+            "/agents/profiles/my-agent",
+            json={
+                "content": updated,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["source"] == "local"
+        assert "updated description" in target.read_text()
+
+    def test_edit_invalid_content_400_no_write(self, client, local_store):
+        target = local_store / "my-agent.md"
+        original = self._valid_profile_text()
+        target.write_text(original, encoding="utf-8")
+
+        invalid = "---\nname: has spaces\n---\nbody\n"
+        resp = client.put(
+            "/agents/profiles/my-agent",
+            json={
+                "content": invalid,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 400
+        assert target.read_text() == original  # unchanged (re-validation blocked)
+
+    def test_edit_builtin_is_refused(self, client, local_store):
+        """A name with no local-store file (e.g. a built-in) is refused — built-ins
+        are read-only (FR6, BR-13)."""
+        resp = client.put(
+            "/agents/profiles/developer",
+            json={
+                "content": self._valid_profile_text("developer"),
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 400
+        assert not (local_store / "developer.md").exists()
+
+    def test_edit_traversal_name_refused(self, client, local_store):
+        resp = client.put(
+            "/agents/profiles/..evil",
+            json={
+                "content": self._valid_profile_text("evil"),
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 400
+        assert list(local_store.rglob("*.md")) == []
+
+    def test_clone_creates_new_local_and_leaves_builtin_unchanged(self, client, local_store):
+        """Clone-to-customize (FR6/AC6.2): cloning a built-in writes a NEW local
+        profile via the content-mode create route (from-content), under a NEW
+        name, and never mutates the packaged built-in. No PUT on the built-in."""
+        builtin = resources.files("cli_agent_orchestrator.agent_store") / "developer.md"
+        before = builtin.read_text(encoding="utf-8")
+
+        # Client clones by submitting the built-in's (edited) content under a NEW
+        # local name via the authorized content-create route.
+        cloned = (
+            "---\nname: developer-copy\ndescription: cloned locally\n"
+            "provider: claude_code\nmodel: opus\n---\n\nBody.\n"
+        )
+        resp = client.post(
+            "/agents/profiles/from-content",
+            json={
+                "name": "developer-copy",
+                "content": cloned,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json() == {
+            "name": "developer-copy",
+            "source": "local",
+            "path": str(local_store / "developer-copy.md"),
+        }
+        # A NEW local profile was written...
+        assert (local_store / "developer-copy.md").exists()
+        assert "cloned locally" in (local_store / "developer-copy.md").read_text()
+        # ...and the packaged built-in is byte-for-byte unchanged (no PUT, no
+        # write to the built-in's name).
+        assert builtin.read_text(encoding="utf-8") == before
+        assert not (local_store / "developer.md").exists()
+
+
+# =============================================================================
+# R6-clone — content-mode create (POST /agents/profiles/from-content, U4 addendum)
+# =============================================================================
+
+
+class TestCreateFromContent:
+    _CONTENT = (
+        "---\nname: cloned-agent\ndescription: a cloned agent\n"
+        "provider: claude_code\nmodel: opus\n---\n\nBody.\n"
+    )
+
+    def _body(self, name="cloned-agent", content=None):
+        return {
+            "name": name,
+            "content": content if content is not None else self._CONTENT,
+            "provider": "claude_code",
+            "model": "opus",
+        }
+
+    def test_writes_new_local_profile(self, client, local_store):
+        resp = client.post("/agents/profiles/from-content", json=self._body())
+        assert resp.status_code == 201
+        assert resp.json()["source"] == "local"
+        assert (local_store / "cloned-agent.md").exists()
+        assert "a cloned agent" in (local_store / "cloned-agent.md").read_text()
+
+    def test_refuses_overwrite_of_existing_name(self, client, local_store):
+        """A clone must never silently clobber an existing local profile → 400,
+        and the original content is left intact."""
+        existing = local_store / "cloned-agent.md"
+        existing.write_text(
+            "---\nname: cloned-agent\ndescription: ORIGINAL\n---\nbody\n", encoding="utf-8"
+        )
+        resp = client.post("/agents/profiles/from-content", json=self._body())
+        assert resp.status_code == 400
+        assert "already exists" in str(resp.json()["detail"])
+        # Untouched.
+        assert "ORIGINAL" in existing.read_text()
+
+    def test_invalid_content_400_no_write(self, client, local_store):
+        """A schema-invalid content → 400, nothing written (F-2 shape)."""
+        bad = "---\nname: has spaces\n---\nbody\n"
+        resp = client.post(
+            "/agents/profiles/from-content", json=self._body(name="new-one", content=bad)
+        )
+        assert resp.status_code == 400
+        assert list(local_store.rglob("*.md")) == []
+
+    def test_requires_provider_and_model(self, client, local_store):
+        resp = client.post(
+            "/agents/profiles/from-content",
+            json={"name": "cloned-agent", "content": self._CONTENT, "provider": "claude_code"},
+        )
+        assert resp.status_code == 422  # Pydantic required-field rejection
+        assert list(local_store.rglob("*.md")) == []
+
+    def test_containment_refuses_traversal_name(self, client, local_store):
+        resp = client.post("/agents/profiles/from-content", json=self._body(name="../evil"))
+        assert resp.status_code == 400
+        assert list(local_store.rglob("*.md")) == []
+
+
+# =============================================================================
+# Contract / auth / routing (FR7, ADR-001/002)
+# =============================================================================
+
+
+class TestRoutingAndContract:
+    def test_search_path_resolves_to_search_handler_not_name(self, client, monkeypatch):
+        """GET-ordering: /agents/profiles/search must resolve to the search
+        handler, NOT GET {name} with name='search'. If the sub-paths were
+        registered after {name}, load_agent_profile('search') would be called and
+        the response would 404."""
+        monkeypatch.setattr(_LIST_PROFILES, lambda: [_profile("sqs-a", "sqs monitoring")])
+        sentinel = MagicMock(side_effect=AssertionError("get {name} handler was reached"))
+        monkeypatch.setattr(main_mod, "load_agent_profile", sentinel)
+
+        resp = client.get("/agents/profiles/search", params={"q": "sqs"})
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+        sentinel.assert_not_called()
+
+    def test_existing_list_endpoint_still_includes_all(self, client, monkeypatch):
+        """Guard: the existing GET /agents/profiles is unchanged — it still
+        returns include-all (unloadable retained), unlike search (BR-14)."""
+        corpus = [
+            _profile("loadable-one", "x", loadable=True),
+            _profile("unloadable-one", "y", loadable=False),
+        ]
+        monkeypatch.setattr(_LIST_PROFILES, lambda: corpus)
+        resp = client.get("/agents/profiles")
+        assert resp.status_code == 200
+        names = {p["name"] for p in resp.json()}
+        assert names == {"loadable-one", "unloadable-one"}
+
+
+@pytest.fixture
+def auth_on(monkeypatch):
+    """Enable the auth layer (default-off otherwise)."""
+    monkeypatch.setenv("CAO_AUTH_JWKS_URI", "https://idp.example/jwks")
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    main_mod.app.dependency_overrides.pop(auth.get_current_scopes, None)
+
+
+def _override_scopes(scopes):
+    async def _dep():
+        return list(scopes)
+
+    return _dep
+
+
+class TestScopeGating:
+    def test_create_forbidden_for_read_token(self, client, auth_on):
+        main_mod.app.dependency_overrides[auth.get_current_scopes] = _override_scopes(
+            [auth.SCOPE_READ]
+        )
+        resp = client.post(
+            "/agents/profiles",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": _VALID_SQS_CONFIG,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 403
+
+    def test_edit_forbidden_for_read_token(self, client, auth_on):
+        main_mod.app.dependency_overrides[auth.get_current_scopes] = _override_scopes(
+            [auth.SCOPE_READ]
+        )
+        resp = client.put(
+            "/agents/profiles/my-agent",
+            json={
+                "content": "---\nname: my-agent\n---\nbody\n",
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 403
+
+    def test_search_is_open_read(self, client, auth_on, monkeypatch):
+        """Read routes carry no scope dependency: search is reachable even with a
+        read-only token (and would be with none)."""
+        monkeypatch.setattr(_LIST_PROFILES, lambda: [_profile("sqs-a", "sqs monitoring")])
+        main_mod.app.dependency_overrides[auth.get_current_scopes] = _override_scopes(
+            [auth.SCOPE_READ]
+        )
+        resp = client.get("/agents/profiles/search", params={"q": "sqs"})
+        assert resp.status_code != 403
+        assert resp.status_code == 200
+
+    def test_preview_is_open_read(self, client, auth_on):
+        """Preview is non-mutating (renders + validates, never writes), so it
+        carries no scope dependency — a read-only token is not 403'd (open-read
+        like /validate; #510 R5-preview)."""
+        main_mod.app.dependency_overrides[auth.get_current_scopes] = _override_scopes(
+            [auth.SCOPE_READ]
+        )
+        resp = client.post(
+            "/agents/profiles/preview",
+            json={
+                "template_name": "aws/sqs-monitor",
+                "config": _VALID_SQS_CONFIG,
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code != 403
+        assert resp.status_code == 200
+
+    def test_from_content_forbidden_for_read_token(self, client, auth_on):
+        """from-content genuinely writes → scope-gated WRITE|ADMIN, so a
+        read-only token is 403'd (NOT in _EXEMPT; #510 R6-clone)."""
+        main_mod.app.dependency_overrides[auth.get_current_scopes] = _override_scopes(
+            [auth.SCOPE_READ]
+        )
+        resp = client.post(
+            "/agents/profiles/from-content",
+            json={
+                "name": "cloned-agent",
+                "content": "---\nname: cloned-agent\nprovider: claude_code\nmodel: opus\n---\nbody\n",
+                "provider": "claude_code",
+                "model": "opus",
+            },
+        )
+        assert resp.status_code == 403

--- a/test/api/test_scope_coverage.py
+++ b/test/api/test_scope_coverage.py
@@ -24,8 +24,16 @@ _MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 # Routes that use a mutating verb but perform no state change, so they are
 # intentionally not scope-gated. ``POST /workflows/validate`` only parses and
-# validates a spec file (read-only), mirroring a GET.
-_EXEMPT = {("POST", "/workflows/validate")}
+# validates a spec file (read-only), mirroring a GET. ``POST
+# /agents/profiles/validate`` likewise only validates profile frontmatter and
+# writes nothing (#510, U1 R4, BR-15 open-read). ``POST
+# /agents/profiles/preview`` renders + validates a profile and writes nothing
+# (#510, U1 R5-preview, FR4/AC4.2 — open-read like /validate).
+_EXEMPT = {
+    ("POST", "/workflows/validate"),
+    ("POST", "/agents/profiles/validate"),
+    ("POST", "/agents/profiles/preview"),
+}
 
 
 def _has_scope_dependency(route) -> bool:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,9 @@ type TabKey = 'home' | 'agents' | 'flows' | 'settings' | 'memory'
 // Memory appended last so Alt+N numbering of existing tabs never shifts
 const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
   { key: 'home', label: 'Home', icon: <Home size={16} /> },
-  { key: 'agents', label: 'Agents', icon: <Bot size={16} /> },
+  // #510: user-facing label only — the route key stays 'agents' (no rename of
+  // the store key, API path, or component wiring).
+  { key: 'agents', label: 'Profiles', icon: <Bot size={16} /> },
   { key: 'flows', label: 'Flows', icon: <Clock size={16} /> },
   { key: 'settings', label: 'Settings', icon: <Settings size={16} /> },
   { key: 'memory', label: 'Memory', icon: <Brain size={16} /> },

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -93,6 +93,152 @@ export interface AgentProfileInfo {
   // Other enabled directories that also define this profile name (the winner
   // above is what loads). Empty/absent when the name is unique. (GH #280)
   duplicated_in?: string[]
+  // Discovery metadata surfaced by list_agent_profiles(); all optional/additive
+  // so existing callers are unaffected. `loadable === false` marks a profile the
+  // load path would reject — the Profiles list badges it View-only (#510).
+  loadable?: boolean
+  capabilities?: string[]
+  tags?: string[]
+  role?: string
+}
+
+/**
+ * One ranked search hit — mirrors the server `search_profiles` result shape
+ * verbatim (GET /agents/profiles/search, #510). The list order is
+ * server-provided (coverage → BM25Plus → name); the client MUST NOT re-sort or
+ * recompute `score` (which is relative to the matched set, not a percentage).
+ */
+export interface ProfileSearchResult {
+  name: string
+  description: string
+  capabilities: string[]
+  tags: string[]
+  role: string | null
+  source: AgentProfileSource
+  coverage: number
+  score: number
+}
+
+/**
+ * Validation outcome from POST /agents/profiles/validate (#510). `valid` is
+ * true iff there are zero `[error]` messages; `[warn]` messages never block
+ * save, mirroring the CLI's "exit 1 only on [error]".
+ */
+export interface ValidateProfileResult {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
+
+/** Request body for POST /agents/profiles/validate — supply exactly one input. */
+export interface ValidateProfilePayload {
+  content?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Full parsed profile from GET /agents/profiles/{name} — the server serializes
+ * its AgentProfile with None fields excluded, so most fields are optional. The
+ * open index signature carries provider-specific keys without repeated widening.
+ */
+export interface AgentProfileDetail {
+  name: string
+  description?: string
+  role?: string
+  provider?: string
+  model?: string
+  system_prompt?: string
+  capabilities?: string[]
+  tags?: string[]
+  allowedTools?: string[]
+  mcpServers?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/** One scaffolding template descriptor — mirrors list_templates() (#510). */
+export interface TemplateInfo {
+  name: string
+  description: string
+  path: string
+}
+
+/**
+ * A template's JSON-Schema (Draft 2020-12) from
+ * GET /agents/profiles/templates/{name}/schema. Left as an open object — the
+ * create form reads `properties`/`required` to build fields.
+ */
+export interface TemplateSchema {
+  type?: string
+  title?: string
+  description?: string
+  properties?: Record<string, JsonSchemaProperty>
+  required?: string[]
+  additionalProperties?: boolean
+  [key: string]: unknown
+}
+
+/** One property node within a template schema, as far as the form widget reads it. */
+export interface JsonSchemaProperty {
+  type?: string
+  description?: string
+  enum?: string[]
+  pattern?: string
+  default?: unknown
+  minimum?: number
+  maximum?: number
+  [key: string]: unknown
+}
+
+/**
+ * Request body for POST /agents/profiles (create) and POST
+ * /agents/profiles/preview. `provider` and `model` are REQUIRED explicit inputs
+ * (ADR-006/F-1) — set as frontmatter on the rendered output server-side, never
+ * merged into `config`.
+ */
+export interface CreateProfileRequest {
+  template_name: string
+  config: Record<string, unknown>
+  provider: string
+  model: string
+}
+
+/** Response for a create/edit write — the persisted local profile (#510). */
+export interface ProfileWriteResult {
+  name: string
+  source: string
+  path: string
+}
+
+/**
+ * Render-only preview from POST /agents/profiles/preview (#510). Carries the
+ * rendered profile `text` (frontmatter already patched with provider/model,
+ * server-side) plus the validation split. NON-MUTATING — nothing is written.
+ */
+export interface PreviewProfileResult {
+  text: string
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
+
+/** Request body for PUT /agents/profiles/{name} (edit — #510 U4). */
+export interface UpdateProfileRequest {
+  content: string
+  provider: string
+  model: string
+}
+
+/**
+ * Request body for POST /agents/profiles/from-content (clone — #510 U4). Writes
+ * a NEW local profile from raw `content` under a new `name`; the server refuses
+ * to overwrite an existing name. `provider`/`model` arrive inside `content` and
+ * are re-asserted on the body (ADR-006).
+ */
+export interface CreateFromContentRequest {
+  name: string
+  content: string
+  provider: string
+  model: string
 }
 
 export interface AgentDirsSettings {
@@ -193,6 +339,61 @@ export const api = {
   // Agent Profiles & Providers
   listProfiles: () => fetchJSON<AgentProfileInfo[]>('/agents/profiles'),
   listProviders: () => fetchJSON<ProviderInfo[]>('/agents/providers'),
+
+  // Profile management (#510 U2). Search + validate are open-read; the server
+  // owns all ranking/validation logic — these wrappers only carry data. Search
+  // results come back in server order and MUST NOT be re-sorted client-side
+  // (coverage → BM25Plus → name is U1's pinned contract). U3 appends its own
+  // template/create methods to this block when it runs.
+  searchProfiles: (q: string, limit?: number) =>
+    fetchJSON<ProfileSearchResult[]>(
+      `/agents/profiles/search?q=${encodeURIComponent(q)}${limit !== undefined ? `&limit=${limit}` : ''}`,
+    ),
+  getProfile: (name: string) =>
+    fetchJSON<AgentProfileDetail>(`/agents/profiles/${encodeURIComponent(name)}`),
+  validateProfile: (payload: ValidateProfilePayload) =>
+    fetchJSON<ValidateProfileResult>('/agents/profiles/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+
+  // Create-from-template flow (#510 U3). Templates + schema are open-read; the
+  // preview is a server-side render (writes nothing); create writes to the local
+  // store via the scope-gated endpoint. No scaffolding/validation logic here.
+  listTemplates: () => fetchJSON<TemplateInfo[]>('/agents/profiles/templates'),
+  getTemplateSchema: (name: string) =>
+    // `name` is category/name (e.g. aws/stepfunction); the server route captures
+    // it with a :path convertor, so the '/' is intentionally NOT encoded.
+    fetchJSON<TemplateSchema>(`/agents/profiles/templates/${name}/schema`),
+  previewProfile: (req: CreateProfileRequest) =>
+    fetchJSON<PreviewProfileResult>('/agents/profiles/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    }),
+  createProfile: (req: CreateProfileRequest) =>
+    fetchJSON<ProfileWriteResult>('/agents/profiles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    }),
+
+  // Edit + clone (#510 U4). Edit updates a local profile in place via PUT;
+  // clone writes a NEW local profile from a built-in's (edited) content via
+  // from-content (the built-in is never mutated). Both server-validated + guarded.
+  updateProfile: (name: string, req: UpdateProfileRequest) =>
+    fetchJSON<ProfileWriteResult>(`/agents/profiles/${encodeURIComponent(name)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    }),
+  createProfileFromContent: (req: CreateFromContentRequest) =>
+    fetchJSON<ProfileWriteResult>('/agents/profiles/from-content', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    }),
 
   // Settings
   getAgentDirs: () => fetchJSON<AgentDirsSettings>('/settings/agent-dirs'),

--- a/web/src/components/AgentPanel.tsx
+++ b/web/src/components/AgentPanel.tsx
@@ -9,6 +9,7 @@ import { CustomSelect, SelectOption } from './CustomSelect'
 import { TerminalMeta } from '../api'
 import { StatusBadge } from './StatusBadge'
 import { OutputViewer } from './OutputViewer'
+import { ProfilesBrowser } from './ProfilesBrowser'
 
 export const FALLBACK_PROVIDERS = ['kiro_cli', 'claude_code', 'q_cli', 'codex', 'gemini_cli', 'hermes', 'kimi_cli', 'copilot_cli', 'opencode_cli', 'cursor_cli']
 
@@ -198,6 +199,10 @@ export function AgentPanel() {
 
   return (
     <div className="space-y-6">
+      {/* Profiles browser (#510): search + grouped list + validate. All ranking
+          and validation logic lives server-side; this only renders results. */}
+      <ProfilesBrowser />
+
       {/* Sessions List */}
       <div className="bg-gray-800/60 border border-gray-700/50 rounded-xl p-5">
         <div className="flex items-center justify-between mb-1">

--- a/web/src/components/CreateProfileWizard.tsx
+++ b/web/src/components/CreateProfileWizard.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useState } from 'react'
+import {
+  api,
+  TemplateInfo,
+  TemplateSchema,
+  PreviewProfileResult,
+  ProfileWriteResult,
+  ApiError,
+} from '../api'
+import { ProfileForm, ProfileFormValues } from './ProfileForm'
+import { X, ChevronLeft, ChevronRight, FileText, Check, AlertTriangle, Loader2 } from 'lucide-react'
+
+// #510 U3: the 4-step create-from-template wizard. Step 1 picks a template from
+// the server (no hardcoded list), step 2 fills the shared ProfileForm, step 3
+// shows a SERVER-rendered preview (POST /agents/profiles/preview — writes
+// nothing), step 4 saves via POST /agents/profiles. All scaffolding/validation/
+// write logic is server-side; this component only orchestrates the flow.
+//
+// F-1 (canonical project.md): provider/model are sent as top-level request
+// fields and patched onto the RENDERED output by the server, never merged into
+// the template `config`. This component keeps them out of `config` accordingly.
+
+// Three reachable steps: pick a template, fill the form, then preview-and-save
+// (the preview panel hosts the Save button — there is no separate save step).
+type Step = 1 | 2 | 3
+
+const STEP_LABELS = ['Pick template', 'Fill form', 'Preview & save']
+
+const EMPTY_VALUES: ProfileFormValues = { config: {}, provider: '', model: '' }
+
+export function CreateProfileWizard({ onClose }: { onClose: (saved?: ProfileWriteResult) => void }) {
+  const [step, setStep] = useState<Step>(1)
+  const [templates, setTemplates] = useState<TemplateInfo[]>([])
+  const [loadingTemplates, setLoadingTemplates] = useState(true)
+  const [templatesError, setTemplatesError] = useState<string | null>(null)
+  const [templateName, setTemplateName] = useState<string>('')
+  const [schema, setSchema] = useState<TemplateSchema | null>(null)
+  const [values, setValues] = useState<ProfileFormValues>(EMPTY_VALUES)
+  const [preview, setPreview] = useState<PreviewProfileResult | null>(null)
+  const [previewing, setPreviewing] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const dirty = templateName !== '' || Object.keys(values.config).length > 0 || !!values.provider || !!values.model
+
+  // Step 1: templates from the server (AC4.1 — no hardcoded list).
+  useEffect(() => {
+    api.listTemplates()
+      .then(t => { setTemplates(t); setLoadingTemplates(false) })
+      .catch((e: ApiError) => { setTemplatesError(e.detail || e.message); setLoadingTemplates(false) })
+  }, [])
+
+  const pickTemplate = async (name: string) => {
+    setTemplateName(name)
+    setSchema(null)
+    setValues(EMPTY_VALUES)
+    try {
+      const s = await api.getTemplateSchema(name)
+      setSchema(s)
+    } catch {
+      setSchema(null) // form still renders provider/model; server validates on preview
+    }
+    setStep(2)
+  }
+
+  // Provider + model are required before preview/save (ADR-006/AC4.4).
+  const providerModelReady = !!values.provider.trim() && !!values.model.trim()
+
+  const runPreview = async () => {
+    setPreviewing(true)
+    setPreviewError(null)
+    setPreview(null)
+    try {
+      // F-1: provider/model travel as top-level fields, NOT inside config.
+      const result = await api.previewProfile({
+        template_name: templateName,
+        config: values.config,
+        provider: values.provider.trim(),
+        model: values.model.trim(),
+      })
+      setPreview(result)
+      setStep(3)
+    } catch (e) {
+      const err = e as ApiError
+      // Invalid config (validate_config) comes back as 400 detail — surface it
+      // and stay on step 2 (AC4.2).
+      setPreviewError(err.detail || err.message)
+    }
+    setPreviewing(false)
+  }
+
+  const runSave = async () => {
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const saved = await api.createProfile({
+        template_name: templateName,
+        config: values.config,
+        provider: values.provider.trim(),
+        model: values.model.trim(),
+      })
+      onClose(saved)
+    } catch (e) {
+      const err = e as ApiError
+      setSaveError(err.detail || err.message)
+      setSaving(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (dirty && !window.confirm('Discard this new profile? Your input will be lost.')) return
+    onClose()
+  }
+
+  // Save is blocked while the preview reports validation errors (AC4.5).
+  const saveBlocked = !preview || !preview.valid || !providerModelReady
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Create profile from template"
+        className="relative bg-gray-800 border border-gray-700 rounded-2xl shadow-2xl shadow-black/50 w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto"
+      >
+        {/* Header + step indicator */}
+        <div className="flex items-center justify-between p-5 border-b border-gray-700/50">
+          <div>
+            <h3 className="text-base font-semibold text-gray-200">Create Profile</h3>
+            <p className="text-xs text-gray-500 mt-1">Step {step} of 3 · {STEP_LABELS[step - 1]}</p>
+          </div>
+          <button onClick={handleClose} aria-label="Close" className="p-1.5 text-gray-500 hover:text-gray-300 rounded-lg hover:bg-gray-700/50">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {/* Step 1 — template picker */}
+          {step === 1 && (
+            <div className="space-y-2" data-testid="template-picker">
+              {loadingTemplates ? (
+                <p className="text-sm text-gray-500">Loading templates…</p>
+              ) : templatesError ? (
+                <p role="alert" className="text-sm text-red-300">Failed to load templates: {templatesError}</p>
+              ) : templates.length === 0 ? (
+                <p className="text-sm text-gray-500">No templates available.</p>
+              ) : (
+                templates.map(t => (
+                  <button
+                    key={t.name}
+                    onClick={() => pickTemplate(t.name)}
+                    className={`w-full text-left px-3 py-2.5 rounded-lg border transition-colors ${
+                      templateName === t.name
+                        ? 'bg-emerald-900/30 border-emerald-700/50'
+                        : 'bg-gray-900/50 border-gray-700/30 hover:bg-gray-800/70'
+                    }`}
+                  >
+                    <div className="text-sm font-medium text-gray-200">{t.name}</div>
+                    {t.description && <div className="text-[11px] text-gray-500">{t.description}</div>}
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Step 2 — fill form (shared ProfileForm, create mode) */}
+          {step === 2 && (
+            <div className="space-y-3">
+              <div className="text-xs text-gray-400">
+                Template: <span className="font-mono text-gray-300">{templateName}</span>
+              </div>
+              <ProfileForm schema={schema} values={values} onChange={setValues} />
+              {!providerModelReady && (
+                <p className="text-[11px] text-amber-300 flex items-center gap-1">
+                  <AlertTriangle size={11} /> Provider and model are required.
+                </p>
+              )}
+              {previewError && (
+                <p role="alert" className="text-xs text-red-300">Preview failed: {previewError}</p>
+              )}
+            </div>
+          )}
+
+          {/* Step 3 — server-rendered preview */}
+          {step === 3 && (
+            <div className="space-y-3" data-testid="preview-panel">
+              <div className="flex items-center gap-2 text-xs text-gray-400">
+                <FileText size={13} /> Server-rendered preview
+              </div>
+              <pre className="bg-gray-950 border border-gray-700/50 rounded-lg p-3 text-[11px] font-mono text-gray-300 whitespace-pre-wrap max-h-72 overflow-y-auto">
+                {preview?.text}
+              </pre>
+              {preview && !preview.valid && (
+                <div role="alert" className="space-y-1">
+                  <div className="text-xs font-semibold text-red-300">Validation errors — save blocked</div>
+                  <ul className="pl-5 list-disc marker:text-red-500">
+                    {preview.errors.map((e, i) => (
+                      <li key={i} className="text-[11px] font-mono text-red-200">{e}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {preview && preview.warnings.length > 0 && (
+                <div className="space-y-1">
+                  <div className="text-xs font-semibold text-amber-300">Warnings (save allowed)</div>
+                  <ul className="pl-5 list-disc marker:text-amber-500">
+                    {preview.warnings.map((w, i) => (
+                      <li key={i} className="text-[11px] font-mono text-amber-200">{w}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {preview && preview.valid && preview.warnings.length === 0 && (
+                <div className="flex items-center gap-1.5 text-xs text-emerald-300">
+                  <Check size={13} /> Valid — ready to save.
+                </div>
+              )}
+              {saveError && <p role="alert" className="text-xs text-red-300">Save failed: {saveError}</p>}
+            </div>
+          )}
+        </div>
+
+        {/* Footer nav */}
+        <div className="flex items-center justify-between gap-3 p-5 border-t border-gray-700/50">
+          <button
+            onClick={() => setStep(s => (s > 1 ? ((s - 1) as Step) : s))}
+            disabled={step === 1}
+            className="flex items-center gap-1.5 px-3 py-2 text-sm text-gray-400 hover:text-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronLeft size={14} /> Back
+          </button>
+
+          {step === 2 && (
+            <button
+              onClick={runPreview}
+              disabled={!providerModelReady || previewing}
+              className="flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-40 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+            >
+              {previewing ? <Loader2 size={14} className="animate-spin" /> : <ChevronRight size={14} />}
+              {previewing ? 'Rendering…' : 'Preview'}
+            </button>
+          )}
+
+          {step === 3 && (
+            <button
+              onClick={runSave}
+              disabled={saveBlocked || saving}
+              className="flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-40 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+            >
+              {saving ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+              {saving ? 'Saving…' : 'Save Profile'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/CustomSelect.tsx
+++ b/web/src/components/CustomSelect.tsx
@@ -15,9 +15,14 @@ interface CustomSelectProps {
   options: SelectOption[]
   placeholder?: string
   className?: string
+  // Optional a11y hooks for the trigger button — used where the select stands in
+  // for a labelled form field (e.g. the required Provider field, #510 U3).
+  ariaLabel?: string
+  ariaRequired?: boolean
+  ariaInvalid?: boolean
 }
 
-export function CustomSelect({ value, onChange, options, placeholder = 'Select...', className = '' }: CustomSelectProps) {
+export function CustomSelect({ value, onChange, options, placeholder = 'Select...', className = '', ariaLabel, ariaRequired, ariaInvalid }: CustomSelectProps) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -57,6 +62,11 @@ export function CustomSelect({ value, onChange, options, placeholder = 'Select..
       <button
         type="button"
         onClick={() => setOpen(!open)}
+        aria-label={ariaLabel}
+        aria-required={ariaRequired}
+        aria-invalid={ariaInvalid}
+        aria-haspopup="listbox"
+        aria-expanded={open}
         className="w-full flex items-center justify-between bg-gray-900 border border-gray-700 text-sm rounded-lg px-3 py-2.5 focus:border-emerald-500 focus:outline-none transition-colors hover:border-gray-600"
       >
         <span className={selected ? 'text-gray-200' : 'text-gray-500'}>

--- a/web/src/components/DashboardHome.tsx
+++ b/web/src/components/DashboardHome.tsx
@@ -263,7 +263,13 @@ export function DashboardHome({ onNavigate }: { onNavigate: (tab: string) => voi
             </div>
           </div>
         </div>
-        <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 rounded-xl p-5 border border-gray-700/50">
+        {/* #510: Profiles stat card links to the Profiles tab (route key 'agents'). */}
+        <button
+          type="button"
+          onClick={() => onNavigate('agents')}
+          aria-label="Go to Profiles tab"
+          className="text-left bg-gradient-to-br from-gray-800/80 to-gray-900/80 rounded-xl p-5 border border-gray-700/50 hover:border-blue-500/50 hover:bg-gray-800/90 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+        >
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-lg bg-blue-900/50 flex items-center justify-center">
               <Package size={20} className="text-blue-400" />
@@ -273,7 +279,7 @@ export function DashboardHome({ onNavigate }: { onNavigate: (tab: string) => voi
               <div className="text-xs text-gray-400 uppercase tracking-wide">Profiles</div>
             </div>
           </div>
-        </div>
+        </button>
       </div>
 
       {/* Quick Actions */}

--- a/web/src/components/EditCloneModal.tsx
+++ b/web/src/components/EditCloneModal.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useState } from 'react'
+import { api, AgentProfileDetail, ProfileWriteResult, ProviderInfo, ApiError } from '../api'
+import { CustomSelect } from './CustomSelect'
+import { X, Check, Loader2, AlertTriangle, Copy, Pencil } from 'lucide-react'
+
+// #510 U4: edit a local profile / clone a built-in. One modal, two modes:
+//  - 'edit'  → PUT /agents/profiles/{name} (in-place, local only; server
+//              re-validates and enforces local-store containment).
+//  - 'clone' → POST /agents/profiles/from-content with a NEW local name (the
+//              packaged built-in is never mutated — AC6.2).
+// The modal prefills the profile CONTENT from api.getProfile and exposes
+// provider/model as explicit REQUIRED fields (ADR-006). All validation and
+// containment is server-side; this component collects input and surfaces errors.
+
+type Mode = 'edit' | 'clone'
+
+function reconstructContent(profile: AgentProfileDetail): string {
+  // Rebuild an editable frontmatter document from the parsed profile. JSON is
+  // valid YAML, so a JSON frontmatter block round-trips through the server's
+  // frontmatter parser (verified). system_prompt is the body, not frontmatter.
+  const { system_prompt, ...meta } = profile
+  const fm = JSON.stringify(meta, null, 2)
+  return `---\n${fm}\n---\n\n${system_prompt ?? ''}`
+}
+
+export function EditCloneModal({ mode, sourceName, onClose }: {
+  mode: Mode
+  sourceName: string
+  onClose: (saved?: ProfileWriteResult) => void
+}) {
+  const [content, setContent] = useState('')
+  const [provider, setProvider] = useState('')
+  const [model, setModel] = useState('')
+  const [cloneName, setCloneName] = useState(mode === 'clone' ? `${sourceName}-copy` : sourceName)
+  const [providers, setProviders] = useState<ProviderInfo[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    api.listProviders().then(setProviders).catch(() => setProviders([]))
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setLoadError(null)
+    api.getProfile(sourceName)
+      .then(p => {
+        if (cancelled) return
+        setContent(reconstructContent(p))
+        // Seed provider/model from the loaded profile, but they remain explicit
+        // editable required fields — never silently inherited on save.
+        if (typeof p.provider === 'string') setProvider(p.provider)
+        if (typeof p.model === 'string') setModel(p.model)
+        setLoading(false)
+      })
+      .catch((e: ApiError) => { if (!cancelled) { setLoadError(e.detail || e.message); setLoading(false) } })
+    return () => { cancelled = true }
+  }, [sourceName])
+
+  const providerModelReady = !!provider.trim() && !!model.trim()
+  const nameReady = mode === 'edit' || !!cloneName.trim()
+  const canSave = providerModelReady && nameReady && !!content.trim() && !saving
+
+  const handleSave = async () => {
+    setSaving(true)
+    setSaveError(null)
+    try {
+      let saved: ProfileWriteResult
+      if (mode === 'edit') {
+        // In-place edit of the local profile; server re-validates (FR5/AC5.1).
+        saved = await api.updateProfile(sourceName, {
+          content, provider: provider.trim(), model: model.trim(),
+        })
+      } else {
+        // Clone → NEW local profile from content; built-in untouched (FR6/AC6.2).
+        saved = await api.createProfileFromContent({
+          name: cloneName.trim(), content, provider: provider.trim(), model: model.trim(),
+        })
+      }
+      onClose(saved)
+    } catch (e) {
+      const err = e as ApiError
+      // Surfaces server errors: validation [error]s, overwrite refusal, or the
+      // containment/local-store guard.
+      setSaveError(err.detail || err.message)
+      setSaving(false)
+    }
+  }
+
+  const providerOptions = providers.map(p => ({
+    value: p.name,
+    label: p.name.replace(/_/g, ' '),
+    sublabel: !p.installed ? 'Not installed' : undefined,
+  }))
+
+  const title = mode === 'edit' ? `Edit ${sourceName}` : `Clone ${sourceName}`
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => onClose()} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="relative bg-gray-800 border border-gray-700 rounded-2xl shadow-2xl shadow-black/50 w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto"
+      >
+        <div className="flex items-center justify-between p-5 border-b border-gray-700/50">
+          <div className="flex items-center gap-2">
+            {mode === 'edit' ? <Pencil size={16} className="text-emerald-400" /> : <Copy size={16} className="text-blue-400" />}
+            <div>
+              <h3 className="text-base font-semibold text-gray-200">{title}</h3>
+              <p className="text-xs text-gray-500 mt-0.5">
+                {mode === 'edit'
+                  ? 'Edit this local profile. Saved changes are re-validated server-side.'
+                  : 'Create a new local profile from this built-in. The built-in is never modified.'}
+              </p>
+            </div>
+          </div>
+          <button onClick={() => onClose()} aria-label="Close" className="p-1.5 text-gray-500 hover:text-gray-300 rounded-lg hover:bg-gray-700/50">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {loading ? (
+            <p className="text-sm text-gray-500">Loading profile…</p>
+          ) : loadError ? (
+            <p role="alert" className="text-sm text-red-300">Failed to load profile: {loadError}</p>
+          ) : (
+            <>
+              {mode === 'clone' && (
+                <div>
+                  <label htmlFor="clone-name" className="block text-xs text-gray-500 mb-1">
+                    New profile name<span className="text-red-400 ml-0.5">*</span>
+                  </label>
+                  <input
+                    id="clone-name"
+                    type="text"
+                    value={cloneName}
+                    onChange={e => setCloneName(e.target.value)}
+                    aria-required="true"
+                    placeholder="new-local-name"
+                    className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2 focus:border-emerald-500 focus:outline-none"
+                  />
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">
+                    Provider<span className="text-red-400 ml-0.5">*</span>
+                  </label>
+                  {providerOptions.length > 0 ? (
+                    <CustomSelect value={provider} onChange={setProvider} placeholder="Select provider…" options={providerOptions} />
+                  ) : (
+                    <input
+                      type="text" value={provider} onChange={e => setProvider(e.target.value)}
+                      aria-required="true" placeholder="e.g. claude_code"
+                      className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2.5 focus:border-emerald-500 focus:outline-none"
+                    />
+                  )}
+                </div>
+                <div>
+                  <label htmlFor="edit-model" className="block text-xs text-gray-500 mb-1">
+                    Model<span className="text-red-400 ml-0.5">*</span>
+                  </label>
+                  <input
+                    id="edit-model" type="text" value={model} onChange={e => setModel(e.target.value)}
+                    aria-required="true" placeholder="e.g. claude-sonnet-4"
+                    className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2.5 focus:border-emerald-500 focus:outline-none"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="profile-content" className="block text-xs text-gray-500 mb-1">
+                  Profile content
+                </label>
+                <textarea
+                  id="profile-content"
+                  value={content}
+                  onChange={e => setContent(e.target.value)}
+                  spellCheck={false}
+                  rows={14}
+                  className="w-full bg-gray-950 border border-gray-700 text-gray-200 text-[12px] font-mono rounded-lg px-3 py-2 focus:border-emerald-500 focus:outline-none"
+                />
+                <p className="text-[10px] text-gray-600 mt-0.5">
+                  Frontmatter + body. The server re-validates against the agent profile schema on save.
+                </p>
+              </div>
+
+              {!providerModelReady && (
+                <p className="text-[11px] text-amber-300 flex items-center gap-1">
+                  <AlertTriangle size={11} /> Provider and model are required.
+                </p>
+              )}
+              {saveError && <p role="alert" className="text-xs text-red-300">Save failed: {saveError}</p>}
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-3 p-5 border-t border-gray-700/50">
+          <button onClick={() => onClose()} className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors">
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            className="flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-40 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+          >
+            {saving ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+            {saving ? 'Saving…' : mode === 'edit' ? 'Save Changes' : 'Create Clone'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ProfileForm.tsx
+++ b/web/src/components/ProfileForm.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from 'react'
+import { api, ProviderInfo, TemplateSchema, JsonSchemaProperty } from '../api'
+import { CustomSelect } from './CustomSelect'
+
+// #510 U3: the create-from-template ProfileForm. Provider and model are ALWAYS
+// explicit, required, visible fields (ADR-006/AC4.4); they are never silently
+// defaulted or inherited. The form holds no scaffolding/validation logic — it
+// collects input; the server renders (preview), validates, and writes. Name
+// containment (_validate_agent_name/_safe_join) is server-side only; the form
+// never validates names itself.
+//
+// NOTE (#510 U4, 2026-07-27): this component was originally designed as a shared
+// two-mode form (create + edit), with U4's edit/clone flow intended to reuse an
+// 'edit' mode. U4 instead ships a raw frontmatter+body content editor
+// (EditCloneModal), because a schema-field-only edit mode cannot edit the
+// system_prompt BODY or arbitrary frontmatter and would silently drop the body
+// on save. So the 'edit' mode had no production consumer and was removed
+// (Stan-approved at the U4 gate). ProfileForm is now create-only; if a future
+// unit needs a shared editor, extend it to handle full-document editing rather
+// than reviving a schema-only 'edit' mode.
+
+export interface ProfileFormValues {
+  config: Record<string, unknown>
+  provider: string
+  model: string
+}
+
+interface ProfileFormProps {
+  // The chosen template's schema drives the config fields.
+  schema?: TemplateSchema | null
+  // Controlled value + change handler (the parent owns the wizard state).
+  values: ProfileFormValues
+  onChange: (values: ProfileFormValues) => void
+  // Per-field inline errors keyed by field name (e.g. from a failed save).
+  fieldErrors?: Record<string, string>
+}
+
+function fieldLabel(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function isRequired(schema: TemplateSchema | null | undefined, field: string): boolean {
+  return Array.isArray(schema?.required) && schema!.required!.includes(field)
+}
+
+// Render one schema property as the appropriate widget (enum → select,
+// everything else → text input). Numbers are coerced on change.
+function SchemaField({
+  name,
+  prop,
+  required,
+  value,
+  error,
+  onChange,
+}: {
+  name: string
+  prop: JsonSchemaProperty
+  required: boolean
+  value: unknown
+  error?: string
+  onChange: (v: unknown) => void
+}) {
+  const describedBy = error ? `${name}-error` : undefined
+  const isNumber = prop.type === 'integer' || prop.type === 'number'
+  return (
+    <div>
+      <label htmlFor={`field-${name}`} className="block text-xs text-gray-500 mb-1">
+        {fieldLabel(name)}
+        {required && <span className="text-red-400 ml-0.5">*</span>}
+      </label>
+      {Array.isArray(prop.enum) ? (
+        <CustomSelect
+          value={value === undefined || value === null ? '' : String(value)}
+          onChange={v => onChange(v)}
+          placeholder={`Select ${fieldLabel(name).toLowerCase()}…`}
+          options={prop.enum.map(o => ({ value: String(o), label: String(o) }))}
+        />
+      ) : (
+        <input
+          id={`field-${name}`}
+          type={isNumber ? 'number' : 'text'}
+          value={value === undefined || value === null ? '' : String(value)}
+          onChange={e => {
+            const raw = e.target.value
+            onChange(isNumber && raw !== '' ? Number(raw) : raw)
+          }}
+          aria-required={required}
+          aria-invalid={!!error}
+          aria-describedby={describedBy}
+          placeholder={prop.description || ''}
+          className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2 focus:border-emerald-500 focus:outline-none"
+        />
+      )}
+      {prop.description && !error && (
+        <p className="text-[10px] text-gray-600 mt-0.5">{prop.description}</p>
+      )}
+      {error && (
+        <p id={`${name}-error`} role="alert" className="text-[11px] text-red-300 mt-0.5">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function ProfileForm({ schema, values, onChange, fieldErrors = {} }: ProfileFormProps) {
+  const [providers, setProviders] = useState<ProviderInfo[]>([])
+
+  useEffect(() => {
+    api.listProviders()
+      .then(setProviders)
+      .catch(() => setProviders([]))
+  }, [])
+
+  const setConfigField = (field: string, v: unknown) => {
+    onChange({ ...values, config: { ...values.config, [field]: v } })
+  }
+
+  const schemaProps = schema?.properties || {}
+  const propNames = Object.keys(schemaProps)
+
+  // Provider options come from the server (never a hardcoded list). When the
+  // list is unavailable the field is a free-text input so the user is never
+  // blocked — but it stays REQUIRED either way.
+  const providerOptions = providers.map(p => ({
+    value: p.name,
+    label: p.name.replace(/_/g, ' '),
+    sublabel: !p.installed ? 'Not installed' : undefined,
+  }))
+
+  return (
+    <div className="space-y-4" data-testid="profile-form">
+      {/* Template-schema-driven config fields */}
+      {propNames.length > 0 && (
+        <div className="space-y-3">
+          {propNames.map(name => (
+            <SchemaField
+              key={name}
+              name={name}
+              prop={schemaProps[name]}
+              required={isRequired(schema, name)}
+              value={values.config[name]}
+              error={fieldErrors[name]}
+              onChange={v => setConfigField(name, v)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Provider + model — ALWAYS explicit and required (ADR-006/AC4.4). */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-1 border-t border-gray-700/40">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1 mt-3">
+            Provider<span className="text-red-400 ml-0.5">*</span>
+          </label>
+          {providerOptions.length > 0 ? (
+            <CustomSelect
+              value={values.provider}
+              onChange={v => onChange({ ...values, provider: v })}
+              placeholder="Select provider…"
+              options={providerOptions}
+              ariaLabel="Provider"
+              ariaRequired
+              ariaInvalid={!!fieldErrors.provider}
+            />
+          ) : (
+            <input
+              type="text"
+              value={values.provider}
+              onChange={e => onChange({ ...values, provider: e.target.value })}
+              aria-required="true"
+              aria-invalid={!!fieldErrors.provider}
+              aria-describedby={fieldErrors.provider ? 'provider-error' : undefined}
+              placeholder="e.g. claude_code"
+              className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2.5 focus:border-emerald-500 focus:outline-none"
+            />
+          )}
+          {fieldErrors.provider && (
+            <p id="provider-error" role="alert" className="text-[11px] text-red-300 mt-0.5">
+              {fieldErrors.provider}
+            </p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="field-model" className="block text-xs text-gray-500 mb-1 mt-3">
+            Model<span className="text-red-400 ml-0.5">*</span>
+          </label>
+          <input
+            id="field-model"
+            type="text"
+            value={values.model}
+            onChange={e => onChange({ ...values, model: e.target.value })}
+            aria-required="true"
+            aria-invalid={!!fieldErrors.model}
+            aria-describedby={fieldErrors.model ? 'model-error' : undefined}
+            placeholder="e.g. claude-sonnet-4"
+            className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2.5 focus:border-emerald-500 focus:outline-none"
+          />
+          {fieldErrors.model && (
+            <p id="model-error" role="alert" className="text-[11px] text-red-300 mt-0.5">
+              {fieldErrors.model}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ProfilesBrowser.tsx
+++ b/web/src/components/ProfilesBrowser.tsx
@@ -1,0 +1,511 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import {
+  api,
+  AgentProfileInfo,
+  AgentProfileDetail,
+  ProfileSearchResult,
+  ValidateProfileResult,
+  ApiError,
+} from '../api'
+import { Search, X, Package, FolderOpen, ShieldAlert, CheckCircle, AlertTriangle, XCircle, Eye, Plus, Copy, Pencil } from 'lucide-react'
+import { CreateProfileWizard } from './CreateProfileWizard'
+import { EditCloneModal } from './EditCloneModal'
+
+// #510 U2 phase-1 frontend: the Profiles browser. Search + grouped list +
+// unloadable treatment + detail/validate panel. Holds NO ranking/validation
+// logic — every result comes from a U1 server endpoint and is rendered verbatim
+// (search order is never re-sorted client-side, not even the name tie-break;
+// the error/warn split is the server's). Rendered inside AgentPanel (which is
+// NOT renamed). The Create wizard (U3) and Edit/Clone modal (U4) are wired in
+// here as their seams landed alongside U2 in the same worktree; the U2
+// deliverable is search + list + detail/validate, and those actions are U3/U4.
+
+const SOURCE_LABELS: Record<string, string> = {
+  'built-in': 'Built-in',
+  local: 'Local',
+  kiro: 'Kiro',
+  claude_code: 'Claude Code',
+  codex: 'Codex',
+  installed: 'Installed',
+  custom: 'Custom',
+}
+
+const SEARCH_DEBOUNCE_MS = 250
+
+function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] || source
+}
+
+/** True only for a profile explicitly marked unloadable by the server. */
+function isUnloadable(p: { loadable?: boolean }): boolean {
+  return p.loadable === false
+}
+
+// ── Unloadable badge (OQ2 client-side treatment; AC1.4-list) ────────────────
+function UnloadableBadge() {
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-amber-900/40 text-amber-300 border border-amber-700/40"
+      title="This profile failed to load (parse or schema error), so it cannot be used. View only."
+    >
+      <ShieldAlert size={10} />
+      unloadable
+    </span>
+  )
+}
+
+// ── Score indicator (relative rank, NOT a percentage; AC1.5) ────────────────
+function ScoreBadge({ score }: { score: number }) {
+  return (
+    <span
+      className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-gray-700/60 text-gray-300"
+      title="Relative rank indicator within these results (higher = more relevant). Not an absolute percentage."
+    >
+      {score.toFixed(2)}
+    </span>
+  )
+}
+
+// ── Validate panel [FR2] ────────────────────────────────────────────────────
+function ValidatePanel({ result }: { result: ValidateProfileResult }) {
+  if (result.valid && result.warnings.length === 0) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-emerald-300" role="status">
+        <CheckCircle size={14} />
+        Valid — no issues.
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-2">
+      {result.errors.length > 0 && (
+        <div role="alert" className="space-y-1">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-red-300">
+            <XCircle size={13} />
+            {result.errors.length} error{result.errors.length !== 1 ? 's' : ''} — save blocked
+          </div>
+          <ul className="pl-5 space-y-0.5 list-disc marker:text-red-500">
+            {result.errors.map((e, i) => (
+              <li key={i} className="text-[11px] font-mono text-red-200 break-words">
+                {e}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {result.warnings.length > 0 && (
+        <div className="space-y-1">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-amber-300">
+            <AlertTriangle size={13} />
+            {result.warnings.length} warning{result.warnings.length !== 1 ? 's' : ''} — save allowed
+          </div>
+          <ul className="pl-5 space-y-0.5 list-disc marker:text-amber-500">
+            {result.warnings.map((w, i) => (
+              <li key={i} className="text-[11px] font-mono text-amber-200 break-words">
+                {w}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {result.valid && (
+        <p className="text-[11px] text-gray-500">
+          Warnings do not block saving (matches the CLI's "exit 1 only on errors").
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ── Profile detail + validate [FR2] ─────────────────────────────────────────
+function ProfileDetail({ name, source, loadable, onClose, onEdit, onClone }: {
+  name: string
+  source: string
+  loadable: boolean
+  onClose: () => void
+  onEdit: (name: string) => void
+  onClone: (name: string) => void
+}) {
+  const [profile, setProfile] = useState<AgentProfileDetail | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [validation, setValidation] = useState<ValidateProfileResult | null>(null)
+  const [validating, setValidating] = useState(false)
+  const [validateError, setValidateError] = useState<string | null>(null)
+
+  const isBuiltIn = source === 'built-in'
+
+  useEffect(() => {
+    let cancelled = false
+    setProfile(null)
+    setLoadError(null)
+    setValidation(null)
+    setValidateError(null)
+    api.getProfile(name)
+      .then(p => { if (!cancelled) setProfile(p) })
+      .catch((e: ApiError) => { if (!cancelled) setLoadError(e.detail || e.message) })
+    return () => { cancelled = true }
+  }, [name])
+
+  const handleValidate = async () => {
+    if (!profile) return
+    setValidating(true)
+    setValidateError(null)
+    try {
+      // Validate the parsed frontmatter metadata. system_prompt is the profile
+      // body, not a frontmatter field, so it is stripped before sending.
+      const { system_prompt, ...metadata } = profile
+      const result = await api.validateProfile({ metadata })
+      setValidation(result)
+    } catch (e) {
+      const err = e as ApiError
+      setValidateError(err.detail || err.message)
+    }
+    setValidating(false)
+  }
+
+  return (
+    <div className="bg-gray-900/70 border border-gray-700/50 rounded-lg p-4 space-y-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2 min-w-0">
+          {isBuiltIn ? <Package size={14} className="text-blue-400 shrink-0" /> : <FolderOpen size={14} className="text-emerald-400 shrink-0" />}
+          <span className="text-sm font-medium text-gray-200 truncate">{name}</span>
+          <span className="text-[10px] text-gray-500">{sourceLabel(source)}</span>
+          {!loadable && <UnloadableBadge />}
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 text-gray-500 hover:text-gray-300 rounded hover:bg-gray-800/50"
+          aria-label="Close profile detail"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {loadError ? (
+        <div role="alert" className="text-xs text-red-300">Failed to load profile: {loadError}</div>
+      ) : !profile ? (
+        <div className="text-xs text-gray-500">Loading profile…</div>
+      ) : (
+        <>
+          <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+            {profile.description && (
+              <>
+                <dt className="text-gray-500">Description</dt>
+                <dd className="text-gray-300">{profile.description}</dd>
+              </>
+            )}
+            {profile.role && (
+              <>
+                <dt className="text-gray-500">Role</dt>
+                <dd className="text-gray-300">{profile.role}</dd>
+              </>
+            )}
+            {profile.provider && (
+              <>
+                <dt className="text-gray-500">Provider</dt>
+                <dd className="text-gray-300 font-mono">{profile.provider}</dd>
+              </>
+            )}
+            {profile.model && (
+              <>
+                <dt className="text-gray-500">Model</dt>
+                <dd className="text-gray-300 font-mono">{profile.model}</dd>
+              </>
+            )}
+          </dl>
+
+          <div className="flex items-center gap-2 pt-1 flex-wrap">
+            <button
+              onClick={handleValidate}
+              disabled={validating}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 disabled:opacity-40 text-white text-xs font-medium rounded-lg transition-colors"
+            >
+              <CheckCircle size={13} />
+              {validating ? 'Validating…' : 'Validate'}
+            </button>
+            {isBuiltIn ? (
+              <>
+                {/* Built-ins are read-only: Clone-to-customize instead of Edit (FR6). */}
+                <button
+                  onClick={() => onClone(name)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors"
+                  title="Create an editable local copy of this built-in. The built-in is never modified."
+                >
+                  <Copy size={13} />
+                  Clone to customize
+                </button>
+                <span className="text-[11px] text-gray-500" aria-disabled="true">
+                  Built-in · read-only
+                </span>
+              </>
+            ) : loadable ? (
+              // Local + loadable: Edit in place (FR5).
+              <button
+                onClick={() => onEdit(name)}
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium rounded-lg transition-colors"
+              >
+                <Pencil size={13} />
+                Edit
+              </button>
+            ) : (
+              // Unloadable local profile: View-only, no Edit.
+              <span className="text-[11px] text-amber-300" aria-disabled="true">
+                Unloadable · view only
+              </span>
+            )}
+          </div>
+
+          {validateError && (
+            <div role="alert" className="text-xs text-red-300">Validation failed: {validateError}</div>
+          )}
+          {validation && <ValidatePanel result={validation} />}
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── Profile row ─────────────────────────────────────────────────────────────
+function ProfileRow({ profile, score, onView, selected }: {
+  profile: { name: string; description?: string; source: string; loadable?: boolean; tags?: string[] }
+  score?: number
+  onView: () => void
+  selected: boolean
+}) {
+  const unloadable = isUnloadable(profile)
+  return (
+    <div
+      data-testid={`profile-row-${profile.name}`}
+      className={`flex items-center justify-between gap-3 px-3 py-2 rounded-lg border transition-colors ${
+        selected
+          ? 'bg-emerald-900/30 border-emerald-700/50'
+          : 'bg-gray-900/50 border-gray-700/30 hover:bg-gray-800/70'
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-200 truncate">{profile.name}</span>
+          {score !== undefined && <ScoreBadge score={score} />}
+          {unloadable && <UnloadableBadge />}
+        </div>
+        {profile.description && (
+          <div className="text-[11px] text-gray-500 truncate">{profile.description}</div>
+        )}
+      </div>
+      <button
+        onClick={onView}
+        className="flex items-center gap-1.5 px-2.5 py-1 bg-gray-700 hover:bg-gray-600 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
+        title="View profile details"
+      >
+        <Eye size={12} />
+        View
+      </button>
+    </div>
+  )
+}
+
+export function ProfilesBrowser() {
+  const [query, setQuery] = useState('')
+  const [profiles, setProfiles] = useState<AgentProfileInfo[]>([])
+  const [loadingList, setLoadingList] = useState(true)
+  const [listError, setListError] = useState<string | null>(null)
+  const [results, setResults] = useState<ProfileSearchResult[] | null>(null)
+  const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<{ name: string; source: string; loadable: boolean } | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [editClone, setEditClone] = useState<{ mode: 'edit' | 'clone'; name: string } | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Load the include-all grouped list (existing endpoint, unchanged — OQ2:
+  // GET /agents/profiles stays include-all; unloadable treatment is client-side).
+  const loadProfiles = useCallback(() => {
+    setLoadingList(true)
+    api.listProfiles()
+      .then(p => { setProfiles(p); setListError(null); setLoadingList(false) })
+      .catch((e: ApiError) => { setListError(e.detail || e.message); setLoadingList(false) })
+  }, [])
+
+  useEffect(() => { loadProfiles() }, [loadProfiles])
+
+  const runSearch = useCallback(async (q: string) => {
+    const trimmed = q.trim()
+    // Empty/whitespace: show the grouped list, do NOT call search (also guarded
+    // server-side, which returns []). This is a UX short-circuit, not the source
+    // of truth.
+    if (!trimmed) {
+      setResults(null)
+      setSearchError(null)
+      setSearching(false)
+      return
+    }
+    setSearching(true)
+    setSearchError(null)
+    try {
+      const res = await api.searchProfiles(trimmed)
+      setResults(res) // rendered in SERVER ORDER — never re-sorted (coverage→BM25Plus→name)
+    } catch (e) {
+      const err = e as ApiError
+      setSearchError(err.detail || err.message)
+      setResults([])
+    }
+    setSearching(false)
+  }, [])
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => runSearch(value), SEARCH_DEBOUNCE_MS)
+  }
+
+  const clearSearch = () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    setQuery('')
+    setResults(null)
+    setSearchError(null)
+    setSearching(false)
+  }
+
+  useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current) }, [])
+
+  // Grouped-by-source list (grouped mode), reusing AgentPanel's grouping idiom.
+  const profilesBySource = profiles.reduce<Record<string, AgentProfileInfo[]>>((acc, p) => {
+    const key = p.source || 'unknown'
+    ;(acc[key] ??= []).push(p)
+    return acc
+  }, {})
+  const sourceOrder = Object.keys(profilesBySource).sort()
+
+  const isRanked = results !== null
+
+  return (
+    <div className="bg-gray-800/60 border border-gray-700/50 rounded-xl p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wide">
+          Agent Profiles
+        </h3>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-gray-500">{profiles.length} profile{profiles.length !== 1 ? 's' : ''}</span>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-colors"
+          >
+            <Plus size={14} />
+            Create Profile
+          </button>
+        </div>
+      </div>
+
+      {/* Search box [FR1] */}
+      <div className="relative">
+        <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
+        <input
+          type="text"
+          value={query}
+          onChange={e => handleQueryChange(e.target.value)}
+          placeholder="Search profiles by name, description, tags, capabilities…"
+          aria-label="Search agent profiles"
+          className="w-full bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg pl-9 pr-9 py-2 focus:border-emerald-500 focus:outline-none"
+        />
+        {query && (
+          <button
+            onClick={clearSearch}
+            aria-label="Clear search"
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 text-gray-500 hover:text-gray-300 rounded"
+          >
+            <X size={14} />
+          </button>
+        )}
+      </div>
+
+      {searchError && (
+        <div role="alert" className="text-xs text-red-300">Search failed: {searchError}</div>
+      )}
+
+      {/* Selected profile detail [FR2] */}
+      {selected && (
+        <ProfileDetail
+          name={selected.name}
+          source={selected.source}
+          loadable={selected.loadable}
+          onClose={() => setSelected(null)}
+          onEdit={(name) => setEditClone({ mode: 'edit', name })}
+          onClone={(name) => setEditClone({ mode: 'clone', name })}
+        />
+      )}
+
+      {/* Results (ranked, server order) or grouped list */}
+      {isRanked ? (
+        <div className="space-y-2">
+          <div className="text-[11px] text-gray-500">
+            {searching ? 'Searching…' : `${results!.length} result${results!.length !== 1 ? 's' : ''} for "${query.trim()}" (ranked)`}
+          </div>
+          {results!.length === 0 && !searching ? (
+            <p className="text-gray-500 text-sm">No profiles matched.</p>
+          ) : (
+            <div className="space-y-1.5" data-testid="search-results">
+              {results!.map(r => (
+                <ProfileRow
+                  key={`${r.source}-${r.name}`}
+                  profile={r}
+                  score={r.score}
+                  selected={selected?.name === r.name}
+                  onView={() => setSelected({ name: r.name, source: r.source, loadable: true })}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      ) : loadingList ? (
+        <p className="text-gray-500 text-sm">Loading profiles…</p>
+      ) : listError ? (
+        <div role="alert" className="text-xs text-red-300">Failed to load profiles: {listError}</div>
+      ) : profiles.length === 0 ? (
+        <p className="text-gray-500 text-sm">No agent profiles found.</p>
+      ) : (
+        <div className="space-y-4" data-testid="grouped-list">
+          {sourceOrder.map(source => (
+            <div key={source} className="space-y-1.5">
+              <div className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
+                {sourceLabel(source)} ({profilesBySource[source].length})
+              </div>
+              {profilesBySource[source].map(p => (
+                <ProfileRow
+                  key={`${p.source}-${p.name}`}
+                  profile={p}
+                  selected={selected?.name === p.name}
+                  onView={() => setSelected({ name: p.name, source: p.source, loadable: p.loadable !== false })}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Create-from-template wizard (#510 U3). On save, refresh the list. */}
+      {showCreate && (
+        <CreateProfileWizard
+          onClose={(saved) => {
+            setShowCreate(false)
+            if (saved) loadProfiles()
+          }}
+        />
+      )}
+
+      {/* Edit (local) / Clone (built-in) modal (#510 U4). On save, refresh. */}
+      {editClone && (
+        <EditCloneModal
+          mode={editClone.mode}
+          sourceName={editClone.name}
+          onClose={(saved) => {
+            setEditClone(null)
+            if (saved) {
+              setSelected(null)
+              loadProfiles()
+            }
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/test/createWizard.test.tsx
+++ b/web/src/test/createWizard.test.tsx
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CreateProfileWizard } from '../components/CreateProfileWizard'
+import { ProfileForm, ProfileFormValues } from '../components/ProfileForm'
+import { api } from '../api'
+import { useState } from 'react'
+
+// #510 U3: create wizard + shared ProfileForm. All scaffolding/validation/write
+// is server-side; these tests assert the flow wires to the (mocked) endpoints
+// and enforces the client-side gates (provider+model required, preview renders
+// server output, save blocked on validation errors, F-1 keeps provider/model
+// out of the render config).
+
+const TEMPLATES = [
+  { name: 'aws/sqs-monitor', description: 'Poll an SQS queue', path: '/x' },
+  { name: 'aws/stepfunction', description: 'Trigger Step Functions', path: '/y' },
+]
+
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    region: { type: 'string', description: 'AWS region' },
+    queue_url: { type: 'string', description: 'SQS queue URL' },
+  },
+  required: ['region', 'queue_url'],
+  additionalProperties: false,
+}
+
+// Provider renders as a CustomSelect when the server returns providers; select
+// claude_code through the dropdown (label is the underscore→space form).
+function selectClaudeProvider() {
+  fireEvent.click(screen.getByText('Select provider…'))
+  fireEvent.click(screen.getByText('claude code'))
+}
+
+function fillModel(value = 'opus') {
+  fireEvent.change(screen.getByPlaceholderText('e.g. claude-sonnet-4'), { target: { value } })
+}
+
+describe('CreateProfileWizard', () => {
+  let listTemplatesSpy: any
+  let getSchemaSpy: any
+  let previewSpy: any
+  let createSpy: any
+
+  beforeEach(() => {
+    listTemplatesSpy = vi.spyOn(api, 'listTemplates').mockResolvedValue(TEMPLATES as any)
+    getSchemaSpy = vi.spyOn(api, 'getTemplateSchema').mockResolvedValue(SCHEMA as any)
+    previewSpy = vi.spyOn(api, 'previewProfile').mockResolvedValue({
+      text: '---\nname: sqs-monitor-agent\nprovider: claude_code\nmodel: opus\n---\nbody',
+      valid: true, errors: [], warnings: [],
+    })
+    createSpy = vi.spyOn(api, 'createProfile').mockResolvedValue({
+      name: 'sqs-monitor-agent', source: 'local', path: '/store/sqs-monitor-agent.md',
+    })
+    vi.spyOn(api, 'listProviders').mockResolvedValue([
+      { name: 'claude_code', binary: 'claude', installed: true },
+    ] as any)
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('step 1 lists templates from the endpoint (no hardcoded list) [AC4.1]', async () => {
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    expect(listTemplatesSpy).toHaveBeenCalled()
+    expect(screen.getByText('aws/sqs-monitor')).toBeInTheDocument()
+    expect(screen.getByText('aws/stepfunction')).toBeInTheDocument()
+  })
+
+  it('picking a template loads its schema and advances to the form', async () => {
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+    await waitFor(() => expect(getSchemaSpy).toHaveBeenCalledWith('aws/sqs-monitor'))
+    // Schema-driven field rendered.
+    expect(screen.getByLabelText(/Region/)).toBeInTheDocument()
+  })
+
+  it('Preview is disabled until provider AND model are filled [ADR-006/AC4.4]', async () => {
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+
+    const previewBtn = screen.getByText('Preview').closest('button')!
+    expect(previewBtn).toBeDisabled()
+
+    // Fill provider only → still disabled.
+    selectClaudeProvider()
+    expect(previewBtn).toBeDisabled()
+
+    // Fill model too → enabled.
+    fillModel()
+    expect(previewBtn).not.toBeDisabled()
+  })
+
+  it('Preview calls the server render and shows its output [AC4.2]', async () => {
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+    selectClaudeProvider()
+    fillModel()
+    fireEvent.click(screen.getByText('Preview'))
+
+    await screen.findByTestId('preview-panel')
+    expect(previewSpy).toHaveBeenCalledWith(expect.objectContaining({
+      template_name: 'aws/sqs-monitor', provider: 'claude_code', model: 'opus',
+    }))
+    // The preview panel shows the SERVER-rendered text.
+    expect(screen.getByText(/name: sqs-monitor-agent/)).toBeInTheDocument()
+  })
+
+  it('preview F-1: provider/model are NOT put into the render config', async () => {
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+    fireEvent.change(screen.getByLabelText(/Region/), { target: { value: 'us-east-1' } })
+    selectClaudeProvider()
+    fillModel()
+    fireEvent.click(screen.getByText('Preview'))
+    await screen.findByTestId('preview-panel')
+
+    const sentConfig = previewSpy.mock.calls[0][0].config
+    expect(sentConfig).not.toHaveProperty('provider')
+    expect(sentConfig).not.toHaveProperty('model')
+    expect(sentConfig.region).toBe('us-east-1')
+  })
+
+  it('invalid config surfaces the preview error and stays on the form [AC4.2]', async () => {
+    previewSpy.mockRejectedValueOnce(Object.assign(new Error('400'), { detail: 'region: required' }))
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+    selectClaudeProvider()
+    fillModel()
+    fireEvent.click(screen.getByText('Preview'))
+
+    expect(await screen.findByText(/Preview failed: region: required/)).toBeInTheDocument()
+    // Still on the form, not the preview panel.
+    expect(screen.getByTestId('profile-form')).toBeInTheDocument()
+    expect(screen.queryByTestId('preview-panel')).not.toBeInTheDocument()
+  })
+
+  it('Save is blocked while the preview reports validation errors [AC4.5]', async () => {
+    previewSpy.mockResolvedValueOnce({
+      text: '---\nname: bad name\n---\n', valid: false,
+      errors: ['[error] name: does not match pattern'], warnings: [],
+    })
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+    selectClaudeProvider()
+    fillModel()
+    fireEvent.click(screen.getByText('Preview'))
+
+    await screen.findByTestId('preview-panel')
+    expect(screen.getByText(/save blocked/i)).toBeInTheDocument()
+    expect(screen.getByText('Save Profile').closest('button')).toBeDisabled()
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  it('Save calls createProfile and reports the saved profile on success [AC4.5]', async () => {
+    const onClose = vi.fn()
+    render(<CreateProfileWizard onClose={onClose} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+    fireEvent.change(screen.getByLabelText(/Region/), { target: { value: 'us-east-1' } })
+    selectClaudeProvider()
+    fillModel()
+    fireEvent.click(screen.getByText('Preview'))
+    await screen.findByTestId('preview-panel')
+    fireEvent.click(screen.getByText('Save Profile'))
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({
+      template_name: 'aws/sqs-monitor', provider: 'claude_code', model: 'opus',
+    })))
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith(expect.objectContaining({ name: 'sqs-monitor-agent', source: 'local' })))
+  })
+
+  it('save F-1: provider/model are NOT put into the createProfile config either', async () => {
+    // The preview F-1 test guards the /preview call; this pins the SAME rule on
+    // the /agents/profiles (create) call, so a regression that leaked
+    // provider/model into config only on the save path is still caught.
+    render(<CreateProfileWizard onClose={() => {}} />)
+    await screen.findByTestId('template-picker')
+    fireEvent.click(screen.getByText('aws/sqs-monitor'))
+    await screen.findByTestId('profile-form')
+    fireEvent.change(screen.getByLabelText(/Region/), { target: { value: 'us-east-1' } })
+    selectClaudeProvider()
+    fillModel()
+    fireEvent.click(screen.getByText('Preview'))
+    await screen.findByTestId('preview-panel')
+    fireEvent.click(screen.getByText('Save Profile'))
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalled())
+    const sentConfig = createSpy.mock.calls[0][0].config
+    expect(sentConfig).not.toHaveProperty('provider')
+    expect(sentConfig).not.toHaveProperty('model')
+    expect(sentConfig.region).toBe('us-east-1')
+  })
+})
+
+// A tiny controlled harness to exercise ProfileForm directly. (ProfileForm is
+// create-only as of #510 U4 — the schema-only 'edit' mode had no production
+// consumer and was removed; U4's editor is EditCloneModal's content textarea.)
+function FormHarness({ schema }: { schema?: any }) {
+  const [values, setValues] = useState<ProfileFormValues>({ config: {}, provider: '', model: '' })
+  return (
+    <div>
+      <ProfileForm schema={schema} values={values} onChange={setValues} />
+      <div data-testid="values">{JSON.stringify(values)}</div>
+    </div>
+  )
+}
+
+describe('ProfileForm (create-from-template, U3-owned)', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'listProviders').mockResolvedValue([
+      { name: 'claude_code', binary: 'claude', installed: true },
+    ] as any)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('always renders explicit required provider and model fields', async () => {
+    render(<FormHarness schema={SCHEMA} />)
+    await screen.findByTestId('profile-form')
+    expect(screen.getByText('Provider')).toBeInTheDocument()
+    expect(screen.getByText('Model')).toBeInTheDocument()
+    // model field is marked required for a11y.
+    expect(screen.getByLabelText(/Model/)).toHaveAttribute('aria-required', 'true')
+  })
+
+  it('renders schema-driven config fields with required markers', async () => {
+    render(<FormHarness schema={SCHEMA} />)
+    await screen.findByTestId('profile-form')
+    expect(screen.getByLabelText(/Region/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Queue Url/)).toBeInTheDocument()
+  })
+
+  it('renders provider/model with no config fields when the schema is absent', async () => {
+    // A template whose schema failed to load (pickTemplate catch → schema=null):
+    // provider/model still render and are required; no config fields appear.
+    render(<FormHarness schema={null} />)
+    await screen.findByTestId('profile-form')
+    expect(screen.getByText('Provider')).toBeInTheDocument()
+    expect(screen.getByText('Model')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Region/)).not.toBeInTheDocument()
+  })
+
+  it('config edits do not leak provider/model into config', async () => {
+    render(<FormHarness schema={SCHEMA} />)
+    await screen.findByTestId('profile-form')
+    fireEvent.change(screen.getByLabelText(/Region/), { target: { value: 'us-west-2' } })
+    fireEvent.change(screen.getByPlaceholderText('e.g. claude-sonnet-4'), { target: { value: 'opus' } })
+    const values = JSON.parse(screen.getByTestId('values').textContent!)
+    expect(values.config).toEqual({ region: 'us-west-2' })
+    expect(values.config).not.toHaveProperty('provider')
+    expect(values.config).not.toHaveProperty('model')
+    expect(values.model).toBe('opus')
+  })
+})

--- a/web/src/test/createWizardApi.test.ts
+++ b/web/src/test/createWizardApi.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { api } from '../api'
+
+// #510 U3: api.ts wrappers for the create-from-template flow. These assert
+// URL/verb/body only; render + validation + write correctness is a server (U1)
+// guarantee.
+describe('create-wizard API wrappers', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => vi.stubGlobal('fetch', mockFetch))
+  afterEach(() => vi.restoreAllMocks())
+
+  function mockResponse(data: unknown, status = 200) {
+    mockFetch.mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      json: () => Promise.resolve(data),
+    })
+  }
+
+  it('listTemplates GETs /agents/profiles/templates', async () => {
+    const templates = [{ name: 'aws/sqs-monitor', description: 'Poll SQS', path: '/x' }]
+    mockResponse(templates)
+    const result = await api.listTemplates()
+    expect(result).toEqual(templates)
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/templates',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('getTemplateSchema keeps the category/name slash unencoded (:path route)', async () => {
+    mockResponse({ type: 'object', properties: {} })
+    await api.getTemplateSchema('aws/sqs-monitor')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/templates/aws/sqs-monitor/schema',
+      expect.any(Object),
+    )
+  })
+
+  it('previewProfile POSTs the create body to /preview (server render, no write)', async () => {
+    const req = { template_name: 'aws/sqs-monitor', config: { region: 'us-east-1' }, provider: 'claude_code', model: 'opus' }
+    mockResponse({ text: '---\nname: x\n---\n', valid: true, errors: [], warnings: [] })
+    const result = await api.previewProfile(req)
+    expect(result.valid).toBe(true)
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/preview',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req),
+      }),
+    )
+  })
+
+  it('previewProfile transmits the request body verbatim (transmit-fidelity, NOT the F-1 guard)', async () => {
+    // NOTE: this is a TRANSMIT-FIDELITY check, not the F-1 rule. It hand-builds a
+    // payload and inspects the wire body, proving api.previewProfile serializes
+    // whatever it is handed without mangling — top-level fields stay top-level,
+    // config stays untouched. It CANNOT catch an F-1 violation, because the F-1
+    // mistake originates in the WIZARD assembling the payload, and the wizard is
+    // not invoked here. The real F-1 guard is createWizard.test.tsx
+    // ("preview F-1: provider/model are NOT put into the render config"), which
+    // drives the actual wizard and fails when provider/model leak into config.
+    mockFetch.mockClear() // isolate this call — the shared mock accumulates history
+    mockResponse({ text: '---\nname: x\n---\n', valid: true, errors: [], warnings: [] })
+    await api.previewProfile({
+      template_name: 'aws/sqs-monitor',
+      config: { region: 'us-east-1', queue_url: 'https://sqs.us-east-1.amazonaws.com/1/q' },
+      provider: 'claude_code',
+      model: 'opus',
+    })
+    const opts = mockFetch.mock.lastCall![1]
+    const sent = JSON.parse((opts as RequestInit).body as string)
+    // Fields are transmitted exactly as handed in — no re-shaping by the wrapper.
+    expect(sent.provider).toBe('claude_code')
+    expect(sent.model).toBe('opus')
+    expect(sent.config).toEqual({ region: 'us-east-1', queue_url: 'https://sqs.us-east-1.amazonaws.com/1/q' })
+  })
+
+  it('createProfile POSTs to /agents/profiles', async () => {
+    const req = { template_name: 'aws/sqs-monitor', config: {}, provider: 'claude_code', model: 'opus' }
+    mockResponse({ name: 'sqs-monitor-agent', source: 'local', path: '/store/sqs-monitor-agent.md' })
+    const result = await api.createProfile(req)
+    expect(result.source).toBe('local')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify(req) }),
+    )
+  })
+
+  it('createProfile surfaces a validation-error 400 as ApiError detail', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ detail: { message: 'Profile validation failed', errors: ['[error] name'] } }),
+    })
+    await expect(
+      api.createProfile({ template_name: 't', config: {}, provider: 'p', model: 'm' }),
+    ).rejects.toMatchObject({ status: 400, detail: 'Profile validation failed' })
+  })
+})

--- a/web/src/test/editClone.test.tsx
+++ b/web/src/test/editClone.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { EditCloneModal } from '../components/EditCloneModal'
+import { ProfilesBrowser } from '../components/ProfilesBrowser'
+import { api } from '../api'
+
+// #510 U4: edit + clone. The modal prefills content from getProfile, exposes
+// explicit required provider/model, and routes edit → PUT / clone → from-content.
+// The key FR6 guarantee: clone calls createProfileFromContent (a NEW local
+// profile) and NEVER updateProfile on the built-in (built-in unmutated).
+
+const DEV_PROFILE = {
+  name: 'developer', description: 'Dev agent', role: 'developer',
+  provider: 'claude_code', model: 'opus', system_prompt: 'Do the work.',
+}
+
+describe('EditCloneModal', () => {
+  let updateSpy: any
+  let fromContentSpy: any
+
+  beforeEach(() => {
+    vi.spyOn(api, 'getProfile').mockResolvedValue(DEV_PROFILE as any)
+    vi.spyOn(api, 'listProviders').mockResolvedValue([
+      { name: 'claude_code', binary: 'claude', installed: true },
+    ] as any)
+    updateSpy = vi.spyOn(api, 'updateProfile').mockResolvedValue({ name: 'my-local', source: 'local', path: '/s/my-local.md' })
+    fromContentSpy = vi.spyOn(api, 'createProfileFromContent').mockResolvedValue({ name: 'developer-copy', source: 'local', path: '/s/developer-copy.md' })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('edit mode prefills content from getProfile and saves via updateProfile (PUT)', async () => {
+    const onClose = vi.fn()
+    render(<EditCloneModal mode="edit" sourceName="my-local" onClose={onClose} />)
+    // content textarea prefilled from the loaded profile
+    const textarea = await screen.findByLabelText('Profile content') as HTMLTextAreaElement
+    await waitFor(() => expect(textarea.value).toContain('"name": "developer"'))
+    // provider/model seeded but editable+required
+    expect((screen.getByLabelText(/Model/) as HTMLInputElement).value).toBe('opus')
+
+    fireEvent.click(screen.getByText('Save Changes'))
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledWith('my-local', expect.objectContaining({
+      provider: 'claude_code', model: 'opus',
+    })))
+    // Edit must NOT call the clone route.
+    expect(fromContentSpy).not.toHaveBeenCalled()
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith(expect.objectContaining({ source: 'local' })))
+  })
+
+  it('clone mode defaults a new name, saves via from-content, and never mutates the built-in', async () => {
+    const onClose = vi.fn()
+    render(<EditCloneModal mode="clone" sourceName="developer" onClose={onClose} />)
+    await screen.findByLabelText('Profile content')
+    // new-name field defaults to <source>-copy
+    const nameInput = screen.getByLabelText(/New profile name/) as HTMLInputElement
+    expect(nameInput.value).toBe('developer-copy')
+
+    fireEvent.click(screen.getByText('Create Clone'))
+    await waitFor(() => expect(fromContentSpy).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'developer-copy', provider: 'claude_code', model: 'opus',
+    })))
+    // FR6/AC6.2: clone is a CREATE, never a PUT on the built-in.
+    expect(updateSpy).not.toHaveBeenCalled()
+    await waitFor(() => expect(onClose).toHaveBeenCalledWith(expect.objectContaining({ name: 'developer-copy' })))
+  })
+
+  it('save is blocked until provider AND model are present [ADR-006]', async () => {
+    vi.spyOn(api, 'getProfile').mockResolvedValueOnce({ name: 'x', description: 'y' } as any) // no provider/model
+    render(<EditCloneModal mode="edit" sourceName="x" onClose={vi.fn()} />)
+    await screen.findByLabelText('Profile content')
+    const saveBtn = screen.getByText('Save Changes').closest('button')!
+    expect(saveBtn).toBeDisabled()
+    // fill model only
+    fireEvent.change(screen.getByLabelText(/Model/), { target: { value: 'opus' } })
+    expect(saveBtn).toBeDisabled() // provider still empty (free-text since providers load async)
+  })
+
+  it('surfaces a server save error (e.g. overwrite refusal) inline', async () => {
+    fromContentSpy.mockRejectedValueOnce(Object.assign(new Error('400'), { detail: "name 'developer-copy' already exists" }))
+    render(<EditCloneModal mode="clone" sourceName="developer" onClose={vi.fn()} />)
+    await screen.findByLabelText('Profile content')
+    fireEvent.click(screen.getByText('Create Clone'))
+    expect(await screen.findByText(/Save failed: name 'developer-copy' already exists/)).toBeInTheDocument()
+  })
+
+  it('edit mode surfaces a server re-validation 400 inline and does not close', async () => {
+    // Symmetry with the clone error path: an edit whose content fails server
+    // re-validation (FR5/AC5.1) must surface the [error] and keep the modal open.
+    const onClose = vi.fn()
+    updateSpy.mockRejectedValueOnce(Object.assign(new Error('400'), { detail: '[error] name: does not match pattern' }))
+    render(<EditCloneModal mode="edit" sourceName="my-local" onClose={onClose} />)
+    await screen.findByLabelText('Profile content')
+    fireEvent.click(screen.getByText('Save Changes'))
+    expect(await screen.findByText(/Save failed: \[error\] name: does not match pattern/)).toBeInTheDocument()
+    // The failed save must NOT close the modal (onClose is only called on success).
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// Integration: from ProfilesBrowser, a built-in offers Clone (not Edit) and a
+// local+loadable profile offers Edit (not Clone) — the FR5/FR6 affordance split.
+describe('ProfilesBrowser edit/clone affordances', () => {
+  const GROUPED: any[] = [
+    { name: 'developer', description: 'Dev', source: 'built-in', loadable: true, tags: [], capabilities: [] },
+    { name: 'my-local', description: 'Local', source: 'local', loadable: true, tags: [], capabilities: [] },
+  ]
+
+  beforeEach(() => {
+    vi.spyOn(api, 'listProfiles').mockResolvedValue(GROUPED as any)
+    vi.spyOn(api, 'searchProfiles').mockResolvedValue([])
+    vi.spyOn(api, 'listProviders').mockResolvedValue([{ name: 'claude_code', binary: 'claude', installed: true }] as any)
+    vi.spyOn(api, 'getProfile').mockResolvedValue(DEV_PROFILE as any)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('built-in detail offers Clone to customize, not Edit', async () => {
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    fireEvent.click(within(screen.getByTestId('profile-row-developer')).getByText('View'))
+    await screen.findByText('Validate')
+    expect(screen.getByText('Clone to customize')).toBeInTheDocument()
+    expect(screen.queryByText(/^Edit$/)).not.toBeInTheDocument()
+  })
+
+  it('local+loadable detail offers Edit, not Clone', async () => {
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    fireEvent.click(within(screen.getByTestId('profile-row-my-local')).getByText('View'))
+    await screen.findByText('Validate')
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.queryByText('Clone to customize')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/test/editCloneApi.test.ts
+++ b/web/src/test/editCloneApi.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { api } from '../api'
+
+// #510 U4: api.ts wrappers for edit (PUT) and clone (from-content). URL/verb/body
+// assertions only; validation/containment/overwrite-refusal are server (U1) rules.
+describe('edit + clone API wrappers', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => vi.stubGlobal('fetch', mockFetch))
+  afterEach(() => vi.restoreAllMocks())
+
+  function mockResponse(data: unknown, status = 200) {
+    mockFetch.mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      json: () => Promise.resolve(data),
+    })
+  }
+
+  it('updateProfile PUTs to /agents/profiles/{name} url-encoded', async () => {
+    const req = { content: '---\nname: my-agent\n---\nbody', provider: 'claude_code', model: 'opus' }
+    mockResponse({ name: 'my-agent', source: 'local', path: '/store/my-agent.md' })
+    const result = await api.updateProfile('my-agent', req)
+    expect(result.source).toBe('local')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/my-agent',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req),
+      }),
+    )
+  })
+
+  it('createProfileFromContent POSTs to /agents/profiles/from-content', async () => {
+    const req = { name: 'developer-copy', content: '---\nname: developer-copy\n---\nbody', provider: 'claude_code', model: 'opus' }
+    mockResponse({ name: 'developer-copy', source: 'local', path: '/store/developer-copy.md' })
+    const result = await api.createProfileFromContent(req)
+    expect(result.name).toBe('developer-copy')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/from-content',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify(req) }),
+    )
+  })
+
+  it('createProfileFromContent surfaces the overwrite-refusal 400 as detail', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ detail: "A local profile named 'x' already exists." }),
+    })
+    await expect(
+      api.createProfileFromContent({ name: 'x', content: 'c', provider: 'p', model: 'm' }),
+    ).rejects.toMatchObject({ status: 400, detail: "A local profile named 'x' already exists." })
+  })
+})

--- a/web/src/test/profileApi.test.ts
+++ b/web/src/test/profileApi.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { api } from '../api'
+
+// #510 U2: api.ts wrappers for the profile-management endpoints. These assert
+// the wrapper hits the right URL/verb/body; ranking + validation correctness is
+// a server (U1) guarantee proven by the Python suite.
+describe('profile management API wrappers', () => {
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mockResponse(data: unknown, status = 200) {
+    mockFetch.mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      json: () => Promise.resolve(data),
+    })
+  }
+
+  it('searchProfiles GETs /agents/profiles/search with an encoded query', async () => {
+    mockResponse([])
+    await api.searchProfiles('monitor sqs')
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/search?q=monitor%20sqs',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('searchProfiles appends limit when provided', async () => {
+    mockResponse([])
+    await api.searchProfiles('sqs', 3)
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/search?q=sqs&limit=3',
+      expect.any(Object),
+    )
+  })
+
+  it('searchProfiles returns the server payload UNCHANGED (no client re-sort)', async () => {
+    // Server order is coverage → BM25 → name; a name-descending payload must be
+    // returned exactly as received. If the wrapper (or a future edit) sorted, the
+    // order below would change — this pins the "never re-sort" contract at the
+    // api boundary.
+    const serverOrder = [
+      { name: 'zzz-full', description: '', capabilities: [], tags: [], role: null, source: 'local', coverage: 2, score: 2.7 },
+      { name: 'aaa-partial', description: '', capabilities: [], tags: [], role: null, source: 'local', coverage: 1, score: 1.5 },
+    ]
+    mockResponse(serverOrder)
+    const result = await api.searchProfiles('sqs monitor')
+    expect(result).toEqual(serverOrder)
+    expect(result.map(r => r.name)).toEqual(['zzz-full', 'aaa-partial'])
+  })
+
+  it('getProfile GETs /agents/profiles/{name} url-encoded', async () => {
+    mockResponse({ name: 'dev', description: 'x' })
+    const result = await api.getProfile('dev')
+    expect(result).toEqual({ name: 'dev', description: 'x' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/dev',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('validateProfile POSTs the payload as JSON', async () => {
+    const payload = { metadata: { name: 'dev' } }
+    mockResponse({ valid: true, errors: [], warnings: [] })
+    const result = await api.validateProfile(payload)
+    expect(result).toEqual({ valid: true, errors: [], warnings: [] })
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/agents/profiles/validate',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }),
+    )
+  })
+
+  it('validateProfile surfaces server errors as ApiError detail', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ detail: 'Could not parse profile content' }),
+    })
+    await expect(api.validateProfile({ content: 'bad' })).rejects.toMatchObject({
+      status: 400,
+      detail: 'Could not parse profile content',
+    })
+  })
+})

--- a/web/src/test/profilesBrowser.test.tsx
+++ b/web/src/test/profilesBrowser.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { ProfilesBrowser } from '../components/ProfilesBrowser'
+import { api } from '../api'
+
+// #510 U2: ProfilesBrowser interaction tests. The component holds no ranking or
+// validation logic — it renders whatever the (mocked) server returns. The key
+// assertions: search renders results in SERVER ORDER (no client re-sort), an
+// empty query shows the grouped list without calling search, unloadable rows
+// are badged + View-only, and the validate panel splits errors/warnings/valid.
+
+const GROUPED: any[] = [
+  { name: 'developer', description: 'Dev agent', source: 'built-in', loadable: true, tags: [], capabilities: [] },
+  { name: 'reviewer', description: 'Review agent', source: 'built-in', loadable: true, tags: [], capabilities: [] },
+  { name: 'my-local', description: 'Local agent', source: 'local', loadable: true, tags: [], capabilities: [] },
+  { name: 'broken-one', description: 'Broken', source: 'local', loadable: false, tags: [], capabilities: [] },
+]
+
+// Server search order is coverage → BM25 → name; this payload is intentionally
+// NOT name-sorted so a client-side re-sort would be detectable.
+const SEARCH_RESULTS: any[] = [
+  { name: 'zzz-full', description: 'sqs monitor', capabilities: [], tags: [], role: null, source: 'local', coverage: 2, score: 2.74 },
+  { name: 'aaa-partial', description: 'sqs', capabilities: [], tags: [], role: null, source: 'built-in', coverage: 1, score: 1.51 },
+]
+
+describe('ProfilesBrowser', () => {
+  let searchSpy: any
+
+  beforeEach(() => {
+    vi.spyOn(api, 'listProfiles').mockResolvedValue(GROUPED as any)
+    searchSpy = vi.spyOn(api, 'searchProfiles').mockResolvedValue(SEARCH_RESULTS as any)
+    vi.spyOn(api, 'getProfile').mockResolvedValue({
+      name: 'developer', description: 'Dev agent', role: 'developer', provider: 'claude_code', model: 'opus',
+    } as any)
+    vi.spyOn(api, 'validateProfile').mockResolvedValue({ valid: true, errors: [], warnings: [] })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('renders the grouped list from listProfiles on mount', async () => {
+    render(<ProfilesBrowser />)
+    expect(await screen.findByTestId('grouped-list')).toBeInTheDocument()
+    expect(screen.getByText('developer')).toBeInTheDocument()
+    expect(screen.getByText('my-local')).toBeInTheDocument()
+    // Grouped by source: both a Built-in and a Local group header appear.
+    expect(screen.getByText(/Built-in \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Local \(2\)/)).toBeInTheDocument()
+  })
+
+  it('badges an unloadable profile and keeps it View-only (no Edit)', async () => {
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    // The unloadable row shows the badge...
+    expect(screen.getByText('unloadable')).toBeInTheDocument()
+    // ...and no Edit/Clone action is offered anywhere in phase-1 (View only).
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    expect(screen.queryByText('Clone')).not.toBeInTheDocument()
+    // Every row (including unloadable) still offers View.
+    expect(screen.getAllByText('View').length).toBe(GROUPED.length)
+  })
+
+  it('does not call searchProfiles for an empty/whitespace query', async () => {
+    vi.useFakeTimers()
+    render(<ProfilesBrowser />)
+    // flush the mount fetch
+    await vi.runOnlyPendingTimersAsync()
+    const input = screen.getByLabelText('Search agent profiles')
+    fireEvent.change(input, { target: { value: '   ' } })
+    await vi.advanceTimersByTimeAsync(300)
+    expect(searchSpy).not.toHaveBeenCalled()
+    // The grouped list is still shown (no ranked results panel).
+    expect(screen.queryByTestId('search-results')).not.toBeInTheDocument()
+    expect(screen.getByTestId('grouped-list')).toBeInTheDocument()
+  })
+
+  it('renders search results in SERVER ORDER (no client re-sort)', async () => {
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    const input = screen.getByLabelText('Search agent profiles')
+    fireEvent.change(input, { target: { value: 'sqs monitor' } })
+
+    const resultsBox = await screen.findByTestId('search-results')
+    await waitFor(() => expect(searchSpy).toHaveBeenCalledWith('sqs monitor'))
+    // The DOM order must equal the server payload order, NOT name-ascending.
+    const names = within(resultsBox).getAllByText(/-(full|partial)/).map(n => n.textContent)
+    expect(names).toEqual(['zzz-full', 'aaa-partial'])
+  })
+
+  it('renders EQUAL-score results verbatim (no client tie-break re-sort)', async () => {
+    // The prior test uses distinct scores, so it only catches a re-sort that
+    // reorders by score. This one pins the tie-break branch (AC1.2): two hits
+    // with IDENTICAL coverage+score are delivered name-DESCENDING. The server
+    // owns the name-ascending tie-break; if the client re-sorted (by score OR
+    // by name) it would flip these — so verbatim render is the only pass.
+    searchSpy.mockResolvedValueOnce([
+      { name: 'zulu-tie', description: '', capabilities: [], tags: [], role: null, source: 'local', coverage: 1, score: 1.5 },
+      { name: 'alpha-tie', description: '', capabilities: [], tags: [], role: null, source: 'local', coverage: 1, score: 1.5 },
+    ] as any)
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    fireEvent.change(screen.getByLabelText('Search agent profiles'), { target: { value: 'tie' } })
+    const resultsBox = await screen.findByTestId('search-results')
+    const names = within(resultsBox).getAllByText(/-tie/).map(n => n.textContent)
+    expect(names).toEqual(['zulu-tie', 'alpha-tie'])
+  })
+
+  it('shows the relative score indicator, not a percentage', async () => {
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    fireEvent.change(screen.getByLabelText('Search agent profiles'), { target: { value: 'sqs' } })
+    await screen.findByTestId('search-results')
+    // score rendered as a bare number (2.74), never a "%".
+    expect(screen.getByText('2.74')).toBeInTheDocument()
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument()
+  })
+
+  it('clear button restores the grouped list', async () => {
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    fireEvent.change(screen.getByLabelText('Search agent profiles'), { target: { value: 'sqs' } })
+    await screen.findByTestId('search-results')
+    fireEvent.click(screen.getByLabelText('Clear search'))
+    expect(await screen.findByTestId('grouped-list')).toBeInTheDocument()
+    expect(screen.queryByTestId('search-results')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a search error in an inline banner', async () => {
+    searchSpy.mockRejectedValueOnce(Object.assign(new Error('500'), { detail: 'boom' }))
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    fireEvent.change(screen.getByLabelText('Search agent profiles'), { target: { value: 'sqs' } })
+    expect(await screen.findByText(/Search failed: boom/)).toBeInTheDocument()
+  })
+})
+
+describe('ProfilesBrowser — ProfileDetail + ValidatePanel', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'listProfiles').mockResolvedValue(GROUPED as any)
+    vi.spyOn(api, 'searchProfiles').mockResolvedValue([])
+    vi.spyOn(api, 'getProfile').mockResolvedValue({
+      name: 'developer', description: 'Dev agent', role: 'developer', provider: 'claude_code', model: 'opus',
+    } as any)
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  async function openDeveloperDetail() {
+    render(<ProfilesBrowser />)
+    await screen.findByTestId('grouped-list')
+    const devRow = screen.getByTestId('profile-row-developer')
+    fireEvent.click(within(devRow).getByText('View'))
+    await screen.findByText('Validate')
+  }
+
+  it('built-in profile shows read-only + Clone-to-customize, no Edit', async () => {
+    await openDeveloperDetail()
+    // U4 wires the Clone action; built-ins never expose Edit (FR6).
+    expect(screen.getByText('Clone to customize')).toBeInTheDocument()
+    expect(screen.getByText(/Built-in · read-only/)).toBeInTheDocument()
+    expect(screen.queryByText(/^Edit$/)).not.toBeInTheDocument()
+  })
+
+  it('validate errors block save and list [error] messages', async () => {
+    vi.spyOn(api, 'validateProfile').mockResolvedValue({
+      valid: false,
+      errors: ['[error] name: does not match pattern'],
+      warnings: [],
+    })
+    await openDeveloperDetail()
+    fireEvent.click(screen.getByText('Validate'))
+    expect(await screen.findByText(/save blocked/)).toBeInTheDocument()
+    expect(screen.getByText('[error] name: does not match pattern')).toBeInTheDocument()
+  })
+
+  it('warnings-only validation is allowed (save not blocked)', async () => {
+    vi.spyOn(api, 'validateProfile').mockResolvedValue({
+      valid: true,
+      errors: [],
+      warnings: ['[warn] role custom is not built-in'],
+    })
+    await openDeveloperDetail()
+    fireEvent.click(screen.getByText('Validate'))
+    expect(await screen.findByText(/save allowed/)).toBeInTheDocument()
+    expect(screen.getByText('[warn] role custom is not built-in')).toBeInTheDocument()
+    expect(screen.queryByText(/save blocked/)).not.toBeInTheDocument()
+  })
+
+  it('valid profile shows a success state', async () => {
+    vi.spyOn(api, 'validateProfile').mockResolvedValue({ valid: true, errors: [], warnings: [] })
+    await openDeveloperDetail()
+    fireEvent.click(screen.getByText('Validate'))
+    expect(await screen.findByText(/Valid — no issues/)).toBeInTheDocument()
+  })
+
+  it('validate sends the parsed metadata without the system_prompt body', async () => {
+    const validateSpy = vi.spyOn(api, 'validateProfile').mockResolvedValue({ valid: true, errors: [], warnings: [] })
+    vi.spyOn(api, 'getProfile').mockResolvedValue({
+      name: 'developer', description: 'Dev', system_prompt: 'SECRET BODY', provider: 'claude_code',
+    } as any)
+    await openDeveloperDetail()
+    fireEvent.click(screen.getByText('Validate'))
+    await waitFor(() => expect(validateSpy).toHaveBeenCalled())
+    const payload = validateSpy.mock.calls[0][0]
+    expect(payload.metadata).toBeDefined()
+    expect(payload.metadata).not.toHaveProperty('system_prompt')
+    expect(payload.metadata?.name).toBe('developer')
+  })
+})

--- a/web/src/test/profilesNav.test.tsx
+++ b/web/src/test/profilesNav.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { DashboardHome } from '../components/DashboardHome'
+import { api } from '../api'
+
+// #510 U2 FR3: the Home "Profiles" stat card links to the Profiles tab, and the
+// nav label reads "Profiles" (route key unchanged). These are label/nav-only
+// changes — no store key / API path / module rename.
+
+describe('DashboardHome — Profiles stat card link [FR3/AC3.2]', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'listProfiles').mockResolvedValue([
+      { name: 'developer', description: 'Dev', source: 'built-in' },
+    ] as any)
+    vi.spyOn(api, 'getSession').mockResolvedValue({ session: { id: 's', name: 's', status: 'active' }, terminals: [] } as any)
+    vi.spyOn(api, 'getTerminalStatus').mockResolvedValue('IDLE' as any)
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders the Profiles stat card as a button that navigates to the agents tab', async () => {
+    const onNavigate = vi.fn()
+    render(<DashboardHome onNavigate={onNavigate} />)
+    const card = await screen.findByLabelText('Go to Profiles tab')
+    expect(card.tagName).toBe('BUTTON')
+    fireEvent.click(card)
+    expect(onNavigate).toHaveBeenCalledWith('agents')
+  })
+
+  it('shows the profile count from listProfiles on the card', async () => {
+    const onNavigate = vi.fn()
+    render(<DashboardHome onNavigate={onNavigate} />)
+    await waitFor(() => expect(screen.getByText('1')).toBeInTheDocument())
+    // The card is keyboard-activatable (a real <button>, focusable by default).
+    const card = screen.getByLabelText('Go to Profiles tab')
+    card.focus()
+    expect(document.activeElement).toBe(card)
+  })
+})
+
+describe('App nav label [FR3/AC3.1]', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('the tab list renders the label "Profiles" while keeping the agents route key', async () => {
+    // Assert against the shipped App shell: the tab list must contain a
+    // "Profiles" label and must NOT contain the old "Agents" label.
+    vi.spyOn(api, 'listSessions').mockResolvedValue([])
+    vi.spyOn(api, 'getMemoryStatus').mockResolvedValue({ enabled: false })
+    const App = (await import('../App')).default
+    render(<App />)
+    // Header brand text is "CLI Agent Orchestrator" (contains "Agent"), so scope
+    // the assertion to the tablist.
+    const tablist = await screen.findByRole('tablist')
+    expect(tablist).toHaveTextContent('Profiles')
+    const tabLabels = Array.from(tablist.querySelectorAll('[role="tab"]')).map(t => t.textContent)
+    expect(tabLabels.some(l => l?.includes('Profiles'))).toBe(true)
+    expect(tabLabels.some(l => l === 'Agents')).toBe(false)
+  })
+
+  it('keeps the internal route key "agents": session badge shows and the tab renders AgentPanel', async () => {
+    // The complement of the label test. Only the user-facing LABEL changed; the
+    // route key stays 'agents'. Two things are keyed on that literal:
+    //   1. the session-count badge (App.tsx: `t.key === 'agents' && sessions...`)
+    //   2. the tab body (`tab === 'agents' && <AgentPanel/>`)
+    // A future contributor "finishing the rename" by changing the key would pass
+    // the label test above while breaking both — so pin them here.
+    vi.spyOn(api, 'listSessions').mockResolvedValue([
+      { id: 's1', name: 's1', status: 'active' },
+      { id: 's2', name: 's2', status: 'active' },
+    ] as any)
+    vi.spyOn(api, 'getMemoryStatus').mockResolvedValue({ enabled: false })
+    vi.spyOn(api, 'getSession').mockResolvedValue(
+      { session: { id: 's1', name: 's1', status: 'active' }, terminals: [] } as any,
+    )
+    vi.spyOn(api, 'listProviders').mockResolvedValue([] as any)
+    vi.spyOn(api, 'listProfiles').mockResolvedValue([] as any)
+
+    const App = (await import('../App')).default
+    render(<App />)
+    const tablist = await screen.findByRole('tablist')
+    const profilesTab = Array.from(tablist.querySelectorAll('[role="tab"]'))
+      .find(t => t.textContent?.includes('Profiles')) as HTMLElement
+    expect(profilesTab).toBeTruthy()
+
+    // (1) The session badge (keyed on 'agents') renders the count on this tab —
+    // proof the key is still 'agents', not a renamed 'profiles'.
+    await waitFor(() => expect(profilesTab).toHaveTextContent('2'))
+
+    // (2) Activating the tab renders AgentPanel — proven by ProfilesBrowser's
+    // "Agent Profiles" heading (mounted at the top of AgentPanel). If the key had
+    // been renamed, `tab === 'agents'` would never match and nothing would show.
+    fireEvent.click(profilesTab)
+    expect(await screen.findByText('Agent Profiles')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #510

## What

Closes the read-only gap that left browser-first users unable to act on the profiles they could see.

**New REST endpoints** on cao-server (`/agents/profiles/*`), all thin wrappers over the existing `services/profile_search.py` and `services/agent_scaffold.py`:

| Route | Purpose |
|---|---|
| `GET /agents/profiles/search` | capability search |
| `GET /agents/profiles/templates` | template list |
| `GET /agents/profiles/templates/{name}/schema` | template schema |
| `POST /agents/profiles/validate` | frontmatter validation (non-mutating) |
| `POST /agents/profiles/preview` | render + validate, writes nothing |
| `POST /agents/profiles` · `POST /agents/profiles/from-content` · `PUT /agents/profiles/{name}` | create / clone / edit |

**Web UI**: `ProfilesBrowser` (search, grouped list, unloadable treatment, detail + validate panel), `CreateProfileWizard` (3-step, template-driven), `ProfileForm` (shared, schema-driven), `EditCloneModal` (edit local, clone-to-customize built-ins), plus the Home "Profiles" stat card linking to the Agents tab.

## Design decisions worth review

- **Search ranking is server-authoritative.** Results render in server order with no client re-sort; score is shown as a relative indicator only. Pinned by a test using two entries with identical `coverage`/`score` delivered name-descending, so any client-side re-sort by score *or* name fails.
- **Provider and model are always explicit** (ADR-006) and are patched onto the *rendered* profile, never merged into the template `config`. Guarded on both the preview and save paths.
- **Built-ins stay read-only.** The client offers Clone (not Edit) for packaged profiles; the server independently refuses a non-local `PUT`.
- **Write routes are scope-gated**; only `/validate` and `/preview` are exempt, and both provably write nothing on any path. This mirrors the existing `POST /workflows/validate` precedent.
- **No renames.** `AgentPanel.tsx`, the `agents` route key, store keys, and API paths are unchanged — the label change is presentation only.

## Tests

- **API**: 548 passing, including a new 43-test suite (`test_api_profiles_management.py`) covering ranking parity vs `search_profiles`, validation error/warn split parity vs `cao profile validate`, create/edit path containment, built-in read-only enforcement, and write-route auth scopes.
- **Web**: 137 passing across 13 files. `tsc --noEmit` and `npm run build` both clean.
- **Coverage ratchet**: python 89.89% against the 87.00% floor.
- A route-resolution test asserts `/agents/profiles/search` does not resolve as `name="search"`, so a future reordering of the GET sub-paths ahead of `/agents/profiles/{name}` fails CI rather than 404-ing silently.

## Known limitation

Composition is test-verified — the real `App` shell renders, the tab mounts `AgentPanel`, and `AgentPanel` mounts `ProfilesBrowser` — but there is **no live SPA↔server end-to-end test** for this feature. Both sides of the contract are pinned against the same shapes (wrapper URL/verb/body tests plus response-shape mocks mirroring the server DTOs), so a live serialization drift the mocks do not model would escape this suite. A Profiles-tab smoke against a running server is the first thing to add if an e2e stage is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)