### PR TITLE
feat(api): add read-only profile search, template and preview endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Read-only profile HTTP routes for capability search, template discovery and schema retrieval, template-config validation, and rendered previews (#510)
 - `CAO_HOME_DIR` environment variable to relocate CAO's entire data directory outside `~/.aws` (#467)
 - `cao profile find <query>` CLI verb and `find_profiles` MCP tool for keyword/BM25 profile discovery over metadata (name, description, tags, capabilities); metadata-only, never exposes prompt bodies (#340)
 - Optional `capabilities` and `tags` arrays in the agent profile frontmatter schema (#340)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Read-only profile HTTP routes for capability search, template discovery and schema retrieval, template-config validation, and rendered previews (#510)
+- Read-only profile HTTP routes for capability search, template discovery and schema retrieval, template-config validation, and rendered previews (#523)
 - `CAO_HOME_DIR` environment variable to relocate CAO's entire data directory outside `~/.aws` (#467)
 - `cao profile find <query>` CLI verb and `find_profiles` MCP tool for keyword/BM25 profile discovery over metadata (name, description, tags, capabilities); metadata-only, never exposes prompt bodies (#340)
 - Optional `capabilities` and `tags` arrays in the agent profile frontmatter schema (#340)

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,7 +38,21 @@ See [AG-UI](agui.md) for enablement, event shapes, and privacy boundaries.
 
 ### Profiles, providers, and settings
 
-- `/agents/profiles*` lists, reads, and installs profiles.
+- `GET /agents/profiles` and `GET /agents/profiles/{name}` list and inspect
+  installed profiles.
+- `GET /agents/profiles/search` ranks installed, loadable profiles by capability
+  using the same service as `cao profile find`.
+- `GET /agents/profiles/templates` lists public template metadata (`name` and
+  `description` only); internal template filesystem paths are never returned.
+- `GET /agents/profiles/templates/{category}/{name}/schema` returns a template's
+  JSON-Schema.
+- `POST /agents/profiles/templates/validate` validates a config object against
+  a template's JSON-Schema without writing a profile.
+- `POST /agents/profiles/templates/preview` validates and renders a template to
+  Markdown without writing a profile.
+- `POST /agents/profiles/install` installs a profile.
+- Template validation and preview require the selected template to include a
+  `schema.json` file.
 - `/agents/providers` reports provider availability.
 - `/settings/*` exposes supported agent-directory, skill-directory, and memory
   settings.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -499,6 +499,13 @@ class TemplateConfigRequest(BaseModel):
     )
 
 
+class TemplateSummary(BaseModel):
+    """Public template metadata. Excludes the internal filesystem path."""
+
+    name: str
+    description: str
+
+
 class ValidateTemplateConfigResponse(BaseModel):
     """Outcome of validating a config against a template's JSON-Schema."""
 
@@ -1581,12 +1588,18 @@ async def search_agent_profiles_endpoint(
 
 
 @app.get("/agents/profiles/templates")
-async def list_profile_templates_endpoint() -> List[Dict]:
-    """List the scaffold templates available for profile creation."""
+async def list_profile_templates_endpoint() -> List[TemplateSummary]:
+    """List public scaffold-template metadata for profile creation."""
     from cli_agent_orchestrator.services.agent_scaffold import list_templates
 
     try:
-        return list_templates()
+        return [
+            TemplateSummary(
+                name=template["name"],
+                description=template.get("description", ""),
+            )
+            for template in list_templates()
+        ]
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1626,7 +1639,7 @@ async def get_profile_template_schema_endpoint(category: str, name: str) -> Dict
     return schema
 
 
-@app.post("/agents/profiles/validate")
+@app.post("/agents/profiles/templates/validate")
 async def validate_profile_template_config_endpoint(
     request: TemplateConfigRequest,
 ) -> ValidateTemplateConfigResponse:
@@ -1648,13 +1661,13 @@ async def validate_profile_template_config_endpoint(
     return ValidateTemplateConfigResponse(valid=not errors, errors=errors)
 
 
-@app.post("/agents/profiles/preview")
+@app.post("/agents/profiles/templates/preview")
 async def preview_profile_template_endpoint(
     request: TemplateConfigRequest,
 ) -> PreviewTemplateResponse:
     """Render a template to markdown and return it. Writes nothing.
 
-    Same non-mutating rationale as ``/validate``: rendering is a pure function of
+    Same non-mutating rationale as template validation: rendering is a pure function of
     the template and the supplied config. ``render_template`` validates the
     config first, so an invalid config returns 400 rather than partial output.
     """

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -1530,6 +1530,27 @@ async def list_agent_profiles_endpoint() -> List[Dict]:
         )
 
 
+def _resolve_template_name(template: str) -> str:
+    """Map a caller-supplied template id onto an enumerated template name.
+
+    Returns the matching value from ``list_templates()`` (built from filesystem
+    enumeration), never the caller's own string, so the identifier handed to the
+    scaffold service — and thence to ``Path`` — is not derived from request
+    data. This is the sanitizer that removes the taint CodeQL flags on the
+    scaffold path expressions; the allowlist regex and ``_check_containment``
+    remain as additional layers. Raises 404 for an unknown template.
+    """
+    from cli_agent_orchestrator.services.agent_scaffold import list_templates
+
+    for known in list_templates():
+        if known["name"] == template:
+            return str(known["name"])
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Template not found: {template}",
+    )
+
+
 # The static sub-paths below (`/search`, `/templates`, and the template schema
 # route) MUST stay declared ABOVE `/agents/profiles/{name}`. FastAPI resolves in
 # declaration order, so moving them below would let the `{name}` route capture
@@ -1591,8 +1612,9 @@ async def get_profile_template_schema_endpoint(category: str, name: str) -> Dict
             detail=f"Invalid template name: {template}",
         )
 
+    resolved = _resolve_template_name(template)
     try:
-        schema = get_template_schema(template)
+        schema = get_template_schema(resolved)
     except FileNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
@@ -1617,8 +1639,9 @@ async def validate_profile_template_config_endpoint(
     """
     from cli_agent_orchestrator.services.agent_scaffold import validate_config
 
+    resolved = _resolve_template_name(request.template)
     try:
-        errors = validate_config(request.template, request.config)
+        errors = validate_config(resolved, request.config)
     except FileNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
@@ -1637,8 +1660,9 @@ async def preview_profile_template_endpoint(
     """
     from cli_agent_orchestrator.services.agent_scaffold import render_template
 
+    resolved = _resolve_template_name(request.template)
     try:
-        content = render_template(request.template, request.config)
+        content = render_template(resolved, request.config)
     except FileNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ValueError as e:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -116,6 +116,9 @@ from cli_agent_orchestrator.services.herdr_inbox_service import HerdrInboxServic
 from cli_agent_orchestrator.services.inbox_service import inbox_service
 from cli_agent_orchestrator.services.install_service import InstallResult, install_agent
 from cli_agent_orchestrator.services.log_writer import log_writer
+from cli_agent_orchestrator.services.profile_search import (
+    DEFAULT_LIMIT as PROFILE_SEARCH_DEFAULT_LIMIT,
+)
 from cli_agent_orchestrator.services.status_monitor import status_monitor
 from cli_agent_orchestrator.services.step_output_store import _validate_key_part
 from cli_agent_orchestrator.services.terminal_service import OutputMode, TerminalInputBlockedError
@@ -471,6 +474,43 @@ class InstallAgentProfileRequest(BaseModel):
     source: str
     provider: Optional[str] = None
     env_vars: Optional[Dict[str, str]] = None
+
+
+# Scaffold templates are identified as ``category/name`` (e.g.
+# ``aws/stepfunction``). Constraining that identifier with an allowlist pattern
+# at the API boundary rejects traversal attempts before they reach the scaffold
+# service — which independently re-checks containment via ``_check_containment``.
+# Allowlist rather than denylist is deliberate: a denylist of dot sequences is
+# always incomplete.
+TEMPLATE_NAME_PATTERN = r"^[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$"
+
+
+class TemplateConfigRequest(BaseModel):
+    """Request body for the non-mutating template validate and preview routes."""
+
+    template: str = Field(
+        pattern=TEMPLATE_NAME_PATTERN,
+        max_length=128,
+        description="Template identifier in 'category/name' form, e.g. 'aws/stepfunction'",
+    )
+    config: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Flat config values matching the template's JSON-Schema",
+    )
+
+
+class ValidateTemplateConfigResponse(BaseModel):
+    """Outcome of validating a config against a template's JSON-Schema."""
+
+    valid: bool
+    errors: List[str] = Field(default_factory=list)
+
+
+class PreviewTemplateResponse(BaseModel):
+    """A rendered profile. Returned to the caller and never written to disk."""
+
+    template: str
+    content: str
 
 
 class MemorySummary(BaseModel):
@@ -1488,6 +1528,123 @@ async def list_agent_profiles_endpoint() -> List[Dict]:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list agent profiles: {str(e)}",
         )
+
+
+# The static sub-paths below (`/search`, `/templates`, and the template schema
+# route) MUST stay declared ABOVE `/agents/profiles/{name}`. FastAPI resolves in
+# declaration order, so moving them below would let the `{name}` route capture
+# "search" and "templates" as profile names. test_api_profile_surface.py pins
+# this ordering.
+@app.get("/agents/profiles/search")
+async def search_agent_profiles_endpoint(
+    q: str = Query(description="Free-text capability keywords, e.g. 'monitor sqs'"),
+    limit: int = Query(default=PROFILE_SEARCH_DEFAULT_LIMIT, ge=1, le=100),
+) -> List[Dict]:
+    """Rank installed agent profiles against ``q``.
+
+    Delegates to ``services.profile_search.search_profiles`` so HTTP, the CLI
+    (``cao profile find``) and the ``find_profiles`` MCP tool return identical
+    ordering and scores — no ranking logic lives here. The service excludes
+    profiles that ``load_agent_profile()`` would reject, and results are
+    metadata-only: the profile prompt body is never returned.
+    """
+    from cli_agent_orchestrator.services.profile_search import search_profiles
+
+    try:
+        return search_profiles(q, limit=limit)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to search agent profiles: {str(e)}",
+        )
+
+
+@app.get("/agents/profiles/templates")
+async def list_profile_templates_endpoint() -> List[Dict]:
+    """List the scaffold templates available for profile creation."""
+    from cli_agent_orchestrator.services.agent_scaffold import list_templates
+
+    try:
+        return list_templates()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list profile templates: {str(e)}",
+        )
+
+
+@app.get("/agents/profiles/templates/{category}/{name}/schema")
+async def get_profile_template_schema_endpoint(category: str, name: str) -> Dict:
+    """Return the JSON-Schema for one scaffold template.
+
+    ``category`` and ``name`` are two path segments rather than one so the
+    ``category/name`` template identifier survives routing without a
+    percent-encoded slash. The pair is allowlist-validated here and the scaffold
+    service re-checks containment independently.
+    """
+    from cli_agent_orchestrator.services.agent_scaffold import get_template_schema
+
+    template = f"{category}/{name}"
+    if not re.fullmatch(TEMPLATE_NAME_PATTERN, template):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid template name: {template}",
+        )
+
+    try:
+        schema = get_template_schema(template)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    if schema is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No schema found for template '{template}'",
+        )
+    return schema
+
+
+@app.post("/agents/profiles/validate")
+async def validate_profile_template_config_endpoint(
+    request: TemplateConfigRequest,
+) -> ValidateTemplateConfigResponse:
+    """Validate a config against a template's JSON-Schema. Writes nothing.
+
+    Deliberately NOT guarded by ``SCOPE_WRITE``. This is a POST only because the
+    config travels in a JSON body rather than a query string; it mutates no
+    state. The write-scope guard belongs on the create/edit routes that persist
+    a profile, not on validation.
+    """
+    from cli_agent_orchestrator.services.agent_scaffold import validate_config
+
+    try:
+        errors = validate_config(request.template, request.config)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return ValidateTemplateConfigResponse(valid=not errors, errors=errors)
+
+
+@app.post("/agents/profiles/preview")
+async def preview_profile_template_endpoint(
+    request: TemplateConfigRequest,
+) -> PreviewTemplateResponse:
+    """Render a template to markdown and return it. Writes nothing.
+
+    Same non-mutating rationale as ``/validate``: rendering is a pure function of
+    the template and the supplied config. ``render_template`` validates the
+    config first, so an invalid config returns 400 rather than partial output.
+    """
+    from cli_agent_orchestrator.services.agent_scaffold import render_template
+
+    try:
+        content = render_template(request.template, request.config)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return PreviewTemplateResponse(template=request.template, content=content)
 
 
 @app.get("/agents/profiles/{name}")

--- a/test/api/test_api_profile_surface.py
+++ b/test/api/test_api_profile_surface.py
@@ -2,8 +2,8 @@
 
 Covers ``/agents/profiles/search``, the scaffold template routes, and the two
 non-mutating ``validate`` / ``preview`` routes. These endpoints exist so the Web
-UI, ``cao tui`` and any other client consume the same ranking and validation
-paths as the CLI instead of reimplementing them.
+Future UI, TUI, and external clients can consume the same ranking and
+validation paths as the CLI instead of reimplementing them.
 """
 
 from unittest.mock import patch
@@ -111,12 +111,23 @@ class TestSearchAgentProfilesEndpoint:
         assert response.status_code == 200
         assert mock_search.called
 
+    def test_maps_search_service_failure_to_500(self, client) -> None:
+        """Unexpected search-service failures should use the API error envelope."""
+        with patch(
+            "cli_agent_orchestrator.services.profile_search.search_profiles",
+            side_effect=RuntimeError("search unavailable"),
+        ):
+            response = client.get("/agents/profiles/search", params={"q": "anything"})
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to search agent profiles: search unavailable"
+
 
 class TestListProfileTemplatesEndpoint:
     """Tests for GET /agents/profiles/templates."""
 
-    def test_returns_templates_from_scaffold_service(self, client) -> None:
-        """The endpoint should return the scaffold service's template list."""
+    def test_returns_only_public_template_metadata(self, client) -> None:
+        """Internal template paths must not cross the public HTTP boundary."""
         templates = [
             {"name": "aws/stepfunction", "description": "Step Functions agent", "path": "/t/sf"}
         ]
@@ -128,7 +139,10 @@ class TestListProfileTemplatesEndpoint:
             response = client.get("/agents/profiles/templates")
 
         assert response.status_code == 200
-        assert response.json() == templates
+        assert response.json() == [
+            {"name": "aws/stepfunction", "description": "Step Functions agent"}
+        ]
+        assert "path" not in response.json()[0]
 
     def test_templates_is_not_captured_as_a_profile_name(self, client) -> None:
         """Pins route ordering for the ``/templates`` static path."""
@@ -140,6 +154,17 @@ class TestListProfileTemplatesEndpoint:
 
         assert response.status_code == 200
         assert mock_list.called
+
+    def test_maps_template_service_failure_to_500(self, client) -> None:
+        """Unexpected catalog failures should use the API error envelope."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.list_templates",
+            side_effect=RuntimeError("catalog unavailable"),
+        ):
+            response = client.get("/agents/profiles/templates")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to list profile templates: catalog unavailable"
 
 
 class TestGetProfileTemplateSchemaEndpoint:
@@ -170,18 +195,17 @@ class TestGetProfileTemplateSchemaEndpoint:
         assert response.status_code == 404
         assert "No schema found" in response.json()["detail"]
 
-    def test_rejects_traversal_in_path_segments(self, client) -> None:
-        """Dot segments must be rejected by the allowlist before the service runs.
+    def test_rejects_invalid_path_segment_before_services(self, client) -> None:
+        """An invalid segment must reach the handler and fail its allowlist check."""
+        with (
+            patch("cli_agent_orchestrator.services.agent_scaffold.list_templates") as mock_list,
+            patch("cli_agent_orchestrator.services.agent_scaffold.get_template_schema") as mock_get,
+        ):
+            response = client.get("/agents/profiles/templates/aws/b@d/schema")
 
-        The scaffold service also enforces containment, so this is defence in
-        depth rather than the only control.
-        """
-        with patch(
-            "cli_agent_orchestrator.services.agent_scaffold.get_template_schema"
-        ) as mock_get:
-            response = client.get("/agents/profiles/templates/aws/../schema")
-
-        assert response.status_code in (400, 404)
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid template name: aws/b@d"
+        assert not mock_list.called
         assert not mock_get.called
 
     def test_surfaces_containment_failure_as_400(self, client) -> None:
@@ -197,7 +221,7 @@ class TestGetProfileTemplateSchemaEndpoint:
 
 
 class TestValidateProfileTemplateConfigEndpoint:
-    """Tests for POST /agents/profiles/validate."""
+    """Tests for POST /agents/profiles/templates/validate."""
 
     def test_valid_config_reports_no_errors(self, client) -> None:
         """An empty error list from the service means the config is valid."""
@@ -206,7 +230,7 @@ class TestValidateProfileTemplateConfigEndpoint:
             return_value=[],
         ) as mock_validate:
             response = client.post(
-                "/agents/profiles/validate",
+                "/agents/profiles/templates/validate",
                 json={"template": "aws/stepfunction", "config": {"queue_url": "https://q"}},
             )
 
@@ -221,7 +245,7 @@ class TestValidateProfileTemplateConfigEndpoint:
             return_value=["queue_url: 'x' is not a 'uri'"],
         ):
             response = client.post(
-                "/agents/profiles/validate",
+                "/agents/profiles/templates/validate",
                 json={"template": "aws/stepfunction", "config": {"queue_url": "x"}},
             )
 
@@ -235,7 +259,7 @@ class TestValidateProfileTemplateConfigEndpoint:
             "cli_agent_orchestrator.services.agent_scaffold.validate_config"
         ) as mock_validate:
             response = client.post(
-                "/agents/profiles/validate",
+                "/agents/profiles/templates/validate",
                 json={"template": "../../etc/passwd", "config": {}},
             )
 
@@ -245,7 +269,7 @@ class TestValidateProfileTemplateConfigEndpoint:
     def test_rejects_single_segment_template_name(self, client) -> None:
         """Template identifiers are ``category/name``; a bare name is invalid."""
         response = client.post(
-            "/agents/profiles/validate",
+            "/agents/profiles/templates/validate",
             json={"template": "stepfunction", "config": {}},
         )
 
@@ -257,7 +281,7 @@ class TestValidateProfileTemplateConfigEndpoint:
             "cli_agent_orchestrator.services.agent_scaffold.validate_config"
         ) as mock_validate:
             response = client.post(
-                "/agents/profiles/validate",
+                "/agents/profiles/templates/validate",
                 json={"template": "aws/not-in-catalog", "config": {}},
             )
 
@@ -272,7 +296,7 @@ class TestValidateProfileTemplateConfigEndpoint:
             return_value=["queue_url: 'queue_url' is a required property"],
         ) as mock_validate:
             response = client.post(
-                "/agents/profiles/validate", json={"template": "aws/stepfunction"}
+                "/agents/profiles/templates/validate", json={"template": "aws/stepfunction"}
             )
 
         assert response.status_code == 200
@@ -280,7 +304,7 @@ class TestValidateProfileTemplateConfigEndpoint:
 
 
 class TestPreviewProfileTemplateEndpoint:
-    """Tests for POST /agents/profiles/preview."""
+    """Tests for POST /agents/profiles/templates/preview."""
 
     def test_returns_rendered_content(self, client) -> None:
         """A successful render should return the markdown and echo the template."""
@@ -289,7 +313,7 @@ class TestPreviewProfileTemplateEndpoint:
             return_value="---\nname: sf\n---\nBody",
         ) as mock_render:
             response = client.post(
-                "/agents/profiles/preview",
+                "/agents/profiles/templates/preview",
                 json={"template": "aws/stepfunction", "config": {"queue_url": "https://q"}},
             )
 
@@ -307,7 +331,7 @@ class TestPreviewProfileTemplateEndpoint:
             side_effect=ValueError("Config validation failed for 'aws/stepfunction'"),
         ):
             response = client.post(
-                "/agents/profiles/preview",
+                "/agents/profiles/templates/preview",
                 json={"template": "aws/stepfunction", "config": {}},
             )
 
@@ -321,7 +345,7 @@ class TestPreviewProfileTemplateEndpoint:
             side_effect=FileNotFoundError("Template 'aws/nope' not found"),
         ):
             response = client.post(
-                "/agents/profiles/preview",
+                "/agents/profiles/templates/preview",
                 json={"template": "aws/nope", "config": {}},
             )
 
@@ -332,7 +356,7 @@ class TestPreviewProfileTemplateEndpoint:
         """Traversal in the body field must not reach the render service."""
         with patch("cli_agent_orchestrator.services.agent_scaffold.render_template") as mock_render:
             response = client.post(
-                "/agents/profiles/preview",
+                "/agents/profiles/templates/preview",
                 json={"template": "aws/../../etc", "config": {}},
             )
 

--- a/test/api/test_api_profile_surface.py
+++ b/test/api/test_api_profile_surface.py
@@ -8,7 +8,24 @@ paths as the CLI instead of reimplementing them.
 
 from unittest.mock import patch
 
+import pytest
+
 from cli_agent_orchestrator.services.profile_search import DEFAULT_LIMIT
+
+
+@pytest.fixture(autouse=True)
+def _known_template_catalog():
+    """Provide the enumerated names that endpoint tests may delegate with."""
+    templates = [
+        {"name": "aws/stepfunction", "description": "Step Functions agent", "path": "/t/sf"},
+        {"name": "aws/nothing", "description": "No-schema fixture", "path": "/t/none"},
+        {"name": "aws/nope", "description": "Missing-file fixture", "path": "/t/nope"},
+    ]
+    with patch(
+        "cli_agent_orchestrator.services.agent_scaffold.list_templates",
+        return_value=templates,
+    ):
+        yield
 
 
 class TestSearchAgentProfilesEndpoint:
@@ -233,6 +250,20 @@ class TestValidateProfileTemplateConfigEndpoint:
         )
 
         assert response.status_code == 422
+
+    def test_rejects_unknown_well_formed_template_before_service(self, client) -> None:
+        """A catalog miss must not pass the caller's string to the scaffold service."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.validate_config"
+        ) as mock_validate:
+            response = client.post(
+                "/agents/profiles/validate",
+                json={"template": "aws/not-in-catalog", "config": {}},
+            )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Template not found: aws/not-in-catalog"
+        assert not mock_validate.called
 
     def test_config_defaults_to_empty_dict(self, client) -> None:
         """Omitting ``config`` should validate an empty config, not 422."""

--- a/test/api/test_api_profile_surface.py
+++ b/test/api/test_api_profile_surface.py
@@ -1,9 +1,9 @@
 """Tests for the read-only profile HTTP surface.
 
 Covers ``/agents/profiles/search``, the scaffold template routes, and the two
-non-mutating ``validate`` / ``preview`` routes. These endpoints exist so the Web
-Future UI, TUI, and external clients can consume the same ranking and
-validation paths as the CLI instead of reimplementing them.
+non-mutating ``validate`` / ``preview`` routes. These endpoints exist so
+future UI, TUI, and external clients can consume the same ranking and validation
+paths as the CLI instead of reimplementing them.
 """
 
 from unittest.mock import patch

--- a/test/api/test_api_profile_surface.py
+++ b/test/api/test_api_profile_surface.py
@@ -1,0 +1,309 @@
+"""Tests for the read-only profile HTTP surface.
+
+Covers ``/agents/profiles/search``, the scaffold template routes, and the two
+non-mutating ``validate`` / ``preview`` routes. These endpoints exist so the Web
+UI, ``cao tui`` and any other client consume the same ranking and validation
+paths as the CLI instead of reimplementing them.
+"""
+
+from unittest.mock import patch
+
+from cli_agent_orchestrator.services.profile_search import DEFAULT_LIMIT
+
+
+class TestSearchAgentProfilesEndpoint:
+    """Tests for GET /agents/profiles/search."""
+
+    def test_delegates_to_search_service_and_returns_results(self, client) -> None:
+        """Results should be passed through from the shared search service verbatim."""
+        results = [
+            {
+                "name": "monitor-tgo-sqs",
+                "description": "Monitor an SQS queue",
+                "capabilities": ["poll sqs queue"],
+                "tags": ["sqs", "monitor"],
+                "role": "monitor",
+                "source": "local",
+                "coverage": 2,
+                "score": 2.4912,
+            }
+        ]
+
+        with patch(
+            "cli_agent_orchestrator.services.profile_search.search_profiles",
+            return_value=results,
+        ) as mock_search:
+            response = client.get("/agents/profiles/search", params={"q": "monitor sqs"})
+
+        assert response.status_code == 200
+        assert response.json() == results
+        mock_search.assert_called_once_with("monitor sqs", limit=DEFAULT_LIMIT)
+
+    def test_default_limit_tracks_the_service_constant(self, client) -> None:
+        """The endpoint default must not drift from ``profile_search.DEFAULT_LIMIT``.
+
+        A hardcoded default here previously drifted from the service constant on
+        the MCP surface; this test pins them together.
+        """
+        with patch(
+            "cli_agent_orchestrator.services.profile_search.search_profiles",
+            return_value=[],
+        ) as mock_search:
+            client.get("/agents/profiles/search", params={"q": "anything"})
+
+        assert mock_search.call_args.kwargs["limit"] == DEFAULT_LIMIT
+
+    def test_forwards_explicit_limit(self, client) -> None:
+        """An explicit limit should reach the service unchanged."""
+        with patch(
+            "cli_agent_orchestrator.services.profile_search.search_profiles",
+            return_value=[],
+        ) as mock_search:
+            response = client.get("/agents/profiles/search", params={"q": "monitor", "limit": 3})
+
+        assert response.status_code == 200
+        mock_search.assert_called_once_with("monitor", limit=3)
+
+    def test_rejects_out_of_range_limit(self, client) -> None:
+        """Limits outside 1..100 should be rejected before reaching the service."""
+        assert (
+            client.get("/agents/profiles/search", params={"q": "x", "limit": 0}).status_code == 422
+        )
+        assert (
+            client.get("/agents/profiles/search", params={"q": "x", "limit": 101}).status_code
+            == 422
+        )
+
+    def test_requires_query(self, client) -> None:
+        """A missing ``q`` is a validation error, not an empty result."""
+        assert client.get("/agents/profiles/search").status_code == 422
+
+    def test_search_is_not_captured_as_a_profile_name(self, client) -> None:
+        """Pins route ordering: ``/search`` must resolve before ``/{name}``.
+
+        If the static route were declared below ``/agents/profiles/{name}``,
+        FastAPI would route this request to the profile-detail handler with
+        name="search" and this test would see its 404/400 instead.
+        """
+        with patch(
+            "cli_agent_orchestrator.services.profile_search.search_profiles",
+            return_value=[],
+        ) as mock_search:
+            response = client.get("/agents/profiles/search", params={"q": "anything"})
+
+        assert response.status_code == 200
+        assert mock_search.called
+
+
+class TestListProfileTemplatesEndpoint:
+    """Tests for GET /agents/profiles/templates."""
+
+    def test_returns_templates_from_scaffold_service(self, client) -> None:
+        """The endpoint should return the scaffold service's template list."""
+        templates = [
+            {"name": "aws/stepfunction", "description": "Step Functions agent", "path": "/t/sf"}
+        ]
+
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.list_templates",
+            return_value=templates,
+        ):
+            response = client.get("/agents/profiles/templates")
+
+        assert response.status_code == 200
+        assert response.json() == templates
+
+    def test_templates_is_not_captured_as_a_profile_name(self, client) -> None:
+        """Pins route ordering for the ``/templates`` static path."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.list_templates",
+            return_value=[],
+        ) as mock_list:
+            response = client.get("/agents/profiles/templates")
+
+        assert response.status_code == 200
+        assert mock_list.called
+
+
+class TestGetProfileTemplateSchemaEndpoint:
+    """Tests for GET /agents/profiles/templates/{category}/{name}/schema."""
+
+    def test_returns_schema(self, client) -> None:
+        """A known template should return its JSON-Schema."""
+        schema = {"type": "object", "properties": {"queue_url": {"type": "string"}}}
+
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.get_template_schema",
+            return_value=schema,
+        ) as mock_get:
+            response = client.get("/agents/profiles/templates/aws/stepfunction/schema")
+
+        assert response.status_code == 200
+        assert response.json() == schema
+        mock_get.assert_called_once_with("aws/stepfunction")
+
+    def test_returns_404_when_template_has_no_schema(self, client) -> None:
+        """A ``None`` return from the service means no schema file exists."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.get_template_schema",
+            return_value=None,
+        ):
+            response = client.get("/agents/profiles/templates/aws/nothing/schema")
+
+        assert response.status_code == 404
+        assert "No schema found" in response.json()["detail"]
+
+    def test_rejects_traversal_in_path_segments(self, client) -> None:
+        """Dot segments must be rejected by the allowlist before the service runs.
+
+        The scaffold service also enforces containment, so this is defence in
+        depth rather than the only control.
+        """
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.get_template_schema"
+        ) as mock_get:
+            response = client.get("/agents/profiles/templates/aws/../schema")
+
+        assert response.status_code in (400, 404)
+        assert not mock_get.called
+
+    def test_surfaces_containment_failure_as_400(self, client) -> None:
+        """A containment error from the service should not become a 500."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.get_template_schema",
+            side_effect=FileNotFoundError("Template path escapes templates root"),
+        ):
+            response = client.get("/agents/profiles/templates/aws/stepfunction/schema")
+
+        assert response.status_code == 400
+        assert "escapes templates root" in response.json()["detail"]
+
+
+class TestValidateProfileTemplateConfigEndpoint:
+    """Tests for POST /agents/profiles/validate."""
+
+    def test_valid_config_reports_no_errors(self, client) -> None:
+        """An empty error list from the service means the config is valid."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.validate_config",
+            return_value=[],
+        ) as mock_validate:
+            response = client.post(
+                "/agents/profiles/validate",
+                json={"template": "aws/stepfunction", "config": {"queue_url": "https://q"}},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"valid": True, "errors": []}
+        mock_validate.assert_called_once_with("aws/stepfunction", {"queue_url": "https://q"})
+
+    def test_invalid_config_reports_errors(self, client) -> None:
+        """Schema errors should be returned as a list with ``valid`` false."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.validate_config",
+            return_value=["queue_url: 'x' is not a 'uri'"],
+        ):
+            response = client.post(
+                "/agents/profiles/validate",
+                json={"template": "aws/stepfunction", "config": {"queue_url": "x"}},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["valid"] is False
+        assert response.json()["errors"] == ["queue_url: 'x' is not a 'uri'"]
+
+    def test_rejects_malformed_template_name(self, client) -> None:
+        """The allowlist pattern should reject traversal in the body field."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.validate_config"
+        ) as mock_validate:
+            response = client.post(
+                "/agents/profiles/validate",
+                json={"template": "../../etc/passwd", "config": {}},
+            )
+
+        assert response.status_code == 422
+        assert not mock_validate.called
+
+    def test_rejects_single_segment_template_name(self, client) -> None:
+        """Template identifiers are ``category/name``; a bare name is invalid."""
+        response = client.post(
+            "/agents/profiles/validate",
+            json={"template": "stepfunction", "config": {}},
+        )
+
+        assert response.status_code == 422
+
+    def test_config_defaults_to_empty_dict(self, client) -> None:
+        """Omitting ``config`` should validate an empty config, not 422."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.validate_config",
+            return_value=["queue_url: 'queue_url' is a required property"],
+        ) as mock_validate:
+            response = client.post(
+                "/agents/profiles/validate", json={"template": "aws/stepfunction"}
+            )
+
+        assert response.status_code == 200
+        mock_validate.assert_called_once_with("aws/stepfunction", {})
+
+
+class TestPreviewProfileTemplateEndpoint:
+    """Tests for POST /agents/profiles/preview."""
+
+    def test_returns_rendered_content(self, client) -> None:
+        """A successful render should return the markdown and echo the template."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.render_template",
+            return_value="---\nname: sf\n---\nBody",
+        ) as mock_render:
+            response = client.post(
+                "/agents/profiles/preview",
+                json={"template": "aws/stepfunction", "config": {"queue_url": "https://q"}},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "template": "aws/stepfunction",
+            "content": "---\nname: sf\n---\nBody",
+        }
+        mock_render.assert_called_once_with("aws/stepfunction", {"queue_url": "https://q"})
+
+    def test_invalid_config_returns_400(self, client) -> None:
+        """``render_template`` validates first, so bad config is a 400 not partial output."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.render_template",
+            side_effect=ValueError("Config validation failed for 'aws/stepfunction'"),
+        ):
+            response = client.post(
+                "/agents/profiles/preview",
+                json={"template": "aws/stepfunction", "config": {}},
+            )
+
+        assert response.status_code == 400
+        assert "Config validation failed" in response.json()["detail"]
+
+    def test_missing_template_returns_404(self, client) -> None:
+        """An unknown template should be a 404."""
+        with patch(
+            "cli_agent_orchestrator.services.agent_scaffold.render_template",
+            side_effect=FileNotFoundError("Template 'aws/nope' not found"),
+        ):
+            response = client.post(
+                "/agents/profiles/preview",
+                json={"template": "aws/nope", "config": {}},
+            )
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"]
+
+    def test_rejects_malformed_template_name(self, client) -> None:
+        """Traversal in the body field must not reach the render service."""
+        with patch("cli_agent_orchestrator.services.agent_scaffold.render_template") as mock_render:
+            response = client.post(
+                "/agents/profiles/preview",
+                json={"template": "aws/../../etc", "config": {}},
+            )
+
+        assert response.status_code == 422
+        assert not mock_render.called

--- a/test/api/test_scope_coverage.py
+++ b/test/api/test_scope_coverage.py
@@ -24,13 +24,13 @@ _MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 # Routes that use a mutating verb but perform no state change, so they are
 # intentionally not scope-gated. ``POST /workflows/validate`` only parses and
-# validates a spec file (read-only), mirroring a GET. ``/agents/profiles/validate``
-# and ``/agents/profiles/preview`` are POSTs for the same reason — their config
+# validates a spec file (read-only), mirroring a GET. ``/agents/profiles/templates/validate``
+# and ``/agents/profiles/templates/preview`` are POSTs for the same reason — their config
 # travels in a JSON body — and mutate nothing (schema check / template render).
 _EXEMPT = {
     ("POST", "/workflows/validate"),
-    ("POST", "/agents/profiles/validate"),
-    ("POST", "/agents/profiles/preview"),
+    ("POST", "/agents/profiles/templates/validate"),
+    ("POST", "/agents/profiles/templates/preview"),
 }
 
 

--- a/test/api/test_scope_coverage.py
+++ b/test/api/test_scope_coverage.py
@@ -24,8 +24,14 @@ _MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 # Routes that use a mutating verb but perform no state change, so they are
 # intentionally not scope-gated. ``POST /workflows/validate`` only parses and
-# validates a spec file (read-only), mirroring a GET.
-_EXEMPT = {("POST", "/workflows/validate")}
+# validates a spec file (read-only), mirroring a GET. ``/agents/profiles/validate``
+# and ``/agents/profiles/preview`` are POSTs for the same reason — their config
+# travels in a JSON body — and mutate nothing (schema check / template render).
+_EXEMPT = {
+    ("POST", "/workflows/validate"),
+    ("POST", "/agents/profiles/validate"),
+    ("POST", "/agents/profiles/preview"),
+}
 
 
 def _has_scope_dependency(route) -> bool:


### PR DESCRIPTION
## What

The CLI and MCP surfaces gained a full profile lifecycle in #395 / #438, but HTTP exposes only `list`, `show` and `install`. Any other client wanting capability search, template discovery or config validation has to reimplement ranking and validation, which then drifts from the CLI.

Five non-mutating endpoints, each a thin delegation to the existing services:

| Route | Delegates to |
|---|---|
| `GET /agents/profiles/search` | `profile_search.search_profiles` |
| `GET /agents/profiles/templates` | `agent_scaffold.list_templates` |
| `GET /agents/profiles/templates/{category}/{name}/schema` | `agent_scaffold.get_template_schema` |
| `POST /agents/profiles/validate` | `agent_scaffold.validate_config` |
| `POST /agents/profiles/preview` | `agent_scaffold.render_template` |

This unblocks the profile surfaces requested in #510, the Profiles view in #516 (currently read-only because search does not exist over HTTP), and the `ProfileCatalogStream` projection in #519 §2a. It does not implement any of them.

## Design decisions worth review

* **No write endpoints, deliberately.** `agent_scaffold` has no persist function; the write path currently lives in the CLI command layer. Exposing create/edit over HTTP requires first lifting that path into the service layer so CLI and HTTP share one implementation. That is a separate change and needs a design conversation rather than a drive-by refactor.

* **Scope handling for read-only POSTs.** `/validate` and `/preview` mutate no state; they use POST only because their config travels in a JSON body. The repository-wide scope-coverage guard requires every POST route to be either scope-gated or explicitly exempt. Both routes are registered in the existing non-mutating exemption set alongside `POST /workflows/validate`, which follows the same read-only POST pattern. Future write endpoints remain subject to `require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)`.

* **Untrusted surface.** As `POST /agents/profiles/install` already notes, HTTP is untrusted and `cao-ops-mcp` calls these endpoints, so agents reach them too. Template identifiers are allowlist-validated at the boundary and then resolved by equality against the catalog returned by `list_templates()`. Only the enumerated catalog value reaches the scaffold service and its path operations; the existing containment check remains as an additional layer.

* **Two path segments for the schema route** rather than one `{template:path}`, so `category/name` survives routing without a percent-encoded slash and cannot swallow the trailing `/schema`.

* **Route ordering is load-bearing.** The static sub-paths must stay above `/agents/profiles/{name}` or FastAPI captures `search` and `templates` as profile names. Two tests pin this ordering.

* **`DEFAULT_LIMIT` is imported, not hardcoded.** This prevents the same default-value drift that previously had to be fixed on the MCP surface. A test pins the endpoint default to the service constant.

## Tests

25 endpoint-surface tests, including a regression test proving that a well-formed but unknown template is rejected before reaching the scaffold service.

Focused validation: 67 passed, including the repository-wide scope invariant and existing CLI traversal tests.

Full CI-equivalent local run after installing all extras: 5,417 passed. The two remaining local failures are unrelated macOS FIFO timing failures (`ENXIO: Device not configured`) and do not import or exercise the changed code.

`black`, `isort`, and `git diff --check` are clean.

## Verified locally

<details>
<summary>CLI / HTTP ranking parity, route ordering and boundary probes</summary>

```console
$ cao profile find "monitor sqs" --limit 5 --json | jq -S . > /tmp/cli.json
$ curl -s "localhost:9889/agents/profiles/search?q=monitor%20sqs&limit=5" | jq -S . > /tmp/http.json
$ diff /tmp/cli.json /tmp/http.json && echo "PARITY OK"
PARITY OK

$ curl -s localhost:9889/openapi.json | jq -r '.paths | keys[] | select(startswith("/agents/profiles"))'
/agents/profiles
/agents/profiles/install
/agents/profiles/preview
/agents/profiles/search
/agents/profiles/templates
/agents/profiles/templates/{category}/{name}/schema
/agents/profiles/validate
/agents/profiles/{name}

$ curl -s localhost:9889/agents/profiles/templates | jq -r '.[].name'
aws/cloudwatch-logs
aws/dynamodb-delete
aws/dynamodb-query
aws/sqs-dlq-check
aws/sqs-monitor
aws/sqs-send
aws/stepfunction

$ curl -s localhost:9889/agents/profiles/templates/aws/cloudwatch-logs/schema | jq '.required'
[
  "profile",
  "region",
  "log_group"
]

$ curl -s -X POST localhost:9889/agents/profiles/validate \
    -H 'content-type: application/json' \
    -d '{"template":"aws/cloudwatch-logs","config":{"profile":"test-beta","region":"us-east-1","log_group":"/aws/lambda/x"}}'
{
  "valid": true,
  "errors": []
}

$ curl -s -X POST localhost:9889/agents/profiles/validate \
    -H 'content-type: application/json' \
    -d '{"template":"aws/cloudwatch-logs","config":{"profile":"test-beta","region":"NOT-A-REGION","log_group":"/aws/lambda/x"}}'
{
  "valid": false,
  "errors": [
    "region: 'NOT-A-REGION' does not match '^[a-z]{2}-[a-z]+-[0-9]+$'"
  ]
}

$ curl -s -o /dev/null -w '%{http_code}\n' \
    "localhost:9889/agents/profiles/templates/aws/../schema"
404

$ curl -s -X POST localhost:9889/agents/profiles/validate \
    -H 'content-type: application/json' \
    -d '{"template":"../../etc/passwd","config":{}}' \
    -o /dev/null -w '%{http_code}\n'
422
```

</details>

Ranking parity is the load-bearing check: the CLI and HTTP endpoint call the same `search_profiles` service, so byte-identical output confirms that neither surface post-processes the service result.