### PR TITLE
fix(deps): upgrade postcss to >=8.5.18 in web

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,7 +26,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "autoprefixer": "^10.4.0",
         "jsdom": "^24.1.3",
-        "postcss": "^8.5.12",
+        "postcss": "^8.5.18",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.0.0",
         "vite": "^8.0.16",
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2553,9 +2553,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2573,7 +2573,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.4.0",
     "jsdom": "^24.1.3",
-    "postcss": "^8.5.12",
+    "postcss": "^8.5.18",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.0.0",
     "vite": "^8.0.16",


### PR DESCRIPTION
Fixes #534 / Dependabot alert #73.

PostCSS `<= 8.5.17` has a path traversal in previous-source-map auto-loading (`sourceMappingURL`) that allows arbitrary `.map` file disclosure. First patched version is `8.5.18`.

## Change
- `web/package.json`: devDependency `postcss` `^8.5.12` → `^8.5.18`
- `web/package-lock.json` refreshed — now resolves **8.5.25** (pulls `nanoid` 3.3.12 → 3.3.16 transitively)

## Scope
Only `web` was affected. `cao_mcp_apps` is already at 8.5.25 (alert #72 fixed) and `docusaurus` resolves 8.5.21 — both left untouched.

## Verification
- `npm ci` → found 0 vulnerabilities
- `npm run build` → succeeded
- `npm test` → 85/85 passed across 6 files (stack traces in output come from an intentional error-boundary test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)