### PR TITLE
fix(test): reset backend registry singleton between tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -142,6 +142,17 @@ def _no_llm_compile_in_tests(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _reset_backend_registry():
+    """Prevent leaked backend singletons from crossing test boundaries (fixes #522)."""
+    from cli_agent_orchestrator.backends import registry
+
+    original = registry._backend
+    registry._backend = None
+    yield
+    registry._backend = original
+
+
+@pytest.fixture(autouse=True)
 def _hermetic_cao_env(monkeypatch):
     """Strip CAO runtime env vars that leak when the suite runs inside a CAO terminal.
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -1756,8 +1756,10 @@ class TestCodexProviderTrustPrompt:
             "test-session", "window-0", "Enter"
         )
 
-    def test_get_status_trust_prompt_v2_is_waiting(self):
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_trust_prompt_v2_is_waiting(self, mock_backend):
         """V2 trust dialog in bottom region classifies WAITING_USER_ANSWER."""
+        mock_backend.return_value.get_pane_current_command.return_value = "codex"
         output = (
             "Note: You're in a subdirectory of a Git project.\n"
             "Trusting will apply to the repository root: /Users/test/project\n"
@@ -1777,8 +1779,10 @@ class TestCodexProviderTrustPrompt:
 
         assert status == TerminalStatus.WAITING_USER_ANSWER
 
-    def test_get_status_trust_v2_in_scrollback_does_not_false_positive(self):
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_trust_v2_in_scrollback_does_not_false_positive(self, mock_backend):
         """V2 trust text in scrollback (not bottom) must NOT trigger WAITING."""
+        mock_backend.return_value.get_pane_current_command.return_value = "codex"
         output = (
             "› explain trust prompts\n"
             '• The dialog says "Do you trust the contents of this directory?"\n'
@@ -1808,6 +1812,15 @@ class TestCodexProviderTrustPrompt:
 
         # Should be COMPLETED (model replied to user question), NOT WAITING
         assert status == TerminalStatus.COMPLETED
+
+    def test_backend_registry_is_clean_at_test_start(self):
+        """Regression for #522: autouse fixture resets the backend singleton."""
+        from cli_agent_orchestrator.backends import registry
+
+        assert registry._backend is None, (
+            "Backend singleton leaked from a prior test — "
+            "_reset_backend_registry fixture is not working"
+        )
 
 
 class TestCodexProviderUpdateDialog:


### PR DESCRIPTION
## Summary

- Add autouse `_reset_backend_registry` fixture in `test/conftest.py` that saves/nulls/restores `backends.registry._backend` around every test
- Patch `get_backend` in the two `TestCodexProviderTrustPrompt` tests that were vulnerable to a leaked singleton
- Add `test_backend_registry_is_clean_at_test_start` regression test

## Root Cause

The module-level singleton in `backends/registry.py` persists across the entire pytest process. When an earlier test installs a backend whose `get_pane_current_command()` returns `"zsh"`, the shell-exit guard in `codex.py:570-575` short-circuits to `ERROR` before trust-prompt classification runs.

## Validation

- Scoped: `TestCodexProviderTrustPrompt` -- 8/8 pass
- Full suite: 5456 passed, target tests pass (62 pre-existing unrelated failures in AGUI/telemetry)

## Test plan

- [x] `pytest test/providers/test_codex_provider_unit.py::TestCodexProviderTrustPrompt` -- all pass
- [x] Full suite (`pytest test/ --ignore=test/e2e -m "not e2e"`) -- both previously-failing tests now pass at full-suite scope

Fixes #522