### PR TITLE
feat(memory): typed memory relationship store (#511)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -88,6 +88,10 @@ See [Workflows](workflows.md).
 
 - `/settings/memory` reports memory enablement (including `learning_enabled`).
 - `/memory*` lists, reads, exports, and deletes memories.
+- `/memory/relationships*` lists, creates, patches, promotes, rejects, and
+  soft-deletes typed relationships between memories. `GET` is read-scoped and
+  capped by `limit` (default 50, max 100); the mutating routes are write-scoped.
+  `DELETE` is a soft-delete — the row is retained with `status=deleted`.
 - `/graph/{provider}*` projects and exports graph views.
 - `/outcomes` records (`POST`, write-scope) and lists (`GET`) workflow
   outcomes for the self-learning loop. Both return 404 while

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -281,7 +281,38 @@ cao memory export --scope global -o ./bundle --include-history --redact --prune
 cao memory import ./memory-bundle --scope global
 cao memory import ./memory-bundle --scope project --conflict merge
 cao memory import ./memory-bundle --scope global --dry-run   # full pipeline, no writes
+
+# Inspect and curate typed relationships between memories
+cao memory relationships list
+cao memory relationships list --scope project --source-key testing-framework
+cao memory relationships list --status proposal        # the review queue
+cao memory relationships list --stale                 # edges older than their source
+cao memory relationships list --format json
+cao memory relationships inspect <relationship-id>
+cao memory relationships promote <relationship-id>    # proposal -> active
+cao memory relationships reject <relationship-id>     # -> rejected (survives recompute)
 ```
+
+### Typed relationships
+
+Memories are linked by typed, provenance-tagged edges (`relates_to`,
+`contradiction`, `supersedes`) held in a durable store rather than inferred at
+read time. Each edge records its `origin` — `compiler`, `wiki_lint`, `human`,
+`legacy_related_keys`, or `external_import` — and a `status`.
+
+Writes are **producer-scoped**: when the compiler or linter recomputes its edges
+for a source memory, it replaces only rows carrying its own origin and type, so a
+human-authored edge on the same memory is never touched.
+
+`reject` is durable curation. A rejected edge is **not** resurrected by a later
+producer recompute, and is not deleted if the producer stops reporting it — the
+operator's verdict outranks the producer, and each refusal is reported back to
+the producer. `promote` refuses to act on a rejected or deleted edge; re-create
+it instead.
+
+`--stale` surfaces edges computed before their source memory was last edited
+(the edge stores the source's `updated_at` at write time), which is the signal
+that a recompute is due.
 
 `cao memory heal` consumes the findings from `cao memory lint` and applies one fix per
 issue type: it deletes orphan pages, resolves contradictions (keeping the newer article),

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -3526,11 +3526,17 @@ async def list_relationships_endpoint(
     source_key: Optional[str] = None,
     status_filter: Optional[str] = Query(default=None, alias="status"),
     stale: bool = False,
+    limit: int = Query(default=50, ge=1, le=100),
     _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
 ):
     """List relationships (read scope). Default returns ACTIVE only; ``status``
     widens; ``stale=true`` filters to stale edges. Each row is a content-free
-    RelationshipDTO exposing provenance/status/timestamps (FR-5.4, AC-7)."""
+    RelationshipDTO exposing provenance/status/timestamps (FR-5.4, AC-7).
+
+    ``limit`` bounds the response, matching ``GET /memory``'s precedent
+    (default 50, max 100). This route previously returned every row in the
+    scope, so a large scope could emit an unbounded payload where every sibling
+    memory list route was already capped (human review, PR #524)."""
     _require_memory_enabled()
     svc = _relationship_service()
     dtos = svc.list_relationships(
@@ -3541,7 +3547,7 @@ async def list_relationships_endpoint(
         stale_only=stale,
         include_non_active=status_filter is not None,
     )
-    return [d.to_dict() for d in dtos]
+    return [d.to_dict() for d in dtos[:limit]]
 
 
 @app.post("/memory/relationships")
@@ -3632,7 +3638,17 @@ async def delete_relationship_endpoint(
     relationship_id: str,
     _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
 ):
-    """Soft-delete (write scope): status -> deleted, row retained (auditable)."""
+    """Soft-delete (write scope): status -> deleted, row retained (auditable).
+
+    WRITE, not ADMIN, is DELIBERATE (human review, PR #524). The ADMIN-gated
+    memory routes destroy user content irreversibly (a memory's file and its
+    metadata row); this one only transitions a derived annotation's status and
+    retains the row, so it is recoverable and forensically intact — the same
+    authority already needed to CREATE the edge via POST, and no more. Gating it
+    ADMIN would also make ordinary curation (rejecting a bad compiler edge)
+    require an admin token while writing one did not, which is the wrong
+    asymmetry. Note this is the SOFT delete; the hard purge is not exposed over
+    HTTP at all — it is driven internally by ``forget()``."""
     _require_memory_enabled()
     svc = _relationship_service()
     try:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -3479,6 +3479,169 @@ async def export_memories_endpoint(
     )
 
 
+# --------------------------------------------------------------------------- #
+# Memory relationship routes (issue #511).
+#
+# Registered BEFORE the single-segment ``/memory/{key}`` catch-all below so the
+# literal ``/memory/relationships`` collection is not captured as a key (FR-5.2;
+# same precedent as ``/memory/export`` above). A route-resolution test guards
+# this ordering. All go through the single MemoryRelationshipService; the route
+# layer is a thin adapter that maps ValueError -> 400 and not-found -> 404 and
+# never issues SQL. Responses are content-free RelationshipDTOs (NFR-1.7).
+# --------------------------------------------------------------------------- #
+
+
+class RelationshipCreateRequest(BaseModel):
+    scope: str
+    scope_id: Optional[str] = None
+    source_key: str
+    target_key: str
+    type: str
+    origin: str
+    status: str = "active"
+    confidence: Optional[float] = None
+    rank: Optional[int] = None
+    attributes: Optional[Dict[str, Any]] = None
+
+
+class RelationshipPatchRequest(BaseModel):
+    status: Optional[str] = None
+    confidence: Optional[float] = None
+    rank: Optional[int] = None
+    attributes: Optional[Dict[str, Any]] = None
+
+
+def _relationship_service():
+    from cli_agent_orchestrator.services.memory_relationship_service import (
+        MemoryRelationshipService,
+    )
+
+    return MemoryRelationshipService()
+
+
+@app.get("/memory/relationships")
+async def list_relationships_endpoint(
+    scope: str,
+    scope_id: Optional[str] = None,
+    source_key: Optional[str] = None,
+    status_filter: Optional[str] = Query(default=None, alias="status"),
+    stale: bool = False,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
+):
+    """List relationships (read scope). Default returns ACTIVE only; ``status``
+    widens; ``stale=true`` filters to stale edges. Each row is a content-free
+    RelationshipDTO exposing provenance/status/timestamps (FR-5.4, AC-7)."""
+    _require_memory_enabled()
+    svc = _relationship_service()
+    dtos = svc.list_relationships(
+        scope,
+        scope_id,
+        source_key,
+        status=status_filter,
+        stale_only=stale,
+        include_non_active=status_filter is not None,
+    )
+    return [d.to_dict() for d in dtos]
+
+
+@app.post("/memory/relationships")
+async def create_relationship_endpoint(
+    body: RelationshipCreateRequest,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+):
+    """Create/upsert a relationship (write scope). Fail-closed: the service
+    rejects invalid type/status/confidence/attributes, self-links, and
+    cross-scope/dangling endpoints with ValueError -> 400, before persistence."""
+    _require_memory_enabled()
+    svc = _relationship_service()
+    try:
+        dto = svc.create(
+            body.scope,
+            body.scope_id,
+            body.source_key,
+            body.target_key,
+            body.type,
+            body.origin,
+            status=body.status,
+            confidence=body.confidence,
+            rank=body.rank,
+            attributes=body.attributes,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    return dto.to_dict()
+
+
+@app.patch("/memory/relationships/{relationship_id}")
+async def patch_relationship_endpoint(
+    relationship_id: str,
+    body: RelationshipPatchRequest,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+):
+    _require_memory_enabled()
+    svc = _relationship_service()
+    try:
+        dto = svc.patch(
+            relationship_id,
+            status=body.status,
+            confidence=body.confidence,
+            rank=body.rank,
+            attributes=body.attributes,
+        )
+    except ValueError as e:
+        # not-found is raised as ValueError by the service; map to 404, other
+        # validation errors to 400.
+        detail = str(e)
+        code = status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        raise HTTPException(status_code=code, detail=detail)
+    return dto.to_dict()
+
+
+@app.post("/memory/relationships/{relationship_id}/promote")
+async def promote_relationship_endpoint(
+    relationship_id: str,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+):
+    _require_memory_enabled()
+    svc = _relationship_service()
+    try:
+        dto = svc.promote(relationship_id)
+    except ValueError as e:
+        detail = str(e)
+        code = status.HTTP_404_NOT_FOUND if "not found" in detail else status.HTTP_400_BAD_REQUEST
+        raise HTTPException(status_code=code, detail=detail)
+    return dto.to_dict()
+
+
+@app.post("/memory/relationships/{relationship_id}/reject")
+async def reject_relationship_endpoint(
+    relationship_id: str,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+):
+    _require_memory_enabled()
+    svc = _relationship_service()
+    try:
+        dto = svc.reject(relationship_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    return dto.to_dict()
+
+
+@app.delete("/memory/relationships/{relationship_id}")
+async def delete_relationship_endpoint(
+    relationship_id: str,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+):
+    """Soft-delete (write scope): status -> deleted, row retained (auditable)."""
+    _require_memory_enabled()
+    svc = _relationship_service()
+    try:
+        dto = svc.soft_delete(relationship_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    return dto.to_dict()
+
+
 @app.get("/memory/{key}", response_model=MemoryDetail)
 async def get_memory_endpoint(
     key: MemoryKey,

--- a/src/cli_agent_orchestrator/cli/commands/memory.py
+++ b/src/cli_agent_orchestrator/cli/commands/memory.py
@@ -865,6 +865,8 @@ def promote_cmd(agent_name, do_apply, min_recalls, profile_path):
     )
     if report.skipped:
         click.echo(f"  skipped (at {MAX_LESSONS}-lesson cap): {', '.join(report.skipped)}")
+
+
 # --------------------------------------------------------------------------- #
 # Relationship review surface (issue #511, U7). Thin adapter over the single
 # MemoryRelationshipService — list proposals, inspect endpoints + provenance,

--- a/src/cli_agent_orchestrator/cli/commands/memory.py
+++ b/src/cli_agent_orchestrator/cli/commands/memory.py
@@ -865,3 +865,112 @@ def promote_cmd(agent_name, do_apply, min_recalls, profile_path):
     )
     if report.skipped:
         click.echo(f"  skipped (at {MAX_LESSONS}-lesson cap): {', '.join(report.skipped)}")
+# --------------------------------------------------------------------------- #
+# Relationship review surface (issue #511, U7). Thin adapter over the single
+# MemoryRelationshipService — list proposals, inspect endpoints + provenance,
+# promote/reject. No SQL here (FR-2.1). Content-free output (NFR-1.7).
+# --------------------------------------------------------------------------- #
+
+
+def _relationship_service():
+    from cli_agent_orchestrator.services.memory_relationship_service import (
+        MemoryRelationshipService,
+    )
+
+    return MemoryRelationshipService()
+
+
+def _resolve_cli_scope_id(svc, scope: str):
+    """Resolve scope_id from the current terminal context (matches other memory
+    commands). Returns None for global/federated."""
+    terminal_context = {"cwd": os.path.realpath(os.getcwd())}
+    try:
+        return svc.resolve_scope_id(scope, terminal_context=terminal_context)
+    except Exception:
+        return None
+
+
+@memory.group(name="relationships")
+def relationships():
+    """Inspect and curate typed memory relationships (issue #511)."""
+
+
+@relationships.command(name="list")
+@click.option("--scope", default="global", help="Scope (default: global).")
+@click.option("--scope-id", default=None, help="Explicit scope_id (else resolved from cwd).")
+@click.option("--source-key", default=None, help="Filter to one source memory key.")
+@click.option(
+    "--status", "status_filter", default=None, help="Filter by status (default: active only)."
+)
+@click.option("--stale", is_flag=True, default=False, help="Only stale edges.")
+@click.option("--format", "out_format", type=click.Choice(["table", "json"]), default="table")
+def relationships_list(scope, scope_id, source_key, status_filter, stale, out_format):
+    """List relationships (default: active). Use --status proposal to review the
+    proposal queue."""
+    import json as _json
+
+    msvc = _get_memory_service()
+    sid = scope_id if scope_id is not None else _resolve_cli_scope_id(msvc, scope)
+    rsvc = _relationship_service()
+    dtos = rsvc.list_relationships(
+        scope,
+        sid,
+        source_key,
+        status=status_filter,
+        stale_only=stale,
+        include_non_active=status_filter is not None,
+    )
+    if out_format == "json":
+        click.echo(_json.dumps([d.to_dict() for d in dtos], indent=2))
+        return
+    if not dtos:
+        click.echo("No relationships found.")
+        return
+    click.echo(f"{'ID':36}  {'TYPE':13}  {'ORIGIN':18}  {'STATUS':9}  STALE  SOURCE -> TARGET")
+    for d in dtos:
+        click.echo(
+            f"{d.id:36}  {d.type:13}  {d.origin:18}  {d.status:9}  "
+            f"{'yes' if d.stale else 'no':5}  {d.source_key} -> {d.target_key}"
+        )
+
+
+@relationships.command(name="inspect")
+@click.argument("relationship_id")
+@click.option("--format", "out_format", type=click.Choice(["table", "json"]), default="table")
+def relationships_inspect(relationship_id, out_format):
+    """Show one relationship's endpoints, provenance, status, and timestamps."""
+    import json as _json
+
+    rsvc = _relationship_service()
+    dto = rsvc.get(relationship_id)
+    if dto is None:
+        raise click.ClickException(f"relationship not found: {relationship_id}")
+    if out_format == "json":
+        click.echo(_json.dumps(dto.to_dict(), indent=2))
+        return
+    for k, v in dto.to_dict().items():
+        click.echo(f"{k:18}: {v}")
+
+
+@relationships.command(name="promote")
+@click.argument("relationship_id")
+def relationships_promote(relationship_id):
+    """Promote a proposal to active."""
+    rsvc = _relationship_service()
+    try:
+        dto = rsvc.promote(relationship_id)
+    except ValueError as e:
+        raise click.ClickException(str(e))
+    click.echo(f"{dto.id}: status -> {dto.status}")
+
+
+@relationships.command(name="reject")
+@click.argument("relationship_id")
+def relationships_reject(relationship_id):
+    """Reject a proposal."""
+    rsvc = _relationship_service()
+    try:
+        dto = rsvc.reject(relationship_id)
+    except ValueError as e:
+        raise click.ClickException(str(e))
+    click.echo(f"{dto.id}: status -> {dto.status}")

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     DateTime,
+    Float,
     Integer,
     String,
     Text,
@@ -110,6 +111,95 @@ class MemoryMetadataModel(Base):
     )
 
 
+# Relationship-store sentinel: ``memory_relationships.scope_id`` is NOT NULL and
+# stores this value for global/federated scope. SQLite treats ``NULL != NULL``
+# in a UNIQUE index, so a nullable scope_id would make the dedup index (and thus
+# ``INSERT ... ON CONFLICT``) inert for global scope — silently duplicating
+# exactly the edges hardest to notice. Storing a NOT-NULL sentinel keeps the
+# dedup tuple total. ``""`` cannot collide with a real sanitized scope_id
+# (``MemoryService._sanitize_key``/``_sanitize_scope_id`` never yield empty —
+# the latter returns ``"unknown"``). This sentinel is scoped to the
+# ``memory_relationships`` table ONLY; ``MemoryMetadataModel.scope_id`` remains
+# genuinely nullable (stores real NULL for global), so cross-table endpoint
+# checks against it use logical ``None`` + ``.is_(None)`` (see the relationship
+# service), never this sentinel.
+RELATIONSHIP_SCOPE_ID_SENTINEL = ""
+
+
+class MemoryRelationshipModel(Base):
+    """SQLAlchemy model for a typed, durable memory relationship edge (issue #511).
+
+    The authoritative relationship store that replaces the lossy
+    ``memory_metadata.related_keys`` text column. One row per typed edge between
+    two memory keys in the same ``(scope, scope_id)``. Written and read ONLY
+    through ``MemoryRelationshipService`` — no other component issues SQL against
+    this table (FR-2.1 single-boundary invariant).
+
+    ``related_keys`` on ``MemoryMetadataModel`` is retained UNCHANGED as the
+    compiler's computation-state marker (NULL = never computed/error, ``""`` =
+    computed-empty) and is NOT modified or retired by this table (retirement is a
+    separate, later change gated on a loss-free proof).
+    """
+
+    __tablename__ = "memory_relationships"
+
+    # Application-generated uuid4 string PK, matching ``MemoryMetadataModel.id``
+    # (str(uuid4())). API-stable identifier exposed in mutation responses.
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    scope = Column(String, nullable=False)
+    # NOT NULL: sentinel RELATIONSHIP_SCOPE_ID_SENTINEL ("") for global/federated
+    # so the dedup UNIQUE index is total (see the sentinel comment above).
+    scope_id = Column(String, nullable=False)
+    source_key = Column(String, nullable=False)
+    target_key = Column(String, nullable=False)
+    # Closed taxonomy reusing the graph EdgeType values.
+    type = Column(String, nullable=False)  # relates_to | contradiction | supersedes
+    # compiler | wiki_lint | human | legacy_related_keys | external_import(reserved)
+    origin = Column(String, nullable=False)
+    # active | proposal | rejected | superseded | deleted (auditable soft-delete)
+    status = Column(String, nullable=False, default="active")
+    # Optional evidence metadata. NULL = no evidence (NEVER fabricated / coerced
+    # to 0); a stored value is a validated REAL in [0, 1].
+    confidence = Column(Float, nullable=True, default=None)
+    # Optional ordering hint (e.g. legacy related_keys position). NULL if none.
+    rank = Column(Integer, nullable=True, default=None)
+    # Bounded JSON blob. NULL if none; the CHECK caps FRESH DBs, the service
+    # caps existing DBs (mirrors the ck_related_keys_length precedent).
+    attributes_json = Column(Text, nullable=True, default=None)
+    # The source memory's updated_at at write time; basis for staleness
+    # detection (an edge is stale when this predates the source's current
+    # updated_at). NULL when unknown.
+    source_updated_at = Column(DateTime(timezone=True), nullable=True, default=None)
+    created_at = Column(DateTime(timezone=True), default=_utcnow)
+    updated_at = Column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
+
+    __table_args__ = (
+        # Dedup: differing type or origin coexist as distinct rows (multi-edge +
+        # provenance-aware coexistence); a repeat of the same tuple upserts.
+        # Every column is non-NULL (scope_id sentinel), so the index and
+        # ON CONFLICT fire for ALL scopes including global.
+        UniqueConstraint(
+            "scope",
+            "scope_id",
+            "source_key",
+            "target_key",
+            "type",
+            "origin",
+            name="uq_memory_rel",
+        ),
+        # FRESH-DB CHECKs only (SQLite cannot retro-add a CHECK); the service
+        # validates confidence range and attributes size on existing DBs.
+        CheckConstraint(
+            "confidence IS NULL OR (confidence >= 0 AND confidence <= 1)",
+            name="ck_memory_rel_confidence_range",
+        ),
+        CheckConstraint(
+            "attributes_json IS NULL OR length(attributes_json) <= 2048",
+            name="ck_memory_rel_attributes_size",
+        ),
+    )
+
+
 class ProjectAliasModel(Base):
     """SQLAlchemy model for project identity aliases (Phase 2.5 U6).
 
@@ -205,6 +295,10 @@ def init_db() -> None:
     _migrate_workflow_run()
     _migrate_workflow_run_step()
     _migrate_workflow_outcome_indexes()
+    # Appended LAST (issue #511). Disjoint from the workflow_run* tables that
+    # #504 also migrates, so registry order is immaterial — never reorder the
+    # entries above.
+    _migrate_memory_relationships()
 
 
 def _restrict_db_file_permissions() -> None:
@@ -358,6 +452,176 @@ def _migrate_add_related_keys() -> None:
                 logger.info("Migration: added related_keys column to memory_metadata")
     except Exception as e:
         logger.debug(f"Migration check for related_keys failed: {e}")
+
+
+def _migrate_memory_relationships() -> None:
+    """Create the ``memory_relationships`` table + indexes and backfill legacy
+    links (issue #511). Appended LAST to the ``init_db()`` registry.
+
+    Idempotent, zero-arg, self-connecting — mirrors the existing migrators.
+    Failure is logged at debug and never propagated (a missing table is
+    recoverable; the service degrades). ``CREATE TABLE IF NOT EXISTS`` covers
+    existing DBs where ``Base.metadata.create_all`` (which builds the model with
+    its CHECK constraints on fresh DBs) has already run or will run — the same
+    fresh-vs-existing split the codebase uses for ``related_keys``.
+
+    Disjoint from the ``workflow_run*`` tables (#504); registry order is
+    immaterial.
+    """
+    import sqlite3
+
+    from cli_agent_orchestrator.constants import DATABASE_FILE
+
+    try:
+        with sqlite3.connect(str(DATABASE_FILE)) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS memory_relationships ("
+                "id TEXT PRIMARY KEY, "
+                "scope TEXT NOT NULL, "
+                "scope_id TEXT NOT NULL, "
+                "source_key TEXT NOT NULL, "
+                "target_key TEXT NOT NULL, "
+                "type TEXT NOT NULL, "
+                "origin TEXT NOT NULL, "
+                "status TEXT NOT NULL DEFAULT 'active', "
+                "confidence REAL, "
+                "rank INTEGER, "
+                "attributes_json TEXT, "
+                "source_updated_at DATETIME, "
+                "created_at DATETIME, "
+                "updated_at DATETIME"
+                ")"
+            )
+            # Dedup UNIQUE index — total because scope_id is NOT NULL (sentinel),
+            # so ON CONFLICT fires for all scopes including global.
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_rel ON memory_relationships "
+                "(scope, scope_id, source_key, target_key, type, origin)"
+            )
+            # Lookup index for the common (scope, scope_id, source_key) read path.
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memory_rel_lookup ON memory_relationships "
+                "(scope, scope_id, source_key)"
+            )
+            conn.commit()
+            _backfill_legacy_related_keys(conn)
+    except Exception as e:
+        logger.debug(f"memory_relationships migration skipped: {e}")
+
+
+def _backfill_legacy_related_keys(conn: Any) -> None:
+    """One-time, idempotent backfill of ``memory_metadata.related_keys`` into
+    ``memory_relationships`` as ``type=relates_to, origin=legacy_related_keys,
+    status=active, confidence=NULL`` rows (issue #511, FR-1.4/FR-1.5).
+
+    - Gated per source memory: if any ``legacy_related_keys`` row already exists
+      for that ``(scope, scope_id, source_key)``, the source is skipped, so
+      re-running ``init_db()`` is a no-op (idempotent).
+    - ``related_keys IS NULL`` or ``""`` yields zero rows (never-computed /
+      computed-empty carry no edge). The NULL-vs-"" marker stays on
+      ``related_keys`` UNCHANGED — this backfill only READS it (ADR-4).
+    - ``confidence`` is always NULL (never fabricated — NFR-2.1). Order is
+      preserved as ``rank``.
+    - A target that no longer resolves to an in-scope memory, a self-link, or a
+      key that fails the sanitiser is REPORTED (logged) and NOT written active
+      (FR-1.5) — never silently activated.
+    - ``scope_id`` is normalised to the sentinel ``""`` for global/federated so
+      the dedup index is total.
+
+    Best-effort: any failure is logged at debug and never propagated (the
+    service can compute relationships later; a partial backfill is safe because
+    the per-source gate resumes cleanly).
+    """
+    # Lazy import to avoid a circular import (memory_service imports database).
+    try:
+        from cli_agent_orchestrator.services.memory_service import MemoryService
+    except Exception as e:  # pragma: no cover - import guard
+        logger.debug(f"backfill skipped (memory_service import): {e}")
+        return
+
+    now_iso = _utcnow().isoformat()
+    reported: list[str] = []
+    try:
+        rows = conn.execute(
+            "SELECT key, scope, scope_id, related_keys, updated_at "
+            "FROM memory_metadata "
+            "WHERE related_keys IS NOT NULL AND related_keys != ''"
+        ).fetchall()
+    except Exception as e:
+        logger.debug(f"backfill skipped (memory_metadata read): {e}")
+        return
+
+    for key, scope, scope_id, related_keys, src_updated_at in rows:
+        sentinel = scope_id if scope_id is not None else RELATIONSHIP_SCOPE_ID_SENTINEL
+        # Per-source idempotency gate (exact = on the sentinel, never IS NULL).
+        existing = conn.execute(
+            "SELECT 1 FROM memory_relationships "
+            "WHERE source_key = ? AND scope = ? AND scope_id = ? "
+            "AND origin = 'legacy_related_keys' LIMIT 1",
+            (key, scope, sentinel),
+        ).fetchone()
+        if existing is not None:
+            continue
+
+        targets = MemoryService._parse_related_keys(related_keys, scope)
+        # Resolve which target keys actually exist in the SAME (scope, scope_id).
+        for rank, target in enumerate(targets):
+            if target == key:
+                reported.append(f"{scope}/{scope_id}/{key}->{target}: self-link")
+                continue
+            # Endpoint existence against memory_metadata: scope_id is genuinely
+            # nullable there (real NULL for global), so match logical NULL, NOT
+            # the sentinel.
+            if scope_id is None:
+                found = conn.execute(
+                    "SELECT 1 FROM memory_metadata "
+                    "WHERE key = ? AND scope = ? AND scope_id IS NULL LIMIT 1",
+                    (target, scope),
+                ).fetchone()
+            else:
+                found = conn.execute(
+                    "SELECT 1 FROM memory_metadata "
+                    "WHERE key = ? AND scope = ? AND scope_id = ? LIMIT 1",
+                    (target, scope, scope_id),
+                ).fetchone()
+            if found is None:
+                reported.append(f"{scope}/{scope_id}/{key}->{target}: dangling")
+                continue
+            try:
+                conn.execute(
+                    "INSERT INTO memory_relationships "
+                    "(id, scope, scope_id, source_key, target_key, type, origin, "
+                    "status, confidence, rank, attributes_json, source_updated_at, "
+                    "created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, 'relates_to', 'legacy_related_keys', "
+                    "'active', NULL, ?, NULL, ?, ?, ?) "
+                    "ON CONFLICT (scope, scope_id, source_key, target_key, type, origin) "
+                    "DO NOTHING",
+                    (
+                        str(uuid.uuid4()),
+                        scope,
+                        sentinel,
+                        key,
+                        target,
+                        rank,
+                        src_updated_at,
+                        now_iso,
+                        now_iso,
+                    ),
+                )
+            except Exception as e:
+                logger.debug(f"backfill insert skipped for {key}->{target}: {e}")
+    try:
+        conn.commit()
+    except Exception:  # pragma: no cover
+        pass
+    if reported:
+        logger.warning(
+            "memory_relationships backfill reported %d stale/malformed legacy "
+            "links (NOT activated): %s",
+            len(reported),
+            "; ".join(reported[:20]),
+        )
 
 
 def _migrate_workflow_index() -> None:

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -494,6 +494,21 @@ def _migrate_memory_relationships() -> None:
             )
             # Dedup UNIQUE index — total because scope_id is NOT NULL (sentinel),
             # so ON CONFLICT fires for all scopes including global.
+            #
+            # ACCEPTED REDUNDANCY on a FRESH db (human review, PR #524): there,
+            # create_all() has already satisfied the model's UniqueConstraint via
+            # an unnamed sqlite_autoindex, so this statement adds a SECOND index
+            # over identical columns (the name matches the constraint, but SQLite
+            # does not treat a table-level UNIQUE as a named index, so
+            # IF NOT EXISTS does not suppress it). Kept deliberately: this
+            # migrator must remain zero-arg and idempotent for EXISTING dbs,
+            # where CREATE TABLE IF NOT EXISTS is a no-op and this is the ONLY
+            # thing that establishes the dedup index that replace_set/create rely
+            # on. Making it fresh-db-aware would mean probing pragma index_list
+            # and branching — more moving parts in a path whose failure mode is
+            # silent duplicate edges. The cost is one extra index on new
+            # installs: some write amplification and disk, no correctness or
+            # query-plan impact.
             conn.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_rel ON memory_relationships "
                 "(scope, scope_id, source_key, target_key, type, origin)"

--- a/src/cli_agent_orchestrator/graph/providers/memory.py
+++ b/src/cli_agent_orchestrator/graph/providers/memory.py
@@ -124,22 +124,46 @@ class MemoryGraphProvider(GraphProvider):
         nodes: dict[str, Node] = {key: Node(id=key, kind="topic", label=key) for key in keys}
         edges: list[Edge] = []
 
-        # related_keys edges (FR-7a). related_keys carries no relevance
-        # score, so edge attrs stay score-free. A target outside this
-        # scope's key set is dropped — never a cross-scope edge (FR-9).
-        related_raw = self._svc._related_keys_lookup(keys, scope, scope_id)
-        for key in keys:
-            for target in MemoryService._parse_related_keys(related_raw.get(key), scope):
-                if target not in nodes or target == key:
-                    continue
-                edges.append(
-                    Edge(
-                        source=key,
-                        target=target,
-                        type=EdgeType.RELATES_TO,
-                        attrs={"source": "related_keys"},
-                    )
+        # Typed relationship edges from the STORE (issue #511, FR-4.3). The
+        # provider projects ACTIVE relationships (relates_to + contradiction +
+        # supersedes) read through the single service — NOT from related_keys and
+        # NOT from projection-time lint. Edge attrs carry provenance (the row's
+        # origin) and NO invented score/relevance. A target outside this scope's
+        # node set is dropped (never a cross-scope edge, FR-9). Multiple edge
+        # types between one pair remain distinct Edges (FR-4.4).
+        _TYPE_MAP = {
+            "relates_to": EdgeType.RELATES_TO,
+            "contradiction": EdgeType.CONTRADICTION,
+            "supersedes": EdgeType.SUPERSEDES,
+        }
+        try:
+            from cli_agent_orchestrator.services.memory_relationship_service import (
+                MemoryRelationshipService,
+            )
+
+            active = MemoryRelationshipService().list_relationships(
+                scope, scope_id, status="active"
+            )
+        except Exception as e:  # degrade to a relationship-free graph, never 500
+            logger.warning("memory graph provider: relationship read failed: %r", e)
+            meta["relationship_error"] = type(e).__name__
+            active = []
+        for rel in active:
+            edge_type = _TYPE_MAP.get(rel.type)
+            if edge_type is None:
+                continue
+            if rel.source_key not in nodes or rel.target_key not in nodes:
+                continue
+            if rel.source_key == rel.target_key:
+                continue
+            edges.append(
+                Edge(
+                    source=rel.source_key,
+                    target=rel.target_key,
+                    type=edge_type,
+                    attrs={"source": rel.origin},
                 )
+            )
 
         issues = []
         if lint_enabled:
@@ -177,19 +201,11 @@ class MemoryGraphProvider(GraphProvider):
                 node = nodes.get(issue.key)
                 if node is not None:
                     node.attrs["is_hub"] = True
-            elif issue.issue_type == "contradiction":
-                if issue.scope_id != scope_id or issue.related_key is None:
-                    continue
-                if issue.key not in nodes or issue.related_key not in nodes:
-                    continue
-                edges.append(
-                    Edge(
-                        source=issue.key,
-                        target=issue.related_key,
-                        type=EdgeType.CONTRADICTION,
-                        attrs={"source": "wiki_lint", "summary": issue.description},
-                    )
-                )
+            # contradiction: NO LONGER projected from live lint here (issue #511).
+            # Contradiction edges now come from the durable store above (persisted
+            # by the wiki_lint producer with origin=wiki_lint), so projecting them
+            # again from the in-request lint run would double-source them. Lint
+            # still runs for the orphan_page/graph_density NODE attrs above.
             # stale_claim / poison_frequency / lint_error → dropped (ADR-2).
 
         return GraphView(nodes=list(nodes.values()), edges=edges, meta=meta)

--- a/src/cli_agent_orchestrator/graph/providers/memory.py
+++ b/src/cli_agent_orchestrator/graph/providers/memory.py
@@ -141,8 +141,19 @@ class MemoryGraphProvider(GraphProvider):
                 MemoryRelationshipService,
             )
 
+            # Bound the query to THIS projection's node set. Without
+            # source_keys the read loads every active relationship in the
+            # (scope, scope_id) and discards the out-of-set rows in Python,
+            # where the pre-#511 related_keys read was naturally bounded to
+            # the current keys.
+            #
+            # This bounds the SOURCE side only. The both-endpoints check below
+            # is still required and must NOT be removed: a source inside the
+            # node set may legitimately point at a target outside it, and
+            # dropping that edge is what enforces FR-9 (never a cross-scope
+            # edge) and keeps GraphView's endpoint validation satisfied.
             active = MemoryRelationshipService().list_relationships(
-                scope, scope_id, status="active"
+                scope, scope_id, status="active", source_keys=keys
             )
         except Exception as e:  # degrade to a relationship-free graph, never 500
             logger.warning("memory graph provider: relationship read failed: %r", e)

--- a/src/cli_agent_orchestrator/graph/providers/memory.py
+++ b/src/cli_agent_orchestrator/graph/providers/memory.py
@@ -136,6 +136,30 @@ class MemoryGraphProvider(GraphProvider):
             "contradiction": EdgeType.CONTRADICTION,
             "supersedes": EdgeType.SUPERSEDES,
         }
+
+        issues = []
+        if lint_enabled:
+            # Lint findings may run expensive detectors. A failure degrades to
+            # a lint-free graph rather than a 500.
+            try:
+                # project_hash arg is only used for run_lint's audit log, not
+                # lookup — `project()` has no cwd/terminal_context to resolve
+                # the real project id (resolve_project_id), so this is a
+                # placeholder.
+                issues = await wiki_lint.run_lint(scope_id or scope, scope=scope)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("memory graph provider: run_lint failed: %r", e, exc_info=True)
+                meta["lint_error"] = type(e).__name__
+
+        # ORDERING (human review, PR #524): the relationship read MUST come after
+        # run_lint. run_lint persists its contradiction findings into this same
+        # store (wiki_lint._persist_contradictions), so reading first meant a
+        # contradiction detected during THIS projection was absent from the graph
+        # it produced — invisible for a full cache window, and reappearing later
+        # with no apparent cause. Reading after makes the projection reflect the
+        # lint run it just performed.
         try:
             from cli_agent_orchestrator.services.memory_relationship_service import (
                 MemoryRelationshipService,
@@ -175,22 +199,6 @@ class MemoryGraphProvider(GraphProvider):
                     attrs={"source": rel.origin},
                 )
             )
-
-        issues = []
-        if lint_enabled:
-            # Lint findings may run expensive detectors. A failure degrades to
-            # a lint-free graph rather than a 500.
-            try:
-                # project_hash arg is only used for run_lint's audit log, not
-                # lookup — `project()` has no cwd/terminal_context to resolve
-                # the real project id (resolve_project_id), so this is a
-                # placeholder.
-                issues = await wiki_lint.run_lint(scope_id or scope, scope=scope)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.warning("memory graph provider: run_lint failed: %r", e, exc_info=True)
-                meta["lint_error"] = type(e).__name__
 
         for issue in issues:
             if issue.issue_type == "orphan_page":

--- a/src/cli_agent_orchestrator/services/audit_log.py
+++ b/src/cli_agent_orchestrator/services/audit_log.py
@@ -90,6 +90,12 @@ NOWAIT_AUDIT_EVENTS: frozenset = frozenset(
         # the CLI/apply path after the profile write completes; content-free
         # (profile name + lesson keys only).
         "instruction_promotion",
+        # Typed memory relationship store (issue #511). NOWAIT: emitted by the
+        # synchronous MemoryRelationshipService on the same write path memory
+        # events use. Content-free (endpoints/type/origin/status only, never a
+        # memory body/prompt — NFR-1.7). MUST be whitelisted or the event is
+        # silently dropped and the content-free-audit test passes vacuously.
+        "relationship_mutation",
     }
 )
 AUDIT_EVENT_WHITELIST: frozenset = SYNC_AUDIT_EVENTS | NOWAIT_AUDIT_EVENTS

--- a/src/cli_agent_orchestrator/services/memory_relationship_service.py
+++ b/src/cli_agent_orchestrator/services/memory_relationship_service.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy.exc import IntegrityError
+
 from cli_agent_orchestrator.clients.database import (
     RELATIONSHIP_SCOPE_ID_SENTINEL,
     MemoryMetadataModel,
@@ -44,6 +46,12 @@ logger = logging.getLogger(__name__)
 # Closed taxonomies (reuse the graph EdgeType string values, ADR-5).
 VALID_TYPES = frozenset({"relates_to", "contradiction", "supersedes"})
 VALID_STATUSES = frozenset({"active", "proposal", "rejected", "superseded", "deleted"})
+# Statuses an OPERATOR reached through an explicit command (`relationships
+# reject` / `relationships delete`). A producer recompute must never overwrite
+# one: re-creation is the documented way back, exactly as ``promote()`` refuses
+# these two. ``superseded`` is excluded on purpose — it is lifecycle-derived, not
+# operator-authored.
+CURATION_TERMINAL_STATUSES = frozenset({"rejected", "deleted"})
 VALID_ORIGINS = frozenset(
     {"compiler", "wiki_lint", "human", "legacy_related_keys", "external_import"}
 )
@@ -51,11 +59,6 @@ VALID_ORIGINS = frozenset(
 # Bounds (NFR-1.6). Final numeric values.
 MAX_EDGES_PER_MUTATION = 64
 MAX_ATTRIBUTES_BYTES = 2048
-
-# Types that recall one-level expansion follows (FR-4.2). contradiction is
-# symmetric evidence (not a traversal edge); supersedes affects ranking, not
-# expansion.
-RECALL_EDGE_TYPES = frozenset({"relates_to"})
 
 # The content-free audit event for relationship mutations (NFR-1.7). MUST be
 # registered in NOWAIT_AUDIT_EVENTS or audit_log drops it silently.
@@ -116,6 +119,11 @@ class ReplaceReport:
     kept: int = 0
     removed: int = 0
     rejected: List[Dict[str, str]] = field(default_factory=list)
+    # Rows left untouched because they carry a curation-terminal status (an
+    # operator's reject/delete verdict). Reported so a producer recompute that
+    # declines to overwrite a human decision is VISIBLE rather than silent —
+    # content-free, like every other field here: target key + status only.
+    preserved: List[Dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -371,18 +379,7 @@ class MemoryRelationshipService:
         with SessionLocal() as db:
             self._assert_endpoint_exists(db, scope, scope_id, src)
             self._assert_endpoint_exists(db, scope, scope_id, tgt)
-            existing = (
-                db.query(MemoryRelationshipModel)
-                .filter(
-                    MemoryRelationshipModel.scope == scope,
-                    MemoryRelationshipModel.scope_id == sentinel,
-                    MemoryRelationshipModel.source_key == src,
-                    MemoryRelationshipModel.target_key == tgt,
-                    MemoryRelationshipModel.type == type,
-                    MemoryRelationshipModel.origin == origin,
-                )
-                .first()
-            )
+            existing = self._find_existing(db, scope, sentinel, src, tgt, type, origin)
             if existing is not None:
                 existing.status = status
                 existing.confidence = conf
@@ -410,10 +407,66 @@ class MemoryRelationshipService:
                 source_updated_at=source_updated_at,
             )
             db.add(row)
-            db.commit()
+            # The existence check above is a read-then-insert with no
+            # transactional protection, so two concurrent creates of the same
+            # dedup tuple both miss and both insert. The loser hit the UNIQUE
+            # index and raised IntegrityError — NOT a ValueError — so it escaped
+            # every REST handler's ValueError->400 mapping as an unhandled 500
+            # (human review, PR #524).
+            #
+            # The dedup index makes the winning row indistinguishable from the
+            # one this call intended to write, so converge on it instead of
+            # failing: that matches create()'s documented upsert contract, where
+            # a same-tuple create returns the existing row. Any OTHER
+            # IntegrityError (a genuine constraint violation) is re-raised as a
+            # ValueError so the boundary policy stays uniform — the service
+            # raises ValueError for caller-fixable input, and the API maps it.
+            try:
+                db.commit()
+            except IntegrityError:
+                db.rollback()
+                winner = self._find_existing(db, scope, sentinel, src, tgt, type, origin)
+                if winner is None:
+                    raise ValueError(
+                        "relationship create conflicted and the conflicting row "
+                        "could not be resolved"
+                    )
+                self._audit("create", winner)
+                return self._to_dto(winner)
             db.refresh(row)
             self._audit("create", row)
             return self._to_dto(row)
+
+    def _find_existing(
+        self,
+        db: Any,
+        scope: str,
+        sentinel: str,
+        src: str,
+        tgt: str,
+        type_: str,
+        origin: str,
+    ) -> Any:
+        """Resolve the row matching ``create()``'s dedup tuple, or None.
+
+        Extracted as the named seam ``create()`` uses to choose upsert-vs-insert,
+        and reused to re-resolve the winner after an ``IntegrityError``. Having
+        one named probe (rather than two inline copies of the same filter) is
+        what lets the concurrency test blind exactly this step and drive the
+        real conflict path.
+        """
+        return (
+            db.query(MemoryRelationshipModel)
+            .filter(
+                MemoryRelationshipModel.scope == scope,
+                MemoryRelationshipModel.scope_id == sentinel,
+                MemoryRelationshipModel.source_key == src,
+                MemoryRelationshipModel.target_key == tgt,
+                MemoryRelationshipModel.type == type_,
+                MemoryRelationshipModel.origin == origin,
+            )
+            .first()
+        )
 
     def replace_set(
         self,
@@ -432,6 +485,13 @@ class MemoryRelationshipService:
         upserted. Rows of ANY OTHER origin or type — human, wiki_lint, legacy,
         supersedes, contradiction — are structurally outside the WHERE clause and
         are never touched. Producers MUST pass their FULL current set.
+
+        Within this producer's own rows, a CURATION-TERMINAL status
+        (``rejected``/``deleted`` — see ``CURATION_TERMINAL_STATUSES``) is
+        preserved on BOTH branches: such a row is neither reactivated when the
+        producer still reports the target nor deleted when it drops it. Each is
+        listed in ``report.preserved`` so the refusal is observable. Without
+        this, a recompile silently undid an operator's ``relationships reject``.
         """
         self._validate_type(type)
         self._validate_origin(origin)
@@ -487,20 +547,53 @@ class MemoryRelationshipService:
             new_targets = set(valid.keys())
 
             # Delete this producer's rows whose target is not in the new set.
+            # A curation-terminal row is RETAINED even when the producer drops
+            # the target: deleting it would discard the operator's verdict just
+            # as surely as reactivating it, and would let the next recompute
+            # re-add the edge as a fresh "active" row with the rejection gone.
             for tgt, r in existing_by_target.items():
                 if tgt not in new_targets:
+                    if r.status in CURATION_TERMINAL_STATUSES:
+                        report.preserved.append({"target": tgt, "status": r.status})
+                        continue
                     db.delete(r)
                     report.removed += 1
 
             now = _utcnow()
+            # Stamp the source memory's updated_at on every row this producer
+            # writes. Without a writer the ``stale`` flag was INERT — it is
+            # derived from ``source_updated_at``, which no production caller ever
+            # set, so the DTO field, the CLI's --stale and the REST ?stale=true
+            # could only ever report False (human review, PR #524). One batched
+            # lookup for the whole set; None when the source has no updated_at,
+            # which simply leaves staleness unknown as before.
+            src_updated = self._source_updated_map(db, scope, scope_id, {src}).get(src)
             for tgt, edge in valid.items():
                 r = existing_by_target.get(tgt)
                 attrs_json = self._validate_attributes(edge.attributes)
                 if r is not None:
+                    # A CURATION-TERMINAL status is a human decision and must
+                    # survive a producer recompute. Forcing "active" here let a
+                    # recompile silently resurrect an edge an operator had
+                    # explicitly rejected via `cao memory relationships reject`,
+                    # with nothing in the report to show it happened — which
+                    # defeats the curation surface this store ships.
+                    #
+                    # The set mirrors ``promote()``'s refusal list: rejected and
+                    # deleted are operator verdicts reached through an explicit
+                    # command, and re-creation (not recompute) is the documented
+                    # way back. ``superseded`` is deliberately NOT terminal here:
+                    # it is lifecycle-DERIVED rather than operator-authored, so a
+                    # producer that still reports the edge is legitimate evidence
+                    # the supersession no longer holds.
+                    if r.status in CURATION_TERMINAL_STATUSES:
+                        report.preserved.append({"target": tgt, "status": r.status})
+                        continue
                     r.confidence = self._validate_confidence(edge.confidence)
                     r.rank = edge.rank
                     r.attributes_json = attrs_json
                     r.status = "active"
+                    r.source_updated_at = src_updated
                     r.updated_at = now
                     report.kept += 1
                 else:
@@ -517,7 +610,7 @@ class MemoryRelationshipService:
                             confidence=self._validate_confidence(edge.confidence),
                             rank=edge.rank,
                             attributes_json=attrs_json,
-                            source_updated_at=None,
+                            source_updated_at=src_updated,
                         )
                     )
                     report.added += 1
@@ -557,6 +650,28 @@ class MemoryRelationshipService:
             )
         except Exception as e:  # pragma: no cover - audit must never break a write
             logger.debug(f"replace_set audit emit failed: {e}")
+
+    def _audit_purge(self, scope: str, sentinel: str, key: str, removed: int) -> None:
+        """Content-free audit for a forget()-driven purge.
+
+        Reuses ``AUDIT_EVENT`` (``relationship_mutation``), which is already in
+        audit_log's closed NOWAIT whitelist — a fresh event type would be dropped
+        silently.
+        """
+        try:
+            from cli_agent_orchestrator.services.audit_log import write_audit_nowait
+
+            write_audit_nowait(
+                AUDIT_EVENT,
+                "relationship purge (memory forgotten)",
+                action="purge_for_key",
+                scope=scope,
+                scope_id=str(sentinel),
+                source_key=key,
+                removed=str(removed),
+            )
+        except Exception as e:  # pragma: no cover - audit must never break a write
+            logger.debug(f"purge audit emit failed: {e}")
 
     def _get_row(self, db: Any, id: str) -> Any:
         row = db.query(MemoryRelationshipModel).filter(MemoryRelationshipModel.id == id).first()
@@ -629,6 +744,52 @@ class MemoryRelationshipService:
             db.refresh(row)
             self._audit("soft_delete", row)
             return self._to_dto(row)
+
+    def purge_for_key(self, scope: str, scope_id: Optional[str], key: str) -> int:
+        """HARD-delete every row touching ``key`` in either direction.
+
+        Called when the underlying memory is FORGOTTEN (human review, PR #524).
+        ``forget()`` removes the wiki file, the index entry and the
+        memory_metadata row, but used to leave these rows behind still ``active``
+        — so a later memory created with the SAME slug silently inherited the
+        dead memory's edges, and every read path had to tolerate endpoints that
+        no longer resolve.
+
+        This is a HARD delete, not the ``soft_delete`` status transition: a
+        soft-deleted row is a curation record ABOUT a live memory, whereas here
+        the endpoint itself is gone and the row can never become meaningful
+        again. Retaining it is what causes the slug-reuse inheritance bug.
+        Deliberately status-agnostic for the same reason — a rejected or
+        proposal row pointing at a deleted memory is equally meaningless.
+
+        Returns the number of rows removed; content-free audit on a non-zero
+        purge. Both directions are covered: an edge INTO the forgotten key is
+        just as dangling as one out of it.
+        """
+        from sqlalchemy import or_
+
+        k = self._sanitize_key(key)
+        sentinel = self._to_sentinel(scope_id)
+        with SessionLocal() as db:
+            rows = (
+                db.query(MemoryRelationshipModel)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    or_(
+                        MemoryRelationshipModel.source_key == k,
+                        MemoryRelationshipModel.target_key == k,
+                    ),
+                )
+                .all()
+            )
+            if not rows:
+                return 0
+            for r in rows:
+                db.delete(r)
+            db.commit()
+        self._audit_purge(scope, sentinel, k, len(rows))
+        return len(rows)
 
     # ------------------------------------------------------------------ #
     # read operations
@@ -849,7 +1010,15 @@ class MemoryRelationshipService:
     ) -> List[RelationshipDTO]:
         """Active contradictions touching ``key`` from EITHER endpoint (FR-4.5
         symmetric visibility, reconstructed at QUERY time — the store holds one
-        directed row, never a reciprocal duplicate)."""
+        directed row, never a reciprocal duplicate).
+
+        NO PRODUCTION CALLER YET (human review, PR #524). Retained rather than
+        deleted because it is the only implementation of FR-4.5's symmetric read
+        and is covered by tests: the graph provider projects each directed row
+        as-is, so the "contradictions touching this key" question has no other
+        answer in the codebase. Kept as the intended entry point for the
+        contradiction-review surface; delete it if that surface is dropped rather
+        than letting a second copy of this query appear elsewhere."""
         from sqlalchemy import or_
 
         sentinel = self._to_sentinel(scope_id)

--- a/src/cli_agent_orchestrator/services/memory_relationship_service.py
+++ b/src/cli_agent_orchestrator/services/memory_relationship_service.py
@@ -1,0 +1,749 @@
+"""Memory relationship service — the single authoritative boundary for the
+``memory_relationships`` table (issue #511).
+
+Every surface (compiler, wiki lint, REST API, CLI, MemoryGraphProvider, recall,
+See Also, future importers) reads and writes relationships THROUGH this service;
+no other component issues SQL against the table (FR-2.1 single-boundary
+invariant). The service owns endpoint resolution + scope checks, type/status
+validation, create/upsert, producer-scoped replacement, dedup, stale detection,
+transactional writes, and read projections.
+
+Design principles held:
+- Absence is not deletion (principle 6): ``replace_set`` replaces only the
+  ``(scope, scope_id, source_key, origin, type)`` tuple's rows, never another
+  producer's or another type's.
+- Confidence is evidence, not invented certainty (principle 7): legacy links and
+  unscored producers store ``confidence=NULL``; a value is stored only when a
+  producer supplies a validated number in [0, 1]; NULL is never coerced to 0 and
+  ranking treats NULL as absence-of-evidence.
+- Scope isolation is invariant (principle 3): both endpoints must resolve inside
+  the same ``(scope, scope_id)``; cross-scope and self-links are rejected before
+  persistence.
+
+Fail-closed: every validation raises ``ValueError`` BEFORE any DB write.
+"""
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from cli_agent_orchestrator.clients.database import (
+    RELATIONSHIP_SCOPE_ID_SENTINEL,
+    MemoryMetadataModel,
+    MemoryRelationshipModel,
+    SessionLocal,
+    _utcnow,
+)
+from cli_agent_orchestrator.services.memory_service import MemoryService
+
+logger = logging.getLogger(__name__)
+
+# Closed taxonomies (reuse the graph EdgeType string values, ADR-5).
+VALID_TYPES = frozenset({"relates_to", "contradiction", "supersedes"})
+VALID_STATUSES = frozenset({"active", "proposal", "rejected", "superseded", "deleted"})
+VALID_ORIGINS = frozenset(
+    {"compiler", "wiki_lint", "human", "legacy_related_keys", "external_import"}
+)
+
+# Bounds (NFR-1.6). Final numeric values.
+MAX_EDGES_PER_MUTATION = 64
+MAX_ATTRIBUTES_BYTES = 2048
+
+# Types that recall one-level expansion follows (FR-4.2). contradiction is
+# symmetric evidence (not a traversal edge); supersedes affects ranking, not
+# expansion.
+RECALL_EDGE_TYPES = frozenset({"relates_to"})
+
+# The content-free audit event for relationship mutations (NFR-1.7). MUST be
+# registered in NOWAIT_AUDIT_EVENTS or audit_log drops it silently.
+AUDIT_EVENT = "relationship_mutation"
+
+
+@dataclass
+class RelationshipDTO:
+    """The inspectable, content-free return/response contract (FR-5.4).
+
+    Contains keys/type/origin/status/confidence/rank/attributes/timestamps and a
+    derived ``stale`` flag — NEVER a memory body or prompt (NFR-1.7). ``scope_id``
+    is denormalised back to ``None`` for global/federated (the row stores the
+    sentinel).
+    """
+
+    id: str
+    scope: str
+    scope_id: Optional[str]
+    source_key: str
+    target_key: str
+    type: str
+    origin: str
+    status: str
+    confidence: Optional[float]
+    rank: Optional[int]
+    attributes: Optional[Dict[str, Any]]
+    source_updated_at: Optional[str]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+    stale: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "scope": self.scope,
+            "scope_id": self.scope_id,
+            "source_key": self.source_key,
+            "target_key": self.target_key,
+            "type": self.type,
+            "origin": self.origin,
+            "status": self.status,
+            "confidence": self.confidence,
+            "rank": self.rank,
+            "attributes": self.attributes,
+            "source_updated_at": self.source_updated_at,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "stale": self.stale,
+        }
+
+
+@dataclass
+class ReplaceReport:
+    """Result of a producer-scoped ``replace_set`` (content-free)."""
+
+    added: int = 0
+    kept: int = 0
+    removed: int = 0
+    rejected: List[Dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class EdgeInput:
+    """One edge in a ``replace_set`` batch."""
+
+    target_key: str
+    confidence: Optional[float] = None
+    rank: Optional[int] = None
+    attributes: Optional[Dict[str, Any]] = None
+
+
+def _iso(value: Any) -> Optional[str]:
+    """Normalise a datetime/str timestamp to an ISO string (or None)."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+class MemoryRelationshipService:
+    """Sole reader/writer of the ``memory_relationships`` table."""
+
+    def __init__(self) -> None:
+        # Reuse MemoryService's static sanitizers; no instance state shared.
+        self._sanitize_key = MemoryService._sanitize_key
+        self._sanitize_scope_id = MemoryService._sanitize_scope_id
+
+    # ------------------------------------------------------------------ #
+    # scope_id normalisation (sentinel is scoped to memory_relationships)
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _to_sentinel(scope_id: Optional[str]) -> str:
+        """Map a logical scope_id to the memory_relationships storage form.
+
+        None (global/federated) -> the NOT-NULL sentinel; else the value.
+        """
+        return scope_id if scope_id is not None else RELATIONSHIP_SCOPE_ID_SENTINEL
+
+    @staticmethod
+    def _from_sentinel(stored: Optional[str]) -> Optional[str]:
+        """Denormalise a stored scope_id back to the logical value for the DTO."""
+        if stored is None or stored == RELATIONSHIP_SCOPE_ID_SENTINEL:
+            return None
+        return stored
+
+    # ------------------------------------------------------------------ #
+    # validation (fail-closed, before any persist)
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _validate_type(type_: str) -> str:
+        if type_ not in VALID_TYPES:
+            raise ValueError(f"invalid relationship type: {type_!r}")
+        return type_
+
+    @staticmethod
+    def _validate_status(status: str) -> str:
+        if status not in VALID_STATUSES:
+            raise ValueError(f"invalid relationship status: {status!r}")
+        return status
+
+    @staticmethod
+    def _validate_origin(origin: str) -> str:
+        if origin not in VALID_ORIGINS:
+            raise ValueError(f"invalid relationship origin: {origin!r}")
+        return origin
+
+    @staticmethod
+    def _validate_confidence(confidence: Optional[float]) -> Optional[float]:
+        if confidence is None:
+            return None
+        if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+            raise ValueError(f"confidence must be a number in [0,1] or None: {confidence!r}")
+        value = float(confidence)
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"confidence out of range [0,1]: {value}")
+        return value
+
+    @staticmethod
+    def _validate_attributes(attributes: Optional[Dict[str, Any]]) -> Optional[str]:
+        if attributes is None:
+            return None
+        if not isinstance(attributes, dict):
+            raise ValueError("attributes must be a dict or None")
+        encoded = json.dumps(attributes, separators=(",", ":"), sort_keys=True)
+        if len(encoded.encode("utf-8")) > MAX_ATTRIBUTES_BYTES:
+            raise ValueError(
+                f"attributes exceed {MAX_ATTRIBUTES_BYTES} bytes ({len(encoded)} chars)"
+            )
+        return encoded
+
+    def _sanitize_endpoints(self, source_key: str, target_key: str) -> tuple:
+        """Sanitise both endpoint keys; reject a self-link. Returns (src, tgt)."""
+        src = self._sanitize_key(source_key)
+        tgt = self._sanitize_key(target_key)
+        if src == tgt:
+            raise ValueError(f"self-link rejected: {src!r}")
+        return src, tgt
+
+    def _assert_endpoint_exists(
+        self, db: Any, scope: str, scope_id: Optional[str], key: str
+    ) -> None:
+        """Assert a memory with ``key`` exists in the SAME (scope, scope_id).
+
+        Queries MemoryMetadataModel, whose scope_id is genuinely nullable (real
+        NULL for global), so match logical None with ``.is_(None)`` — NOT the
+        relationship-table sentinel (which would match nothing for global).
+        """
+        q = db.query(MemoryMetadataModel).filter(
+            MemoryMetadataModel.key == key,
+            MemoryMetadataModel.scope == scope,
+        )
+        if scope_id is not None:
+            q = q.filter(MemoryMetadataModel.scope_id == scope_id)
+        else:
+            q = q.filter(MemoryMetadataModel.scope_id.is_(None))
+        if q.first() is None:
+            raise ValueError(f"endpoint does not resolve in scope ({scope},{scope_id}): {key!r}")
+
+    # ------------------------------------------------------------------ #
+    # DTO projection
+    # ------------------------------------------------------------------ #
+    def _to_dto(
+        self, row: Any, source_updated_lookup: Optional[datetime] = None
+    ) -> RelationshipDTO:
+        attrs = None
+        if row.attributes_json:
+            try:
+                attrs = json.loads(row.attributes_json)
+            except (ValueError, TypeError):
+                attrs = None
+        stale = False
+        if row.source_updated_at is not None and source_updated_lookup is not None:
+            stale = row.source_updated_at < source_updated_lookup
+        return RelationshipDTO(
+            id=row.id,
+            scope=row.scope,
+            scope_id=self._from_sentinel(row.scope_id),
+            source_key=row.source_key,
+            target_key=row.target_key,
+            type=row.type,
+            origin=row.origin,
+            status=row.status,
+            confidence=row.confidence,
+            rank=row.rank,
+            attributes=attrs,
+            source_updated_at=_iso(row.source_updated_at),
+            created_at=_iso(row.created_at),
+            updated_at=_iso(row.updated_at),
+            stale=stale,
+        )
+
+    def _audit(self, action: str, row: Any) -> None:
+        """Emit a content-free relationship_mutation audit event (NFR-1.7)."""
+        try:
+            from cli_agent_orchestrator.services.audit_log import write_audit_nowait
+
+            write_audit_nowait(
+                AUDIT_EVENT,
+                f"relationship {action}",
+                action=action,
+                id=row.id,
+                scope=row.scope,
+                scope_id=str(row.scope_id),
+                source_key=row.source_key,
+                target_key=row.target_key,
+                type=row.type,
+                origin=row.origin,
+                status=row.status,
+            )
+        except Exception as e:  # pragma: no cover - audit must never break a write
+            logger.debug(f"relationship audit emit failed ({action}): {e}")
+
+    # ------------------------------------------------------------------ #
+    # write operations
+    # ------------------------------------------------------------------ #
+    def create(
+        self,
+        scope: str,
+        scope_id: Optional[str],
+        source_key: str,
+        target_key: str,
+        type: str,
+        origin: str,
+        *,
+        status: str = "active",
+        confidence: Optional[float] = None,
+        rank: Optional[int] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+        source_updated_at: Optional[datetime] = None,
+    ) -> RelationshipDTO:
+        """Create-or-upsert one relationship. Validates fail-closed, then upserts
+        on the dedup tuple (existing row updates mutable fields; FR-2.6). One
+        transaction (NFR-1.5)."""
+        self._validate_type(type)
+        self._validate_status(status)
+        self._validate_origin(origin)
+        conf = self._validate_confidence(confidence)
+        attrs_json = self._validate_attributes(attributes)
+        src, tgt = self._sanitize_endpoints(source_key, target_key)
+        sentinel = self._to_sentinel(scope_id)
+
+        with SessionLocal() as db:
+            self._assert_endpoint_exists(db, scope, scope_id, src)
+            self._assert_endpoint_exists(db, scope, scope_id, tgt)
+            existing = (
+                db.query(MemoryRelationshipModel)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    MemoryRelationshipModel.source_key == src,
+                    MemoryRelationshipModel.target_key == tgt,
+                    MemoryRelationshipModel.type == type,
+                    MemoryRelationshipModel.origin == origin,
+                )
+                .first()
+            )
+            if existing is not None:
+                existing.status = status
+                existing.confidence = conf
+                existing.rank = rank
+                existing.attributes_json = attrs_json
+                if source_updated_at is not None:
+                    existing.source_updated_at = source_updated_at
+                existing.updated_at = _utcnow()
+                db.commit()
+                db.refresh(existing)
+                self._audit("create", existing)
+                return self._to_dto(existing)
+            row = MemoryRelationshipModel(
+                id=str(uuid.uuid4()),
+                scope=scope,
+                scope_id=sentinel,
+                source_key=src,
+                target_key=tgt,
+                type=type,
+                origin=origin,
+                status=status,
+                confidence=conf,
+                rank=rank,
+                attributes_json=attrs_json,
+                source_updated_at=source_updated_at,
+            )
+            db.add(row)
+            db.commit()
+            db.refresh(row)
+            self._audit("create", row)
+            return self._to_dto(row)
+
+    def replace_set(
+        self,
+        scope: str,
+        scope_id: Optional[str],
+        source_key: str,
+        origin: str,
+        type: str,
+        edges: List[EdgeInput],
+    ) -> ReplaceReport:
+        """Producer-scoped replacement (principle 6, FR-2.5).
+
+        In ONE transaction, replaces exactly the rows matching
+        ``(scope, scope_id, source_key, origin, type)`` with ``edges``: rows of
+        that tuple whose target is absent from ``edges`` are deleted; edges are
+        upserted. Rows of ANY OTHER origin or type — human, wiki_lint, legacy,
+        supersedes, contradiction — are structurally outside the WHERE clause and
+        are never touched. Producers MUST pass their FULL current set.
+        """
+        self._validate_type(type)
+        self._validate_origin(origin)
+        if len(edges) > MAX_EDGES_PER_MUTATION:
+            raise ValueError(f"replace_set exceeds {MAX_EDGES_PER_MUTATION} edges: {len(edges)}")
+        src = self._sanitize_key(source_key)
+        sentinel = self._to_sentinel(scope_id)
+        report = ReplaceReport()
+
+        # Validate + resolve the incoming set first (fail-closed); collect valid
+        # targets, report the rest (FR-1.5-style) without aborting the whole op.
+        valid: Dict[str, EdgeInput] = {}
+        with SessionLocal() as db:
+            for edge in edges:
+                try:
+                    tgt = self._sanitize_key(edge.target_key)
+                except ValueError:
+                    report.rejected.append({"target": edge.target_key, "reason": "unsanitised"})
+                    continue
+                if tgt == src:
+                    report.rejected.append({"target": tgt, "reason": "self"})
+                    continue
+                # Per-edge SOFT rejection for confidence/attributes, consistent
+                # with self/dangling above (reviewer F3): one bad edge in a batch
+                # is reported, not a hard abort of the whole replace_set.
+                try:
+                    self._validate_confidence(edge.confidence)
+                    self._validate_attributes(edge.attributes)
+                except ValueError:
+                    report.rejected.append({"target": tgt, "reason": "invalid_attrs_or_confidence"})
+                    continue
+                try:
+                    self._assert_endpoint_exists(db, scope, scope_id, tgt)
+                except ValueError:
+                    report.rejected.append({"target": tgt, "reason": "dangling"})
+                    continue
+                valid[tgt] = edge
+            # Source must exist too.
+            self._assert_endpoint_exists(db, scope, scope_id, src)
+
+            existing_rows = (
+                db.query(MemoryRelationshipModel)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    MemoryRelationshipModel.source_key == src,
+                    MemoryRelationshipModel.origin == origin,
+                    MemoryRelationshipModel.type == type,
+                )
+                .all()
+            )
+            existing_by_target = {r.target_key: r for r in existing_rows}
+            new_targets = set(valid.keys())
+
+            # Delete this producer's rows whose target is not in the new set.
+            for tgt, r in existing_by_target.items():
+                if tgt not in new_targets:
+                    db.delete(r)
+                    report.removed += 1
+
+            now = _utcnow()
+            for tgt, edge in valid.items():
+                r = existing_by_target.get(tgt)
+                attrs_json = self._validate_attributes(edge.attributes)
+                if r is not None:
+                    r.confidence = self._validate_confidence(edge.confidence)
+                    r.rank = edge.rank
+                    r.attributes_json = attrs_json
+                    r.status = "active"
+                    r.updated_at = now
+                    report.kept += 1
+                else:
+                    db.add(
+                        MemoryRelationshipModel(
+                            id=str(uuid.uuid4()),
+                            scope=scope,
+                            scope_id=sentinel,
+                            source_key=src,
+                            target_key=tgt,
+                            type=type,
+                            origin=origin,
+                            status="active",
+                            confidence=self._validate_confidence(edge.confidence),
+                            rank=edge.rank,
+                            attributes_json=attrs_json,
+                            source_updated_at=None,
+                        )
+                    )
+                    report.added += 1
+            db.commit()
+        # Content-free summary audit for the bulk producer write (reviewer F2):
+        # replace_set is the highest-volume path (compiler/lint every compile),
+        # so it must leave a forensic trail. Counts + endpoints/origin/type only,
+        # never a memory body/prompt (NFR-1.7).
+        self._audit_replace_set(scope, sentinel, src, origin, type, report)
+        return report
+
+    def _audit_replace_set(
+        self,
+        scope: str,
+        sentinel: str,
+        src: str,
+        origin: str,
+        type_: str,
+        report: "ReplaceReport",
+    ) -> None:
+        try:
+            from cli_agent_orchestrator.services.audit_log import write_audit_nowait
+
+            write_audit_nowait(
+                AUDIT_EVENT,
+                f"relationship replace_set ({origin}/{type_})",
+                action="replace_set",
+                scope=scope,
+                scope_id=str(sentinel),
+                source_key=src,
+                origin=origin,
+                type=type_,
+                added=str(report.added),
+                kept=str(report.kept),
+                removed=str(report.removed),
+                rejected=str(len(report.rejected)),
+            )
+        except Exception as e:  # pragma: no cover - audit must never break a write
+            logger.debug(f"replace_set audit emit failed: {e}")
+
+    def _get_row(self, db: Any, id: str) -> Any:
+        row = db.query(MemoryRelationshipModel).filter(MemoryRelationshipModel.id == id).first()
+        if row is None:
+            raise ValueError(f"relationship not found: {id!r}")
+        return row
+
+    def patch(
+        self,
+        id: str,
+        *,
+        status: Optional[str] = None,
+        confidence: Optional[float] = None,
+        rank: Optional[int] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> RelationshipDTO:
+        """Partial update of mutable fields (status/confidence/rank/attributes).
+        Endpoints/type/origin/scope are immutable. A field left as ``None`` is
+        unchanged (to clear confidence/attributes, pass an explicit sentinel via
+        a future dedicated call; #511 has no clear-to-null API requirement)."""
+        if status is not None:
+            self._validate_status(status)
+        with SessionLocal() as db:
+            row = self._get_row(db, id)
+            if status is not None:
+                row.status = status
+            if confidence is not None:
+                row.confidence = self._validate_confidence(confidence)
+            if rank is not None:
+                row.rank = rank
+            if attributes is not None:
+                row.attributes_json = self._validate_attributes(attributes)
+            row.updated_at = _utcnow()
+            db.commit()
+            db.refresh(row)
+            self._audit("patch", row)
+            return self._to_dto(row)
+
+    def promote(self, id: str) -> RelationshipDTO:
+        """proposal -> active (FR-2.2)."""
+        with SessionLocal() as db:
+            row = self._get_row(db, id)
+            if row.status in ("rejected", "deleted"):
+                raise ValueError(f"cannot promote a {row.status} relationship; re-create it")
+            row.status = "active"
+            row.updated_at = _utcnow()
+            db.commit()
+            db.refresh(row)
+            self._audit("promote", row)
+            return self._to_dto(row)
+
+    def reject(self, id: str) -> RelationshipDTO:
+        """-> rejected (FR-2.2)."""
+        with SessionLocal() as db:
+            row = self._get_row(db, id)
+            row.status = "rejected"
+            row.updated_at = _utcnow()
+            db.commit()
+            db.refresh(row)
+            self._audit("reject", row)
+            return self._to_dto(row)
+
+    def soft_delete(self, id: str) -> RelationshipDTO:
+        """-> deleted (auditable soft-delete; row retained, FR-2.4)."""
+        with SessionLocal() as db:
+            row = self._get_row(db, id)
+            row.status = "deleted"
+            row.updated_at = _utcnow()
+            db.commit()
+            db.refresh(row)
+            self._audit("soft_delete", row)
+            return self._to_dto(row)
+
+    # ------------------------------------------------------------------ #
+    # read operations
+    # ------------------------------------------------------------------ #
+    def _source_updated_map(
+        self, db: Any, scope: str, scope_id: Optional[str], source_keys: set
+    ) -> Dict[str, datetime]:
+        """Batch-load source memories' updated_at for staleness (avoid N+1)."""
+        if not source_keys:
+            return {}
+        q = db.query(MemoryMetadataModel).filter(
+            MemoryMetadataModel.scope == scope,
+            MemoryMetadataModel.key.in_(list(source_keys)),
+        )
+        if scope_id is not None:
+            q = q.filter(MemoryMetadataModel.scope_id == scope_id)
+        else:
+            q = q.filter(MemoryMetadataModel.scope_id.is_(None))
+        return {m.key: m.updated_at for m in q.all() if m.updated_at is not None}
+
+    def list_relationships(
+        self,
+        scope: str,
+        scope_id: Optional[str] = None,
+        source_key: Optional[str] = None,
+        *,
+        status: Optional[Any] = None,
+        types: Optional[List[str]] = None,
+        stale_only: bool = False,
+        include_non_active: bool = False,
+    ) -> List[RelationshipDTO]:
+        """Query relationships. Default returns ACTIVE only (FR-4.3); an explicit
+        ``status`` or ``include_non_active`` widens. Computes the derived
+        ``stale`` flag; ``stale_only`` filters to stale rows."""
+        sentinel = self._to_sentinel(scope_id)
+        with SessionLocal() as db:
+            q = db.query(MemoryRelationshipModel).filter(
+                MemoryRelationshipModel.scope == scope,
+                MemoryRelationshipModel.scope_id == sentinel,
+            )
+            if source_key is not None:
+                q = q.filter(MemoryRelationshipModel.source_key == self._sanitize_key(source_key))
+            if status is not None:
+                if isinstance(status, (list, tuple, set)):
+                    q = q.filter(MemoryRelationshipModel.status.in_(list(status)))
+                else:
+                    q = q.filter(MemoryRelationshipModel.status == status)
+            elif not include_non_active:
+                q = q.filter(MemoryRelationshipModel.status == "active")
+            if types:
+                q = q.filter(MemoryRelationshipModel.type.in_(list(types)))
+            rows = q.all()
+            src_map = self._source_updated_map(db, scope, scope_id, {r.source_key for r in rows})
+            dtos = [self._to_dto(r, src_map.get(r.source_key)) for r in rows]
+        if stale_only:
+            dtos = [d for d in dtos if d.stale]
+        return dtos
+
+    def get(self, id: str) -> Optional[RelationshipDTO]:
+        with SessionLocal() as db:
+            row = db.query(MemoryRelationshipModel).filter(MemoryRelationshipModel.id == id).first()
+            if row is None:
+                return None
+            src_map = self._source_updated_map(
+                db, row.scope, self._from_sentinel(row.scope_id), {row.source_key}
+            )
+            return self._to_dto(row, src_map.get(row.source_key))
+
+    def active_targets(
+        self,
+        scope: str,
+        scope_id: Optional[str],
+        source_key: str,
+        type: str = "relates_to",
+    ) -> List[str]:
+        """Active edge targets of ``type`` from the source, in (rank, created_at)
+        order — the See-Also / recall projection helper (FR-4.1/4.2)."""
+        sentinel = self._to_sentinel(scope_id)
+        with SessionLocal() as db:
+            rows = (
+                db.query(MemoryRelationshipModel)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    MemoryRelationshipModel.source_key == self._sanitize_key(source_key),
+                    MemoryRelationshipModel.type == type,
+                    MemoryRelationshipModel.status == "active",
+                )
+                .all()
+            )
+        rows.sort(
+            key=lambda r: (
+                r.rank if r.rank is not None else 1_000_000,
+                r.created_at or datetime.min,
+            )
+        )
+        return [r.target_key for r in rows]
+
+    def is_superseded(self, scope: str, scope_id: Optional[str], key: str) -> bool:
+        """True iff an ACTIVE ``supersedes`` edge TARGETS ``key`` (FR-4.6 ranking
+        input): some memory supersedes this one, so it must not outrank active
+        guidance."""
+        sentinel = self._to_sentinel(scope_id)
+        with SessionLocal() as db:
+            hit = (
+                db.query(MemoryRelationshipModel)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    MemoryRelationshipModel.target_key == self._sanitize_key(key),
+                    MemoryRelationshipModel.type == "supersedes",
+                    MemoryRelationshipModel.status == "active",
+                )
+                .first()
+            )
+        return hit is not None
+
+    def superseded_targets(self, scope: str, scope_id: Optional[str], keys: List[str]) -> set:
+        """BATCH form of is_superseded (FR-4.6): given many candidate keys in one
+        (scope, scope_id), return the subset that are the TARGET of an ACTIVE
+        supersedes edge — in ONE query (avoids the N-query loop in a large recall
+        ranking pass)."""
+        if not keys:
+            return set()
+        sentinel = self._to_sentinel(scope_id)
+        sanitized = {self._sanitize_key(k): k for k in keys}
+        with SessionLocal() as db:
+            rows = (
+                db.query(MemoryRelationshipModel.target_key)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    MemoryRelationshipModel.type == "supersedes",
+                    MemoryRelationshipModel.status == "active",
+                    MemoryRelationshipModel.target_key.in_(list(sanitized.keys())),
+                )
+                .all()
+            )
+        # Map sanitized targets back to the caller's original key strings.
+        return {sanitized[r[0]] for r in rows if r[0] in sanitized}
+
+    def contradictions_for(
+        self, scope: str, scope_id: Optional[str], key: str
+    ) -> List[RelationshipDTO]:
+        """Active contradictions touching ``key`` from EITHER endpoint (FR-4.5
+        symmetric visibility, reconstructed at QUERY time — the store holds one
+        directed row, never a reciprocal duplicate)."""
+        from sqlalchemy import or_
+
+        sentinel = self._to_sentinel(scope_id)
+        sk = self._sanitize_key(key)
+        with SessionLocal() as db:
+            rows = (
+                db.query(MemoryRelationshipModel)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    MemoryRelationshipModel.type == "contradiction",
+                    MemoryRelationshipModel.status == "active",
+                    or_(
+                        MemoryRelationshipModel.source_key == sk,
+                        MemoryRelationshipModel.target_key == sk,
+                    ),
+                )
+                .all()
+            )
+            return [self._to_dto(r) for r in rows]

--- a/src/cli_agent_orchestrator/services/memory_relationship_service.py
+++ b/src/cli_agent_orchestrator/services/memory_relationship_service.py
@@ -27,7 +27,7 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from cli_agent_orchestrator.clients.database import (
@@ -137,6 +137,40 @@ def _iso(value: Any) -> Optional[str]:
     return str(value)
 
 
+def _sort_dt(value: Any) -> datetime:
+    """Normalise a ``created_at`` to a tz-AWARE UTC datetime for sorting.
+
+    Sorting relationship rows on a raw ``created_at`` is unsafe in two ways, and
+    a tz-aware sentinel alone only fixes the first:
+
+    1. ``created_at`` is nullable with no DB default, so a NULL row previously
+       fell back to a NAIVE ``datetime.min`` while a populated row on a
+       ``DateTime(timezone=True)`` column is tz-AWARE — comparing them raises
+       ``TypeError: can't compare offset-naive and offset-aware datetimes``.
+    2. SQLite does not persist timezone offsets, so two POPULATED rows can also
+       disagree on awareness depending on how each was written. Normalising both
+       sides (rather than only the sentinel) closes that wider hole too.
+
+    A naive value is interpreted as UTC — the only sane reading, since every
+    write path stamps UTC (``_utcnow``).
+    """
+    if not isinstance(value, datetime):
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _rank_then_created(row: Any) -> tuple:
+    """The See-Also / recall projection order: ``(rank, created_at)``.
+
+    NULL rank sorts last (``1_000_000`` sentinel, preserved from the original
+    ordering); ``created_at`` is normalised by ``_sort_dt`` so a NULL or naive
+    value never crashes the comparison.
+    """
+    return (row.rank if row.rank is not None else 1_000_000, _sort_dt(row.created_at))
+
+
 class MemoryRelationshipService:
     """Sole reader/writer of the ``memory_relationships`` table."""
 
@@ -201,10 +235,25 @@ class MemoryRelationshipService:
             return None
         if not isinstance(attributes, dict):
             raise ValueError("attributes must be a dict or None")
-        encoded = json.dumps(attributes, separators=(",", ":"), sort_keys=True)
-        if len(encoded.encode("utf-8")) > MAX_ATTRIBUTES_BYTES:
+        # json.dumps raises TypeError for a non-serialisable value and ValueError
+        # for a circular reference. A TypeError escaping here would break TWO
+        # contracts, so it is re-raised as ValueError (the service's single
+        # fail-closed validation type, per this module's docstring):
+        #   1. every REST handler maps ONLY ValueError -> 400/404, so a TypeError
+        #      surfaces as an unhandled 500 instead of a client error;
+        #   2. replace_set's per-edge soft rejection catches ONLY ValueError, so
+        #      one bad edge would abort the whole batch instead of being dropped.
+        try:
+            encoded = json.dumps(attributes, separators=(",", ":"), sort_keys=True)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"attributes must be JSON-serialisable: {e}") from e
+        # The limit is enforced in BYTES, so the message must report bytes — a
+        # char count understates any multi-byte payload and misleads the caller
+        # about how much to trim.
+        encoded_bytes = len(encoded.encode("utf-8"))
+        if encoded_bytes > MAX_ATTRIBUTES_BYTES:
             raise ValueError(
-                f"attributes exceed {MAX_ATTRIBUTES_BYTES} bytes ({len(encoded)} chars)"
+                f"attributes exceed {MAX_ATTRIBUTES_BYTES} bytes ({encoded_bytes} bytes)"
             )
         return encoded
 
@@ -610,10 +659,20 @@ class MemoryRelationshipService:
         types: Optional[List[str]] = None,
         stale_only: bool = False,
         include_non_active: bool = False,
+        source_keys: Optional[List[str]] = None,
     ) -> List[RelationshipDTO]:
         """Query relationships. Default returns ACTIVE only (FR-4.3); an explicit
         ``status`` or ``include_non_active`` widens. Computes the derived
-        ``stale`` flag; ``stale_only`` filters to stale rows."""
+        ``stale`` flag; ``stale_only`` filters to stale rows.
+
+        ``source_keys`` bounds the rows FETCHED to edges leaving that set of
+        source keys — used by the graph provider to scope its query to the
+        current node set instead of loading every active relationship in the
+        scope. It is a fetch bound ONLY: it can constrain the source side but
+        says nothing about targets, so a caller that needs both endpoints inside
+        a node set MUST still check the target side itself (an edge may
+        legitimately point at a key outside the set).
+        """
         sentinel = self._to_sentinel(scope_id)
         with SessionLocal() as db:
             q = db.query(MemoryRelationshipModel).filter(
@@ -622,6 +681,24 @@ class MemoryRelationshipService:
             )
             if source_key is not None:
                 q = q.filter(MemoryRelationshipModel.source_key == self._sanitize_key(source_key))
+            if source_keys is not None:
+                # An EMPTY set means "no nodes", which must yield no edges — not
+                # "unfiltered". in_([]) is the correct, empty-result filter.
+                #
+                # A key that cannot sanitize (e.g. a malformed index entry like
+                # "...") is DROPPED from the filter rather than allowed to raise.
+                # Every stored source_key was sanitized at write time, so an
+                # unsanitizable key can never match a row — but raising here
+                # would abort the whole query, and the graph provider's except
+                # branch would then silently discard EVERY edge in the scope
+                # because of one bad index entry.
+                sanitized_sources = []
+                for k in source_keys:
+                    try:
+                        sanitized_sources.append(self._sanitize_key(k))
+                    except ValueError:
+                        continue
+                q = q.filter(MemoryRelationshipModel.source_key.in_(sanitized_sources))
             if status is not None:
                 if isinstance(status, (list, tuple, set)):
                     q = q.filter(MemoryRelationshipModel.status.in_(list(status)))
@@ -670,13 +747,59 @@ class MemoryRelationshipService:
                 )
                 .all()
             )
-        rows.sort(
-            key=lambda r: (
-                r.rank if r.rank is not None else 1_000_000,
-                r.created_at or datetime.min,
-            )
-        )
+        rows.sort(key=_rank_then_created)
         return [r.target_key for r in rows]
+
+    def active_targets_for(
+        self,
+        scope: str,
+        scope_id: Optional[str],
+        source_keys: List[str],
+        type: str = "relates_to",
+    ) -> Dict[str, List[str]]:
+        """BATCH form of ``active_targets``: the ordered active targets of
+        ``type`` for MANY source keys in one ``(scope, scope_id)``, in ONE query.
+
+        Mirrors the ``superseded_targets`` batching precedent. Recall's one-level
+        expansion groups its primaries by ``(scope, scope_id)`` already, so one
+        call per group replaces one query per primary (the N+1 this fixes).
+
+        Returns ``{source_key: [target_key, ...]}`` keyed by the CALLER's
+        original key strings, with each list in the same ``(rank, created_at)``
+        order single-key ``active_targets`` returns. A source key with no active
+        edges is ABSENT from the mapping (callers use ``.get(key, [])`` and treat
+        absence as "the store has nothing", which is what triggers the legacy
+        ``related_keys`` fallback).
+        """
+        if not source_keys:
+            return {}
+        sentinel = self._to_sentinel(scope_id)
+        # Map sanitized -> caller's original, as superseded_targets does. A dict
+        # also collapses duplicate inputs, so the IN list carries no repeats.
+        sanitized = {self._sanitize_key(k): k for k in source_keys}
+        with SessionLocal() as db:
+            rows = (
+                db.query(MemoryRelationshipModel)
+                .filter(
+                    MemoryRelationshipModel.scope == scope,
+                    MemoryRelationshipModel.scope_id == sentinel,
+                    MemoryRelationshipModel.type == type,
+                    MemoryRelationshipModel.status == "active",
+                    MemoryRelationshipModel.source_key.in_(list(sanitized.keys())),
+                )
+                .all()
+            )
+        grouped: Dict[str, List[Any]] = {}
+        for row in rows:
+            original = sanitized.get(row.source_key)
+            if original is None:  # pragma: no cover - IN filter makes this unreachable
+                continue
+            grouped.setdefault(original, []).append(row)
+        out: Dict[str, List[str]] = {}
+        for original, group in grouped.items():
+            group.sort(key=_rank_then_created)
+            out[original] = [r.target_key for r in group]
+        return out
 
     def is_superseded(self, scope: str, scope_id: Optional[str], key: str) -> bool:
         """True iff an ACTIVE ``supersedes`` edge TARGETS ``key`` (FR-4.6 ranking

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -2685,6 +2685,10 @@ class MemoryService:
                 self._delete_metadata(key, scope, scope_id)
             except Exception as e:
                 logger.warning(f"Memory metadata SQLite delete failed (key={key}): {e}")
+            # The relationship rows are just as stale as the metadata row was —
+            # purge them on this path too, else a file that vanished out-of-band
+            # leaves edges that a same-slug memory would later inherit.
+            self._purge_relationships(key, scope, scope_id)
             return False
 
         # Delete the wiki file
@@ -2703,7 +2707,35 @@ class MemoryService:
         except Exception as e:
             logger.warning(f"Memory metadata SQLite delete failed (key={key}): {e}")
 
+        # Drop the typed relationship rows too (issue #511 / PR #524 review):
+        # the file, the index entry and the metadata row are all gone, so any
+        # edge touching this key is dangling.
+        self._purge_relationships(key, scope, scope_id)
+
         return True
+
+    def _purge_relationships(self, key: str, scope: str, scope_id: Optional[str]) -> None:
+        """Hard-delete relationship rows for a FORGOTTEN memory. Best-effort.
+
+        Without this, ``forget()`` left ``active`` rows pointing at a key that no
+        longer resolves, and a later memory created with the SAME slug silently
+        inherited the dead memory's edges. Non-blocking: a store failure must not
+        turn a successful forget into an exception, since the file and metadata
+        row are already gone by this point.
+        """
+        try:
+            from cli_agent_orchestrator.services.memory_relationship_service import (
+                MemoryRelationshipService,
+            )
+
+            # ``scope_id`` here is already the resolved LOGICAL value (forget()
+            # resolves it before use); the store maps None to its own NOT-NULL
+            # sentinel internally, so it must NOT be pre-mapped here.
+            removed = MemoryRelationshipService().purge_for_key(scope, scope_id, key)
+            if removed:
+                logger.info(f"Purged {removed} relationship row(s) for forgotten memory: {key}")
+        except Exception as e:  # noqa: BLE001 — never fail a completed forget
+            logger.warning(f"Relationship purge failed (key={key}): {e}")
 
     # -------------------------------------------------------------------------
     # Context for terminal injection

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -1601,6 +1601,20 @@ class MemoryService:
                 out.add((g_scope, g_scope_id, k))
         return out
 
+    def _is_superseded(self, m, superseded: set) -> bool:
+        """The demotion predicate recall's sort key applies to ONE memory.
+
+        Extracted so the cross-project regression test can drive the REAL
+        predicate. A test that re-expresses this comparison locally cannot fail
+        when the production sort key is keyed too loosely — it proves only that
+        ``_superseded_keys`` is well-formed, which is a different claim.
+
+        Identity is the FULL ``(scope, scope_id, key)`` 3-tuple: a ``(scope,
+        key)`` comparison lets one project's supersedes edge demote a
+        same-named memory in a DIFFERENT project's scope_id.
+        """
+        return (m.scope, self._effective_scope_id(m), m.key) in superseded
+
     def _expand_related(self, primaries: list) -> list:
         """One-level cross-reference traversal for ``recall(include_related=True)``.
 
@@ -2012,13 +2026,7 @@ class MemoryService:
                         # Full (scope, scope_id, key) identity — see
                         # _superseded_keys. A (scope, key) comparison would
                         # cross-project-demote a same-named memory.
-                        results.sort(
-                            key=lambda m: (
-                                1
-                                if (m.scope, self._effective_scope_id(m), m.key) in superseded
-                                else 0
-                            )
-                        )
+                        results.sort(key=lambda m: 1 if self._is_superseded(m, superseded) else 0)
                 except Exception as e:  # noqa: BLE001 — non-blocking
                     logger.debug(f"superseded demotion skipped: {e}")
             if not scope:

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -1561,10 +1561,23 @@ class MemoryService:
         return None
 
     def _superseded_keys(self, memories: list) -> set:
-        """Return {(scope, key)} for memories that are the target of an active
-        supersedes edge (FR-4.6 ranking input). BATCHED per (scope, scope_id) —
-        one query per scope group, not one per memory (avoids N queries on a
-        large recall). Best-effort; empty on failure."""
+        """Return ``{(scope, scope_id, key)}`` for memories that are the target of
+        an active supersedes edge (FR-4.6 ranking input). BATCHED per
+        (scope, scope_id) — one query per scope group, not one per memory (avoids
+        N queries on a large recall). Best-effort; empty on failure.
+
+        The identity is the FULL 3-tuple matching ``MemoryMetadataModel``'s
+        ``(key, scope, scope_id)`` uniqueness. Keying on ``(scope, key)`` alone
+        would let the same key in one project's scope_id mark a DIFFERENT,
+        non-superseded memory as superseded whenever a recall spans projects.
+
+        ``scope_id`` here is the LOGICAL value from ``_effective_scope_id`` —
+        ``None`` for global — never the ``""`` sentinel. That sentinel belongs to
+        the ``memory_relationships`` table's own NOT NULL column (it exists so
+        the dedup UNIQUE index is total); ``MemoryMetadataModel.scope_id`` is
+        genuinely nullable, and the Memory objects compared against this set
+        carry the logical value.
+        """
         if not memories:
             return set()
         try:
@@ -1585,7 +1598,7 @@ class MemoryService:
             except Exception:  # noqa: BLE001 — non-blocking
                 continue
             for k in hits:
-                out.add((g_scope, k))
+                out.add((g_scope, g_scope_id, k))
         return out
 
     def _expand_related(self, primaries: list) -> list:
@@ -1626,26 +1639,39 @@ class MemoryService:
         for m in primaries:
             groups.setdefault((m.scope, self._effective_scope_id(m)), []).append(m)
         legacy_lookups: dict = {}
+        # Batch-load the STORE's active relates_to targets per (scope, scope_id)
+        # too — one query per group, matching the legacy lookup's grouping. A
+        # per-primary active_targets call here was an N+1 on the authoritative
+        # read path while the legacy fallback beside it was already batched.
+        store_lookups: dict = {}
         for (g_scope, g_scope_id), members in groups.items():
+            member_keys = [m.key for m in members]
             try:
                 legacy_lookups[(g_scope, g_scope_id)] = self._related_keys_lookup(
-                    [m.key for m in members], g_scope, g_scope_id
+                    member_keys, g_scope, g_scope_id
                 )
             except Exception as e:  # noqa: BLE001 — non-blocking
                 logger.debug(f"related_keys lookup failed for {g_scope}: {e}")
                 legacy_lookups[(g_scope, g_scope_id)] = {}
+            if rel_svc is None:
+                store_lookups[(g_scope, g_scope_id)] = {}
+                continue
+            try:
+                store_lookups[(g_scope, g_scope_id)] = rel_svc.active_targets_for(
+                    g_scope, g_scope_id, member_keys, type="relates_to"
+                )
+            except Exception as e:  # noqa: BLE001 — non-blocking
+                logger.debug(f"active_targets_for failed for {g_scope}: {e}")
+                store_lookups[(g_scope, g_scope_id)] = {}
 
         for primary in primaries:
             primary_scope_id = self._effective_scope_id(primary)
-            targets: list = []
-            if rel_svc is not None:
-                try:
-                    targets = rel_svc.active_targets(
-                        primary.scope, primary_scope_id, primary.key, type="relates_to"
-                    )
-                except Exception as e:  # noqa: BLE001 — non-blocking
-                    logger.debug(f"active_targets failed for {primary.key}: {e}")
-                    targets = []
+            # Absent from the map == the store has no active edges for this
+            # primary, which is exactly the condition the legacy fallback below
+            # keys on (the store stays authoritative whenever it HAS edges).
+            targets: list = list(
+                store_lookups.get((primary.scope, primary_scope_id), {}).get(primary.key) or []
+            )
             # Legacy fallback: only when the store yielded nothing for this
             # primary (the store is authoritative when it has edges).
             if not targets:
@@ -1983,7 +2009,16 @@ class MemoryService:
                 try:
                     superseded = self._superseded_keys(results)
                     if superseded:
-                        results.sort(key=lambda m: 1 if (m.scope, m.key) in superseded else 0)
+                        # Full (scope, scope_id, key) identity — see
+                        # _superseded_keys. A (scope, key) comparison would
+                        # cross-project-demote a same-named memory.
+                        results.sort(
+                            key=lambda m: (
+                                1
+                                if (m.scope, self._effective_scope_id(m), m.key) in superseded
+                                else 0
+                            )
+                        )
                 except Exception as e:  # noqa: BLE001 — non-blocking
                     logger.debug(f"superseded demotion skipped: {e}")
             if not scope:

--- a/src/cli_agent_orchestrator/services/memory_service.py
+++ b/src/cli_agent_orchestrator/services/memory_service.py
@@ -1134,10 +1134,45 @@ class MemoryService:
                 provider_hint=provider_hint,
             )
             if related_result.used_llm:
+                # Marker write FIRST (ADR-4 / reviewer Finding 4): related_keys
+                # stays the compiler's computation-state marker.
                 related_keys_value = ",".join(related_result.related_keys)
-                if related_result.related_keys:
+                # Route the compiler's relationship set through the single service
+                # (FR-3.1), best-effort and AFTER the marker so a service failure
+                # never loses the marker. Producer-scoped: replaces only this
+                # source's (origin=compiler, type=relates_to) edges — human/lint/
+                # legacy edges are preserved (principle 6). Passes the FULL set.
+                see_also_targets = list(related_result.related_keys)
+                try:
+                    from cli_agent_orchestrator.services.memory_relationship_service import (
+                        EdgeInput,
+                        MemoryRelationshipService,
+                    )
+
+                    rel_svc = MemoryRelationshipService()
+                    rel_svc.replace_set(
+                        scope,
+                        scope_id,
+                        key,
+                        "compiler",
+                        "relates_to",
+                        [EdgeInput(target_key=t) for t in related_result.related_keys],
+                    )
+                    # ## See Also is a pure projection of ACTIVE relates_to edges
+                    # (FR-4.1) — so it reflects human-authored edges too, not just
+                    # the compiler's set. Fall back to the compiler set if the
+                    # store read fails.
+                    try:
+                        see_also_targets = rel_svc.active_targets(
+                            scope, scope_id, key, type="relates_to"
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
+                except Exception as e:  # noqa: BLE001 — non-blocking; marker already written
+                    logger.warning(f"relationship replace_set (compiler) failed, ignoring: {e}")
+                if see_also_targets:
                     see_also = self._render_see_also(
-                        related_result.related_keys,
+                        see_also_targets,
                         topic_scope=scope,
                         topic_scope_id=scope_id,
                     )
@@ -1525,6 +1560,34 @@ class MemoryService:
                 return None
         return None
 
+    def _superseded_keys(self, memories: list) -> set:
+        """Return {(scope, key)} for memories that are the target of an active
+        supersedes edge (FR-4.6 ranking input). BATCHED per (scope, scope_id) —
+        one query per scope group, not one per memory (avoids N queries on a
+        large recall). Best-effort; empty on failure."""
+        if not memories:
+            return set()
+        try:
+            from cli_agent_orchestrator.services.memory_relationship_service import (
+                MemoryRelationshipService,
+            )
+
+            rel_svc = MemoryRelationshipService()
+        except Exception:  # pragma: no cover - import guard
+            return set()
+        groups: dict = {}
+        for m in memories:
+            groups.setdefault((m.scope, self._effective_scope_id(m)), []).append(m.key)
+        out: set = set()
+        for (g_scope, g_scope_id), keys in groups.items():
+            try:
+                hits = rel_svc.superseded_targets(g_scope, g_scope_id, keys)
+            except Exception:  # noqa: BLE001 — non-blocking
+                continue
+            for k in hits:
+                out.add((g_scope, k))
+        return out
+
     def _expand_related(self, primaries: list) -> list:
         """One-level cross-reference traversal for ``recall(include_related=True)``.
 
@@ -1537,20 +1600,58 @@ class MemoryService:
             return primaries
         visited: set = {m.key for m in primaries}
         extras: list = []
-        # Group primaries by (scope, scope_id) so each SQLite lookup is
-        # batched per scope rather than per row.
+        # One-level expansion follows ACTIVE relates_to edges from the
+        # relationship STORE (issue #511, FR-4.2 — the store is authoritative for
+        # typed edges: only active relates_to is traversed; proposal/rejected/
+        # superseded/deleted and contradiction/supersedes are NOT expansion edges).
+        # UNION with the legacy ``related_keys`` marker for any primary the store
+        # returns nothing for, so a related_keys value written by a route OTHER
+        # than an LLM compile (a direct write, an import, a restore, or a row that
+        # predates the one-time backfill and was modified after) is still
+        # traversable during the compatibility window S6 protects — retirement of
+        # related_keys stays gated on the loss-free proof (ADR-4/FR-7.2). Both
+        # sources dedupe against ``visited``. Best-effort throughout.
+        try:
+            from cli_agent_orchestrator.services.memory_relationship_service import (
+                MemoryRelationshipService,
+            )
+
+            rel_svc: Any = MemoryRelationshipService()
+        except Exception as e:  # pragma: no cover - import guard
+            logger.debug(f"related expansion service import failed: {e}")
+            rel_svc = None
+        # Batch-load the legacy related_keys marker per (scope, scope_id) so the
+        # fallback is not N+1 (mirrors the pre-#511 grouping).
         groups: dict = {}
         for m in primaries:
             groups.setdefault((m.scope, self._effective_scope_id(m)), []).append(m)
-        lookups: dict = {}
+        legacy_lookups: dict = {}
         for (g_scope, g_scope_id), members in groups.items():
-            lookups[(g_scope, g_scope_id)] = self._related_keys_lookup(
-                [m.key for m in members], g_scope, g_scope_id
-            )
+            try:
+                legacy_lookups[(g_scope, g_scope_id)] = self._related_keys_lookup(
+                    [m.key for m in members], g_scope, g_scope_id
+                )
+            except Exception as e:  # noqa: BLE001 — non-blocking
+                logger.debug(f"related_keys lookup failed for {g_scope}: {e}")
+                legacy_lookups[(g_scope, g_scope_id)] = {}
+
         for primary in primaries:
             primary_scope_id = self._effective_scope_id(primary)
-            raw = lookups.get((primary.scope, primary_scope_id), {}).get(primary.key)
-            for rk in self._parse_related_keys(raw, scope=primary.scope):
+            targets: list = []
+            if rel_svc is not None:
+                try:
+                    targets = rel_svc.active_targets(
+                        primary.scope, primary_scope_id, primary.key, type="relates_to"
+                    )
+                except Exception as e:  # noqa: BLE001 — non-blocking
+                    logger.debug(f"active_targets failed for {primary.key}: {e}")
+                    targets = []
+            # Legacy fallback: only when the store yielded nothing for this
+            # primary (the store is authoritative when it has edges).
+            if not targets:
+                raw = legacy_lookups.get((primary.scope, primary_scope_id), {}).get(primary.key)
+                targets = self._parse_related_keys(raw, scope=primary.scope)
+            for rk in targets:
                 if rk in visited:
                     continue
                 visited.add(rk)
@@ -1872,6 +1973,19 @@ class MemoryService:
                         m.key,
                     )
                 )
+                # FR-4.6: a memory that is the TARGET of an active supersedes edge
+                # must not outrank active guidance merely by textual similarity.
+                # Apply a stable demotion — superseded memories sink below
+                # non-superseded ones while preserving the composite order within
+                # each group. Best-effort; a store read failure leaves the order
+                # unchanged. NULL confidence is NOT used here (never treated as
+                # zero — NFR-2.3); this demotion is purely lifecycle-based.
+                try:
+                    superseded = self._superseded_keys(results)
+                    if superseded:
+                        results.sort(key=lambda m: 1 if (m.scope, m.key) in superseded else 0)
+                except Exception as e:  # noqa: BLE001 — non-blocking
+                    logger.debug(f"superseded demotion skipped: {e}")
             if not scope:
                 # Stable scope-precedence sort AFTER score/usage preserves
                 # within-scope ordering while enforcing scope dominance.

--- a/src/cli_agent_orchestrator/services/wiki_lint.py
+++ b/src/cli_agent_orchestrator/services/wiki_lint.py
@@ -1150,4 +1150,55 @@ async def run_lint(
     except Exception as e:
         logger.debug(f"audit_log lint write failed: {e}")
 
+    # Persist contradiction findings through the single relationship service
+    # (issue #511, FR-3.2) so they are inspectable durable rows (origin=wiki_lint,
+    # type=contradiction) rather than only projection-time findings. Grouped per
+    # source and written with producer-scoped replace_set so a re-run RETRACTS
+    # contradictions no longer detected while preserving human-authored ones
+    # (BR-LP6). Best-effort: a failure logs and never breaks lint.
+    try:
+        _persist_contradictions(issues, scope)
+    except Exception as e:  # noqa: BLE001 — non-blocking
+        logger.debug(f"contradiction persistence skipped: {e}")
+
     return issues
+
+
+def _persist_contradictions(issues: list, scope: Optional[str]) -> None:
+    """Route wiki_lint contradiction findings into the relationship store.
+
+    One directed row per (source, target) contradiction (origin=wiki_lint); the
+    symmetric view is reconstructed at read time by the service, so no reciprocal
+    row is written. Uses producer-scoped replace_set per source key so stale
+    contradictions are retracted on re-lint while human/other-origin edges are
+    untouched (principle 6). Endpoints that no longer resolve in-scope are
+    rejected by the service (fail-closed) and simply dropped from the report.
+    """
+    from cli_agent_orchestrator.services.memory_relationship_service import (
+        EdgeInput,
+        MemoryRelationshipService,
+    )
+
+    # Group detected contradictions by (scope, scope_id, source_key).
+    grouped: dict = {}
+    for issue in issues:
+        if issue.issue_type != "contradiction" or issue.related_key is None:
+            continue
+        desc = (issue.description or "")[:512]
+        grouped.setdefault((issue.scope_id, issue.key), []).append((issue.related_key, desc))
+    if not grouped:
+        return
+
+    rel_svc = MemoryRelationshipService()
+    for (scope_id, source_key), targets in grouped.items():
+        eff_scope = scope or "global"
+        edges = [
+            EdgeInput(target_key=tgt, attributes={"summary": desc} if desc else None)
+            for tgt, desc in targets
+        ]
+        try:
+            rel_svc.replace_set(
+                eff_scope, scope_id, source_key, "wiki_lint", "contradiction", edges
+            )
+        except Exception as e:  # noqa: BLE001 — per-source best-effort
+            logger.debug(f"contradiction replace_set failed for {source_key}: {e}")

--- a/src/cli_agent_orchestrator/services/wiki_lint.py
+++ b/src/cli_agent_orchestrator/services/wiki_lint.py
@@ -445,6 +445,66 @@ async def _check_pair(
     )
 
 
+#: ``lint_error`` descriptions that mean the contradiction pass did NOT examine
+#: every candidate source. Retraction is evidence-of-absence, so it is only safe
+#: after an EXHAUSTIVE pass — ``completion["contradiction"]`` alone is too weak a
+#: gate: the detector returns NORMALLY (setting it True) both when no LLM
+#: provider is configured and when the pair set was truncated by ``max_pairs``.
+#: Retracting on either would wipe live contradiction edges across the whole
+#: wiki the moment the LLM was unavailable.
+_CONTRADICTION_INCOMPLETE_MARKERS = (
+    "contradiction detector disabled",
+    "contradiction pass capped at",
+    "contradiction skipped:",
+    "contradiction timed out",
+    "contradiction did not complete",
+    "contradiction pair timed out",
+    "contradiction pair LLM error",
+    "contradiction pair output validation failed",
+    "contradiction task raised",
+)
+
+
+def _contradiction_pass_was_exhaustive(issues: list) -> bool:
+    """True only if every candidate pair was actually adjudicated.
+
+    Any degradation marker — no LLM provider, a ``max_pairs`` truncation, a
+    global or per-pair timeout, a task exception, a validation failure — means
+    some source's contradictions went unexamined this run. Treating that as
+    "clean" would retract real edges on absent evidence, so it fails CLOSED.
+    """
+    for i in issues:
+        if i.issue_type != "lint_error":
+            continue
+        desc = i.description or ""
+        if any(m in desc for m in _CONTRADICTION_INCOMPLETE_MARKERS):
+            return False
+    return True
+
+
+def _contradiction_candidates(rows: list) -> set:
+    """``{(scope_id, key)}`` for rows the contradiction detector could pair.
+
+    Retraction needs the EXAMINED set, not the finding set: a source whose last
+    contradiction was resolved emits no issue, so it never appears in the
+    findings and its final stale edge would persist forever.
+
+    The membership test mirrors ``_build_pairs``' own filters — a body of at
+    least 50 chars and at least one non-empty tag — so this can only ever name a
+    source the detector actually considered. A row excluded there is excluded
+    here, and is therefore left alone rather than having its edges retracted on
+    evidence that was never gathered.
+    """
+    candidates: set = set()
+    for r in rows:
+        if len(r.get("content") or "") < 50:
+            continue
+        if not any(t.strip() for t in (r.get("tags") or "").split(",")):
+            continue
+        candidates.add((r.get("scope_id"), r.get("key")))
+    return candidates
+
+
 def _build_pairs(rows: list, max_pairs: int) -> tuple[list, int]:
     """Build deduplicated tag-bucket pairs sorted by recency for stability.
 
@@ -1156,15 +1216,32 @@ async def run_lint(
     # source and written with producer-scoped replace_set so a re-run RETRACTS
     # contradictions no longer detected while preserving human-authored ones
     # (BR-LP6). Best-effort: a failure logs and never breaks lint.
+    #
+    # Retraction requires knowing which sources were EXAMINED, not just which
+    # produced a finding — a source whose last contradiction was resolved emits
+    # no issue at all, so grouping by findings alone can never retract its final
+    # stale edge. ``linted_sources`` supplies that set, and it is passed ONLY
+    # when the pass was EXHAUSTIVE. ``completion["contradiction"]`` is necessary
+    # but NOT sufficient: the detector also returns normally (setting it True)
+    # when no LLM provider is configured and when max_pairs truncated the pair
+    # set, so the marker scan fails closed on any degradation. Retracting off a
+    # partial pass would delete real edges on absent evidence.
     try:
-        _persist_contradictions(issues, scope)
+        _exhaustive = completion["contradiction"] and _contradiction_pass_was_exhaustive(issues)
+        _persist_contradictions(
+            issues,
+            scope,
+            linted_sources=_contradiction_candidates(rows) if _exhaustive else None,
+        )
     except Exception as e:  # noqa: BLE001 — non-blocking
         logger.debug(f"contradiction persistence skipped: {e}")
 
     return issues
 
 
-def _persist_contradictions(issues: list, scope: Optional[str]) -> None:
+def _persist_contradictions(
+    issues: list, scope: Optional[str], *, linted_sources: Optional[set] = None
+) -> None:
     """Route wiki_lint contradiction findings into the relationship store.
 
     One directed row per (source, target) contradiction (origin=wiki_lint); the
@@ -1173,6 +1250,15 @@ def _persist_contradictions(issues: list, scope: Optional[str]) -> None:
     contradictions are retracted on re-lint while human/other-origin edges are
     untouched (principle 6). Endpoints that no longer resolve in-scope are
     rejected by the service (fail-closed) and simply dropped from the report.
+
+    ``linted_sources`` is the ``{(scope_id, key)}`` set the detector EXAMINED.
+    Sources in it with no finding this run are replaced with an EMPTY edge set,
+    which is what retracts a source's LAST contradiction — previously the
+    function grouped only sources that had a finding and returned early when
+    there were none, so a fully-resolved source kept its final stale edge
+    forever (the docstring already promised this retraction). Pass ``None`` when
+    the detector did not complete: no examined set means no evidence of absence,
+    so nothing is retracted.
     """
     from cli_agent_orchestrator.services.memory_relationship_service import (
         EdgeInput,
@@ -1186,6 +1272,11 @@ def _persist_contradictions(issues: list, scope: Optional[str]) -> None:
             continue
         desc = (issue.description or "")[:512]
         grouped.setdefault((issue.scope_id, issue.key), []).append((issue.related_key, desc))
+    # Every EXAMINED source with no finding this run gets an empty edge set, so
+    # replace_set retracts whatever it held. Without this a resolved source is
+    # simply absent from `grouped` and its last edge is never revisited.
+    for source in linted_sources or ():
+        grouped.setdefault(source, [])
     if not grouped:
         return
 

--- a/test/api/test_memory_relationship_routes.py
+++ b/test/api/test_memory_relationship_routes.py
@@ -56,3 +56,47 @@ def test_get_memory_relationships_resolves_to_relationships_handler():
                 matched = r.name
                 break
     assert matched == "list_relationships_endpoint"
+
+
+def test_create_maps_unserialisable_attributes_to_400_not_500(monkeypatch):
+    """FR-4.2 at the HTTP boundary: an unserialisable attribute value must
+    surface as a 400, not an unhandled 500.
+
+    Every relationship handler catches ONLY ValueError. The service's
+    ``_validate_attributes`` previously let ``json.dumps``' TypeError escape, so
+    this input produced an unhandled 500. The handler is driven directly (no
+    server) and the service's real validator runs, so this asserts the actual
+    exception-mapping contract rather than a stub's.
+    """
+    import asyncio
+
+    from fastapi import HTTPException
+
+    from cli_agent_orchestrator.api.main import (
+        RelationshipCreateRequest,
+        create_relationship_endpoint,
+    )
+
+    body = RelationshipCreateRequest(
+        scope="global",
+        source_key="a",
+        target_key="b",
+        type="relates_to",
+        origin="human",
+    )
+    # A set is not JSON-serialisable. Bypass pydantic's own coercion by setting
+    # the attribute post-construction — the point under test is the SERVICE's
+    # validator and the handler's except clause, not request-model validation.
+    object.__setattr__(body, "attributes", {"bad": {1, 2, 3}})
+
+    try:
+        asyncio.run(create_relationship_endpoint(body, _scopes=[]))
+    except HTTPException as e:
+        assert e.status_code == 400, f"must map to 400, got {e.status_code}"
+        assert "JSON-serialisable" in str(e.detail)
+    except TypeError as e:  # pragma: no cover - this is the pre-fix failure
+        raise AssertionError(
+            f"TypeError escaped the handler and would surface as a 500: {e}"
+        ) from e
+    else:
+        raise AssertionError("expected an HTTPException(400)")

--- a/test/api/test_memory_relationship_routes.py
+++ b/test/api/test_memory_relationship_routes.py
@@ -1,0 +1,58 @@
+"""U6 REST route tests (issue #511): route ORDERING (relationships before the
+{key} catch-all, FR-5.2) and that the routes are registered with the right
+methods. Route resolution is asserted structurally against the app's route table
+(no server needed)."""
+
+from starlette.routing import Route
+
+from cli_agent_orchestrator.api.main import app
+
+
+def _memory_routes():
+    return [r for r in app.routes if isinstance(r, Route) and r.path.startswith("/memory")]
+
+
+def test_relationships_routes_registered():
+    # GET + POST on the collection, with the expected methods present.
+    by_name = {r.name: r for r in _memory_routes()}
+    assert "GET" in (by_name["list_relationships_endpoint"].methods or [])
+    assert "POST" in (by_name["create_relationship_endpoint"].methods or [])
+    assert "DELETE" in (by_name["delete_relationship_endpoint"].methods or [])
+    # all named routes exist
+    names = {r.name for r in _memory_routes()}
+    assert "list_relationships_endpoint" in names
+    assert "create_relationship_endpoint" in names
+    assert "patch_relationship_endpoint" in names
+    assert "promote_relationship_endpoint" in names
+    assert "reject_relationship_endpoint" in names
+    assert "delete_relationship_endpoint" in names
+
+
+def test_relationships_before_key_catchall():
+    """FR-5.2: the literal /memory/relationships* routes MUST be registered
+    before the single-segment /memory/{key} catch-all, or FastAPI captures
+    'relationships' as a key. This is the route-ordering hazard."""
+    routes = [r for r in app.routes if isinstance(r, Route)]
+    rel_idx = [i for i, r in enumerate(routes) if "relationships" in r.path]
+    key_idx = [i for i, r in enumerate(routes) if r.path == "/memory/{key}"]
+    assert rel_idx, "relationships routes must exist"
+    assert key_idx, "/memory/{key} must exist"
+    assert max(rel_idx) < min(
+        key_idx
+    ), "every /memory/relationships* route must be registered before /memory/{key}"
+
+
+def test_get_memory_relationships_resolves_to_relationships_handler():
+    """Resolving the path /memory/relationships must hit the relationships list
+    handler, not get_memory_endpoint (which would treat 'relationships' as key)."""
+    matched = None
+    for r in app.routes:
+        if isinstance(r, Route) and "GET" in (r.methods or []):
+            scope = {"type": "http", "method": "GET", "path": "/memory/relationships"}
+            match, _ = r.matches(scope)
+            from starlette.routing import Match
+
+            if match == Match.FULL:
+                matched = r.name
+                break
+    assert matched == "list_relationships_endpoint"

--- a/test/cli/commands/test_memory_relationships_cmd.py
+++ b/test/cli/commands/test_memory_relationships_cmd.py
@@ -1,0 +1,231 @@
+"""Tests for the `cao memory relationships` CLI subgroup (issue #511).
+
+The subgroup shipped with NO tests (human review, PR #524). These cover each
+subcommand's contract: what it passes to the service, what it renders, and how it
+reports the failure modes an operator will actually hit (unknown id, a service
+ValueError). The service is mocked — this is the CLI's own logic under test, the
+same isolation the sibling memory CLI tests use.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cli_agent_orchestrator.cli.commands.memory import (
+    relationships_inspect,
+    relationships_list,
+    relationships_promote,
+    relationships_reject,
+)
+
+
+def _dto(
+    id="11111111-1111-4111-8111-111111111111",
+    source_key="a",
+    target_key="b",
+    type="relates_to",
+    origin="compiler",
+    status="active",
+    stale=False,
+):
+    """A stand-in RelationshipDTO: MagicMock would render its repr in the table,
+    so the attributes the renderer reads are set explicitly."""
+    d = MagicMock()
+    d.id = id
+    d.source_key = source_key
+    d.target_key = target_key
+    d.type = type
+    d.origin = origin
+    d.status = status
+    d.stale = stale
+    d.to_dict.return_value = {
+        "id": id,
+        "source_key": source_key,
+        "target_key": target_key,
+        "type": type,
+        "origin": origin,
+        "status": status,
+        "stale": stale,
+    }
+    return d
+
+
+def _patched(rsvc, scope_id="proj1"):
+    """Patch the CLI's service accessors; returns the patch context managers."""
+    msvc = MagicMock()
+    return (
+        patch(
+            "cli_agent_orchestrator.cli.commands.memory._relationship_service", return_value=rsvc
+        ),
+        patch("cli_agent_orchestrator.cli.commands.memory._get_memory_service", return_value=msvc),
+        patch(
+            "cli_agent_orchestrator.cli.commands.memory._resolve_cli_scope_id",
+            return_value=scope_id,
+        ),
+    )
+
+
+class TestRelationshipsList:
+    def test_renders_a_table_row_per_edge(self):
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = [_dto(), _dto(id="2", target_key="c", stale=True)]
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_list, [])
+        assert result.exit_code == 0, result.output
+        assert "SOURCE -> TARGET" in result.output
+        assert "a -> b" in result.output
+        assert "a -> c" in result.output
+        # The stale column is rendered per row, not as a constant.
+        assert "yes" in result.output and "no" in result.output
+
+    def test_empty_result_is_reported_not_an_empty_table(self):
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = []
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_list, [])
+        assert result.exit_code == 0
+        assert "No relationships found." in result.output
+        assert "SOURCE -> TARGET" not in result.output
+
+    def test_status_filter_widens_beyond_active(self):
+        """--status must reach the service AND set include_non_active, else the
+        proposal queue the flag exists to show comes back empty."""
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = []
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_list, ["--status", "proposal"])
+        assert result.exit_code == 0
+        kwargs = rsvc.list_relationships.call_args.kwargs
+        assert kwargs["status"] == "proposal"
+        assert kwargs["include_non_active"] is True
+
+    def test_default_does_not_widen(self):
+        """Control for the above: with no --status the listing stays active-only."""
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = []
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            CliRunner().invoke(relationships_list, [])
+        kwargs = rsvc.list_relationships.call_args.kwargs
+        assert kwargs["status"] is None
+        assert kwargs["include_non_active"] is False
+
+    def test_stale_flag_is_forwarded(self):
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = []
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            CliRunner().invoke(relationships_list, ["--stale"])
+        assert rsvc.list_relationships.call_args.kwargs["stale_only"] is True
+
+    def test_explicit_scope_id_overrides_cwd_resolution(self):
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = []
+        p1, p2, p3 = _patched(rsvc, scope_id="resolved-from-cwd")
+        with p1, p2, p3:
+            CliRunner().invoke(relationships_list, ["--scope-id", "explicit"])
+        # positional: (scope, scope_id, source_key)
+        assert rsvc.list_relationships.call_args.args[1] == "explicit"
+
+    def test_scope_id_falls_back_to_cwd_resolution(self):
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = []
+        p1, p2, p3 = _patched(rsvc, scope_id="resolved-from-cwd")
+        with p1, p2, p3:
+            CliRunner().invoke(relationships_list, [])
+        assert rsvc.list_relationships.call_args.args[1] == "resolved-from-cwd"
+
+    def test_json_format_emits_parseable_json(self):
+        import json
+
+        rsvc = MagicMock()
+        rsvc.list_relationships.return_value = [_dto()]
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_list, ["--format", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload[0]["source_key"] == "a"
+        assert "SOURCE -> TARGET" not in result.output
+
+
+class TestRelationshipsInspect:
+    def test_renders_each_field(self):
+        rsvc = MagicMock()
+        rsvc.get.return_value = _dto()
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_inspect, ["some-id"])
+        assert result.exit_code == 0
+        assert "source_key" in result.output
+        assert "relates_to" in result.output
+
+    def test_unknown_id_is_a_clean_error_not_a_traceback(self):
+        rsvc = MagicMock()
+        rsvc.get.return_value = None
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_inspect, ["nope"])
+        assert result.exit_code != 0
+        assert "relationship not found" in result.output
+        assert "Traceback" not in result.output
+
+    def test_json_format_emits_parseable_json(self):
+        import json
+
+        rsvc = MagicMock()
+        rsvc.get.return_value = _dto()
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_inspect, ["some-id", "--format", "json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["status"] == "active"
+
+
+class TestRelationshipsPromoteReject:
+    def test_promote_reports_the_new_status(self):
+        rsvc = MagicMock()
+        rsvc.promote.return_value = _dto(status="active")
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_promote, ["rid"])
+        assert result.exit_code == 0
+        rsvc.promote.assert_called_once_with("rid")
+        assert "status -> active" in result.output
+
+    def test_reject_reports_the_new_status(self):
+        rsvc = MagicMock()
+        rsvc.reject.return_value = _dto(status="rejected")
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_reject, ["rid"])
+        assert result.exit_code == 0
+        rsvc.reject.assert_called_once_with("rid")
+        assert "status -> rejected" in result.output
+
+    def test_promote_surfaces_a_service_valueerror_cleanly(self):
+        """``promote()`` raises ValueError for a rejected/deleted row. The CLI must
+        render that as a ClickException message, not a traceback."""
+        rsvc = MagicMock()
+        rsvc.promote.side_effect = ValueError(
+            "cannot promote a rejected relationship; re-create it"
+        )
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_promote, ["rid"])
+        assert result.exit_code != 0
+        assert "cannot promote a rejected relationship" in result.output
+        assert "Traceback" not in result.output
+
+    def test_reject_surfaces_a_service_valueerror_cleanly(self):
+        rsvc = MagicMock()
+        rsvc.reject.side_effect = ValueError("relationship not found: 'rid'")
+        p1, p2, p3 = _patched(rsvc)
+        with p1, p2, p3:
+            result = CliRunner().invoke(relationships_reject, ["rid"])
+        assert result.exit_code != 0
+        assert "relationship not found" in result.output
+        assert "Traceback" not in result.output

--- a/test/clients/test_memory_relationships_migration.py
+++ b/test/clients/test_memory_relationships_migration.py
@@ -1,0 +1,205 @@
+"""U1 persistence tests (issue #511): schema shape, migrator registry placement,
+dedup for global scope, idempotent re-run, and loss-aware legacy backfill."""
+
+import sqlite3
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cli_agent_orchestrator.clients import database as db_mod
+from cli_agent_orchestrator.clients.database import Base, MemoryMetadataModel
+
+
+@pytest.fixture
+def fresh_db(tmp_path, monkeypatch):
+    """A fresh sqlite file wired as both DATABASE_FILE (for the migrator's raw
+    sqlite3 connect) and SessionLocal/engine (for ORM inserts)."""
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr("cli_agent_orchestrator.constants.DATABASE_FILE", db_path, raising=False)
+    # database.py imports DATABASE_FILE lazily inside migrators via
+    # `from cli_agent_orchestrator.constants import DATABASE_FILE`, so patch the
+    # constants module attribute.
+    import cli_agent_orchestrator.constants as consts
+
+    monkeypatch.setattr(consts, "DATABASE_FILE", db_path, raising=False)
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", sessionmaker(bind=engine))
+    return db_path, engine
+
+
+def _seed(engine, key, related_keys=None, scope="global", scope_id=None):
+    s = sessionmaker(bind=engine)()
+    try:
+        s.add(
+            MemoryMetadataModel(
+                id=str(uuid.uuid4()),
+                key=key,
+                memory_type="project",
+                scope=scope,
+                scope_id=scope_id,
+                file_path=f"/{key}.md",
+                tags="t",
+                related_keys=related_keys,
+            )
+        )
+        s.commit()
+    finally:
+        s.close()
+
+
+def test_table_shape_14_columns(fresh_db):
+    db_path, _ = fresh_db
+    db_mod._migrate_memory_relationships()
+    conn = sqlite3.connect(str(db_path))
+    cols = {r[1]: r[3] for r in conn.execute("PRAGMA table_info(memory_relationships)")}
+    expected = {
+        "id",
+        "scope",
+        "scope_id",
+        "source_key",
+        "target_key",
+        "type",
+        "origin",
+        "status",
+        "confidence",
+        "rank",
+        "attributes_json",
+        "source_updated_at",
+        "created_at",
+        "updated_at",
+    }
+    assert set(cols) == expected
+    # NOT NULL on the dedup-tuple columns incl scope_id (the sentinel column).
+    for c in ("scope", "scope_id", "source_key", "target_key", "type", "origin", "status"):
+        assert cols[c] == 1, f"{c} must be NOT NULL"
+    for c in ("confidence", "rank", "attributes_json", "source_updated_at"):
+        assert cols[c] == 0, f"{c} must be nullable"
+
+
+def test_indexes_created(fresh_db):
+    db_path, _ = fresh_db
+    db_mod._migrate_memory_relationships()
+    conn = sqlite3.connect(str(db_path))
+    idx = {r[1] for r in conn.execute("PRAGMA index_list('memory_relationships')")}
+    assert "uq_memory_rel" in idx
+    assert "idx_memory_rel_lookup" in idx
+
+
+def test_migrator_appended_last_in_registry():
+    """The migrator is registered, and appended after _migrate_workflow_run_step
+    (extend, do not reorder). Reads the init_db source to assert ordering without
+    executing every migrator."""
+    import inspect
+
+    src = inspect.getsource(db_mod.init_db)
+    assert "_migrate_memory_relationships()" in src
+    assert src.index("_migrate_workflow_run_step()") < src.index("_migrate_memory_relationships()")
+    # Must not issue SQL against the workflow tables. Parse the two functions
+    # with ast and drop docstrings (which legitimately reference #504's
+    # workflow_run* tables in prose), then assert no remaining code mentions
+    # workflow_run while it does touch memory_relationships / memory_metadata.
+    import ast
+    import textwrap
+
+    def _code_without_docstrings(fn) -> str:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+                doc = ast.get_docstring(node, clean=False)
+                if doc and node.body and isinstance(node.body[0], ast.Expr):
+                    node.body = node.body[1:] or [ast.Pass()]
+        return ast.unparse(tree)
+
+    code = (
+        _code_without_docstrings(db_mod._migrate_memory_relationships)
+        + "\n"
+        + _code_without_docstrings(db_mod._backfill_legacy_related_keys)
+    )
+    assert "workflow_run" not in code, "migrator must not issue SQL against workflow tables"
+    assert "memory_relationships" in code
+    assert "memory_metadata" in code  # backfill reads it
+
+
+def test_idempotent_rerun(fresh_db):
+    db_path, _ = fresh_db
+    db_mod._migrate_memory_relationships()
+    db_mod._migrate_memory_relationships()  # no error, no duplicate table
+    conn = sqlite3.connect(str(db_path))
+    n = conn.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='memory_relationships'"
+    ).fetchone()[0]
+    assert n == 1
+
+
+def test_backfill_happy_path_preserves_rank_null_confidence(fresh_db):
+    db_path, engine = fresh_db
+    for k in ("src", "a", "b", "c"):
+        _seed(engine, k)
+    _seed_src = sessionmaker(bind=engine)()
+    # give src a related_keys list a,b,c
+    row = _seed_src.query(MemoryMetadataModel).filter(MemoryMetadataModel.key == "src").first()
+    row.related_keys = "a,b,c"
+    _seed_src.commit()
+    _seed_src.close()
+
+    db_mod._migrate_memory_relationships()
+    conn = sqlite3.connect(str(db_path))
+    rows = conn.execute(
+        "SELECT target_key, rank, confidence, type, origin, status FROM memory_relationships "
+        "WHERE source_key='src' ORDER BY rank"
+    ).fetchall()
+    assert [r[0] for r in rows] == ["a", "b", "c"]
+    assert [r[1] for r in rows] == [0, 1, 2]  # rank preserved
+    assert all(r[2] is None for r in rows)  # confidence NULL, never fabricated
+    assert all(
+        r[3] == "relates_to" and r[4] == "legacy_related_keys" and r[5] == "active" for r in rows
+    )
+
+
+def test_backfill_null_and_empty_yield_zero_rows(fresh_db):
+    db_path, engine = fresh_db
+    _seed(engine, "never", related_keys=None)  # never computed
+    _seed(engine, "empty", related_keys="")  # computed-empty
+    db_mod._migrate_memory_relationships()
+    conn = sqlite3.connect(str(db_path))
+    n = conn.execute("SELECT COUNT(*) FROM memory_relationships").fetchone()[0]
+    assert n == 0
+
+
+def test_backfill_dangling_reported_not_activated(fresh_db):
+    db_path, engine = fresh_db
+    _seed(engine, "src", related_keys="ghost")  # ghost does not exist
+    db_mod._migrate_memory_relationships()
+    conn = sqlite3.connect(str(db_path))
+    n = conn.execute("SELECT COUNT(*) FROM memory_relationships WHERE source_key='src'").fetchone()[
+        0
+    ]
+    assert n == 0  # dangling link NOT activated (reported instead)
+
+
+def test_backfill_idempotent_per_source(fresh_db):
+    db_path, engine = fresh_db
+    _seed(engine, "src", related_keys="a")
+    _seed(engine, "a")
+    db_mod._migrate_memory_relationships()
+    db_mod._migrate_memory_relationships()  # re-run
+    conn = sqlite3.connect(str(db_path))
+    n = conn.execute(
+        "SELECT COUNT(*) FROM memory_relationships WHERE source_key='src' AND target_key='a'"
+    ).fetchone()[0]
+    assert n == 1  # not double-inserted
+
+
+def test_related_keys_column_untouched(fresh_db):
+    """The migrator must NOT modify memory_metadata.related_keys (retirement is a
+    separate later change)."""
+    db_path, engine = fresh_db
+    _seed(engine, "src", related_keys="a")
+    _seed(engine, "a")
+    db_mod._migrate_memory_relationships()
+    conn = sqlite3.connect(str(db_path))
+    val = conn.execute("SELECT related_keys FROM memory_metadata WHERE key='src'").fetchone()[0]
+    assert val == "a"  # unchanged

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -78,26 +78,71 @@ def _insert_row(db_engine, key: str, file_path: str, *, tags: str = "t", related
         session.close()
 
 
+def _insert_relationship(
+    db_engine,
+    source_key,
+    target_key,
+    type_="relates_to",
+    origin="compiler",
+    status="active",
+    scope="global",
+    scope_id="",
+):
+    """Seed a row in the memory_relationships STORE (issue #511). scope_id "" is
+    the global-scope sentinel used by the relationship table."""
+    import uuid as _uuid
+
+    from cli_agent_orchestrator.clients.database import MemoryRelationshipModel
+
+    Session = sessionmaker(bind=db_engine)
+    session = Session()
+    try:
+        session.add(
+            MemoryRelationshipModel(
+                id=str(_uuid.uuid4()),
+                scope=scope,
+                scope_id=scope_id,
+                source_key=source_key,
+                target_key=target_key,
+                type=type_,
+                origin=origin,
+                status=status,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+
 @pytest.fixture
 def populated_scope(svc, db_engine, monkeypatch):
-    """Three global topics: a→b via related_keys, a/b share a tag (pairable)."""
+    """Three global topics; a→b as an ACTIVE relates_to edge in the relationship
+    STORE (issue #511 — the provider reads the store, not related_keys). The
+    related_keys column is still set as the compiler's computation-state marker
+    but is NO LONGER the graph edge source."""
     paths = {key: _write_topic(svc, key) for key in ("a", "b", "c")}
     _write_index(svc, ["a", "b", "c"])
     _insert_row(db_engine, "a", paths["a"], tags="t", related_keys="b")
     _insert_row(db_engine, "b", paths["b"], tags="t")
     _insert_row(db_engine, "c", paths["c"], tags="other")
+    # Store edge a→b (compiler origin). This is what the provider projects now.
+    _insert_relationship(db_engine, "a", "b", type_="relates_to", origin="compiler")
 
-    # run_lint constructs MemoryService() and SessionLocal() internally —
-    # point both at the test fixtures.
+    # run_lint AND the relationship service both construct SessionLocal()
+    # internally — point them at the test engine.
     _patch_lint_env(monkeypatch, db_engine, svc)
     return svc
 
 
 def _patch_lint_env(monkeypatch, db_engine, svc) -> None:
     from cli_agent_orchestrator.clients import database as db_mod
+    from cli_agent_orchestrator.services import memory_relationship_service as mrs_mod
     from cli_agent_orchestrator.services import memory_service as ms_mod
 
-    monkeypatch.setattr(db_mod, "SessionLocal", sessionmaker(bind=db_engine))
+    session_factory = sessionmaker(bind=db_engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", session_factory)
+    # The relationship service imported SessionLocal into its own namespace.
+    monkeypatch.setattr(mrs_mod, "SessionLocal", session_factory)
     monkeypatch.setattr(ms_mod, "MEMORY_BASE_DIR", svc.base_dir)
     # Hermeticity: run_lint short-circuits on is_memory_enabled() — pin it so
     # a CAO_MEMORY_ENABLED=0 environment can't fail these tests (N3).
@@ -121,11 +166,18 @@ def _disable_llm(monkeypatch) -> None:
 class TestMemoryProviderHappyPath:
     @pytest.mark.asyncio
     async def test_nodes_edges_from_populated_scope(self, populated_scope, monkeypatch):
-        """AC 1-4: topic nodes for every index key; related_keys edge with
-        source attr; contradiction edge from the lint finding; no edge
-        outside the scope's node set.
-        """
-        _stub_llm_contradicts(monkeypatch)
+        """AC 1-4, updated for issue #511: topic nodes for every index key; the
+        relates_to edge now comes from the relationship STORE (attrs.source is
+        the row ORIGIN, not "related_keys"); a store contradiction edge is
+        projected when present; no edge outside the scope's node set.
+
+        DELIBERATE EXPECTATION CHANGE (issue #511): edges are sourced from the
+        durable store, not related_keys / projection-time lint. attrs.source is
+        the provenance origin. A contradiction now requires a stored row, not a
+        live-lint stub."""
+        # The fixture already seeded the ACTIVE relates_to a→b store edge
+        # (origin=compiler). No contradiction is stored here, so none projects —
+        # a separate test covers store-sourced contradictions.
         provider = MemoryGraphProvider(memory_service=populated_scope)
 
         view = await provider.project(scope="global")
@@ -135,13 +187,10 @@ class TestMemoryProviderHappyPath:
         assert all(n.status.value == "active" for n in view.nodes)
         related = [e for e in view.edges if e.type == EdgeType.RELATES_TO]
         assert [(e.source, e.target) for e in related] == [("a", "b")]
-        assert related[0].attrs["source"] == "related_keys"
-        # related_keys carries no relevance score — none must be invented.
+        # attrs.source is now the row ORIGIN (provenance), not "related_keys".
+        assert related[0].attrs["source"] == "compiler"
+        # No relevance score is invented (FR-4.3).
         assert "score" not in related[0].attrs and "relevance" not in related[0].attrs
-
-        contradictions = [e for e in view.edges if e.type == EdgeType.CONTRADICTION]
-        assert len(contradictions) == 1
-        assert {contradictions[0].source, contradictions[0].target} == {"a", "b"}
 
         node_ids = {n.id for n in view.nodes}
         for edge in view.edges:
@@ -261,7 +310,8 @@ class TestMemoryProviderEdgeCases:
         assert by_id["lonely"].attrs["is_orphan"] is True
         assert by_id["lonely"].kind == "topic"
         assert by_id["a"].attrs["is_hub"] is True
-        # Cross-container contradiction filtered; only the related_keys edge remains.
+        # Contradictions no longer come from live lint (issue #511) — the store
+        # holds none here — so only the store relates_to edge (a→b) remains.
         assert [e.type for e in view.edges] == [EdgeType.RELATES_TO]
         # EdgeType has no orphan/hub/stale/poison members.
         assert {t.value for t in EdgeType} == {"relates_to", "contradiction", "supersedes"}

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -245,6 +245,34 @@ class TestMemoryProviderEdgeCases:
         assert view.edges == []
 
     @pytest.mark.asyncio
+    async def test_stored_edge_to_out_of_node_set_target_is_dropped(
+        self, svc, db_engine, monkeypatch
+    ):
+        """FR-2.3a: the node-set query bound must NOT replace the target check.
+
+        The provider now passes ``source_keys=<node set>`` to bound the rows
+        FETCHED, but that bounds only the SOURCE side. Here source "a" IS in the
+        node set while its target "ghost" is NOT (no index entry), so the row is
+        fetched and must still be dropped in Python. Without the surviving
+        both-endpoints check this would emit an edge to a non-existent node,
+        breaking GraphView's endpoint validation and FR-9's no-cross-scope-edge
+        guarantee — i.e. a performance fix turning into a correctness bug.
+        """
+        path_a = _write_topic(svc, "a")
+        _write_index(svc, ["a"])
+        _insert_row(db_engine, "a", path_a, tags="t")
+        # A real, ACTIVE store row whose target is outside this scope's node set.
+        _insert_relationship(db_engine, "a", "ghost", type_="relates_to", origin="compiler")
+        _disable_llm(monkeypatch)
+        _patch_lint_env(monkeypatch, db_engine, svc)
+        provider = MemoryGraphProvider(memory_service=svc)
+
+        view = await provider.project(scope="global")
+
+        assert {n.id for n in view.nodes} == {"a"}
+        assert view.edges == [], "an edge whose target is outside the node set must be dropped"
+
+    @pytest.mark.asyncio
     async def test_session_scope_id_filters_shared_index(self, svc, db_engine, monkeypatch):
         """FR-9(c): session/agent entries live in the shared global index
         with scope_id embedded in the entry path; projecting one session

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -273,6 +273,48 @@ class TestMemoryProviderEdgeCases:
         assert view.edges == [], "an edge whose target is outside the node set must be dropped"
 
     @pytest.mark.asyncio
+    async def test_relationship_read_is_bounded_to_the_node_set(
+        self, populated_scope, db_engine, monkeypatch
+    ):
+        """FR-2.3a (efficiency): the provider must push the node-set filter INTO
+        the query, not fetch every active row and discard the surplus in Python.
+
+        This is an over-read, so a correctness test cannot catch it: filtering
+        in Python yields exactly the same graph, just after reading the whole
+        (scope, scope_id). The guard therefore asserts on the CALL at the
+        service boundary — that ``source_keys`` is passed and carries this
+        projection's node set. ``list_relationships`` accepting the parameter is
+        a different (already covered) claim; nothing else proved the provider
+        actually uses it.
+        """
+        from cli_agent_orchestrator.services import memory_relationship_service as _mrs
+
+        seen = {}
+        real = _mrs.MemoryRelationshipService.list_relationships
+
+        def _recording(self, scope, scope_id, **kw):
+            seen["source_keys"] = kw.get("source_keys", "MISSING")
+            return real(self, scope, scope_id, **kw)
+
+        monkeypatch.setattr(_mrs.MemoryRelationshipService, "list_relationships", _recording)
+        _disable_llm(monkeypatch)
+        provider = MemoryGraphProvider(memory_service=populated_scope)
+
+        view = await provider.project(scope="global")
+
+        assert seen.get("source_keys") not in (
+            "MISSING",
+            None,
+        ), "the relationship read must be bounded by source_keys, not load the whole scope"
+        assert set(seen["source_keys"]) == {
+            "a",
+            "b",
+            "c",
+        }, f"source_keys must carry this projection's node set, got {seen['source_keys']}"
+        # And the bound must not have cost us the real edge.
+        assert [(e.source, e.target) for e in view.edges] == [("a", "b")]
+
+    @pytest.mark.asyncio
     async def test_session_scope_id_filters_shared_index(self, svc, db_engine, monkeypatch):
         """FR-9(c): session/agent entries live in the shared global index
         with scope_id embedded in the entry path; projecting one session

--- a/test/graph/providers/test_memory_provider.py
+++ b/test/graph/providers/test_memory_provider.py
@@ -273,6 +273,42 @@ class TestMemoryProviderEdgeCases:
         assert view.edges == [], "an edge whose target is outside the node set must be dropped"
 
     @pytest.mark.asyncio
+    async def test_edge_written_by_run_lint_is_visible_in_the_same_projection(
+        self, populated_scope, db_engine, monkeypatch
+    ):
+        """Human review (PR #524): the relationship read must happen AFTER
+        run_lint, because run_lint persists its contradiction findings into the
+        same store.
+
+        Reading first made a contradiction detected during THIS projection absent
+        from the graph it produced — invisible for a full cache window, then
+        appearing later with no apparent cause. Here a stubbed run_lint writes a
+        real store row for a pair already in the node set; the returned view must
+        contain that edge.
+        """
+        written = {"n": 0}
+
+        async def _lint_that_writes(project_hash, scope=None, **kw):
+            # Stands in for _persist_contradictions: a real row, written while
+            # run_lint is executing.
+            _insert_relationship(db_engine, "b", "c", type_="contradiction", origin="wiki_lint")
+            written["n"] += 1
+            return []
+
+        monkeypatch.setattr(wiki_lint, "run_lint", _lint_that_writes)
+        _disable_llm(monkeypatch)
+        provider = MemoryGraphProvider(memory_service=populated_scope)
+
+        view = await provider.project(scope="global")
+
+        assert written["n"] == 1, "run_lint must have run"
+        contra = [(e.source, e.target) for e in view.edges if e.type == EdgeType.CONTRADICTION]
+        assert contra == [("b", "c")], (
+            "an edge run_lint wrote during this projection must appear in it; "
+            f"got contradiction edges {contra}"
+        )
+
+    @pytest.mark.asyncio
     async def test_relationship_read_is_bounded_to_the_node_set(
         self, populated_scope, db_engine, monkeypatch
     ):

--- a/test/services/test_audit_log.py
+++ b/test/services/test_audit_log.py
@@ -418,6 +418,10 @@ class TestT9SyncVsNowait:
                 "find_related_completed",
                 # Self-learning instruction promotion (CLI/apply path).
                 "instruction_promotion",
+                # Typed memory relationship store (issue #511) — content-free
+                # mutation audit, emitted by the synchronous relationship service
+                # via write_audit_nowait (same path as the memory_* events).
+                "relationship_mutation",
             }
         )
 

--- a/test/services/test_memory_relationship_integration.py
+++ b/test/services/test_memory_relationship_integration.py
@@ -850,18 +850,16 @@ def test_superseded_keys_does_not_cross_project_scope_ids(bound, db_engine, monk
     p1_mem, p2_mem = _mem("guide", "p1"), _mem("guide", "p2")
     hits = svc._superseded_keys([p1_mem, p2_mem])
 
-    # BEHAVIOURAL assertion: the demotion predicate recall actually applies must
-    # mark p1's copy and spare p2's. Expressed exactly as the recall sort does,
-    # so this fails for a set keyed too loosely REGARDLESS of tuple arity.
-    def _is_demoted(m):
-        return (m.scope, svc._effective_scope_id(m), m.key) in hits or (
-            m.scope,
-            m.key,
-        ) in hits
-
-    assert _is_demoted(p1_mem), "p1's superseded copy must be demoted"
-    assert not _is_demoted(
-        p2_mem
+    # BEHAVIOURAL assertion driving the PRODUCTION predicate (``_is_superseded``,
+    # which recall's demotion sort key calls) — NOT a local re-expression of it.
+    # An earlier version of this test defined its own ``_is_demoted`` that OR-ed
+    # in the loose ``(scope, key)`` form; that made it pass even when the real
+    # sort key was mutated back to the cross-project-demoting comparison, so it
+    # proved only that ``_superseded_keys`` was well-formed. Calling the shipped
+    # predicate is what gives this test a genuine failure mode.
+    assert svc._is_superseded(p1_mem, hits), "p1's superseded copy must be demoted"
+    assert not svc._is_superseded(
+        p2_mem, hits
     ), "p2's untouched copy must NOT be demoted — a (scope, key) set cross-project-demotes it"
     # And the identity stored is the full 3-tuple.
     assert ("project", "p1", "guide") in hits

--- a/test/services/test_memory_relationship_integration.py
+++ b/test/services/test_memory_relationship_integration.py
@@ -593,6 +593,93 @@ def test_replace_set_soft_rejects_bad_edge_not_whole_batch(bound, db_engine):
     assert svc.active_targets("global", None, "s") == ["good"]
 
 
+def test_replace_set_does_not_resurrect_a_human_rejected_edge(bound, db_engine):
+    """Human review (PR #524): an operator's ``relationships reject`` verdict must
+    survive the next producer recompute.
+
+    ``replace_set``'s existing-row query is deliberately status-agnostic (it owns
+    every row of its producer tuple), so a rejected row lands in
+    ``existing_by_target``. The keep-branch used to force ``status = "active"``
+    unconditionally, so the very next compile silently resurrected an edge a human
+    had explicitly rejected — no report entry, nothing in the output. That defeats
+    the curation surface (``cao memory relationships reject``) this store ships.
+
+    Drives the REAL path: reject via the service, then recompute through
+    ``replace_set`` with the target STILL in the producer's set.
+    """
+    for k in ("s", "keepme"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    dto = svc.create("global", None, "s", "keepme", "relates_to", "compiler")
+    assert svc.reject(dto.id).status == "rejected"
+
+    # The producer recomputes and STILL reports the edge.
+    report = svc.replace_set("global", None, "s", "compiler", "relates_to", [EdgeInput("keepme")])
+
+    row = svc.get(dto.id)
+    assert row.status == "rejected", (
+        "a producer recompute must NOT reactivate a human-rejected edge; "
+        f"got status={row.status}"
+    )
+    # The refusal is visible, not silent.
+    assert {"target": "keepme", "status": "rejected"} in report.preserved
+    assert report.kept == 0, "a preserved row is not a kept row"
+    # And it stays out of the active projection.
+    assert svc.active_targets("global", None, "s") == []
+
+
+def test_replace_set_does_not_delete_a_rejected_edge_dropped_by_the_producer(bound, db_engine):
+    """The other half of the same guarantee: DROPPING the target from the
+    producer's set must not delete the operator's verdict either.
+
+    Deleting the row would discard the rejection just as surely as reactivating
+    it — and worse, the next recompute that re-reports the target would insert a
+    fresh ``active`` row with the rejection gone. So the delete-branch must skip
+    curation-terminal rows too.
+    """
+    for k in ("s", "dropme", "other"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    dto = svc.create("global", None, "s", "dropme", "relates_to", "compiler")
+    svc.reject(dto.id)
+
+    # Recompute WITHOUT "dropme" — the producer no longer reports it.
+    report = svc.replace_set("global", None, "s", "compiler", "relates_to", [EdgeInput("other")])
+
+    assert (
+        svc.get(dto.id).status == "rejected"
+    ), "dropping the target must not delete the rejection row"
+    assert {"target": "dropme", "status": "rejected"} in report.preserved
+    assert report.removed == 0, "a preserved row must not count as removed"
+
+    # The rejection still suppresses a later recompute that re-reports it.
+    svc.replace_set("global", None, "s", "compiler", "relates_to", [EdgeInput("dropme")])
+    assert (
+        svc.active_targets("global", None, "s") == []
+    ), "a re-reported rejected target must not come back as active"
+
+
+def test_replace_set_still_reactivates_a_superseded_edge(bound, db_engine):
+    """Scoping control for the fix: ``superseded`` is NOT curation-terminal.
+
+    It is lifecycle-DERIVED rather than operator-authored, so a producer that
+    still reports the edge is legitimate evidence the supersession no longer
+    holds. This pins the boundary — a fix that over-broadly froze every
+    non-active status would turn this test RED.
+    """
+    for k in ("s", "t"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    dto = svc.create("global", None, "s", "t", "relates_to", "compiler")
+    svc.patch(dto.id, status="superseded")
+
+    report = svc.replace_set("global", None, "s", "compiler", "relates_to", [EdgeInput("t")])
+
+    assert svc.get(dto.id).status == "active", "a superseded edge is reactivated by its producer"
+    assert report.kept == 1
+    assert report.preserved == []
+
+
 def test_replace_set_emits_audit(bound, db_engine, monkeypatch):
     """reviewer F2: replace_set (bulk producer path) emits a content-free summary
     audit event, so producer writes are not forensically silent."""
@@ -965,3 +1052,191 @@ def test_list_relationships_source_keys_drops_unsanitizable_key(bound, db_engine
     svc.create("global", None, "good", "t", "relates_to", "human")
     dtos = svc.list_relationships("global", None, source_keys=["good", "...", "___"])
     assert [d.source_key for d in dtos] == ["good"], "the valid key's edge must survive"
+
+
+def test_forget_purges_relationships_and_slug_reuse_inherits_nothing(
+    bound, db_engine, tmp_path, monkeypatch
+):
+    """Human review (PR #524): ``forget()`` must purge the key's relationship rows.
+
+    forget() removed the wiki file, the index entry and the memory_metadata row
+    but left memory_relationships rows behind, still ``active``. Two consequences:
+    every read path had to tolerate endpoints that no longer resolve, and a later
+    memory created with the SAME slug silently INHERITED the dead memory's edges.
+
+    Drives the real composed path: store -> edge -> forget -> re-store same slug.
+    """
+    import asyncio
+
+    from cli_agent_orchestrator.clients import database as db_mod
+    from cli_agent_orchestrator.services import memory_service as ms_mod
+
+    svc = ms_mod.MemoryService(base_dir=tmp_path, db_engine=db_engine)
+    monkeypatch.setattr(ms_mod, "MEMORY_BASE_DIR", tmp_path)
+    Session = sessionmaker(bind=db_engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", Session)
+
+    async def _setup():
+        for k in ("doomed", "survivor"):
+            await svc.store(content=f"# {k}\nbody", key=k, memory_type="project", scope="global")
+
+    asyncio.run(_setup())
+
+    rel = _svc()
+    # An edge in EACH direction — both are dangling once "doomed" is gone.
+    rel.create("global", None, "doomed", "survivor", "relates_to", "compiler")
+    rel.create("global", None, "survivor", "doomed", "relates_to", "compiler")
+    assert len(rel.list_relationships("global", None, "doomed")) == 1
+    assert len(rel.list_relationships("global", None, "survivor")) == 1
+
+    assert asyncio.run(svc.forget("doomed", scope="global", scope_id=None)) is True
+
+    # Both directions are gone...
+    assert rel.list_relationships("global", None, "doomed") == []
+    assert (
+        rel.list_relationships("global", None, "survivor") == []
+    ), "an edge INTO the forgotten key is equally dangling and must also be purged"
+
+    # ...and a NEW memory reusing the slug inherits nothing.
+    asyncio.run(
+        svc.store(
+            content="# doomed\nreused slug", key="doomed", memory_type="project", scope="global"
+        )
+    )
+    assert (
+        rel.active_targets("global", None, "doomed") == []
+    ), "a same-slug memory must not inherit the forgotten memory's edges"
+
+
+def test_forget_purges_relationships_when_the_file_already_vanished(
+    bound, db_engine, tmp_path, monkeypatch
+):
+    """The other forget() exit path: the wiki file is already gone (removed
+    out-of-band), so forget() returns False early. The relationship rows are just
+    as stale on that path and must be purged too — otherwise the cleanup depends
+    on which branch happened to run."""
+    import asyncio
+
+    from cli_agent_orchestrator.clients import database as db_mod
+    from cli_agent_orchestrator.services import memory_service as ms_mod
+
+    svc = ms_mod.MemoryService(base_dir=tmp_path, db_engine=db_engine)
+    monkeypatch.setattr(ms_mod, "MEMORY_BASE_DIR", tmp_path)
+    Session = sessionmaker(bind=db_engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", Session)
+
+    async def _setup():
+        for k in ("ghost", "other"):
+            await svc.store(content=f"# {k}\nbody", key=k, memory_type="project", scope="global")
+
+    asyncio.run(_setup())
+    rel = _svc()
+    rel.create("global", None, "ghost", "other", "relates_to", "compiler")
+
+    # Remove the file out-of-band so forget() takes the not-exists branch.
+    svc.get_wiki_path("global", None, "ghost").unlink()
+
+    assert asyncio.run(svc.forget("ghost", scope="global", scope_id=None)) is False
+    assert (
+        rel.list_relationships("global", None, "ghost") == []
+    ), "the vanished-file path must purge relationships too"
+
+
+def test_stale_flag_is_live_after_the_source_is_edited(bound, db_engine):
+    """Human review (PR #524): the ``stale`` flag was INERT.
+
+    Staleness is derived from ``row.source_updated_at``, but NO production caller
+    ever wrote that column — so the DTO field, the CLI's ``--stale`` and the REST
+    ``?stale=true`` could only ever report False. ``replace_set`` now stamps the
+    source memory's ``updated_at`` at write time, which makes the whole advertised
+    surface real.
+
+    Timeline: write the edge, THEN advance the source memory's updated_at. The
+    edge was computed against the older body, so it is stale.
+    """
+    from datetime import timedelta
+
+    for k in ("s", "t"):
+        _seed_memory(db_engine, k)
+    Session = sessionmaker(bind=db_engine)
+
+    t0 = datetime.now(timezone.utc) - timedelta(hours=2)
+    s = Session()
+    try:
+        row = s.query(MemoryMetadataModel).filter(MemoryMetadataModel.key == "s").first()
+        row.updated_at = t0
+        s.commit()
+    finally:
+        s.close()
+
+    svc = _svc()
+    svc.replace_set("global", None, "s", "compiler", "relates_to", [EdgeInput("t")])
+
+    # Fresh right after the write — the stamp equals the source's updated_at.
+    assert svc.list_relationships("global", None, "s")[0].stale is False
+
+    # The source memory is edited AFTER the edge was computed.
+    s = Session()
+    try:
+        row = s.query(MemoryMetadataModel).filter(MemoryMetadataModel.key == "s").first()
+        row.updated_at = t0 + timedelta(hours=1)
+        s.commit()
+    finally:
+        s.close()
+
+    dto = svc.list_relationships("global", None, "s")[0]
+    assert dto.stale is True, (
+        "an edge computed before the source memory was edited must read stale; "
+        "without a source_updated_at writer this can never be True"
+    )
+    # And the advertised filter surfaces it.
+    assert [d.target_key for d in svc.list_relationships("global", None, "s", stale_only=True)] == [
+        "t"
+    ]
+
+
+def test_concurrent_create_of_same_tuple_does_not_raise_integrityerror(
+    bound, db_engine, monkeypatch
+):
+    """Human review (PR #524): the dedup race must not surface as a 500.
+
+    ``create()`` is a read-then-insert with no transactional protection, so two
+    concurrent creates of the same dedup tuple both miss the existence check and
+    both insert. The loser hit the UNIQUE index and raised ``IntegrityError`` —
+    not ``ValueError`` — which escaped every REST handler's ValueError->400
+    mapping as an unhandled 500.
+
+    Simulates the interleaving deterministically by making the LOSER's existence
+    probe return None while a committed row already exists — exactly the state
+    the losing thread observes. The probe is blinded via a one-shot flag on the
+    service's own query helper rather than a string match on the SQL, so this
+    test genuinely exercises the IntegrityError path: removing the handler turns
+    it RED (verified by mutation).
+    """
+    for k in ("s", "t"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    first = svc.create("global", None, "s", "t", "relates_to", "human")
+    assert first is not None
+
+    # Blind exactly the next existence probe. ``_find_existing`` is the seam
+    # create() uses to decide insert-vs-upsert; returning None there puts us on
+    # the insert branch with the row already committed => UNIQUE violation.
+    real_find = mrs_mod.MemoryRelationshipService._find_existing
+    state = {"blinded": False}
+
+    def _blind_once(self, db, scope, sentinel, src, tgt, type_, origin):
+        if not state["blinded"]:
+            state["blinded"] = True
+            return None
+        return real_find(self, db, scope, sentinel, src, tgt, type_, origin)
+
+    monkeypatch.setattr(mrs_mod.MemoryRelationshipService, "_find_existing", _blind_once)
+
+    # Must NOT raise IntegrityError; converges on the winning row.
+    second = svc.create("global", None, "s", "t", "relates_to", "human")
+
+    assert state["blinded"], "the probe must actually have been blinded"
+    assert second.id == first.id, "the racing create must converge on the winning row"
+    rows = svc.list_relationships("global", None, "s")
+    assert len([r for r in rows if r.target_key == "t"]) == 1, "no duplicate row may land"

--- a/test/services/test_memory_relationship_integration.py
+++ b/test/services/test_memory_relationship_integration.py
@@ -22,13 +22,19 @@ Scenarios:
 """
 
 import uuid
+from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from cli_agent_orchestrator.clients import database as db_mod
-from cli_agent_orchestrator.clients.database import Base, MemoryMetadataModel
+from cli_agent_orchestrator.clients.database import (
+    Base,
+    MemoryMetadataModel,
+    MemoryRelationshipModel,
+)
 from cli_agent_orchestrator.services import memory_relationship_service as mrs_mod
 from cli_agent_orchestrator.services.memory_relationship_service import (
     EdgeInput,
@@ -53,7 +59,31 @@ def bound(monkeypatch, db_engine):
     return Session
 
 
-def _seed_memory(db_engine, key, scope="global", scope_id=None, body="body"):
+def _seed_memory(db_engine, key, scope="global", scope_id=None, body=None, body_dir=None):
+    """Seed a memory_metadata row.
+
+    ``body`` is the memory's CONTENT. Memory bodies live in files, not in
+    ``memory_metadata`` (the table has no body/content column), so a body is
+    only storable when the caller supplies ``body_dir``: the file is written
+    there and ``file_path`` points at it, making the content genuinely
+    retrievable from the row.
+
+    This signature deliberately refuses to accept-and-discard a body. An earlier
+    version took ``body="body"`` and silently dropped it, which made every
+    "the secret must not leak" assertion pass vacuously — the secret had never
+    been written anywhere. If you pass ``body`` you MUST pass ``body_dir``.
+    """
+    if body is not None and body_dir is None:
+        raise AssertionError(
+            "_seed_memory: body requires body_dir — a body with nowhere to live "
+            "would be discarded, making content-leak assertions vacuous"
+        )
+    if body is not None:
+        file_path = str(Path(body_dir) / f"{key}.md")
+        Path(body_dir).mkdir(parents=True, exist_ok=True)
+        Path(file_path).write_text(body, encoding="utf-8")
+    else:
+        file_path = f"/{key}.md"
     Session = sessionmaker(bind=db_engine)
     s = Session()
     try:
@@ -64,7 +94,7 @@ def _seed_memory(db_engine, key, scope="global", scope_id=None, body="body"):
                 memory_type="project",
                 scope=scope,
                 scope_id=scope_id,
-                file_path=f"/{key}.md",
+                file_path=file_path,
                 tags="t",
             )
         )
@@ -460,23 +490,50 @@ def test_s6_legacy_related_keys_unconverted_still_expands(bound, db_engine, tmp_
     ), f"unconverted legacy related_keys must still expand; got {keys}"
 
 
-def test_s1_composed_path_and_content_free(bound, db_engine):
+def test_s1_composed_path_and_content_free(bound, db_engine, tmp_path):
     """S1 (end-to-end) + SEC-IP4 content-free: a compiler-written edge is
     projectable and every read surface (list DTO, active_targets) exposes only
-    content-free fields — no body/body_hash/prompt. (See Also/recall/graph
-    composition over MemoryService is covered by the provider + memory_service
-    suites; here we assert the store->DTO path is content-free.)"""
+    content-free fields — no body/body_hash/prompt.
+
+    The secret is written to the seeded memories' real FILES, and those files are
+    reachable from the store's own rows (``memory_metadata.file_path``). That is
+    what gives this assertion a genuine failure mode: a projection that resolved
+    an endpoint's ``file_path`` and inlined its content — the plausible way this
+    boundary would actually leak — turns the test RED.
+
+    Guarding the guard: the test asserts the secret IS retrievable through the
+    row before asserting the DTO omits it. Without that first assertion the
+    whole check passes vacuously whenever the content was never stored, which is
+    precisely the defect this test previously had (it passed a ``body`` argument
+    that ``_seed_memory`` silently discarded).
+    """
+    secret = "SECRET BODY TEXT that must never leak"
     for k in ("a", "b"):
-        _seed_memory(db_engine, k, body="SECRET BODY TEXT that must never leak")
+        _seed_memory(db_engine, k, body=secret, body_dir=tmp_path / "wiki")
+    # PRE-ASSERTION: the secret is genuinely stored and reachable from the row,
+    # so "not in the DTO" is a real claim about the projection.
+    Session = sessionmaker(bind=db_engine)
+    s = Session()
+    try:
+        row = s.query(MemoryMetadataModel).filter(MemoryMetadataModel.key == "a").first()
+        assert row is not None and row.file_path
+        assert secret in Path(row.file_path).read_text(
+            encoding="utf-8"
+        ), "content must actually exist behind the row, or the leak check is vacuous"
+    finally:
+        s.close()
+
     svc = _svc()
     svc.replace_set("global", None, "a", "compiler", "relates_to", [EdgeInput("b")])
     # active_targets is the See-Also/recall projection helper
-    assert svc.active_targets("global", None, "a") == ["b"]
+    targets = svc.active_targets("global", None, "a")
+    assert targets == ["b"]
+    assert secret not in str(targets), "active_targets must project keys only, never content"
     dto = svc.list_relationships("global", None, "a")[0]
     d = dto.to_dict()
-    for forbidden in ("body", "body_hash", "prompt"):
+    for forbidden in ("body", "body_hash", "prompt", "content", "file_path"):
         assert forbidden not in d, f"DTO must be content-free ({forbidden})"
-    assert "SECRET BODY" not in str(d), "no memory body may leak into the DTO"
+    assert secret not in str(d), "no memory body may leak into the DTO"
 
 
 def test_secs12_audit_written_and_content_free(bound, db_engine, tmp_path, monkeypatch):
@@ -570,3 +627,343 @@ def test_stale_flag_and_filter(bound, db_engine):
     all_edges = svc.list_relationships("global", None, "a")
     assert all_edges and all_edges[0].stale is True
     assert len(svc.list_relationships("global", None, "a", stale_only=True)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# PR #524 review-round regressions (each fails on the pre-fix code)
+# --------------------------------------------------------------------------- #
+def test_rank_then_created_handles_null_and_naive_created_at():
+    """FR-3.1/FR-3.2: the sort key never raises on a NULL or naive ``created_at``.
+
+    Why this is asserted on the sort FUNCTION and not through a DB round-trip:
+    ``DATABASE_URL`` is SQLite-only (constants.py) and SQLite does not persist
+    timezone offsets, so every ``created_at`` READ BACK from the DB is naive —
+    including on the ``DateTime(timezone=True)`` column. A DB-level test can
+    therefore never produce the naive/aware mix, and asserting there would pass
+    whether or not the fix is present (a vacuous test).
+
+    The mix IS reachable at the function boundary: ``_utcnow`` stamps an AWARE
+    value, so a row object still holding its Python-side default (not yet
+    refreshed from the DB) sorts aware, while a NULL row falls back to the
+    sentinel and any DB-loaded row is naive. Pre-fix the key was
+    ``r.created_at or datetime.min`` — a NAIVE sentinel — so mixing it with an
+    aware value raised ``TypeError: can't compare offset-naive and offset-aware
+    datetimes``. Both sides are now normalised to tz-aware UTC.
+
+    Equal ranks force the datetime comparison; with distinct ranks the tuple's
+    first element decides and ``created_at`` is never compared.
+    """
+
+    class _Row:
+        def __init__(self, rank, created_at, target_key):
+            self.rank = rank
+            self.created_at = created_at
+            self.target_key = target_key
+
+    aware = _Row(1, datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc), "t-aware")
+    naive = _Row(1, datetime(2026, 6, 1, 12, 0), "t-naive")
+    nulled = _Row(1, None, "t-null")
+
+    # Pre-fix: sorting these together raises TypeError.
+    rows = [aware, nulled, naive]
+    rows.sort(key=mrs_mod._rank_then_created)
+    assert [r.target_key for r in rows] == ["t-null", "t-naive", "t-aware"], (
+        "NULL sorts first (earliest instant), then the naive value read as UTC, "
+        "then the later aware value"
+    )
+    # Every normalised key is tz-aware, so any pair is comparable.
+    for row in rows:
+        assert mrs_mod._sort_dt(row.created_at).tzinfo is not None
+
+
+def test_active_targets_orders_by_rank_then_created_at(bound, db_engine):
+    """FR-3.1 through the real DB path: a NULL ``created_at`` row alongside a
+    populated one sorts without raising, and the NULL row comes first.
+
+    This is the end-to-end companion to the function-level test above. On SQLite
+    both values read back naive, so this cannot reproduce the naive/aware
+    TypeError — it guards the NULL-fallback ordering itself.
+    """
+    for k in ("src", "t-null", "t-populated"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    svc.create("global", None, "src", "t-populated", "relates_to", "human", rank=1)
+    svc.create("global", None, "src", "t-null", "relates_to", "human", rank=1)
+    Session = sessionmaker(bind=db_engine)
+    s = Session()
+    try:
+        row = (
+            s.query(MemoryRelationshipModel)
+            .filter(MemoryRelationshipModel.target_key == "t-null")
+            .first()
+        )
+        assert row is not None
+        row.created_at = None
+        s.commit()
+    finally:
+        s.close()
+
+    targets = svc.active_targets("global", None, "src")
+    assert sorted(targets) == ["t-null", "t-populated"]
+    assert targets[0] == "t-null", "the NULL-created_at row sorts first"
+
+
+def test_active_targets_for_batches_many_sources(bound, db_engine):
+    """FR-2.1/FR-2.5: the batched read returns per-source ordered targets and
+    matches single-key ``active_targets`` for every source."""
+    for k in ("s1", "s2", "s3", "t1", "t2", "t3"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    # s1 -> t2 (rank 2), t1 (rank 1): rank decides the order, not insertion.
+    svc.create("global", None, "s1", "t2", "relates_to", "compiler", rank=2)
+    svc.create("global", None, "s1", "t1", "relates_to", "compiler", rank=1)
+    svc.create("global", None, "s2", "t3", "relates_to", "compiler")
+    # s3 has no edges at all.
+    out = svc.active_targets_for("global", None, ["s1", "s2", "s3"])
+    assert out["s1"] == ["t1", "t2"], "must honour (rank, created_at) order"
+    assert out["s2"] == ["t3"]
+    assert "s3" not in out, "a source with no active edges is absent, not empty"
+    # Batched result agrees with the single-key helper for every source.
+    for k in ("s1", "s2", "s3"):
+        assert out.get(k, []) == svc.active_targets("global", None, k)
+    # Empty input short-circuits.
+    assert svc.active_targets_for("global", None, []) == {}
+
+
+def test_active_targets_for_excludes_non_active_and_other_types(bound, db_engine):
+    """FR-2.5: the batched read applies the same status/type filters as the
+    single-key helper — only ACTIVE edges of the requested type."""
+    for k in ("s", "t-active", "t-rejected", "t-contra"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    svc.create("global", None, "s", "t-active", "relates_to", "human")
+    rejected = svc.create("global", None, "s", "t-rejected", "relates_to", "human")
+    svc.reject(rejected.id)
+    svc.create("global", None, "s", "t-contra", "contradiction", "wiki_lint")
+    out = svc.active_targets_for("global", None, ["s"])
+    assert out["s"] == ["t-active"]
+    contra = svc.active_targets_for("global", None, ["s"], type="contradiction")
+    assert contra["s"] == ["t-contra"]
+
+
+def test_list_relationships_source_keys_bounds_the_fetch(bound, db_engine):
+    """FR-2.3: the ``source_keys`` filter bounds which rows are fetched."""
+    for k in ("in1", "in2", "out1", "t"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    for src in ("in1", "in2", "out1"):
+        svc.create("global", None, src, "t", "relates_to", "human")
+    bounded = svc.list_relationships("global", None, source_keys=["in1", "in2"])
+    assert sorted(d.source_key for d in bounded) == ["in1", "in2"]
+    # An EMPTY node set means no edges — not "unfiltered".
+    assert svc.list_relationships("global", None, source_keys=[]) == []
+    # Absent filter still returns everything.
+    assert len(svc.list_relationships("global", None)) == 3
+
+
+def test_validate_attributes_rejects_unserialisable_as_valueerror(bound, db_engine):
+    """FR-4.1/FR-4.2: a non-JSON-serialisable attribute raises ValueError, not
+    TypeError.
+
+    A TypeError would escape the REST layer's ``ValueError -> 400`` mapping (an
+    unhandled 500) and defeat ``replace_set``'s per-edge soft rejection, which
+    catches only ValueError.
+    """
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    with pytest.raises(ValueError, match="JSON-serialisable"):
+        svc.create("global", None, "a", "b", "relates_to", "human", attributes={"bad": {1, 2, 3}})
+
+
+def test_replace_set_soft_rejects_unserialisable_edge_not_whole_batch(bound, db_engine):
+    """FR-4.2: the per-edge soft rejection now covers an unserialisable
+    attribute — pre-fix the TypeError aborted the entire batch."""
+    for k in ("s", "good", "bad"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    report = svc.replace_set(
+        "global",
+        None,
+        "s",
+        "compiler",
+        "relates_to",
+        [EdgeInput("bad", attributes={"x": {1, 2}}), EdgeInput("good")],
+    )
+    assert report.added == 1, "the good edge must still land"
+    assert report.rejected, "the unserialisable edge must be soft-rejected"
+    assert svc.active_targets("global", None, "s") == ["good"]
+
+
+def test_attributes_size_error_reports_bytes(bound, db_engine):
+    """FR-4.3: the size message reports the unit actually enforced (bytes).
+
+    A multi-byte payload is used so a char count and a byte count differ — a
+    message still reporting chars would show the smaller, misleading number.
+    """
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    # Each "€" is 3 UTF-8 bytes, so chars << bytes.
+    oversized = {"k": "€" * 1200}
+    with pytest.raises(ValueError, match=r"exceed 2048 bytes \(\d+ bytes\)") as e:
+        svc.create("global", None, "a", "b", "relates_to", "human", attributes=oversized)
+    assert "chars" not in str(e.value)
+
+
+def test_superseded_keys_does_not_cross_project_scope_ids(bound, db_engine, monkeypatch):
+    """FR-5.4: the same key in two DIFFERENT project scope_ids must not share a
+    superseded verdict.
+
+    ``memory_metadata`` is unique on ``(key, scope, scope_id)``, so "guide" in
+    project P1 and "guide" in project P2 are DIFFERENT memories. Pre-fix
+    ``_superseded_keys`` returned ``{(scope, key)}``, so superseding P1's copy
+    marked P2's untouched copy as superseded too whenever a recall spanned both
+    projects. The identity is now the full ``(scope, scope_id, key)`` 3-tuple.
+    """
+    from datetime import datetime as _dt
+
+    from cli_agent_orchestrator.models.memory import Memory
+    from cli_agent_orchestrator.services.memory_service import MemoryService
+
+    # "guide" exists in BOTH projects; only p1's copy is superseded.
+    _seed_memory(db_engine, "guide", scope="project", scope_id="p1")
+    _seed_memory(db_engine, "newer", scope="project", scope_id="p1")
+    _seed_memory(db_engine, "guide", scope="project", scope_id="p2")
+    _svc().create("project", "p1", "newer", "guide", "supersedes", "human")
+
+    def _mem(key, scope_id):
+        now = _dt.now(timezone.utc)
+        return Memory(
+            id=str(uuid.uuid4()),
+            key=key,
+            memory_type="project",
+            scope="project",
+            scope_id=scope_id,
+            file_path=f"/{key}.md",
+            tags="",
+            created_at=now,
+            updated_at=now,
+        )
+
+    svc = MemoryService()
+    p1_mem, p2_mem = _mem("guide", "p1"), _mem("guide", "p2")
+    hits = svc._superseded_keys([p1_mem, p2_mem])
+
+    # BEHAVIOURAL assertion: the demotion predicate recall actually applies must
+    # mark p1's copy and spare p2's. Expressed exactly as the recall sort does,
+    # so this fails for a set keyed too loosely REGARDLESS of tuple arity.
+    def _is_demoted(m):
+        return (m.scope, svc._effective_scope_id(m), m.key) in hits or (
+            m.scope,
+            m.key,
+        ) in hits
+
+    assert _is_demoted(p1_mem), "p1's superseded copy must be demoted"
+    assert not _is_demoted(
+        p2_mem
+    ), "p2's untouched copy must NOT be demoted — a (scope, key) set cross-project-demotes it"
+    # And the identity stored is the full 3-tuple.
+    assert ("project", "p1", "guide") in hits
+    assert ("project", "p2", "guide") not in hits
+
+
+def test_expand_related_does_not_query_the_store_per_primary(bound, db_engine, monkeypatch):
+    """FR-2.2: the store read in recall's expansion is BATCHED per
+    (scope, scope_id) — one call for N primaries, not one per primary.
+
+    A correctness test cannot catch this: an N+1 returns exactly the right
+    answers, just with N queries. So the guard counts service calls. The legacy
+    ``related_keys`` fallback beside it was already batched; the store read was
+    not, which made the AUTHORITATIVE path the slow one.
+    """
+    from datetime import datetime as _dt
+
+    from cli_agent_orchestrator.models.memory import Memory
+    from cli_agent_orchestrator.services import memory_service as ms_mod
+    from cli_agent_orchestrator.services.memory_service import MemoryService
+
+    primaries_keys = ["p1", "p2", "p3", "p4", "p5"]
+    for k in primaries_keys + ["t1"]:
+        _seed_memory(db_engine, k)
+    svc_rel = _svc()
+    for k in primaries_keys:
+        svc_rel.create("global", None, k, "t1", "relates_to", "compiler")
+
+    calls = {"batched": 0, "per_key": 0}
+    real_batched = mrs_mod.MemoryRelationshipService.active_targets_for
+    real_single = mrs_mod.MemoryRelationshipService.active_targets
+
+    def _counting_batched(self, *a, **kw):
+        calls["batched"] += 1
+        return real_batched(self, *a, **kw)
+
+    def _counting_single(self, *a, **kw):
+        calls["per_key"] += 1
+        return real_single(self, *a, **kw)
+
+    monkeypatch.setattr(mrs_mod.MemoryRelationshipService, "active_targets_for", _counting_batched)
+    monkeypatch.setattr(mrs_mod.MemoryRelationshipService, "active_targets", _counting_single)
+    monkeypatch.setattr(ms_mod, "MEMORY_BASE_DIR", Path(str(db_engine.url).split("///")[-1]).parent)
+
+    def _mem(key):
+        now = _dt.now(timezone.utc)
+        return Memory(
+            id=str(uuid.uuid4()),
+            key=key,
+            memory_type="project",
+            scope="global",
+            scope_id=None,
+            file_path=f"/{key}.md",
+            tags="",
+            created_at=now,
+            updated_at=now,
+        )
+
+    svc = MemoryService()
+    svc._expand_related([_mem(k) for k in primaries_keys])
+
+    assert calls["batched"] == 1, (
+        f"5 primaries in ONE (scope, scope_id) must cost ONE batched store read, "
+        f"got {calls['batched']}"
+    )
+    assert calls["per_key"] == 0, (
+        f"the per-primary active_targets call is the N+1 — it must not be used in "
+        f"the expansion path, got {calls['per_key']} calls"
+    )
+
+
+def test_patch_rejects_unserialisable_attributes_as_valueerror(bound, db_engine):
+    """FR-4.1 on the PATCH path: ``patch`` validates attributes through the same
+    helper as ``create``, so it must also raise ValueError (not TypeError).
+
+    The PATCH handler maps ValueError to 404-or-400; a TypeError would surface as
+    a 500 there exactly as it did on create. Reviewer finding: the create path had
+    a test and the patch path did not, even though both call the same validator.
+    """
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    dto = svc.create("global", None, "a", "b", "relates_to", "human")
+    with pytest.raises(ValueError, match="JSON-serialisable"):
+        svc.patch(dto.id, attributes={"bad": {1, 2}})
+    # The row is unchanged (validation happens before the field is assigned).
+    assert svc.get(dto.id).attributes is None
+
+
+def test_list_relationships_source_keys_drops_unsanitizable_key(bound, db_engine):
+    """A malformed key in the node set must not abort the whole query.
+
+    Reviewer finding: ``source_keys`` sanitizes each key, and ``_sanitize_key``
+    RAISES for a key that reduces to empty (e.g. "..."). If that propagated, the
+    graph provider's ``except`` branch would degrade the ENTIRE scope to a
+    relationship-free graph because of one bad index entry. Unsanitizable keys are
+    dropped from the filter instead — they can never match a stored row anyway,
+    since every stored source_key was sanitized at write time.
+    """
+    _seed_memory(db_engine, "good")
+    _seed_memory(db_engine, "t")
+    svc = _svc()
+    svc.create("global", None, "good", "t", "relates_to", "human")
+    dtos = svc.list_relationships("global", None, source_keys=["good", "...", "___"])
+    assert [d.source_key for d in dtos] == ["good"], "the valid key's edge must survive"

--- a/test/services/test_memory_relationship_integration.py
+++ b/test/services/test_memory_relationship_integration.py
@@ -1,0 +1,572 @@
+"""U8 integration-proof (issue #511): the COMPOSED-PATH tests.
+
+These are the acceptance gate for the feature's real functionality — the direct
+answer to the PR #516 failure mode (154 green per-module tests over a
+non-functional feature). Each scenario drives the REAL composition (real
+MemoryService + MemoryRelationshipService + graph provider), not mocks, and has
+a genuine failure mode: a surface not wired to the service, or wrong
+producer-scoping, makes the scenario RED.
+
+Scenarios:
+- S1  compiler-write-via-service -> See Also -> recall -> graph, end to end
+- S2  producer-scoped replacement PRESERVES a human edge (principle 6) [load-bearing]
+- S2b fail-before-pass control: an UNSCOPED replace WOULD nuke the human edge
+- S3  migrated legacy edge + human edge coexist through a compiler recompute
+- S4  multi-edge coexistence (relates_to + contradiction) visible in the graph
+- S5  superseded does not outrank active (FR-4.6)
+- S6  loss-free compatibility proof gating related_keys retirement (FR-7.2)
+- S7  NULL-confidence edge not ranked below a 0.0-confidence edge (NFR-2.3)
+- GLOBAL cross-table scope_id: a global relationship is ACCEPTED (endpoint check
+  uses .is_(None) against MemoryMetadataModel, NOT the "" sentinel)
+- content-free audit: relationship_mutation is registered AND written (SEC-S12)
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cli_agent_orchestrator.clients import database as db_mod
+from cli_agent_orchestrator.clients.database import Base, MemoryMetadataModel
+from cli_agent_orchestrator.services import memory_relationship_service as mrs_mod
+from cli_agent_orchestrator.services.memory_relationship_service import (
+    EdgeInput,
+    MemoryRelationshipService,
+)
+
+
+@pytest.fixture
+def db_engine(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+@pytest.fixture
+def bound(monkeypatch, db_engine):
+    """Bind SessionLocal (used by the relationship service) to the test engine."""
+    Session = sessionmaker(bind=db_engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", Session)
+    monkeypatch.setattr(mrs_mod, "SessionLocal", Session)
+    return Session
+
+
+def _seed_memory(db_engine, key, scope="global", scope_id=None, body="body"):
+    Session = sessionmaker(bind=db_engine)
+    s = Session()
+    try:
+        s.add(
+            MemoryMetadataModel(
+                id=str(uuid.uuid4()),
+                key=key,
+                memory_type="project",
+                scope=scope,
+                scope_id=scope_id,
+                file_path=f"/{key}.md",
+                tags="t",
+            )
+        )
+        s.commit()
+    finally:
+        s.close()
+
+
+def _svc():
+    return MemoryRelationshipService()
+
+
+# --------------------------------------------------------------------------- #
+# GLOBAL cross-table scope_id acceptance (the "second silent bug" test)
+# --------------------------------------------------------------------------- #
+def test_global_scope_relationship_accepted(bound, db_engine):
+    """A relationship between two GLOBAL-scope endpoints (scope_id NULL in
+    memory_metadata) is ACCEPTED. Must pass because the endpoint check uses
+    .is_(None) against MemoryMetadataModel, NOT the "" sentinel — a sentinel
+    lookup would match no global memory and falsely reject."""
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    dto = _svc().create("global", None, "a", "b", "relates_to", "human")
+    assert dto.status == "active"
+    assert dto.scope_id is None  # denormalised from the "" sentinel
+    # And it is retrievable / dedups (proving the row actually landed under sentinel).
+    again = _svc().create("global", None, "a", "b", "relates_to", "human")
+    assert again.id == dto.id  # upsert, not a duplicate (dedup index fired for global)
+
+
+def test_global_dedup_index_fires(bound, db_engine):
+    """Two identical global-scope creates collapse to one row (NULL-in-UNIQUE bug
+    would otherwise duplicate)."""
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    svc.create("global", None, "a", "b", "relates_to", "human")
+    svc.create("global", None, "a", "b", "relates_to", "human")
+    rows = svc.list_relationships("global", None, "a")
+    assert len([r for r in rows if r.target_key == "b"]) == 1
+
+
+# --------------------------------------------------------------------------- #
+# S2 / S2b — producer-scoped replacement (principle 6), fail-before-pass
+# --------------------------------------------------------------------------- #
+def test_s2_producer_scoped_replace_preserves_human_edge(bound, db_engine):
+    """S2 (load-bearing): a compiler recompute that drops its own edge must NOT
+    remove a human-authored edge on the same source."""
+    for k in ("a", "b", "c"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    svc.create("global", None, "a", "c", "relates_to", "human")  # human edge
+    svc.replace_set("global", None, "a", "compiler", "relates_to", [EdgeInput("b")])
+    # recompute: compiler now finds nothing
+    svc.replace_set("global", None, "a", "compiler", "relates_to", [])
+    active = {(d.origin, d.target_key) for d in svc.list_relationships("global", None, "a")}
+    assert ("human", "c") in active, "human edge must survive"
+    assert not any(o == "compiler" for o, _ in active), "compiler edge must be gone"
+
+
+def test_s2b_unscoped_delete_would_nuke_human_edge(bound, db_engine):
+    """S2 fail-before-pass control: prove the scoping is what protects the human
+    edge. An UNSCOPED delete-all-from-source (the wrong implementation) removes
+    the human edge — so S2 passing is meaningful, not vacuous."""
+    for k in ("a", "b", "c"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    svc.create("global", None, "a", "c", "relates_to", "human")
+    svc.create("global", None, "a", "b", "relates_to", "compiler")
+    # Simulate the WRONG unscoped replace: delete ALL edges from source a.
+    Session = sessionmaker(bind=db_engine)
+    s = Session()
+    try:
+        from cli_agent_orchestrator.clients.database import MemoryRelationshipModel
+
+        s.query(MemoryRelationshipModel).filter(MemoryRelationshipModel.source_key == "a").delete()
+        s.commit()
+    finally:
+        s.close()
+    active = svc.list_relationships("global", None, "a")
+    assert (
+        active == []
+    ), "unscoped delete removes EVERYTHING incl the human edge (the bug S2 guards)"
+
+
+# --------------------------------------------------------------------------- #
+# S4 — multi-edge coexistence
+# --------------------------------------------------------------------------- #
+def test_s4_multi_edge_coexistence(bound, db_engine):
+    """relates_to and contradiction between the same pair coexist as distinct
+    rows (differ by type)."""
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    svc.create("global", None, "a", "b", "relates_to", "human")
+    svc.create("global", None, "a", "b", "contradiction", "human")
+    rows = svc.list_relationships("global", None, "a")
+    types = {r.type for r in rows if r.target_key == "b"}
+    assert types == {"relates_to", "contradiction"}
+
+
+def test_s4_contradiction_symmetric_query(bound, db_engine):
+    """A single directed contradiction row is visible from BOTH endpoints via the
+    query-side union (FR-4.5) — no reciprocal row written."""
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    svc.create("global", None, "a", "b", "contradiction", "human")
+    from_a = svc.contradictions_for("global", None, "a")
+    from_b = svc.contradictions_for("global", None, "b")
+    assert len(from_a) == 1 and len(from_b) == 1
+    assert from_a[0].id == from_b[0].id  # same single directed row, seen both ways
+
+
+# --------------------------------------------------------------------------- #
+# S5 — superseded is queryable (ranking input)
+# --------------------------------------------------------------------------- #
+def test_s5_is_superseded(bound, db_engine):
+    """A memory that is the TARGET of an active supersedes edge reads as
+    superseded; the superseding one does not."""
+    _seed_memory(db_engine, "new")
+    _seed_memory(db_engine, "old")
+    svc = _svc()
+    svc.create("global", None, "new", "old", "supersedes", "human")  # new supersedes old
+    assert svc.is_superseded("global", None, "old") is True
+    assert svc.is_superseded("global", None, "new") is False
+
+
+# --------------------------------------------------------------------------- #
+# S7 — NULL confidence is not treated as zero (NFR-2.3)
+# --------------------------------------------------------------------------- #
+def test_superseded_targets_batched(bound, db_engine):
+    """FR-4.6 ranking input, batched: superseded_targets returns exactly the keys
+    that are the target of an active supersedes edge, in one query for many keys."""
+    for k in ("new1", "old1", "new2", "old2", "unrelated"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    svc.create("global", None, "new1", "old1", "supersedes", "human")
+    svc.create("global", None, "new2", "old2", "supersedes", "human")
+    hits = svc.superseded_targets("global", None, ["old1", "old2", "new1", "unrelated"])
+    assert hits == {"old1", "old2"}  # targets of active supersedes; sources/unrelated excluded
+
+
+def test_s7_null_confidence_not_zero(bound, db_engine):
+    """A NULL-confidence edge is stored as NULL (never coerced to 0), and a
+    0.0-confidence edge is stored as 0.0 — they are distinguishable, so ranking
+    can treat NULL as absence-of-evidence rather than lowest quality."""
+    for k in ("a", "b", "c"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    null_edge = svc.create("global", None, "a", "b", "relates_to", "human")  # confidence None
+    zero_edge = svc.create("global", None, "a", "c", "relates_to", "human", confidence=0.0)
+    assert null_edge.confidence is None
+    assert zero_edge.confidence == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed security (NFR-1.1..1.6)
+# --------------------------------------------------------------------------- #
+def test_fail_closed_self_link(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    with pytest.raises(ValueError):
+        _svc().create("global", None, "a", "a", "relates_to", "human")
+
+
+def test_fail_closed_dangling_endpoint(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    with pytest.raises(ValueError):
+        _svc().create("global", None, "a", "ghost", "relates_to", "human")
+
+
+def test_fail_closed_bad_type(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    with pytest.raises(ValueError):
+        _svc().create("global", None, "a", "b", "not_a_type", "human")
+
+
+def test_fail_closed_confidence_out_of_range(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    with pytest.raises(ValueError):
+        _svc().create("global", None, "a", "b", "relates_to", "human", confidence=1.5)
+
+
+def test_fail_closed_edge_count_bound(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    with pytest.raises(ValueError):
+        _svc().replace_set(
+            "global",
+            None,
+            "a",
+            "compiler",
+            "relates_to",
+            [EdgeInput(f"t{i}") for i in range(65)],
+        )
+
+
+def test_fail_closed_attributes_size_bound(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    big = {"x": "y" * 3000}
+    with pytest.raises(ValueError):
+        _svc().create("global", None, "a", "b", "relates_to", "human", attributes=big)
+
+
+# --------------------------------------------------------------------------- #
+# read-projection defaults (FR-4.3)
+# --------------------------------------------------------------------------- #
+def test_proposal_excluded_by_default(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    svc.create("global", None, "a", "b", "relates_to", "human", status="proposal")
+    assert svc.list_relationships("global", None, "a") == []  # active-only default
+    widened = svc.list_relationships("global", None, "a", status="proposal")
+    assert len(widened) == 1
+
+
+def test_lifecycle_promote_reject_soft_delete(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    d = svc.create("global", None, "a", "b", "relates_to", "human", status="proposal")
+    assert svc.promote(d.id).status == "active"
+    assert svc.reject(d.id).status == "rejected"
+    assert svc.soft_delete(d.id).status == "deleted"
+
+
+# --------------------------------------------------------------------------- #
+# coverage of patch / get / list filters / active_targets / stale / upsert
+# --------------------------------------------------------------------------- #
+def test_patch_mutable_fields(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    d = svc.create("global", None, "a", "b", "relates_to", "human")
+    patched = svc.patch(d.id, status="proposal", confidence=0.7, rank=3, attributes={"k": "v"})
+    assert patched.status == "proposal"
+    assert patched.confidence == 0.7
+    assert patched.rank == 3
+    assert patched.attributes == {"k": "v"}
+
+
+def test_get_and_not_found(bound, db_engine):
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    d = svc.create("global", None, "a", "b", "relates_to", "human")
+    assert svc.get(d.id).id == d.id
+    assert svc.get("nonexistent-id") is None
+    with pytest.raises(ValueError):
+        svc.patch("nonexistent-id", status="active")
+
+
+def test_list_filters_status_list_and_types(bound, db_engine):
+    for k in ("a", "b", "c"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    svc.create("global", None, "a", "b", "relates_to", "human")
+    svc.create("global", None, "a", "c", "contradiction", "human", status="proposal")
+    # status as a list widens
+    got = svc.list_relationships("global", None, "a", status=["active", "proposal"])
+    assert len(got) == 2
+    # types filter
+    only_rel = svc.list_relationships(
+        "global", None, "a", status=["active", "proposal"], types=["relates_to"]
+    )
+    assert [d.type for d in only_rel] == ["relates_to"]
+
+
+def test_active_targets_rank_order_and_project_scope(bound, db_engine):
+    for k in ("src", "t1", "t2"):
+        _seed_memory(db_engine, k, scope="project", scope_id="proj1")
+    svc = _svc()
+    svc.replace_set(
+        "project",
+        "proj1",
+        "src",
+        "compiler",
+        "relates_to",
+        [EdgeInput("t2", rank=1), EdgeInput("t1", rank=0)],
+    )
+    # ordered by rank (0 before 1) — exercises a non-global scope_id path too
+    assert svc.active_targets("project", "proj1", "src") == ["t1", "t2"]
+
+
+def test_s3_legacy_and_human_survive_compiler_recompute(bound, db_engine):
+    """S3 (SEC-IP3/REL-IP1): a migrated legacy edge AND a human edge on the same
+    source both survive a compiler recompute — three-way coexistence where the
+    compiler replace_set touches ONLY origin=compiler rows."""
+    for k in ("s", "leg", "hum", "comp"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    # legacy backfill row (simulate what U1 backfill writes)
+    svc.create("global", None, "s", "leg", "relates_to", "legacy_related_keys")
+    # human edge
+    svc.create("global", None, "s", "hum", "relates_to", "human")
+    # compiler set, then recompute to a different set
+    svc.replace_set("global", None, "s", "compiler", "relates_to", [EdgeInput("comp")])
+    svc.replace_set(
+        "global", None, "s", "compiler", "relates_to", [EdgeInput("hum")]
+    )  # compiler now points at hum
+    active = {(d.origin, d.target_key) for d in svc.list_relationships("global", None, "s")}
+    assert ("legacy_related_keys", "leg") in active, "legacy edge must survive"
+    assert ("human", "hum") in active, "human edge must survive"
+    assert ("compiler", "hum") in active, "compiler's new edge present"
+    assert ("compiler", "comp") not in active, "compiler's old edge replaced"
+
+
+def test_s6_loss_free_compatibility_proof(bound, db_engine):
+    """S6 (SEC-IP2/REL-IP2/BR-IP3, FR-7.2): every valid legacy related_keys link
+    is reachable as an ACTIVE store row through the service, and a dangling one
+    is NOT activated — the proof that GATES related_keys retirement. Drives the
+    real U1 backfill via init_db over a memory_metadata row with related_keys."""
+    from cli_agent_orchestrator.clients import database as db_mod
+
+    # Seed a memory with related_keys "x,y" (x exists, y exists) + a dangling "z".
+    for k in ("home", "x", "y"):
+        _seed_memory(db_engine, k)
+    Session = sessionmaker(bind=db_engine)
+    s = Session()
+    try:
+        row = s.query(MemoryMetadataModel).filter(MemoryMetadataModel.key == "home").first()
+        row.related_keys = "x,y,ghost"  # ghost is dangling
+        s.commit()
+    finally:
+        s.close()
+    # Run the real backfill against this engine's connection.
+    conn = db_engine.raw_connection()
+    try:
+        db_mod._backfill_legacy_related_keys(conn.driver_connection)
+    finally:
+        conn.close()
+    svc = _svc()
+    active = svc.list_relationships("global", None, "home")
+    targets = {d.target_key: d for d in active}
+    assert "x" in targets and "y" in targets, "valid legacy links reachable as active rows"
+    assert targets["x"].origin == "legacy_related_keys"
+    assert targets["x"].confidence is None, "no fabricated confidence (NFR-2.1)"
+    assert "ghost" not in targets, "dangling legacy link NOT activated (reported, FR-1.5)"
+
+
+def test_s6_legacy_related_keys_unconverted_still_expands(bound, db_engine, tmp_path, monkeypatch):
+    """S6 strengthening (reviewer/Stan): the loss-freedom proof must cover the
+    path that actually loses data — a related_keys value written by a route OTHER
+    than an LLM compile (here: a direct DB write after store(), with NO store edge
+    and NO backfill run) MUST still expand via recall(include_related=True). This
+    would have caught the _expand_related regression (store-only, no legacy
+    fallback → silent empty expansion). It fails if the union fallback is removed."""
+    import asyncio
+
+    from cli_agent_orchestrator.clients import database as db_mod
+    from cli_agent_orchestrator.services import memory_service as ms_mod
+
+    # A real MemoryService bound to the test engine + tmp base dir.
+    svc = ms_mod.MemoryService(base_dir=tmp_path, db_engine=db_engine)
+    monkeypatch.setattr(ms_mod, "MEMORY_BASE_DIR", tmp_path)
+    Session = sessionmaker(bind=db_engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", Session)
+
+    async def _setup():
+        await svc.store(
+            content="# root\nalpha unique-token", key="root", memory_type="project", scope="global"
+        )
+        await svc.store(
+            content="# legacyfriend\nbeta",
+            key="legacyfriend",
+            memory_type="project",
+            scope="global",
+        )
+
+    asyncio.run(_setup())
+
+    # Write related_keys DIRECTLY (post-store, never via LLM compile) — the exact
+    # path that produces no store edge and that the backfill (which we do NOT run
+    # here) would not convert.
+    s = Session()
+    try:
+        row = s.query(MemoryMetadataModel).filter(MemoryMetadataModel.key == "root").first()
+        row.related_keys = "legacyfriend"
+        s.commit()
+    finally:
+        s.close()
+    # No store row exists for root→legacyfriend:
+    assert _svc().active_targets("global", None, "root") == []
+
+    # recall must STILL surface legacyfriend as a related expansion (union fallback).
+    res = asyncio.run(svc.recall(query="alpha", scope="global", include_related=True, limit=1))
+    keys = [(m.key, getattr(m, "is_related", False)) for m in res]
+    assert any(
+        k == "legacyfriend" and rel for k, rel in keys
+    ), f"unconverted legacy related_keys must still expand; got {keys}"
+
+
+def test_s1_composed_path_and_content_free(bound, db_engine):
+    """S1 (end-to-end) + SEC-IP4 content-free: a compiler-written edge is
+    projectable and every read surface (list DTO, active_targets) exposes only
+    content-free fields — no body/body_hash/prompt. (See Also/recall/graph
+    composition over MemoryService is covered by the provider + memory_service
+    suites; here we assert the store->DTO path is content-free.)"""
+    for k in ("a", "b"):
+        _seed_memory(db_engine, k, body="SECRET BODY TEXT that must never leak")
+    svc = _svc()
+    svc.replace_set("global", None, "a", "compiler", "relates_to", [EdgeInput("b")])
+    # active_targets is the See-Also/recall projection helper
+    assert svc.active_targets("global", None, "a") == ["b"]
+    dto = svc.list_relationships("global", None, "a")[0]
+    d = dto.to_dict()
+    for forbidden in ("body", "body_hash", "prompt"):
+        assert forbidden not in d, f"DTO must be content-free ({forbidden})"
+    assert "SECRET BODY" not in str(d), "no memory body may leak into the DTO"
+
+
+def test_secs12_audit_written_and_content_free(bound, db_engine, tmp_path, monkeypatch):
+    """SEC-S12 two-part: a create writes a relationship_mutation audit record
+    (registration alone is not enough — a closed whitelist would drop it), and
+    the record is content-free (endpoints/origin/status, no memory body)."""
+    import asyncio
+
+    from cli_agent_orchestrator.services import audit_log
+
+    # Point the audit dir at tmp and capture the awaited write.
+    monkeypatch.setattr(audit_log, "MEMORY_BASE_DIR", tmp_path)
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    # Drive the awaited write path directly (NOWAIT flush is loop-dependent).
+    asyncio.run(
+        audit_log.write_audit(
+            "relationship_mutation",
+            "relationship create",
+            action="create",
+            id="x",
+            scope="global",
+            scope_id="",
+            source_key="a",
+            target_key="b",
+            type="relates_to",
+            origin="human",
+            status="active",
+        )
+    )
+    logdir = tmp_path / "logs" / "memory"
+    files = list(logdir.glob("*.md")) if logdir.exists() else []
+    assert files, "a relationship_mutation record MUST be written (not vacuously absent)"
+    text = "".join(f.read_text() for f in files)
+    assert "relationship_mutation" in text
+    assert "source_key" in text and "origin" in text  # provenance present
+    for forbidden in ("body", "body_hash", "prompt"):
+        assert forbidden not in text, f"audit must be content-free ({forbidden})"
+
+
+def test_replace_set_soft_rejects_bad_edge_not_whole_batch(bound, db_engine):
+    """reviewer F3: one edge with out-of-range confidence is soft-rejected into
+    the report; the valid edges in the same batch still land."""
+    for k in ("s", "good"):
+        _seed_memory(db_engine, k)
+    svc = _svc()
+    report = svc.replace_set(
+        "global",
+        None,
+        "s",
+        "compiler",
+        "relates_to",
+        [EdgeInput("good"), EdgeInput("nope", confidence=2.0)],
+    )
+    assert report.added == 1
+    assert any(r["reason"] == "invalid_attrs_or_confidence" for r in report.rejected)
+    assert svc.active_targets("global", None, "s") == ["good"]
+
+
+def test_replace_set_emits_audit(bound, db_engine, monkeypatch):
+    """reviewer F2: replace_set (bulk producer path) emits a content-free summary
+    audit event, so producer writes are not forensically silent."""
+    calls = []
+
+    def _fake_nowait(event, summary, **fields):
+        calls.append((event, fields))
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.audit_log.write_audit_nowait", _fake_nowait
+    )
+    for k in ("s", "t"):
+        _seed_memory(db_engine, k)
+    _svc().replace_set("global", None, "s", "compiler", "relates_to", [EdgeInput("t")])
+    rs = [c for c in calls if c[1].get("action") == "replace_set"]
+    assert rs, "replace_set must emit an audit event"
+    fields = rs[0][1]
+    assert fields["origin"] == "compiler" and "added" in fields
+    for forbidden in ("body", "prompt"):
+        assert forbidden not in fields
+
+
+def test_stale_flag_and_filter(bound, db_engine):
+    from datetime import datetime, timedelta, timezone
+
+    _seed_memory(db_engine, "a")
+    _seed_memory(db_engine, "b")
+    svc = _svc()
+    # edge whose source_updated_at is in the past → stale vs the memory's now()
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+    svc.create("global", None, "a", "b", "relates_to", "human", source_updated_at=past)
+    all_edges = svc.list_relationships("global", None, "a")
+    assert all_edges and all_edges[0].stale is True
+    assert len(svc.list_relationships("global", None, "a", stale_only=True)) == 1

--- a/test/services/test_memory_relationship_integration.py
+++ b/test/services/test_memory_relationship_integration.py
@@ -70,7 +70,7 @@ def _seed_memory(db_engine, key, scope="global", scope_id=None, body=None, body_
 
     This signature deliberately refuses to accept-and-discard a body. An earlier
     version took ``body="body"`` and silently dropped it, which made every
-    "the secret must not leak" assertion pass vacuously — the secret had never
+    "the body must not leak" assertion pass vacuously — the body had never
     been written anywhere. If you pass ``body`` you MUST pass ``body_dir``.
     """
     if body is not None and body_dir is None:
@@ -495,29 +495,29 @@ def test_s1_composed_path_and_content_free(bound, db_engine, tmp_path):
     projectable and every read surface (list DTO, active_targets) exposes only
     content-free fields — no body/body_hash/prompt.
 
-    The secret is written to the seeded memories' real FILES, and those files are
+    The canary body is written to the seeded memories' real FILES, and those files are
     reachable from the store's own rows (``memory_metadata.file_path``). That is
     what gives this assertion a genuine failure mode: a projection that resolved
     an endpoint's ``file_path`` and inlined its content — the plausible way this
     boundary would actually leak — turns the test RED.
 
-    Guarding the guard: the test asserts the secret IS retrievable through the
+    Guarding the guard: the test asserts the canary IS retrievable through the
     row before asserting the DTO omits it. Without that first assertion the
     whole check passes vacuously whenever the content was never stored, which is
     precisely the defect this test previously had (it passed a ``body`` argument
     that ``_seed_memory`` silently discarded).
     """
-    secret = "SECRET BODY TEXT that must never leak"
+    canary_body = "CANARY-MARKER-4f2a memory body text that must never leak"
     for k in ("a", "b"):
-        _seed_memory(db_engine, k, body=secret, body_dir=tmp_path / "wiki")
-    # PRE-ASSERTION: the secret is genuinely stored and reachable from the row,
+        _seed_memory(db_engine, k, body=canary_body, body_dir=tmp_path / "wiki")
+    # PRE-ASSERTION: the canary body is genuinely stored and reachable from the row,
     # so "not in the DTO" is a real claim about the projection.
     Session = sessionmaker(bind=db_engine)
     s = Session()
     try:
         row = s.query(MemoryMetadataModel).filter(MemoryMetadataModel.key == "a").first()
         assert row is not None and row.file_path
-        assert secret in Path(row.file_path).read_text(
+        assert canary_body in Path(row.file_path).read_text(
             encoding="utf-8"
         ), "content must actually exist behind the row, or the leak check is vacuous"
     finally:
@@ -528,12 +528,12 @@ def test_s1_composed_path_and_content_free(bound, db_engine, tmp_path):
     # active_targets is the See-Also/recall projection helper
     targets = svc.active_targets("global", None, "a")
     assert targets == ["b"]
-    assert secret not in str(targets), "active_targets must project keys only, never content"
+    assert canary_body not in str(targets), "active_targets must project keys only, never content"
     dto = svc.list_relationships("global", None, "a")[0]
     d = dto.to_dict()
     for forbidden in ("body", "body_hash", "prompt", "content", "file_path"):
         assert forbidden not in d, f"DTO must be content-free ({forbidden})"
-    assert secret not in str(d), "no memory body may leak into the DTO"
+    assert canary_body not in str(d), "no memory body may leak into the DTO"
 
 
 def test_secs12_audit_written_and_content_free(bound, db_engine, tmp_path, monkeypatch):

--- a/test/services/test_wiki_lint.py
+++ b/test/services/test_wiki_lint.py
@@ -1181,3 +1181,219 @@ class TestT10PartialRunSummary:
             if i.issue_type == "lint_error" and "graph_density did not complete" in i.description
         ]
         assert per_det
+
+
+# ===========================================================================
+# Human review (PR #524) — contradiction RETRACTION
+# ===========================================================================
+
+
+class TestContradictionRetraction:
+    """``_persist_contradictions`` must retract a source's LAST contradiction.
+
+    The docstring always promised "stale contradictions are retracted on
+    re-lint", but the function grouped only sources that had a finding in THIS
+    run and returned early on ``if not grouped``. A source whose contradictions
+    were all resolved therefore never reached ``replace_set``, so its final edge
+    persisted forever — the one case where retraction actually matters.
+    """
+
+    def _bind(self, db_engine, monkeypatch):
+        from cli_agent_orchestrator.clients import database as db_mod
+        from cli_agent_orchestrator.services import memory_relationship_service as mrs_mod
+
+        Session = sessionmaker(bind=db_engine)
+        monkeypatch.setattr(db_mod, "SessionLocal", Session)
+        monkeypatch.setattr(mrs_mod, "SessionLocal", Session)
+        return mrs_mod.MemoryRelationshipService()
+
+    def _seed(self, db_engine, *keys):
+        Session = sessionmaker(bind=db_engine)
+        s = Session()
+        try:
+            for k in keys:
+                s.add(
+                    MemoryMetadataModel(
+                        key=k,
+                        memory_type="project",
+                        scope="global",
+                        scope_id=None,
+                        file_path=f"/{k}.md",
+                        tags="t",
+                        token_estimate=0,
+                    )
+                )
+            s.commit()
+        finally:
+            s.close()
+
+    def _seed_with_paths(self, db_engine, svc, keys):
+        """Seed metadata rows whose file_path points at the REAL wiki file, so
+        run_lint loads a non-empty body and the keys are genuine candidates."""
+        Session = sessionmaker(bind=db_engine)
+        s = Session()
+        try:
+            for k in keys:
+                s.add(
+                    MemoryMetadataModel(
+                        key=k,
+                        memory_type="project",
+                        scope="global",
+                        scope_id=None,
+                        file_path=str(svc.get_wiki_path("global", None, k)),
+                        tags="t",
+                        token_estimate=0,
+                    )
+                )
+            s.commit()
+        finally:
+            s.close()
+
+    def test_last_contradiction_is_retracted_when_source_is_clean(self, db_engine, monkeypatch):
+        """a→b existed; this run examined "a" and found NOTHING. The edge must go."""
+        rel = self._bind(db_engine, monkeypatch)
+        self._seed(db_engine, "a", "b")
+        rel.create("global", None, "a", "b", "contradiction", "wiki_lint")
+        assert rel.active_targets("global", None, "a", type="contradiction") == ["b"]
+
+        # No contradiction issues this run, but "a" WAS examined.
+        wiki_lint._persist_contradictions([], "global", linted_sources={(None, "a")})
+
+        assert (
+            rel.active_targets("global", None, "a", type="contradiction") == []
+        ), "a source examined with no finding must have its last contradiction retracted"
+
+    def test_no_retraction_when_the_detector_did_not_complete(self, db_engine, monkeypatch):
+        """Guards the fix against over-reach: with ``linted_sources=None`` (a
+        timed-out or LLM-disabled pass) there is no evidence of absence, so a
+        real edge must SURVIVE. A fix that retracted unconditionally would
+        silently wipe the store whenever the LLM was unavailable."""
+        rel = self._bind(db_engine, monkeypatch)
+        self._seed(db_engine, "a", "b")
+        rel.create("global", None, "a", "b", "contradiction", "wiki_lint")
+
+        wiki_lint._persist_contradictions([], "global", linted_sources=None)
+
+        assert rel.active_targets("global", None, "a", type="contradiction") == [
+            "b"
+        ], "an incomplete detector pass must not retract anything"
+
+    def test_unexamined_source_is_not_retracted(self, db_engine, monkeypatch):
+        """Only EXAMINED sources are retractable. "a" holds an edge but was not
+        in this run's examined set (too short a body, or no tag), so it is left
+        alone even though the run reported no findings for it."""
+        rel = self._bind(db_engine, monkeypatch)
+        self._seed(db_engine, "a", "b", "z")
+        rel.create("global", None, "a", "b", "contradiction", "wiki_lint")
+
+        wiki_lint._persist_contradictions([], "global", linted_sources={(None, "z")})
+
+        assert rel.active_targets("global", None, "a", type="contradiction") == ["b"]
+
+    def test_candidates_mirror_build_pairs_filters(self):
+        """``_contradiction_candidates`` must not claim a source ``_build_pairs``
+        would have skipped — otherwise retraction fires on evidence the detector
+        never gathered. Short bodies and tagless rows are excluded."""
+        rows = [
+            _row("long_tagged", content="x" * 60, tags="t"),
+            _row("too_short", content="x" * 10, tags="t"),
+            _row("untagged", content="x" * 60, tags=""),
+        ]
+        got = wiki_lint._contradiction_candidates(rows)
+        assert (None, "long_tagged") in got
+        assert (None, "too_short") not in got
+        assert (None, "untagged") not in got
+
+    def test_pass_is_not_exhaustive_when_llm_is_unavailable(self):
+        """The gate that makes retraction safe. ``completion["contradiction"]``
+        is True even with NO LLM provider — the detector returns normally after
+        emitting a ``detector disabled`` lint_error. Gating on completion alone
+        would therefore treat an unadjudicated wiki as "clean" and retract EVERY
+        contradiction edge the moment the LLM was unavailable.
+        """
+        disabled = [
+            LintIssue(
+                issue_type="lint_error",
+                key="contradiction",
+                description="contradiction detector disabled (no LLM provider configured)",
+                severity="warning",
+            )
+        ]
+        assert wiki_lint._contradiction_pass_was_exhaustive(disabled) is False
+
+    def test_pass_is_not_exhaustive_when_pairs_were_capped(self):
+        """A ``max_pairs`` truncation also returns normally, leaving some sources
+        unexamined — so it must not license retraction either."""
+        capped = [
+            LintIssue(
+                issue_type="lint_error",
+                key="contradiction",
+                description="contradiction pass capped at 200 pairs (had 900)",
+                severity="warning",
+            )
+        ]
+        assert wiki_lint._contradiction_pass_was_exhaustive(capped) is False
+
+    def test_clean_pass_is_exhaustive(self):
+        """Control: a run with no degradation markers IS exhaustive, so the
+        retraction path stays reachable (a gate that always returned False would
+        silently disable the fix)."""
+        clean = [
+            LintIssue(issue_type="orphan_page", key="x", severity="warning"),
+            LintIssue(
+                issue_type="lint_error",
+                key="run_lint",
+                description="lint_run_completed: 5/5",
+                severity="info",
+            ),
+        ]
+        assert wiki_lint._contradiction_pass_was_exhaustive(clean) is True
+
+    def test_run_lint_with_no_llm_does_not_retract_existing_edges(
+        self, svc, tmp_path, db_engine, monkeypatch
+    ):
+        """END-TO-END form of the same guarantee, through real ``run_lint``.
+
+        Seeds a live wiki_lint contradiction edge, then runs the full lint with
+        NO LLM provider. The edge must survive: an unadjudicated pass is not
+        evidence the contradiction was resolved.
+        """
+        from cli_agent_orchestrator.clients import database as db_mod
+        from cli_agent_orchestrator.services import memory_relationship_service as mrs_mod
+        from cli_agent_orchestrator.services import settings_service
+
+        Session = sessionmaker(bind=db_engine)
+        monkeypatch.setattr(db_mod, "SessionLocal", Session)
+        monkeypatch.setattr(mrs_mod, "SessionLocal", Session)
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.services.memory_service.MemoryService",
+            lambda *a, **kw: svc,
+        )
+        monkeypatch.setattr(settings_service, "is_memory_enabled", lambda: True)
+        monkeypatch.setattr(wiki_lint, "_build_llm_client", lambda: None)
+
+        # The rows must be REAL contradiction candidates, else this test passes
+        # vacuously: run_lint fills `content` from the wiki FILE, so a row with
+        # no file on disk has an empty body, fails _build_pairs' 50-char floor,
+        # and is never a candidate — the retraction path would be unreachable
+        # regardless of the gate. Write the files and assert candidacy below.
+        body = "a long enough article body to clear the fifty character floor" + " filler" * 10
+        for k in ("a", "b"):
+            p = svc.get_wiki_path("global", None, k)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+        self._seed_with_paths(db_engine, svc, ("a", "b"))
+        rel = mrs_mod.MemoryRelationshipService()
+        rel.create("global", None, "a", "b", "contradiction", "wiki_lint")
+
+        # PRE-ASSERTION: "a" really is examinable, so "the edge survived" is a
+        # claim about the GATE and not about an empty candidate set.
+        assert (None, "a") in wiki_lint._contradiction_candidates(
+            [_row("a", content=body, tags="t")]
+        )
+
+        _run(wiki_lint.run_lint("global", scope="global"))
+
+        assert rel.active_targets("global", None, "a", type="contradiction") == [
+            "b"
+        ], "run_lint with no LLM must not retract a real contradiction edge"


### PR DESCRIPTION
Closes #511.

Replaces the `related_keys` CSV marker with a typed, scoped relationship table behind a single service boundary (`MemoryRelationshipService`). Adds 6 REST routes, a `memory relationships` CLI subgroup, and wires the compiler/lint producers through the service.

## Key decisions

- **Union, not replace.** `_expand_related` reads active `relates_to` edges from the store **and** falls back to `related_keys` for any primary the store has no edges for (batched per scope, no N+1). A store-only rewrite would silently lose expansion for every row written by a route other than an LLM compile.
- **Producer-scoped `replace_set`.** A compiler recompute replaces only its own `(origin, type)` edges — human and lint edges survive.
- **NOT-NULL sentinel scoped to one table.** `memory_relationships.scope_id` stores `""` for global so the dedup UNIQUE index is total (SQLite treats `NULL != NULL`); cross-table checks against `MemoryMetadataModel` use logical `None` + `.is_(None)`.
- `related_keys` is **untouched** — retirement is gated on the S6 loss-free proof.

## Verification

- 2635 passed / 0 failed across `test/services/ test/clients/ test/api/ test/graph/` (isolated HOME, `-p no:randomly`).
- Full suite: 2 failed / 5399 passed. Both failures are **pre-existing** at base `8ecf9be` (baseline: 3 failed / 5357) — a leaked `registry._backend` singleton, filed separately as #522. This branch carries one *fewer* failure than base.
- Relationship service coverage 92% (ratchet floor 87.0). `black`/`isort` clean at CI scope.
- Every load-bearing guard is mutation-verified: un-whitelisting the audit event turns the audit test RED; stubbing the legacy fallback turns the S6 loss-free test RED; dropping the `replace_set` origin filter turns the human-edge-survival test RED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)