### PR TITLE
fix(codex): recognize v0.145 idle composer at startup

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -99,6 +99,23 @@ UPDATE_DIALOG_PATTERN = r"Update available!\s+\S+\s+->\s+\S+"
 UPDATE_DIALOG_MENU_PATTERN = r"Skip until next version"
 UPDATE_DIALOG_FOOTER = TRUST_PROMPT_FOOTER
 STARTUP_PROMPT_BOTTOM_LINES = 15
+STARTUP_ACTIVITY_PATTERN = r"^\s*•[^\S\n]+\S"
+STARTUP_BLOCKING_INPUT_PATTERN = (
+    r"(?:Command Approval Required|\[[aA]\]\s+Accept\b|"
+    r"\[[dD]\]\s+Decline\b|Press enter to continue)"
+)
+STARTUP_IDLE_PLACEHOLDER_PATTERN = (
+    rf"^\s*{IDLE_PROMPT_PATTERN}[^\S\n]+(?:"
+    r"Explain this codebase|"
+    r"Summarize recent commits|"
+    r"Implement \{feature\}|"
+    r"Find and fix a bug in @filename|"
+    r"Write tests for @filename|"
+    r"Improve documentation in @filename|"
+    r"Run /review on my current changes|"
+    r"Use /skills to list available skills"
+    r")\s*$"
+)
 
 # Codex welcome banner indicating normal startup (no trust prompt)
 CODEX_WELCOME_PATTERN = r"OpenAI Codex"
@@ -233,6 +250,32 @@ def _has_update_dialog_in_bottom(clean_output: str) -> bool:
         and re.search(UPDATE_DIALOG_MENU_PATTERN, bottom) is not None
         and re.search(UPDATE_DIALOG_FOOTER, bottom) is not None
     )
+
+
+def _has_startup_idle_composer(clean_output: str) -> bool:
+    """Return True when the bottom of the pane shows Codex's idle composer."""
+    all_lines = clean_output.splitlines()
+    tail_lines = all_lines[-STARTUP_PROMPT_BOTTOM_LINES:]
+    tail_output = "\n".join(tail_lines)
+
+    if re.search(STARTUP_ACTIVITY_PATTERN, tail_output, re.MULTILINE):
+        return False
+    if re.search(WAITING_PROMPT_PATTERN, tail_output, re.IGNORECASE | re.MULTILINE):
+        return False
+    if re.search(STARTUP_BLOCKING_INPUT_PATTERN, tail_output, re.IGNORECASE):
+        return False
+
+    legacy_tail = all_lines[-IDLE_PROMPT_TAIL_LINES:]
+    if any(re.match(IDLE_PROMPT_STRICT_PATTERN, line) for line in legacy_tail):
+        return True
+
+    # Codex 0.145 renders placeholder text inside the idle composer instead of
+    # an empty prompt. Match only known placeholder copy and require its status
+    # footer below it so typed drafts and ordinary output are not treated as ready.
+    for index in range(len(tail_lines) - 1, -1, -1):
+        if re.match(STARTUP_IDLE_PLACEHOLDER_PATTERN, tail_lines[index]):
+            return any(re.search(TUI_FOOTER_PATTERN, line) for line in tail_lines[index + 1 :])
+    return False
 
 
 def _find_assistant_marker(text: str) -> Optional[re.Match[str]]:
@@ -480,8 +523,7 @@ class CodexProvider(BaseProvider):
             # Exit when the bottom region shows the idle composer prompt AND no
             # dialog is active. The welcome banner alone is insufficient — it
             # renders as normal startup chrome BEFORE a late update dialog appears.
-            bottom_tail_lines = clean_output.splitlines()[-IDLE_PROMPT_TAIL_LINES:]
-            has_idle = any(re.match(IDLE_PROMPT_STRICT_PATTERN, line) for line in bottom_tail_lines)
+            has_idle = _has_startup_idle_composer(clean_output)
             has_dialog = (
                 re.search(TRUST_PROMPT_PATTERN, bottom_region)
                 or (

--- a/test/providers/fixtures/codex_v0145_idle_output.txt
+++ b/test/providers/fixtures/codex_v0145_idle_output.txt
@@ -1,0 +1,14 @@
+╭──────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.145.0)                   │
+│                                              │
+│ model:       gpt-5.6-sol medium              │
+│ directory:   ~/project                       │
+│ permissions: YOLO mode                       │
+╰──────────────────────────────────────────────╯
+
+  Tip: Build faster with the Desktop app.
+
+
+› Write tests for @filename
+
+  gpt-5.6-sol medium · Context 100% left

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -11,6 +11,7 @@ from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.codex import (
     CodexProvider,
     ProviderError,
+    _has_startup_idle_composer,
     _toml_override,
     _toml_scalar,
 )
@@ -1658,6 +1659,146 @@ class TestCodexProviderMisc:
 
 class TestCodexProviderTrustPrompt:
     """Tests for Codex workspace trust prompt handling."""
+
+    @pytest.mark.parametrize(
+        "placeholder",
+        [
+            "Explain this codebase",
+            "Summarize recent commits",
+            "Implement {feature}",
+            "Find and fix a bug in @filename",
+            "Write tests for @filename",
+            "Improve documentation in @filename",
+            "Run /review on my current changes",
+            "Use /skills to list available skills",
+        ],
+    )
+    def test_v0145_idle_composer_placeholders(self, placeholder):
+        output = (
+            f"OpenAI Codex (v0.145.0)\n› {placeholder}\n"
+            "  gpt-5.6-sol medium · Context 100% left\n"
+        )
+
+        assert _has_startup_idle_composer(output) is True
+
+    @pytest.mark.asyncio
+    @patch(
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 20.0],
+    )
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_handle_trust_prompt_returns_on_v0145_idle_composer(
+        self, mock_backend, mock_error, mock_sleep, _mock_time
+    ):
+        """Codex 0.145's placeholder composer is a ready state, not a timeout."""
+        mock_backend.return_value.get_history.return_value = load_fixture(
+            "codex_v0145_idle_output.txt"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(timeout=20.0)
+
+        mock_backend.return_value.get_history.assert_called_once()
+        mock_sleep.assert_not_awaited()
+        mock_error.assert_not_called()
+        mock_backend.return_value.send_keys.assert_not_called()
+        mock_backend.return_value.send_special_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 1.0, 2.0, 20.0],
+    )
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_handle_trust_prompt_waits_for_complete_v0145_composer_frame(
+        self, mock_backend, mock_error, mock_sleep, _mock_time
+    ):
+        """Chunked redraws are not ready until composer and footer are both visible."""
+        fixture = load_fixture("codex_v0145_idle_output.txt")
+        mock_backend.return_value.get_history.side_effect = [
+            "OpenAI Codex (v0.145.0)\n",
+            "OpenAI Codex (v0.145.0)\n› Write tests for @filename\n",
+            fixture,
+            "timeout tail",
+        ]
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(timeout=20.0)
+
+        assert mock_backend.return_value.get_history.call_count == 3
+        assert mock_sleep.await_count == 2
+        mock_error.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            (
+                "› Fix the failing tests\n"
+                "• Working (2s • esc to interrupt)\n"
+                "› Write tests for @filename\n"
+                "  gpt-5.6-sol medium · Context 100% left\n"
+            ),
+            (
+                "› Fix the failing tests\n"
+                "• Working\n"
+                "› Write tests for @filename\n"
+                "  gpt-5.6-sol medium · Context 100% left\n"
+            ),
+            (
+                "Approve this command? [y/n]\n"
+                "› Write tests for @filename\n"
+                "  gpt-5.6-sol medium · Context 100% left\n"
+            ),
+            (
+                "› Write tests for @filename\n"
+                "  gpt-5.6-sol medium · Context 100% left\n"
+                "╭─ Command Approval Required ─╮\n"
+                "│ [a] Accept  [d] Decline     │\n"
+                "╰─────────────────────────────╯\n"
+            ),
+            ("› fix the failing tests\n" "  gpt-5.6-sol medium · Context 100% left\n"),
+            "OpenAI Codex (v0.145.0)\nLoading project instructions\n",
+            (
+                "The docs show › Write tests for @filename as an example.\n"
+                "This is not a Codex footer: Context 100% left\n"
+            ),
+            "› \nold output\n\nstill running\n\nlatest output\n",
+        ],
+        ids=[
+            "working",
+            "partial-working-frame",
+            "approval",
+            "boxed-approval",
+            "typed-draft",
+            "ordinary-output",
+            "similar-strings",
+            "stale-legacy-prompt",
+        ],
+    )
+    @pytest.mark.asyncio
+    @patch(
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 20.0],
+    )
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_handle_trust_prompt_does_not_treat_non_ready_output_as_idle(
+        self, mock_backend, mock_error, mock_sleep, _mock_time, output
+    ):
+        mock_backend.return_value.get_history.return_value = output
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(timeout=20.0)
+
+        mock_sleep.assert_awaited_once_with(1.0)
+        mock_error.assert_called_once()
+        mock_backend.return_value.send_keys.assert_not_called()
+        mock_backend.return_value.send_special_key.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.get_backend")


### PR DESCRIPTION
## Summary

Codex CLI 0.145.0 renders placeholder text in its ready composer instead of an
empty `›` prompt. CAO's startup prompt handler only recognized the empty form,
so terminal creation kept polling until its startup timeout even though
`get_status()` already reported the terminal as idle.

This change:

- recognizes Codex 0.145.0's eight upstream placeholder strings only when a
  matching TUI footer follows the composer;
- preserves the existing five-physical-line window for legacy empty prompts;
- fails closed for active output, partial `Working` redraws, approval dialogs,
  typed drafts, ordinary output, and stale prompts in scrollback.

No status, message extraction, or prompt delivery behavior is otherwise
changed.

## Root cause

`_handle_trust_prompt()` used `IDLE_PROMPT_STRICT_PATTERN`, which intentionally
matches only an empty prompt. Codex 0.145.0's ready frame instead looks like:

```text
› Write tests for @filename
  gpt-5.6-sol medium · Context 100% left
```

The strict startup check therefore missed a valid ready state and waited for
the full timeout.

## Tests

TDD evidence before the production change:

- initial regression set: `2 failed, 4 passed`;
- expanded review cases: `4 failed, 4 passed` (partial activity, boxed
  approval, typed draft, and stale legacy prompt).

Final local results:

- Codex provider: `164 passed, 3 skipped`;
- all provider tests: `1129 passed, 3 skipped, 1 xfailed`;
- full Python suite: `5413 passed, 26 skipped, 15 deselected, 1 xfailed`
  with 91% total coverage;
- explicit disabled-memory semantics: `2 passed`;
- Web UI: typecheck passed, `85 passed`, build passed;
- MCP Apps: typecheck passed, `78 passed`, all builds/JIT scan/size budgets
  passed;
- coverage ratchet: Python `90.51%` (floor 87%), frontend `90.06%` (floor
  90%);
- HTTP-only boundary: `2 passed`;
- Black, isort, Markdown link validation, and `git diff --check`: passed.

Two repository baselines remain unchanged:

- `mypy src/`: `88 errors in 8 files`, identical on clean `main` and tolerated
  by the current CI job;
- MCP Apps E2E on alternate port 19889: `6 passed, 1 failed`, identical on
  clean `main`; the event-stream test still connects to the service on 9889
  and receives one row instead of two.

Local gitleaks execution was unavailable (`gitleaks` is not installed), so I
will rely on the repository's Secret Scan workflow for that check.

## Compatibility and risk

The legacy empty-prompt path is unchanged. The new path deliberately matches
only Codex 0.145.0's current upstream placeholder set plus a following footer,
rather than accepting arbitrary composer text. If future Codex versions add,
localize, or wrap placeholder text, CAO will conservatively keep waiting
instead of reporting a blocked or active TUI as ready.

The final diff also received two rounds of independent review; the first found
and the patch closed partial-redraw and stale-scrollback cases, and the second
reported no blocking findings.

Thank you for taking the time to review this. I understand you may prefer a
different way to model the TUI boundary, and I would be glad to adjust the
implementation or tests based on your guidance.
