### PR TITLE
fix(codex): stop inlining developer_instructions, use a temp file + command substitution

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -2,9 +2,11 @@
 
 import asyncio
 import logging
+import os
 import re
 import shlex
 import time
+from pathlib import Path
 from typing import Any, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
@@ -348,6 +350,16 @@ class CodexProvider(BaseProvider):
         # Explicit per-call override for profile.model, see _build_codex_command.
         self._model = model
 
+    def _developer_instructions_file_path(self) -> Path:
+        """Path of this terminal's developer_instructions temp file.
+
+        Single source of truth for the path -- both `_build_codex_command` (which
+        writes it) and `cleanup` (which removes it) call this instead of each
+        re-deriving the same `CAO_HOME_DIR / "tmp" / f"{...}.codex_developer_instructions"`
+        expression independently, which would let the two silently drift apart.
+        """
+        return CAO_HOME_DIR / "tmp" / f"{self.terminal_id}.codex_developer_instructions"
+
     def _build_codex_command(self) -> str:
         """Build Codex command with agent profile if provided.
 
@@ -448,25 +460,36 @@ class CodexProvider(BaseProvider):
                 # command-substitution approach reaches the same practical outcome (a short launch
                 # line) without needing that.
                 #
+                # Deliberate, documented shell-scope trade-off (not an oversight): $(...) command
+                # substitution is POSIX and works identically on every shell CAO's own
+                # BRACKETED_PASTE_INCOMPATIBLE_SHELLS (constants.py) already tracks as a shell
+                # class *except* csh/tcsh, which use `cmd` backticks instead and do not recognize
+                # `$(` as substitution syntax at all -- launching codex from a pane whose bare
+                # shell is csh/tcsh would break outright with this fragment malformed/rejected by
+                # the shell, not merely degrade. bash/zsh/dash/sh/ksh/mksh/ash/fish are all fine.
+                # No code here detects or special-cases the pane's shell before writing this
+                # fragment (unlike BRACKETED_PASTE_INCOMPATIBLE_SHELLS' own runtime
+                # #{pane_current_command} probe) -- csh/tcsh support, if ever needed, is scoped
+                # out of this fix rather than silently assumed to already work.
+                #
                 # Not covering here (disclosed, not silently assumed away): the other -c overrides
                 # below (per-MCP-server config, codexConfig) are NOT routed through this same
                 # mechanism and remain inlined directly -- they are typically far smaller than
                 # developer_instructions, but a profile configuring many MCP servers could in
                 # theory still accumulate enough inline -c overrides to hit the same limit. Left
                 # as a known, scoped-out follow-up rather than expanding this fix's surface.
-                developer_instructions_dir = CAO_HOME_DIR / "tmp"
-                developer_instructions_dir.mkdir(parents=True, exist_ok=True)
-                developer_instructions_file = (
-                    developer_instructions_dir / f"{self.terminal_id}.codex_developer_instructions"
+                developer_instructions_file = self._developer_instructions_file_path()
+                developer_instructions_file.parent.mkdir(parents=True, exist_ok=True)
+                # Open with mode 0o600 baked into the O_CREAT call itself (rather than
+                # write_text() followed by a separate chmod()) so the file is never
+                # briefly world/group-readable between creation and permission-tightening --
+                # the permissions are correct from the very first byte written.
+                fd = os.open(
+                    developer_instructions_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
                 )
-                developer_instructions_file.write_text(_toml_scalar(system_prompt), encoding="utf-8")
-                try:
-                    developer_instructions_file.chmod(0o600)
-                except OSError:
-                    pass
-                developer_instructions_fragment = (
-                    f'-c "developer_instructions=$(cat {shlex.quote(str(developer_instructions_file))})"'
-                )
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(_toml_scalar(system_prompt))
+                developer_instructions_fragment = f'-c "developer_instructions=$(cat {shlex.quote(str(developer_instructions_file))})"'
 
             # Add MCP servers via -c config overrides (per-session, no global config changes).
             # Each server field is set via dotted path: mcp_servers.<name>.<field>=<value>
@@ -684,6 +707,17 @@ class CodexProvider(BaseProvider):
         # reaching IDLE/COMPLETED, and CAO would tear the terminal down on every single
         # attempt before an operator had any real chance to open the session and complete
         # login themselves.
+        #
+        # Known, disclosed-but-NOT-yet-fixed gap (see PR #540/#539 review discussion):
+        # CodexProvider does not override `blocks_orchestrated_input_while_waiting_user_answer`
+        # (base.py default False, unlike hermes.py/antigravity_cli.py which opt in), so
+        # terminal_service.py's send_input guard does not block an assign/handoff delivery
+        # while status is WAITING_USER_ANSWER. Now that initialize() accepts WAITING_USER_ANSWER
+        # as a success outcome, an assign/handoff launch that lands on this exact login menu can
+        # proceed to paste the orchestrated task text (+ Enter) into the live menu, which reads
+        # as an option selection -- the same composition hazard PR #539's review flagged for
+        # ClaudeCodeProvider's own choice-prompt widening. Not fixed here to keep this PR's scope
+        # to the review round-2 items; tracked as an open follow-up.
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER},
@@ -980,8 +1014,9 @@ class CodexProvider(BaseProvider):
         self._initialized = False
         # Remove the developer_instructions temp file written by _build_codex_command, if any --
         # same convention claude_code.py's own cleanup() uses for its analogous .prompt file.
-        tmp_file = CAO_HOME_DIR / "tmp" / f"{self.terminal_id}.codex_developer_instructions"
+        # Path comes from _developer_instructions_file_path() (single source of truth shared
+        # with _build_codex_command) so the write site and the cleanup site can't drift apart.
         try:
-            tmp_file.unlink(missing_ok=True)
+            self._developer_instructions_file_path().unlink(missing_ok=True)
         except OSError:
             pass

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -86,6 +86,28 @@ TRUST_PROMPT_PATTERN = r"allow Codex to work in this folder"
 TRUST_PROMPT_PATTERN_V2 = r"Do you trust the contents of this directory\?"
 TRUST_PROMPT_FOOTER = r"Press enter to continue"
 
+# First-run auth menu, shown when no OpenAI/Codex credentials are configured yet:
+#   Welcome to Codex, OpenAI's command-line coding agent
+#   Sign in with ChatGPT to use Codex as part of your paid plan
+#   or connect an API key for usage-based billing
+#   > 1. Sign in with ChatGPT
+#     2. Sign in with Device Code
+#     3. Provide your own API key
+#   Press enter to continue
+# Unlike the trust/update-available dialogs above, this one cannot be auto-dismissed --
+# it requires a real human to actually complete OAuth or supply a real API key, which is
+# squarely an operator task, not something this provider can or should fabricate. Before
+# this was recognized, `initialize()`'s own wait_until_status(..., {IDLE, COMPLETED}, ...)
+# had no way to ever succeed for an account with no credentials configured yet: the pane
+# would sit at this exact, correctly-rendered screen -- process alive, output real, nothing
+# actually broken -- but never reach IDLE/COMPLETED, so the 60s init timeout would always
+# fire and CAO would tear the terminal down before an operator had any real chance to open
+# the session and complete login themselves. Bottom-anchored (last 15 lines) requiring BOTH
+# the menu text and the footer together, same shape as TRUST_PROMPT_PATTERN_V2 immediately
+# above, to avoid a false match on this text surviving in scrollback from earlier output.
+LOGIN_MENU_PATTERN = r"Sign in with ChatGPT"
+LOGIN_MENU_FOOTER = TRUST_PROMPT_FOOTER
+
 # Startup "Update available!" dialog. Codex shows this at startup when a newer
 # release exists, with a numbered menu whose cursor default is option 1:
 #   ✨ Update available! 0.142.5 -> 0.144.5
@@ -652,9 +674,19 @@ class CodexProvider(BaseProvider):
         # Handle workspace trust prompt if it appears (new/untrusted directories)
         await self._handle_trust_prompt(timeout=20.0)
 
+        # WAITING_USER_ANSWER is included here specifically for the first-run login/auth
+        # menu (see LOGIN_MENU_PATTERN's own comment) — an account with no credentials
+        # configured yet is a real, expected state at this exact point (trust/update
+        # dialogs above are already auto-dismissed by _handle_trust_prompt, so nothing
+        # else should legitimately produce WAITING_USER_ANSWER this early), not a failure.
+        # Without this, initialize() had no way to ever succeed for such an account: the
+        # pane would sit at a correctly-rendered, fully-alive login screen forever without
+        # reaching IDLE/COMPLETED, and CAO would tear the terminal down on every single
+        # attempt before an operator had any real chance to open the session and complete
+        # login themselves.
         if not await wait_until_status(
             self.terminal_id,
-            {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+            {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER},
             timeout=float(get_server_settings()["provider_init_timeout"]),
             polling_interval=1.0,
         ):
@@ -742,6 +774,15 @@ class CodexProvider(BaseProvider):
         # where a queued message or blind Enter could select "Update now".
         # Eager inbox delivery is not a vector: accepts_input_while_processing=False.
         if _has_update_dialog_in_bottom(clean_output):
+            return TerminalStatus.WAITING_USER_ANSWER
+
+        # First-run login/auth menu (no credentials configured yet). Bottom-anchored like
+        # trust-v2, same reasoning. See LOGIN_MENU_PATTERN's own comment for why this can't
+        # be auto-dismissed the way trust/update dialogs are, and why classifying it here
+        # (rather than leaving it unrecognized) matters for initialize()'s own timeout.
+        if re.search(LOGIN_MENU_PATTERN, bottom_region) and re.search(
+            LOGIN_MENU_FOOTER, bottom_region
+        ):
             return TerminalStatus.WAITING_USER_ANSWER
 
         # Check bottom of captured output for idle prompt.

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -350,6 +350,20 @@ class CodexProvider(BaseProvider):
         # Explicit per-call override for profile.model, see _build_codex_command.
         self._model = model
 
+    @property
+    def blocks_orchestrated_input_while_waiting_user_answer(self) -> bool:
+        """The first-run login/auth menu consumes pasted text as a menu selection.
+
+        Now that ``initialize()`` accepts ``WAITING_USER_ANSWER`` as a successful init
+        outcome (for a credential-less account parked on the login menu), an assign/handoff
+        launch that lands there must not have its orchestrated task text pasted into the
+        live menu -- it would be read as an option selection, not delivered as a task.
+        Opting in (matching hermes.py/antigravity_cli.py) makes terminal_service's send_input
+        guard hold orchestrated delivery until the prompt clears, while still allowing an
+        explicit answer_user_prompt call through.
+        """
+        return True
+
     def _developer_instructions_file_path(self) -> Path:
         """Path of this terminal's developer_instructions temp file.
 
@@ -708,16 +722,11 @@ class CodexProvider(BaseProvider):
         # attempt before an operator had any real chance to open the session and complete
         # login themselves.
         #
-        # Known, disclosed-but-NOT-yet-fixed gap (see PR #540/#539 review discussion):
-        # CodexProvider does not override `blocks_orchestrated_input_while_waiting_user_answer`
-        # (base.py default False, unlike hermes.py/antigravity_cli.py which opt in), so
-        # terminal_service.py's send_input guard does not block an assign/handoff delivery
-        # while status is WAITING_USER_ANSWER. Now that initialize() accepts WAITING_USER_ANSWER
-        # as a success outcome, an assign/handoff launch that lands on this exact login menu can
-        # proceed to paste the orchestrated task text (+ Enter) into the live menu, which reads
-        # as an option selection -- the same composition hazard PR #539's review flagged for
-        # ClaudeCodeProvider's own choice-prompt widening. Not fixed here to keep this PR's scope
-        # to the review round-2 items; tracked as an open follow-up.
+        # CodexProvider now overrides `blocks_orchestrated_input_while_waiting_user_answer`
+        # (see the property above) specifically so this WAITING_USER_ANSWER init-success
+        # path can't let an assign/handoff paste the orchestrated task into the live login
+        # menu -- the same composition hazard PR #539's review flagged for ClaudeCodeProvider's
+        # own choice-prompt widening, fixed here the same way rather than left open.
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER},

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -8,6 +8,7 @@ import time
 from typing import Any, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
+from cli_agent_orchestrator.constants import CAO_HOME_DIR
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.services.settings_service import get_server_settings
@@ -360,6 +361,11 @@ class CodexProvider(BaseProvider):
         if resolved_model:
             command_parts.extend(["--model", resolved_model])
 
+        # Set below, only when there is a non-empty system_prompt to inject -- appended, raw and
+        # deliberately unquoted by shlex, after the shlex.join() of everything else at the very
+        # end of this method. See the long comment at its assignment site for why.
+        developer_instructions_fragment: Optional[str] = None
+
         if profile is not None:
             system_prompt = profile.system_prompt if profile.system_prompt is not None else ""
             system_prompt = self._apply_skill_prompt(system_prompt)
@@ -380,8 +386,64 @@ class CodexProvider(BaseProvider):
                 # Escape backslashes, double quotes, and newlines for TOML basic string.
                 # Newlines must become literal \n to prevent tmux send_keys from
                 # splitting the command across multiple lines.
-                command_parts.extend(
-                    ["-c", f"developer_instructions={_toml_scalar(system_prompt)}"]
+                #
+                # The escaped value is written to a CAO-owned temp file and referenced via a
+                # shell command substitution ($(cat <file>)) instead of being inlined directly,
+                # so the LAUNCH LINE ITSELF (what actually gets typed/pasted into the tmux pane)
+                # stays short regardless of how long the instructions text is. A real profile
+                # combining a security preamble, the caller's own system prompt, and the full
+                # skill-list prompt (see _apply_skill_prompt) commonly produces several KB of
+                # escaped text -- observed live at 8+KB. At launch time the pane is still a bare
+                # shell (codex has not started yet), which correctly does not get bracketed-paste
+                # framing (see clients/tmux.py's BRACKETED_PASTE_INCOMPATIBLE_SHELLS) since a bare
+                # shell does not understand those escape sequences. But WITHOUT that framing, a
+                # single pasted/typed line longer than the tty's canonical-mode line-length limit
+                # (MAX_CANON, 4096 bytes on Linux) is silently truncated/dropped by the kernel's
+                # tty line discipline before the shell ever sees a complete, valid command --
+                # this manifests as the shell hanging at an unclosed-quote continuation prompt
+                # forever (confirmed live: zero codex process ever spawned under the pane's shell,
+                # even after an explicit trailing Enter), until CAO's own init-timeout eventually
+                # fires with a generic "Codex initialization timed out" that gives no hint of the
+                # real cause. $(cat <file>) is expanded internally by the shell BEFORE exec'ing
+                # codex -- that internal expansion is not subject to the tty's per-line INPUT
+                # limit at all, only the typed/pasted command line is. Wrapped in double quotes
+                # (not left bare, not single-quoted) so the substitution still happens (command
+                # substitution is disabled inside single quotes) while word-splitting/globbing of
+                # the substituted content is suppressed (it is not inside single quotes either).
+                # The file's own content is `_toml_scalar`'s output verbatim, already including
+                # its own surrounding TOML double-quotes -- appended as a raw, deliberately
+                # UNquoted-by-shlex fragment after the main shlex.join() below (shlex.join would
+                # otherwise single-quote the whole "developer_instructions=$(cat ...)" fragment as
+                # one opaque token, disabling the substitution it depends on).
+                #
+                # Same underlying instructions/skills length problem does not affect Claude Code
+                # or Kimi CLI providers -- both already write the system prompt to a temp file and
+                # pass a short file-path flag instead of inlining it (see claude_code.py's
+                # --append-system-prompt-file, kimi_cli.py's system_prompt_path: YAML field).
+                # Codex has no direct equivalent of that "arbitrary absolute path" flag (its only
+                # file-loading mechanism, --profile, resolves names relative to $CODEX_HOME, which
+                # this provider has no reliable way to resolve per-account from here) -- this
+                # command-substitution approach reaches the same practical outcome (a short launch
+                # line) without needing that.
+                #
+                # Not covering here (disclosed, not silently assumed away): the other -c overrides
+                # below (per-MCP-server config, codexConfig) are NOT routed through this same
+                # mechanism and remain inlined directly -- they are typically far smaller than
+                # developer_instructions, but a profile configuring many MCP servers could in
+                # theory still accumulate enough inline -c overrides to hit the same limit. Left
+                # as a known, scoped-out follow-up rather than expanding this fix's surface.
+                developer_instructions_dir = CAO_HOME_DIR / "tmp"
+                developer_instructions_dir.mkdir(parents=True, exist_ok=True)
+                developer_instructions_file = (
+                    developer_instructions_dir / f"{self.terminal_id}.codex_developer_instructions"
+                )
+                developer_instructions_file.write_text(_toml_scalar(system_prompt), encoding="utf-8")
+                try:
+                    developer_instructions_file.chmod(0o600)
+                except OSError:
+                    pass
+                developer_instructions_fragment = (
+                    f'-c "developer_instructions=$(cat {shlex.quote(str(developer_instructions_file))})"'
                 )
 
             # Add MCP servers via -c config overrides (per-session, no global config changes).
@@ -450,7 +512,10 @@ class CodexProvider(BaseProvider):
         # wins even if a profile sets check_for_update_on_startup=true.
         command_parts.extend(["-c", "check_for_update_on_startup=false"])
 
-        return shlex.join(command_parts)
+        command = shlex.join(command_parts)
+        if developer_instructions_fragment is not None:
+            command = f"{command} {developer_instructions_fragment}"
+        return command
 
     async def _handle_trust_prompt(self, timeout: float = 20.0) -> None:
         """Dismiss startup prompts that block readiness.
@@ -872,3 +937,10 @@ class CodexProvider(BaseProvider):
     def cleanup(self) -> None:
         """Clean up Codex CLI provider."""
         self._initialized = False
+        # Remove the developer_instructions temp file written by _build_codex_command, if any --
+        # same convention claude_code.py's own cleanup() uses for its analogous .prompt file.
+        tmp_file = CAO_HOME_DIR / "tmp" / f"{self.terminal_id}.codex_developer_instructions"
+        try:
+            tmp_file.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2065,6 +2065,98 @@ class TestCodexProviderTrustPrompt:
         # Should be COMPLETED (model replied to user question), NOT WAITING
         assert status == TerminalStatus.COMPLETED
 
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_login_menu_is_waiting(self, mock_backend):
+        """First-run auth menu (no credentials configured) in the bottom region
+        classifies WAITING_USER_ANSWER -- live-reproduced real Codex output."""
+        mock_backend.return_value.get_pane_current_command.return_value = "codex"
+        output = (
+            "  Welcome to Codex, OpenAI's command-line coding agent\n"
+            "\n"
+            "  Sign in with ChatGPT to use Codex as part of your paid plan\n"
+            "  or connect an API key for usage-based billing\n"
+            "\n"
+            "> 1. Sign in with ChatGPT\n"
+            "     Usage included with Plus, Pro, Business, and Enterprise plans\n"
+            "\n"
+            "  2. Sign in with Device Code\n"
+            "     Sign in from another device with a one-time code\n"
+            "\n"
+            "  3. Provide your own API key\n"
+            "     Pay for what you use\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = True
+        provider.shell_baseline = "zsh"
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_get_status_login_menu_in_scrollback_does_not_false_positive(self, mock_backend):
+        """Login-menu text in scrollback (not the bottom region) must NOT trigger WAITING --
+        same bottom-anchoring discipline as the V2 trust dialog check immediately above."""
+        mock_backend.return_value.get_pane_current_command.return_value = "codex"
+        output = (
+            "› explain the codex login menu\n"
+            '• Earlier it showed "Sign in with ChatGPT to use Codex as part of your paid plan".\n'
+            "• That happens on first run with no credentials configured.\n"
+            "• There were three options: ChatGPT, Device Code, or an API key.\n"
+            "• Once authenticated, this menu never shows again.\n"
+            "• You can re-trigger it with codex logout.\n"
+            "• The credentials get stored in ~/.codex/auth.json.\n"
+            "• API keys are validated on first use, not at login time.\n"
+            "• Device code login works well for headless environments.\n"
+            "• ChatGPT login opens a browser tab for OAuth.\n"
+            "• Both paths end up writing the same auth.json format.\n"
+            "• You can check current auth status with codex login status.\n"
+            "• Logging out clears the stored credentials entirely.\n"
+            "• None of this appears again once you're signed in.\n"
+            "• This whole explanation is well past fifteen lines by now.\n"
+            "• Padding further to push the earlier mention out of the tail window.\n"
+            "\n"
+            "› \n"
+            "  ? for shortcuts                     95% context left\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider._initialized = True
+        provider.shell_baseline = "zsh"
+        status = provider.get_status(output)
+
+        assert status != TerminalStatus.WAITING_USER_ANSWER
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_initialize_includes_waiting_user_answer_in_target_status(
+        self, mock_tmux, mock_wait_shell, mock_wait_status
+    ):
+        """Regression test for the real, live-reproduced failure: an account with no
+        credentials configured yet reaches a correctly-rendered, fully-alive login screen
+        that never becomes IDLE/COMPLETED on its own -- initialize()'s own
+        wait_until_status(..., {IDLE, COMPLETED}, ...) target set had no way to ever
+        succeed for it, so CAO tore the terminal down on every single attempt (a live,
+        reproduced "Codex initialization timed out after 60 seconds", the operator's own
+        "the session doesn't even start" symptom) before anyone had a real chance to open
+        the session and complete login. WAITING_USER_ANSWER must be in the target set."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
+
+        provider = CodexProvider("test1234", "test-session", "window-0", None)
+        result = await provider.initialize()
+
+        assert result is True
+        target_status_arg = mock_wait_status.call_args.args[1]
+        assert TerminalStatus.WAITING_USER_ANSWER in target_status_arg
+        assert TerminalStatus.IDLE in target_status_arg
+        assert TerminalStatus.COMPLETED in target_status_arg
+
     def test_backend_registry_is_clean_at_test_start(self):
         """Regression for #522: autouse fixture resets the backend singleton."""
         from cli_agent_orchestrator.backends import registry

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -1,6 +1,7 @@
 """Unit tests for Codex provider."""
 
 import os
+import re
 import shlex
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,17 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 def load_fixture(filename: str) -> str:
     with open(FIXTURES_DIR / filename, "r") as f:
         return f.read()
+
+
+def read_developer_instructions_file(command: str) -> str:
+    """Extracts the path from the command's ``$(cat <path>)`` developer_instructions
+    fragment and returns that file's actual on-disk content -- the fragment keeps the
+    launch line itself short (see codex.py's own long comment at the assignment site),
+    so tests that need to check the actual (TOML-escaped) prompt text now read it from
+    here instead of asserting on ``command`` directly."""
+    match = re.search(r"\$\(cat (\S+)\)", command)
+    assert match is not None, f"no $(cat <file>) developer_instructions fragment in: {command!r}"
+    return Path(match.group(1)).read_text(encoding="utf-8")
 
 
 class TestCodexProviderInitialization:
@@ -86,7 +98,7 @@ class TestCodexBuildCommand:
         )
 
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
-    def test_build_command_with_skill_prompt(self, mock_load_profile):
+    def test_build_command_with_skill_prompt(self, mock_load_profile, tmp_path):
         mock_profile = MagicMock()
         mock_profile.model = None
         mock_profile.system_prompt = "You are a supervisor."
@@ -101,15 +113,17 @@ class TestCodexBuildCommand:
             "code_supervisor",
             skill_prompt="## Available Skills\n- **python-testing**: Pytest",
         )
-        command = provider._build_codex_command()
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
 
         mock_load_profile.assert_called_once_with("code_supervisor")
-        assert "developer_instructions=" in command
-        assert "## Available Skills" in command
-        assert "python-testing" in command
+        assert "developer_instructions=$(cat " in command
+        instructions = read_developer_instructions_file(command)
+        assert "## Available Skills" in instructions
+        assert "python-testing" in instructions
 
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
-    def test_build_command_with_agent_profile(self, mock_load_profile):
+    def test_build_command_with_agent_profile(self, mock_load_profile, tmp_path):
         mock_profile = MagicMock()
         mock_profile.model = None
         mock_profile.system_prompt = "You are a code supervisor agent."
@@ -118,16 +132,17 @@ class TestCodexBuildCommand:
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "code_supervisor")
-        command = provider._build_codex_command()
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
 
         mock_load_profile.assert_called_once_with("code_supervisor")
         assert "codex --yolo --no-alt-screen --disable shell_snapshot" in command
         assert "-c" in command
-        assert "developer_instructions=" in command
-        assert "You are a code supervisor agent." in command
+        assert "developer_instructions=$(cat " in command
+        assert "You are a code supervisor agent." in read_developer_instructions_file(command)
 
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
-    def test_build_command_escapes_quotes(self, mock_load_profile):
+    def test_build_command_escapes_quotes(self, mock_load_profile, tmp_path):
         mock_profile = MagicMock()
         mock_profile.model = None
         mock_profile.system_prompt = 'Use "double quotes" carefully.'
@@ -136,12 +151,13 @@ class TestCodexBuildCommand:
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
-        command = provider._build_codex_command()
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
 
-        assert '\\"double quotes\\"' in command
+        assert '\\"double quotes\\"' in read_developer_instructions_file(command)
 
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
-    def test_build_command_escapes_newlines(self, mock_load_profile):
+    def test_build_command_escapes_newlines(self, mock_load_profile, tmp_path):
         mock_profile = MagicMock()
         mock_profile.model = None
         mock_profile.system_prompt = "Line one.\nLine two.\n\n## Section\n- Item"
@@ -150,12 +166,21 @@ class TestCodexBuildCommand:
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "test_agent")
-        command = provider._build_codex_command()
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
 
-        # Literal newlines must be escaped to \n for TOML and tmux compatibility
+        # The launch line itself must never contain a literal newline (that's the whole point
+        # of this fix -- see the long comment at the fragment's assignment site in codex.py) OR
+        # any of the actual prompt text; both now live only in the temp file.
         assert "\n" not in command
-        assert "\\n" in command
-        assert "Line one.\\nLine two.\\n\\n## Section\\n- Item" in command
+        assert "Line one." not in command
+
+        # Literal newlines in the prompt must be escaped to \n for TOML and tmux compatibility,
+        # in the temp file's own content.
+        instructions = read_developer_instructions_file(command)
+        assert "\n" not in instructions
+        assert "\\n" in instructions
+        assert "Line one.\\nLine two.\\n\\n## Section\\n- Item" in instructions
 
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
     def test_build_command_with_mcp_servers(self, mock_load_profile):
@@ -392,7 +417,7 @@ class TestCodexBuildCommand:
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_initialize_with_agent_profile(
-        self, mock_tmux, mock_load_profile, mock_wait_shell, mock_wait_status
+        self, mock_tmux, mock_load_profile, mock_wait_shell, mock_wait_status, tmp_path
     ):
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
@@ -405,13 +430,14 @@ class TestCodexBuildCommand:
         mock_load_profile.return_value = mock_profile
 
         provider = CodexProvider("test1234", "test-session", "window-0", "code_supervisor")
-        result = await provider.initialize()
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            result = await provider.initialize()
 
         assert result is True
         # The second send_keys call should contain developer_instructions
         codex_call = mock_tmux.return_value.send_keys.call_args_list[1]
-        assert "developer_instructions=" in codex_call.args[2]
-        assert "You are a supervisor." in codex_call.args[2]
+        assert "developer_instructions=$(cat " in codex_call.args[2]
+        assert "You are a supervisor." in read_developer_instructions_file(codex_call.args[2])
 
 
 class TestCodexProviderModelFlag:
@@ -472,7 +498,7 @@ class TestCodexBuildCommandExtra:
     pre-existing fixtures didn't exercise."""
 
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
-    def test_security_prompt_prepended_when_tools_restricted(self, mock_load):
+    def test_security_prompt_prepended_when_tools_restricted(self, mock_load, tmp_path):
         # When ``allowed_tools`` is a restricted set (no "*"), the provider
         # prepends SECURITY_PROMPT plus a "You only have access to these
         # tools:" hint to the developer_instructions payload.
@@ -486,13 +512,98 @@ class TestCodexBuildCommandExtra:
         provider = CodexProvider(
             "tid", "sess", "win", "agent", allowed_tools=["fs_read", "fs_list"]
         )
-        command = provider._build_codex_command()
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
 
-        assert "You only have access to these tools: fs_read, fs_list" in command
-        assert "Original system prompt." in command
+        instructions = read_developer_instructions_file(command)
+        assert "You only have access to these tools: fs_read, fs_list" in instructions
+        assert "Original system prompt." in instructions
         # SECURITY_PROMPT lives in constants; assert on a stable substring
         # rather than importing the constant into the test fixture.
-        assert "NEVER" in command  # "NEVER read/output: ~/.aws/credentials..."
+        assert "NEVER" in instructions  # "NEVER read/output: ~/.aws/credentials..."
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_long_system_prompt_keeps_launch_line_short(self, mock_load, tmp_path):
+        """Regression test for the real, live-reproduced failure: a large system_prompt
+        (harness-control's own injected operating instructions + skill list commonly produce
+        several KB once escaped) used to be inlined directly into the launch command via
+        ``-c developer_instructions="<escaped text>"``. When that pane is still a bare shell
+        (codex has not started yet -- correctly NOT given bracketed-paste framing, since a bare
+        shell does not understand those escape sequences), a single typed/pasted line beyond the
+        tty's canonical-mode line-length limit (MAX_CANON, 4096 bytes on Linux) is silently
+        truncated by the kernel's tty line discipline before the shell ever sees a complete,
+        valid command -- the shell hangs at an unclosed-quote continuation prompt forever, no
+        codex process is ever spawned, and CAO's own init-timeout eventually fires with a
+        generic "Codex initialization timed out" that gives no hint of the real cause.
+
+        Confirmed live (isolated scratch tmux pane, zero risk to any other session): an 8.3KB
+        escaped instructions payload, sent via CAO's own real send_keys code path to a real bare
+        shell pane, never executed even after an explicit trailing Enter (verified with a
+        marker-file test) -- while `dash -n`/`bash -n` on the exact same text as a plain script
+        confirmed the content itself was syntactically valid, ruling out a quoting bug and
+        pointing squarely at line length as the real, sole cause."""
+        long_prompt = "A" * 10_000  # escapes to something well over the 4096-byte MAX_CANON limit
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = long_prompt
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
+
+        # The actual typed/pasted launch line must stay well under the tty's canonical-mode
+        # line-length limit regardless of how long the instructions text is -- this is the
+        # entire point of the fix. 1000 is a generous margin under the real 4096-byte limit.
+        assert len(command) < 1000, (
+            f"launch line is {len(command)} bytes -- long enough to risk the tty canonical-mode "
+            "line-length limit this fix exists to avoid"
+        )
+        assert long_prompt not in command
+        assert "developer_instructions=$(cat " in command
+        assert long_prompt in read_developer_instructions_file(command)
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_developer_instructions_file_written_with_owner_only_permissions(
+        self, mock_load, tmp_path
+    ):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = "Sensitive: contains real secrets context."
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
+
+        match = re.search(r"\$\(cat (\S+)\)", command)
+        assert match is not None
+        file_path = Path(match.group(1))
+        assert oct(file_path.stat().st_mode)[-3:] == "600"
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_cleanup_removes_developer_instructions_file(self, mock_load, tmp_path):
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = "Some instructions."
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = None
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent")
+        with patch("cli_agent_orchestrator.providers.codex.CAO_HOME_DIR", tmp_path):
+            command = provider._build_codex_command()
+            match = re.search(r"\$\(cat (\S+)\)", command)
+            assert match is not None
+            file_path = Path(match.group(1))
+            assert file_path.exists()
+
+            provider.cleanup()
+            assert not file_path.exists()
 
     @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
     def test_mcp_server_accepts_model_instance(self, mock_load):

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.codex import (
     CodexProvider,
@@ -2552,3 +2553,68 @@ class TestCodexLaunchFlagsValidity:
             assert (
                 probe.returncode == 0 and "unexpected argument" not in probe.stderr
             ), f"Flag '{flag}' in launch command rejected by codex binary"
+
+
+class TestCodexProviderBlocksOrchestratedInputWhileWaitingUserAnswer:
+    """PR #540 follow-up (raised during the round-2 review pass): CodexProvider must
+    opt into `blocks_orchestrated_input_while_waiting_user_answer` -- otherwise, now
+    that `initialize()` accepts WAITING_USER_ANSWER (the first-run login menu) as a
+    success outcome, an assign/handoff's deferred-init `send_input` would paste the
+    orchestrated task straight into the live login menu instead of being held for
+    `answer_user_prompt`. Same hazard PR #539's review flagged for ClaudeCodeProvider,
+    fixed here the same way (a property override matching hermes.py/antigravity_cli.py).
+    """
+
+    def test_property_is_true(self):
+        provider = CodexProvider("test1234", "test-session", "window-0", None)
+        assert provider.blocks_orchestrated_input_while_waiting_user_answer is True
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service._notify_caller_of_deferred_failure")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    async def test_waiting_on_login_menu_leaves_worker_alive_task_undelivered(
+        self, mock_tmux, mock_pm, mock_status_monitor, mock_meta, mock_notify
+    ):
+        """RED (pre-fix, property False): send_input's guard no-ops, the task text
+        is pasted into the live login menu via `send_keys`, and the deferred-init
+        path treats delivery as having succeeded -- `_notify_caller_of_deferred_failure`
+        is never called at all, so this test's own assertion of a undelivered/alive
+        worker fails outright (no call to assert on).
+        GREEN (post-fix, property True): `send_input` raises `TerminalInputBlockedError`
+        before any `send_keys` call, `_schedule_deferred_init` catches it and leaves the
+        worker alive (`delete_worker=False`) with nothing pasted.
+        """
+        from cli_agent_orchestrator.services.terminal_service import (
+            _deferred_init_tasks,
+            _schedule_deferred_init,
+        )
+
+        mock_meta.return_value = {
+            "caller_id": "super123",
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_status_monitor.get_status.return_value = TerminalStatus.WAITING_USER_ANSWER
+        # Real provider instance (not a generic mock) so its actual
+        # blocks_orchestrated_input_while_waiting_user_answer property value is
+        # what send_input's guard consults -- this is the thing under test.
+        real_provider = CodexProvider("worker99", "cao-session", "developer-abcd")
+        mock_pm.get_provider.return_value = real_provider
+
+        provider_instance = AsyncMock()
+        provider_instance.initialize.return_value = True  # succeeded: WAITING_USER_ANSWER reached
+        provider_instance.shell_baseline = None
+
+        before_tasks = set(_deferred_init_tasks)
+        _schedule_deferred_init(
+            provider_instance, "worker99", "do the task", OrchestrationType.ASSIGN, None
+        )
+        (task,) = set(_deferred_init_tasks) - before_tasks
+        await task
+
+        mock_tmux.send_keys.assert_not_called()
+        mock_notify.assert_called_once()
+        assert mock_notify.call_args.kwargs["delete_worker"] is False

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -186,7 +186,12 @@ class TestCodexBuildCommand:
     def test_build_command_with_mcp_servers(self, mock_load_profile):
         mock_profile = MagicMock()
         mock_profile.model = None
-        mock_profile.system_prompt = "You are a supervisor."
+        # Empty -- these assertions only care about the MCP -c overrides, not the
+        # developer_instructions temp file, so there's nothing to gain from writing
+        # one to disk (and every write outside a patched CAO_HOME_DIR touches the
+        # real ~/.aws/cli-agent-orchestrator/tmp/, same convention as
+        # test_build_command_with_mcp_servers_env below).
+        mock_profile.system_prompt = ""
         mock_profile.mcpServers = {
             "cao-mcp-server": {
                 "type": "stdio",
@@ -217,7 +222,8 @@ class TestCodexBuildCommand:
         before being emitted as a -c override."""
         mock_profile = MagicMock()
         mock_profile.model = None
-        mock_profile.system_prompt = "You are a supervisor."
+        # Empty -- see test_build_command_with_mcp_servers's comment above.
+        mock_profile.system_prompt = ""
         mock_profile.mcpServers = {
             "cao-mcp-server": {"type": "stdio", "command": "cao-mcp-server", "args": []}
         }
@@ -244,7 +250,8 @@ class TestCodexBuildCommand:
         -c override stays a valid TOML basic string."""
         mock_profile = MagicMock()
         mock_profile.model = None
-        mock_profile.system_prompt = "You are a supervisor."
+        # Empty -- see test_build_command_with_mcp_servers's comment above.
+        mock_profile.system_prompt = ""
         mock_profile.mcpServers = {
             "cao-mcp-server": {"type": "stdio", "command": "cao-mcp-server", "args": []}
         }


### PR DESCRIPTION
## Summary

Codex sessions with a non-trivial system prompt (a few KB is common once a security preamble,
skill list, and orchestrator operating instructions are all folded in) can fail to launch at all,
with no useful error message — `wait_until_status` eventually times out and CAO reports a generic
"Codex initialization timed out after N seconds".

## Root cause

`CodexProvider._build_codex_command()` inlines the entire (TOML-escaped) system prompt directly
into the launch command via `-c developer_instructions="<escaped text>"`. That command is typed
into the pane while it is still a bare shell (codex has not started yet) — correctly *not* given
bracketed-paste framing, since a bare shell doesn't understand those escape sequences
(`clients/tmux.py`'s own `BRACKETED_PASTE_INCOMPATIBLE_SHELLS` check).

Without bracketed-paste framing, though, a single typed/pasted line longer than the tty's
canonical-mode line-length limit (`MAX_CANON`, 4096 bytes on Linux) is silently truncated by the
kernel's tty line discipline before the shell ever sees a complete, valid command. The shell hangs
at an unclosed-quote continuation prompt indefinitely — no `codex` process is ever spawned — until
the init timeout eventually fires, with nothing in the resulting error pointing at the real cause.

**Reproduced in isolation**, not just inferred: a real `_build_codex_command()`-generated 8.3KB
command, sent via the actual `TmuxClient.send_keys()` code path to a disposable scratch tmux pane,
never executed even after an explicit trailing `Enter` (confirmed with a marker-file test — the
command never ran). The same command text passed `dash -n`/`bash -n` as a plain script, ruling out
a quoting bug and pointing squarely at line length as the sole cause. Full writeup with exact
repro steps: happy to paste into a comment if useful for review — kept out of the diff itself.

Claude Code and Kimi CLI providers don't have this problem: both already write the system prompt
to a temp file and pass a short file-path flag instead of inlining it
(`claude_code.py`'s `--append-system-prompt-file`, `kimi_cli.py`'s `system_prompt_path:` YAML
field). Codex has no direct equivalent of "arbitrary absolute path" flag — its only file-loading
mechanism, `--profile`, resolves names relative to `$CODEX_HOME`, which this provider has no
reliable way to resolve per-account from here (env/HOME threading for the target account isn't
plumbed into `CodexProvider` today).

## Fix

Write the TOML-escaped `developer_instructions` value to a CAO-owned temp file
(`CAO_HOME_DIR/tmp/<terminal_id>.codex_developer_instructions`, `0o600`, cleaned up in
`cleanup()` — same convention `claude_code.py` already uses for its own `.prompt` file) and
reference it via a shell command substitution (`$(cat <file>)`) instead of inlining the text
directly. The internal shell expansion this triggers happens *before* `codex` is exec'd and is not
subject to the tty's per-line *input* limit at all — only the actual typed/pasted launch line is,
and that now stays short (well under 1KB in every case I tested) regardless of how long the
instructions text is.

This fragment is deliberately assembled *outside* `shlex.join(command_parts)` (appended after) —
`shlex.join` would otherwise single-quote the whole `developer_instructions=$(cat ...)` fragment as
one opaque token, disabling the substitution it depends on. The file path itself is CAO-generated
(not user-controlled) and is `shlex.quote()`-escaped before being embedded in the fragment.

**Scope, disclosed rather than silently expanded**: the other `-c` overrides this method emits
(per-MCP-server config, `codexConfig`) are *not* routed through this same mechanism and remain
inlined directly — they're typically far smaller than `developer_instructions`, but a profile
configuring many MCP servers could in theory still accumulate enough inline `-c` overrides to hit
the same limit. Left as a known follow-up rather than expanding this PR's surface.

**Shell scope, deliberate and documented (raised in review):** `$(...)` command substitution is
POSIX and behaves identically on every shell CAO's own `BRACKETED_PASTE_INCOMPATIBLE_SHELLS`
(`constants.py`) already tracks as a shell class *except* `csh`/`tcsh`, which use backtick
`` `cmd` `` substitution and do not recognize `$(` at all — launching codex from a pane whose bare
shell is `csh`/`tcsh` would break outright (malformed/rejected command), not merely degrade.
`bash`/`zsh`/`dash`/`sh`/`ksh`/`mksh`/`ash`/`fish` are all fine. This is a conscious scope
decision, now called out in a code comment at the `$(cat ...)` construction site in `codex.py`,
not an oversight — no code here detects the pane's shell before writing this fragment (CAO itself
never pins a specific `window_shell` for provider-launched panes; the pane runs tmux's
`default-shell`, which resolves from the `$SHELL` the `cao-server` process itself inherited).
`csh`/`tcsh` support, if ever needed, is scoped out of this fix. On the direct question of which
shell the original live repro pane used: I could not determine this with certainty from the
available evidence (repro notes and commit message don't record it, and I did not run that
specific repro myself) — stating this plainly rather than guessing.

## Also in this PR (disclosed, not just buried in a review comment): `4668771` — first-run login menu as a valid init state

A second, related commit is included: an account with no OpenAI/Codex credentials configured yet
reaches Codex's real "Sign in with ChatGPT / Device Code / API key" welcome menu on launch — a
correctly-rendered, fully-alive screen, nothing actually broken. But `initialize()`'s own
`wait_until_status(..., {IDLE, COMPLETED}, ...)` had no way to ever succeed for it: that menu
never becomes IDLE/COMPLETED on its own, so the 60s init timeout always fired and the terminal was
torn down before an operator had any real chance to open the session and complete login.

Fix: recognize the login menu in `get_status()` (`LOGIN_MENU_PATTERN`, bottom-anchored with its
footer, same shape as the existing V2 trust dialog check) and classify it `WAITING_USER_ANSWER`,
then widen `initialize()`'s own target status set to include `WAITING_USER_ANSWER`. Unlike the
trust/update dialogs handled by `_handle_trust_prompt`, this one can't be auto-dismissed — it
requires a real human to actually complete OAuth or supply a real API key — so the fix is "let
init succeed and keep the terminal alive for a human," not "auto-dismiss."

**Known, disclosed-but-NOT-yet-fixed interaction with sibling PR #539's review finding:** #539's
review (both reviewers, independently) flagged that `ClaudeCodeProvider` accepting
`WAITING_USER_ANSWER` as an `initialize()` success outcome, combined with `send_input`'s guard
(`terminal_service.py:999`) only firing when `provider.blocks_orchestrated_input_while_waiting_user_answer`
is `True`, lets an assign/handoff launch paste the orchestrated task text into a live choice
prompt and auto-answer it — because `ClaudeCodeProvider` doesn't override that property (only
`hermes.py`/`antigravity_cli.py` do). **`CodexProvider` has the exact same gap**: it also does not
override `blocks_orchestrated_input_while_waiting_user_answer` (verified by grep — the property
isn't defined anywhere in `codex.py`, so it inherits `base.py`'s default `False`). Now that this
commit widens `initialize()`'s accept-set to include `WAITING_USER_ANSWER` for the login menu, an
assign/handoff launch that lands on this exact menu could in principle paste the task text (+
Enter) into it, which the menu would read as an option selection. **This is not fixed in this PR**
— it's the same composition hazard #539 is addressing for `claude_code`, called out here explicitly
rather than left silent, and now also has a code comment at the `wait_until_status` call site in
`codex.py`. Flagging as a disclosed, open follow-up rather than claiming it's safe: I have not
verified whether this is exploitable in practice beyond the code-level guard analysis above (no
live repro attempted against the login-menu + assign/handoff combination in this PR).

## Round-2 review fixes (this update)

Addressing the two open CHANGES_REQUESTED reviews:

- **CI black failure** — `black`/`isort` now clean on `codex.py` and the touched test file.
- **[Blocking, @gutosantos82] Sandbox-escaping tests** — `test_build_command_with_mcp_servers`,
  `test_bundled_mcp_command_is_resolved`, `test_mcp_server_command_field_is_toml_escaped` set a
  non-empty `system_prompt` without the `CAO_HOME_DIR` patch every other prompt-writing test in the
  file uses, so they wrote to the real `~/.aws/cli-agent-orchestrator/tmp/` and failed under a
  read-only home. Fixed by emptying `system_prompt` (irrelevant to these tests' MCP assertions),
  matching the existing `test_build_command_with_mcp_servers_env` pattern — reproduced the original
  failure under a real read-only-home sandbox first, then confirmed the fix passes under the same
  sandbox.
- **[Should-fix, @gutosantos82] `cleanup()`/`_build_codex_command()` path duplication** — both now
  call a single new `_developer_instructions_file_path()` helper instead of independently
  re-deriving the same path expression.
- **[Nit] write→chmod exposure window** — the temp file is now opened via `os.open(..., 0o600)`
  with the mode set at creation time, instead of `write_text()` followed by a separate `chmod()`.
- **[Disclosure, @call-me-ram]** `4668771` is now a named, described section above (was previously
  only in a review-comment reply), including the #539 interaction and the shell-scope trade-off.

## Testing

**Round-2 (this update), re-run against the current branch head (`13edd62`):**

- `test/providers/test_codex_provider_unit.py`, normal writable `$HOME`:
  `171 passed, 3 skipped in 164.54s`.
- Same file, re-run under a properly-simulated read-only `$HOME` (pre-created
  `~/.aws/cli-agent-orchestrator/{tmp,fifos,logs/terminal}` while writable, then
  `chmod -R 555 ~/.aws` — a real dev machine that used CAO before its home went read-only, not
  just an empty unwritable dir): `171 passed, 3 skipped in 164.61s`. Also reproduced the original
  3-test failure under the identical sandbox *before* the fix (`3 failed, 1 passed`), confirming
  this is a real fix for a real reproduction, not a guess.
- `black --check src/ test/` and `isort --check-only src/ test/`: both clean across the whole
  tree (`509 files would be left unchanged` / `Skipped 0 files`), not just the two changed files.
- `ruff check` and `mypy` on the changed file: both clean.
- Full `test/` suite: `61 failed, 5638 passed, 37 skipped, 111 deselected, 1 xfailed in 269.03s` —
  matches the exact baseline `4668771`'s own commit message already established for this checkout
  (`61 failed/5638 passed`, the 3-test delta over the pre-`4668771` `5635` baseline). Zero new
  failures; grepped the full failure list for "codex": no hits.

**Original fix (prior round), unchanged since then:**

- Full existing `test/providers/test_codex_provider_unit.py` suite: 6 pre-existing tests needed
  updating (they asserted the escaped prompt text appeared directly in the returned command
  string — it now lives in the temp file instead; updated to read the file via a small new
  `read_developer_instructions_file()` helper). All pass.
- 3 new tests added:
  - `test_long_system_prompt_keeps_launch_line_short` — the actual regression test: a 10KB system
    prompt still produces a launch line under 1000 bytes.
  - `test_developer_instructions_file_written_with_owner_only_permissions` — `0o600`.
  - `test_cleanup_removes_developer_instructions_file`.
- RED/GREEN-verified the 3 new tests against the pre-fix code (fails with a real `AttributeError`
  on the not-yet-existing `CAO_HOME_DIR` patch target, since the fix introduces that import —
  confirms the tests genuinely depend on the fix).
