### PR TITLE
refactor(profile): extract local-store persistence into profile_store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cao profile find <query>` CLI verb and `find_profiles` MCP tool for keyword/BM25 profile discovery over metadata (name, description, tags, capabilities); metadata-only, never exposes prompt bodies (#340)
 - Optional `capabilities` and `tags` arrays in the agent profile frontmatter schema (#340)
 
+### Changed
+
+- consolidate local agent-store persistence into `services/profile_store.py` so the store write path, profile-name validation, and store-path containment live in one service instead of being spread across `install_service`, `cli/commands/install`, and `cli/commands/profile`. `cao profile remove` now reports "Invalid profile name" instead of "not found in local store" for names that fail `[A-Za-z0-9_-]{1,64}` but are still contained (for example `has space`, `has.dot`, or over 64 characters); the exit code is unchanged (#543)
+
 ### Fixed
 
+- profile store writes are now atomic and inter-process safe. Both store writes were previously bare `write_text` calls, so a concurrent `cao profile` write and a server-side write could interleave or leave a partial file. Adds `locked_atomic_write` to `utils/atomic_file.py` as the blind-write sibling of `locked_atomic_rewrite` (#492): it shares the same lock, temp file, fsync, mode preservation and `os.replace`, but skips the read, so a corrupt or non-UTF-8 file in the agent store can still be replaced by the install that would have repaired it instead of failing with `UnicodeDecodeError` (#543)
 - self-healing pipe-pane liveness watchdog for silently-stalled FIFO forwarding (fixes #388) (#397), including detection of a stall that settles into a new static frame before the next poll and of a pipe that never delivers a single byte from terminal creation (cold start, harness-control#93) — see `CAO_PIPE_LIVENESS_COLD_START_GRACE_S` / `CAO_PIPE_LIVENESS_MAX_COLD_START_ATTEMPTS` in `docs/configuration.md`
 - web: attach web terminals through the configured backend so herdr-backed terminals no longer fail to attach (#417)
 - honor profile frontmatter `provider:` during install (flag > frontmatter > default) (#414)

--- a/src/cli_agent_orchestrator/cli/commands/install.py
+++ b/src/cli_agent_orchestrator/cli/commands/install.py
@@ -9,10 +9,10 @@ import click
 from cli_agent_orchestrator.constants import (
     CAO_ENV_FILE,
     DEFAULT_PROVIDER,
-    LOCAL_AGENT_STORE_DIR,
     PROVIDERS,
 )
 from cli_agent_orchestrator.services.install_service import install_agent, parse_env_assignment
+from cli_agent_orchestrator.services.profile_store import write_profile
 
 # Profile names are used as filesystem path segments; this matches the stricter
 # validator inside install_service.py (kept duplicated deliberately — the CLI
@@ -51,11 +51,10 @@ def _copy_local_profile_to_store(agent_source: str) -> Optional[str]:
             f"Profile filename stem '{stem}' must match [A-Za-z0-9_-]{{1,64}}."
         )
 
-    LOCAL_AGENT_STORE_DIR.mkdir(parents=True, exist_ok=True)
-    # Build the destination from the validated stem, not from source_path.name,
-    # so nothing from the user-provided string flows into the dest Path.
-    dest_file = LOCAL_AGENT_STORE_DIR / f"{stem}.md"
-    dest_file.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    # Pass the validated stem, not source_path.name, so nothing from the
+    # user-provided string reaches the destination path. overwrite=True keeps
+    # the pre-existing re-install behaviour of replacing the stored copy.
+    write_profile(stem, source_path.read_text(encoding="utf-8"), overwrite=True)
     return stem
 
 

--- a/src/cli_agent_orchestrator/cli/commands/profile.py
+++ b/src/cli_agent_orchestrator/cli/commands/profile.py
@@ -13,6 +13,12 @@ import frontmatter
 from jsonschema import Draft202012Validator
 
 from cli_agent_orchestrator.constants import LOCAL_AGENT_STORE_DIR, ROLE_TOOL_DEFAULTS
+from cli_agent_orchestrator.services.profile_store import (
+    InvalidProfileNameError,
+    ProfileNotFoundError,
+    delete_profile,
+    store_path,
+)
 from cli_agent_orchestrator.utils.agent_profiles import (
     list_agent_profiles,
 )
@@ -57,9 +63,11 @@ def _resolve_profile_path(name_or_path: str) -> Optional[Path]:
 
     # The shared lookup found it. Now find the actual path for display.
     # Check local store first (most common case for user-installed profiles)
-    store_root = LOCAL_AGENT_STORE_DIR.resolve()
-    candidate = (LOCAL_AGENT_STORE_DIR / f"{name_or_path}.md").resolve()
-    if candidate.is_relative_to(store_root) and candidate.exists():
+    try:
+        candidate = store_path(name_or_path)
+    except InvalidProfileNameError:
+        return None
+    if candidate.exists():
         return candidate
 
     # For built-in/provider profiles, return None — caller uses _read_profile_text.
@@ -253,11 +261,9 @@ def remove_cmd(name: str, yes: bool):
     Only removes profiles from ~/.aws/cli-agent-orchestrator/agent-store/.
     Does not affect built-in or provider-managed profiles.
     """
-    store_root = LOCAL_AGENT_STORE_DIR.resolve()
-    target = (LOCAL_AGENT_STORE_DIR / f"{name}.md").resolve()
-
-    # Containment check
-    if not target.is_relative_to(store_root):
+    try:
+        target = store_path(name)
+    except InvalidProfileNameError:
         raise click.ClickException(f"Invalid profile name '{name}'.")
 
     if not target.exists():
@@ -269,7 +275,10 @@ def remove_cmd(name: str, yes: bool):
     if not yes:
         click.confirm(f"Remove profile '{name}' from local store?", abort=True)
 
-    target.unlink()
+    try:
+        delete_profile(name)
+    except ProfileNotFoundError as e:  # lost a race with another remover
+        raise click.ClickException(str(e))
     click.echo(f"✓ Removed '{name}' from {LOCAL_AGENT_STORE_DIR}")
 
 

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -16,7 +16,6 @@ from cli_agent_orchestrator.constants import (
     COPILOT_AGENTS_DIR,
     DEFAULT_PROVIDER,
     KIRO_AGENTS_DIR,
-    LOCAL_AGENT_STORE_DIR,
     OPENCODE_AGENTS_DIR,
     SKILLS_DIR,
 )
@@ -25,6 +24,7 @@ from cli_agent_orchestrator.models.kiro_agent import KiroAgentConfig
 from cli_agent_orchestrator.models.kiro_engine import KiroEngine
 from cli_agent_orchestrator.models.opencode_agent import OpenCodeAgentConfig
 from cli_agent_orchestrator.models.provider import ProviderType
+from cli_agent_orchestrator.services.profile_store import write_profile
 from cli_agent_orchestrator.utils.agent_profiles import (
     _read_agent_profile_source,
     parse_agent_profile_text,
@@ -153,11 +153,11 @@ def _download_agent(source: str) -> str:
     has legitimate filesystem trust, and keeping Path(user_input) out of the
     HTTP-reachable layer closes an entire class of py/path-injection alerts
     (CodeQL #49/#61 kept reopening while this lived here). The CLI entry point
-    copies local files into LOCAL_AGENT_STORE_DIR itself and then calls
+    resolves the local file itself and stores it via profile_store, then calls
     install_agent() with the bare stem, which flows through the "name" branch.
+    This function only ever hands profile_store a stem it has already validated,
+    never a caller-supplied path.
     """
-    LOCAL_AGENT_STORE_DIR.mkdir(parents=True, exist_ok=True)
-
     # SSRF hardening: narrow what a caller-provided URL can reach before any
     # network I/O happens. https-only rules out http://169.254.169.254/...;
     # the host allowlist rules out arbitrary internal services; the path
@@ -198,9 +198,12 @@ def _download_agent(source: str) -> str:
         raise ValueError("Redirects are not allowed for profile downloads.")
     response.raise_for_status()
 
-    dest_file = LOCAL_AGENT_STORE_DIR / filename
-    dest_file.write_text(response.text, encoding="utf-8")
-    return dest_file.stem
+    # The stem was validated against _PROFILE_NAME_RE above; profile_store owns
+    # the store join and the atomic write. overwrite=True preserves the
+    # pre-existing re-download behaviour of replacing the stored copy.
+    stem = filename[: -len(".md")]
+    write_profile(stem, response.text, overwrite=True)
+    return stem
 
 
 def parse_env_assignment(env_assignment: str) -> Tuple[str, str]:

--- a/src/cli_agent_orchestrator/services/profile_store.py
+++ b/src/cli_agent_orchestrator/services/profile_store.py
@@ -1,0 +1,163 @@
+"""Local agent-store persistence for CAO agent profiles.
+
+Single owner of the ``LOCAL_AGENT_STORE_DIR`` boundary: resolving a profile
+*name* to a path inside the store, writing a profile atomically, and deleting
+one. Every public function takes a name, never a caller-supplied path.
+
+Why names and not paths: the store is a fixed root joined with a single
+validated segment, which is safe to centralise. Filesystem handling of
+caller-supplied *paths* deliberately stays in the CLI (see
+``cli/commands/install.py::_copy_local_profile_to_store``) so that
+``Path(user_input)`` never reaches the HTTP-reachable service layer -- the
+property that closed the recurring ``py/path-injection`` alerts. Callers keep
+their own input validation; this module validates the segment it is handed.
+
+Ref: https://github.com/awslabs/cli-agent-orchestrator/issues/510
+"""
+
+import re
+from pathlib import Path
+
+from cli_agent_orchestrator.constants import LOCAL_AGENT_STORE_DIR
+from cli_agent_orchestrator.utils.atomic_file import locked_atomic_write
+
+# A profile name becomes a single filesystem segment under
+# LOCAL_AGENT_STORE_DIR. Restricting to [A-Za-z0-9_-] with a 64-char cap
+# blocks traversal ("../etc/passwd"), separators, and absolute paths at the
+# boundary. CodeQL also recognises this regex as a path-injection sanitiser.
+#
+# The fullmatch below is repeated INLINE in every function that joins a name
+# into a filesystem path, rather than factored into a shared helper, because
+# CodeQL's py/path-injection dataflow only recognises a barrier that guards --
+# in the same function as the sink -- the very variable that reaches it. The
+# repetition is load-bearing, not an oversight.
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+__all__ = [
+    "InvalidProfileNameError",
+    "ProfileExistsError",
+    "ProfileNotFoundError",
+    "delete_profile",
+    "store_path",
+    "write_profile",
+]
+
+
+class InvalidProfileNameError(ValueError):
+    """Raised when a profile name is not a safe single path segment."""
+
+
+class ProfileNotFoundError(FileNotFoundError):
+    """Raised when a profile is not present in the local store."""
+
+
+class ProfileExistsError(FileExistsError):
+    """Raised when a write would clobber an existing profile."""
+
+
+def store_path(name: str) -> Path:
+    """Resolve ``name`` to its path inside the local agent store.
+
+    Does not require the profile to exist: this answers "where would this
+    live", not "is it there".
+
+    Args:
+        name: Profile name, used as the filename stem.
+
+    Returns:
+        The resolved absolute path of ``<store>/<name>.md``.
+
+    Raises:
+        InvalidProfileNameError: If ``name`` is not a safe single segment.
+    """
+    # Inline guard: see _PROFILE_NAME_RE. Must stay in the same function as the
+    # path join below for CodeQL to treat it as a sanitiser.
+    if not _PROFILE_NAME_RE.fullmatch(name):
+        raise InvalidProfileNameError(f"Profile name '{name}' must match [A-Za-z0-9_-]{{1,64}}.")
+    root = LOCAL_AGENT_STORE_DIR.resolve()
+    candidate = (LOCAL_AGENT_STORE_DIR / f"{name}.md").resolve()
+    # Defence in depth: the regex already rules out separators, but a symlinked
+    # store root could still resolve outside itself.
+    if not candidate.is_relative_to(root):
+        raise InvalidProfileNameError(f"Profile name '{name}' escapes the local store.")
+    return candidate
+
+
+def write_profile(name: str, content: str, *, overwrite: bool = False) -> Path:
+    """Write ``content`` as the profile ``name`` in the local store.
+
+    The write is atomic and inter-process safe: ``locked_atomic_write`` holds
+    an exclusive lock across the whole replace, so a concurrent ``cao profile``
+    write and an HTTP write cannot interleave or leave a partial file behind.
+
+    This module deliberately exposes no standalone ``profile_exists`` helper.
+    An existence check is only meaningful to a would-be writer if it happens
+    in the same critical section as the write, so ``overwrite=False`` is the
+    only supported way to ask "create, but do not clobber". A caller that
+    instead did ``if exists(name): reject`` before calling here would put the
+    check outside the lock, letting two concurrent creators both observe an
+    absent file and the second silently overwrite the first. Callers wanting
+    409-style semantics should pass ``overwrite=False`` and catch
+    :class:`ProfileExistsError`.
+
+    Args:
+        name: Profile name, used as the filename stem.
+        content: Full profile text (frontmatter + body).
+        overwrite: Permit replacing an existing profile. Defaults to False so a
+            caller must opt in to clobbering. Enforced under the same lock as
+            the write, so two concurrent creators cannot both succeed.
+
+    Returns:
+        The path written.
+
+    Raises:
+        InvalidProfileNameError: If ``name`` is not a safe single segment.
+        ProfileExistsError: If the profile exists and ``overwrite`` is False.
+    """
+    # Inline guard: see _PROFILE_NAME_RE.
+    if not _PROFILE_NAME_RE.fullmatch(name):
+        raise InvalidProfileNameError(f"Profile name '{name}' must match [A-Za-z0-9_-]{{1,64}}.")
+    root = LOCAL_AGENT_STORE_DIR.resolve()
+    target = (LOCAL_AGENT_STORE_DIR / f"{name}.md").resolve()
+    if not target.is_relative_to(root):
+        raise InvalidProfileNameError(f"Profile name '{name}' escapes the local store.")
+
+    # locked_atomic_write, not locked_atomic_rewrite: a profile write is a full
+    # replace, so there is nothing to read. The RMW helper would decode the
+    # existing file first, which means a corrupt or non-UTF-8 file in the store
+    # could not be repaired by the very install that would have replaced it.
+    #
+    # The existence check is delegated rather than done here on purpose: it has
+    # to happen inside the lock, or two concurrent creators both see an absent
+    # file and the second silently clobbers the first.
+    try:
+        locked_atomic_write(target, content, overwrite=overwrite)
+    except FileExistsError as exc:
+        raise ProfileExistsError(
+            f"Profile '{name}' already exists in the local store. "
+            f"Pass overwrite=True to replace it."
+        ) from exc
+    return target
+
+
+def delete_profile(name: str) -> None:
+    """Delete the profile ``name`` from the local store.
+
+    Args:
+        name: Profile name, used as the filename stem.
+
+    Raises:
+        InvalidProfileNameError: If ``name`` is not a safe single segment.
+        ProfileNotFoundError: If the profile is not in the local store.
+    """
+    # Inline guard: see _PROFILE_NAME_RE.
+    if not _PROFILE_NAME_RE.fullmatch(name):
+        raise InvalidProfileNameError(f"Profile name '{name}' must match [A-Za-z0-9_-]{{1,64}}.")
+    root = LOCAL_AGENT_STORE_DIR.resolve()
+    target = (LOCAL_AGENT_STORE_DIR / f"{name}.md").resolve()
+    if not target.is_relative_to(root):
+        raise InvalidProfileNameError(f"Profile name '{name}' escapes the local store.")
+
+    if not target.exists():
+        raise ProfileNotFoundError(f"Profile '{name}' not found in the local store.")
+    target.unlink()

--- a/src/cli_agent_orchestrator/utils/atomic_file.py
+++ b/src/cli_agent_orchestrator/utils/atomic_file.py
@@ -1,4 +1,12 @@
-"""Shared helper for inter-process-safe atomic read-modify-write on a file.
+"""Shared helpers for inter-process-safe atomic writes to a file.
+
+Two entry points share one set of guarantees:
+
+* :func:`locked_atomic_rewrite` — read the existing content, compute the new
+  content from it, publish atomically. For genuine read-modify-write callers.
+* :func:`locked_atomic_write` — publish new content without reading the old.
+  For full replaces, where the read is pointless and is the only step that can
+  fail on a target holding undecodable bytes.
 
 Several call sites (the Codex/Claude Code memory-injection plugins,
 ``utils/skill_injection.py``) implement the same "read existing content,
@@ -230,35 +238,95 @@ def locked_atomic_rewrite(
 
     with _file_lock(lock_path, lock_timeout):
         existing = target.read_text(encoding=encoding) if target.exists() else ""
-        new_content = compute_new_content(existing)
+        _atomic_publish(target, compute_new_content(existing), encoding)
 
-        # Capture the mode to apply to the published file BEFORE we write —
-        # tempfile.mkstemp creates the temp at 0600, so without this fixup the
-        # os.replace below would downgrade a user-authored 0644 file to 0600.
-        mode = _target_mode(target)
 
-        # Unique temp file in the SAME directory as target (same filesystem,
-        # so the final os.replace stays atomic) rather than a fixed
-        # ``target + ".tmp"`` name, so an unrelated unlocked writer (or a
-        # retry of this same call) can never collide with this call's temp
-        # file or unlink it out from under another in-flight write.
-        fd, temp_name = tempfile.mkstemp(
-            dir=str(target.parent),
-            prefix=f".{target.name}.",
-            suffix=".tmp",
-        )
-        temp_path = Path(temp_name)
-        try:
-            with os.fdopen(fd, "w", encoding=encoding) as handle:
-                handle.write(new_content)
-                handle.flush()
-                # Restore the target's (or umask-default) mode on the temp file
-                # before the replace, so the published file keeps its intended
-                # permissions rather than inheriting mkstemp's 0600.
-                os.fchmod(handle.fileno(), mode)
-                os.fsync(handle.fileno())
-            os.replace(temp_path, target)
-        finally:
-            # Only ever removes OUR OWN uniquely-named temp file.
-            with contextlib.suppress(FileNotFoundError):
-                temp_path.unlink()
+def locked_atomic_write(
+    target: Path,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    lock_timeout: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
+    overwrite: bool = True,
+) -> None:
+    """Replace ``target``'s entire contents atomically and safely across processes.
+
+    The blind-write sibling of :func:`locked_atomic_rewrite`. Identical locking,
+    temp-file, fsync, mode-preservation and ``os.replace`` semantics, but it
+    never reads the existing file.
+
+    Use this when the new content does not depend on the old. Reaching for
+    ``locked_atomic_rewrite`` with a callback that ignores its argument looks
+    equivalent but is not: that path decodes the existing bytes first, so a
+    target holding invalid ``encoding`` bytes raises ``UnicodeDecodeError``
+    instead of being replaced. For a full replace that read is both pointless
+    and the only thing that can fail, which makes a corrupt file unrepairable
+    by the very call that would have fixed it.
+
+    Args:
+        target: The file to replace. Parent directory is created if missing.
+        content: The full new content to write.
+        encoding: Text encoding for the write.
+        lock_timeout: Seconds to wait for the lock before raising
+            ``LockTimeoutError``.
+        overwrite: When False, refuse to replace an existing target. The check
+            runs *inside* the lock, so two concurrent creators cannot both
+            observe an absent file. Callers must not pre-check with
+            ``target.exists()`` themselves: that test would sit outside this
+            critical section and reintroduce the race.
+
+    Raises:
+        FileExistsError: If ``target`` exists and ``overwrite`` is False.
+        LockTimeoutError: If the lock is not acquired within ``lock_timeout``
+            seconds.
+        OSError: Propagated from filesystem operations (write, fsync, replace).
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = _lock_path_for(target)
+
+    with _file_lock(lock_path, lock_timeout):
+        # Checked HERE, not by the caller: an exists() test outside this
+        # critical section lets two concurrent creators both see "absent" and
+        # both write, so the second silently clobbers the first.
+        if not overwrite and target.exists():
+            raise FileExistsError(f"{target} already exists")
+        _atomic_publish(target, content, encoding)
+
+
+def _atomic_publish(target: Path, content: str, encoding: str) -> None:
+    """Write ``content`` to ``target`` via a unique temp file + ``os.replace``.
+
+    Shared by :func:`locked_atomic_rewrite` and :func:`locked_atomic_write`.
+    The caller MUST already hold the target's lock; this helper does no locking
+    of its own.
+    """
+    # Capture the mode to apply to the published file BEFORE we write —
+    # tempfile.mkstemp creates the temp at 0600, so without this fixup the
+    # os.replace below would downgrade a user-authored 0644 file to 0600.
+    mode = _target_mode(target)
+
+    # Unique temp file in the SAME directory as target (same filesystem,
+    # so the final os.replace stays atomic) rather than a fixed
+    # ``target + ".tmp"`` name, so an unrelated unlocked writer (or a
+    # retry of this same call) can never collide with this call's temp
+    # file or unlink it out from under another in-flight write.
+    fd, temp_name = tempfile.mkstemp(
+        dir=str(target.parent),
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as handle:
+            handle.write(content)
+            handle.flush()
+            # Restore the target's (or umask-default) mode on the temp file
+            # before the replace, so the published file keeps its intended
+            # permissions rather than inheriting mkstemp's 0600.
+            os.fchmod(handle.fileno(), mode)
+            os.fsync(handle.fileno())
+        os.replace(temp_path, target)
+    finally:
+        # Only ever removes OUR OWN uniquely-named temp file.
+        with contextlib.suppress(FileNotFoundError):
+            temp_path.unlink()

--- a/test/cli/commands/test_install.py
+++ b/test/cli/commands/test_install.py
@@ -139,7 +139,7 @@ class TestInstallCommand:
         local_store = tmp_path / "agent-store"
         local_store.mkdir()
         monkeypatch.setattr(
-            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR",
+            "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR",
             local_store,
         )
         source_profile = tmp_path / "local.md"
@@ -173,7 +173,7 @@ class TestInstallCommand:
     ) -> None:
         """A `.md`-suffixed path that doesn't exist should fail before the service call."""
         monkeypatch.setattr(
-            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR",
+            "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR",
             tmp_path / "agent-store",
         )
 
@@ -191,7 +191,7 @@ class TestInstallCommand:
     ) -> None:
         """A local .md file whose stem contains unsafe characters must be refused."""
         monkeypatch.setattr(
-            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR",
+            "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR",
             tmp_path / "agent-store",
         )
         bad = tmp_path / "evil space.md"
@@ -254,7 +254,7 @@ class TestCopyLocalProfileToStore:
     ) -> None:
         store = tmp_path / "store"
         monkeypatch.setattr(
-            "cli_agent_orchestrator.cli.commands.install.LOCAL_AGENT_STORE_DIR", store
+            "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR", store
         )
         src = tmp_path / "my-agent.md"
         src.write_text("body", encoding="utf-8")

--- a/test/cli/commands/test_install_opencode.py
+++ b/test/cli/commands/test_install_opencode.py
@@ -36,7 +36,7 @@ def install_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Dict[s
     # opencode_agents intentionally NOT pre-created — install must mkdir it.
 
     monkeypatch.setattr(
-        "cli_agent_orchestrator.services.install_service.LOCAL_AGENT_STORE_DIR", local_store
+        "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR", local_store
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.utils.agent_profiles.LOCAL_AGENT_STORE_DIR", local_store
@@ -531,7 +531,7 @@ class TestOpencodeAgentListIntegration:
         context_dir.mkdir(parents=True)
 
         monkeypatch.setattr(
-            "cli_agent_orchestrator.services.install_service.LOCAL_AGENT_STORE_DIR", local_store
+            "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR", local_store
         )
         monkeypatch.setattr(
             "cli_agent_orchestrator.utils.agent_profiles.LOCAL_AGENT_STORE_DIR", local_store

--- a/test/cli/test_profile_cmd.py
+++ b/test/cli/test_profile_cmd.py
@@ -348,7 +348,10 @@ class TestProfileRemoveVerb:
         profile_file = store / "test-agent.md"
         profile_file.write_text("---\nname: test-agent\n---\ntest")
 
-        with patch("cli_agent_orchestrator.cli.commands.profile.LOCAL_AGENT_STORE_DIR", store):
+        with (
+            patch("cli_agent_orchestrator.cli.commands.profile.LOCAL_AGENT_STORE_DIR", store),
+            patch("cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR", store),
+        ):
             result = runner.invoke(profile, ["remove", "test-agent", "-y"])
         assert result.exit_code == 0
         assert "Removed" in result.output
@@ -361,7 +364,10 @@ class TestProfileRemoveVerb:
         store = tmp_path / "store"
         store.mkdir()
 
-        with patch("cli_agent_orchestrator.cli.commands.profile.LOCAL_AGENT_STORE_DIR", store):
+        with (
+            patch("cli_agent_orchestrator.cli.commands.profile.LOCAL_AGENT_STORE_DIR", store),
+            patch("cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR", store),
+        ):
             result = runner.invoke(profile, ["remove", "../../etc/passwd", "-y"])
         assert result.exit_code != 0
         assert "Invalid" in result.output or "not found" in result.output.lower()
@@ -375,7 +381,10 @@ class TestProfileRemoveVerb:
         profile_file = store / "keep-me.md"
         profile_file.write_text("---\nname: keep-me\n---\ntest")
 
-        with patch("cli_agent_orchestrator.cli.commands.profile.LOCAL_AGENT_STORE_DIR", store):
+        with (
+            patch("cli_agent_orchestrator.cli.commands.profile.LOCAL_AGENT_STORE_DIR", store),
+            patch("cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR", store),
+        ):
             result = runner.invoke(profile, ["remove", "keep-me"], input="n\n")
         assert profile_file.exists()  # File should still be there
 

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -59,7 +59,7 @@ def install_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, 
         path.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(
-        "cli_agent_orchestrator.services.install_service.LOCAL_AGENT_STORE_DIR",
+        "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR",
         local_store_dir,
     )
     monkeypatch.setattr(
@@ -637,7 +637,7 @@ class TestInstallSkillCatalogBaking:
             d.mkdir()
 
         monkeypatch.setattr(
-            "cli_agent_orchestrator.services.install_service.LOCAL_AGENT_STORE_DIR",
+            "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR",
             local_store_dir,
         )
         monkeypatch.setattr(

--- a/test/services/test_profile_store.py
+++ b/test/services/test_profile_store.py
@@ -1,0 +1,246 @@
+"""Tests for the local agent-store persistence service (issue #510, phase 3).
+
+``profile_store`` is the single owner of the ``LOCAL_AGENT_STORE_DIR``
+boundary. These tests pin the three properties its callers rely on:
+
+* **Name validation** happens before any path join, so a traversal-shaped or
+  separator-bearing name can never reach the filesystem.
+* **Writes are atomic** and leave no temp debris, and refuse to clobber unless
+  the caller opts in.
+* **Deletion** is containment-checked and reports a missing profile distinctly
+  from an invalid name.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from cli_agent_orchestrator.services import profile_store
+from cli_agent_orchestrator.services.profile_store import (
+    InvalidProfileNameError,
+    ProfileExistsError,
+    ProfileNotFoundError,
+    delete_profile,
+    store_path,
+    write_profile,
+)
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the store at a tmp dir that does NOT pre-exist.
+
+    Deliberately not created here: ``write_profile`` must make the parent
+    itself, which is what lets a first-ever install work on a clean machine.
+    """
+    target = tmp_path / "agent-store"
+    monkeypatch.setattr(profile_store, "LOCAL_AGENT_STORE_DIR", target)
+    return target
+
+
+# --------------------------------------------------------------------------
+# store_path
+# --------------------------------------------------------------------------
+
+
+def test_store_path_joins_name_under_the_store(store: Path) -> None:
+    assert store_path("my-agent") == (store / "my-agent.md").resolve()
+
+
+def test_store_path_does_not_require_existence(store: Path) -> None:
+    """store_path is pure resolution: it answers "where would this live", not
+    "is it there". Deliberately no existence helper sits beside it -- an
+    existence check that gates a write has to happen under the write's lock,
+    which is why write_profile(overwrite=False) owns that question instead."""
+    resolved = store_path("absent")
+    assert not resolved.exists()
+    assert resolved.name == "absent.md"
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "../../etc/passwd",
+        "..",
+        ".",
+        "a/b",
+        "a\\b",
+        "/absolute",
+        "",
+        "has space",
+        "has.dot",
+        "x" * 65,
+    ],
+)
+def test_store_path_rejects_unsafe_names(store: Path, bad_name: str) -> None:
+    with pytest.raises(InvalidProfileNameError):
+        store_path(bad_name)
+
+
+def test_store_path_accepts_the_maximum_length(store: Path) -> None:
+    """64 chars is the documented cap, so it must be inclusive."""
+    name = "x" * 64
+    assert store_path(name).name == f"{name}.md"
+
+
+# --------------------------------------------------------------------------
+# write_profile
+# --------------------------------------------------------------------------
+
+
+def test_write_profile_creates_the_store_and_the_file(store: Path) -> None:
+    assert not store.exists()
+    written = write_profile("alpha", "---\nname: alpha\n---\nbody\n")
+    assert written == (store / "alpha.md").resolve()
+    assert written.read_text(encoding="utf-8") == "---\nname: alpha\n---\nbody\n"
+
+
+def test_write_profile_refuses_to_clobber_by_default(store: Path) -> None:
+    write_profile("beta", "original")
+    with pytest.raises(ProfileExistsError):
+        write_profile("beta", "replacement")
+    assert (store / "beta.md").read_text(encoding="utf-8") == "original"
+
+
+def test_write_profile_replaces_when_overwrite_is_requested(store: Path) -> None:
+    write_profile("beta", "original")
+    write_profile("beta", "replacement", overwrite=True)
+    assert (store / "beta.md").read_text(encoding="utf-8") == "replacement"
+
+
+def test_write_profile_rejects_an_unsafe_name_before_touching_disk(store: Path) -> None:
+    with pytest.raises(InvalidProfileNameError):
+        write_profile("../escape", "payload")
+    # The guard must fire before the store is even created, so a rejected write
+    # leaves no trace at all.
+    assert not store.exists()
+
+
+def test_write_profile_can_replace_a_corrupt_store_file(store: Path) -> None:
+    """Regression: a non-UTF-8 file in the store must not be unrepairable.
+
+    ``write_profile`` deliberately uses ``locked_atomic_write`` rather than
+    ``locked_atomic_rewrite``. The read-modify-write helper decodes the existing
+    file first, so a truncated download or a binary accidentally named ``.md``
+    would raise ``UnicodeDecodeError`` and block the very re-install that would
+    have replaced it.
+    """
+    store.mkdir(parents=True, exist_ok=True)
+    corrupt = store / "corrupt.md"
+    corrupt.write_bytes(b"\xff\xfe not utf-8 \x80")
+
+    write_profile("corrupt", "---\nname: corrupt\n---\nrepaired\n", overwrite=True)
+
+    assert corrupt.read_text(encoding="utf-8") == "---\nname: corrupt\n---\nrepaired\n"
+
+
+def test_write_profile_leaves_no_temp_debris(store: Path) -> None:
+    """The helper writes via mkstemp + os.replace; a leaked temp file would
+    show up in `cao profile list` as a bogus entry."""
+    write_profile("gamma", "content")
+    assert [p.name for p in store.iterdir()] == ["gamma.md"]
+
+
+def test_write_profile_serializes_concurrent_writers(store: Path) -> None:
+    """Two threads writing the same profile must produce one of the two exact
+    payloads, never a mix. A full-replace write has no lost-update semantics to
+    protect, but a torn file would still be observable without the lock.
+    """
+    write_profile("delta", "seed")
+    payload_a = "A" * 4096
+    payload_b = "B" * 4096
+    errors: list[BaseException] = []
+
+    def writer(content: str) -> None:
+        try:
+            write_profile("delta", content, overwrite=True)
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    t1 = threading.Thread(target=writer, args=(payload_a,))
+    t2 = threading.Thread(target=writer, args=(payload_b,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert errors == [], f"writers must not raise: {errors}"
+    final = (store / "delta.md").read_text(encoding="utf-8")
+    assert final in (payload_a, payload_b), "file was torn between the two writers"
+
+
+def test_write_profile_lets_exactly_one_concurrent_creator_win(store: Path) -> None:
+    """overwrite=False must serialize, not just usually work.
+
+    Regression test: the guard originally lived here as a ``target.exists()``
+    check before the lock was taken, so two threads both saw an absent file and
+    both wrote, the second silently clobbering the first. The check now runs
+    inside ``locked_atomic_write``'s critical section. Phase 4's
+    ``POST /agents/profiles`` depends on this to answer 409 rather than
+    overwrite a profile someone else just created.
+    """
+    arrived = threading.Barrier(2, timeout=5)
+    won: list[str] = []
+    rejected: list[str] = []
+    unexpected: list[BaseException] = []
+
+    def creator(tag: str) -> None:
+        arrived.wait()
+        try:
+            write_profile("contended", tag, overwrite=False)
+            won.append(tag)
+        except ProfileExistsError:
+            rejected.append(tag)
+        except BaseException as exc:  # pragma: no cover - failure path
+            unexpected.append(exc)
+
+    t1 = threading.Thread(target=creator, args=("FIRST",))
+    t2 = threading.Thread(target=creator, args=("SECOND",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert unexpected == [], f"unexpected failures: {unexpected}"
+    assert len(won) == 1, f"exactly one creator must win, got {won}"
+    assert len(rejected) == 1, f"the loser must see ProfileExistsError, got {rejected}"
+    assert (store / "contended.md").read_text(encoding="utf-8") == won[0]
+
+
+# --------------------------------------------------------------------------
+# delete_profile
+# --------------------------------------------------------------------------
+
+
+def test_delete_profile_removes_the_file(store: Path) -> None:
+    write_profile("doomed", "bye")
+    delete_profile("doomed")
+    assert not (store / "doomed.md").exists()
+
+
+def test_delete_profile_reports_a_missing_profile(store: Path) -> None:
+    with pytest.raises(ProfileNotFoundError):
+        delete_profile("never-existed")
+
+
+def test_delete_profile_rejects_an_unsafe_name(store: Path) -> None:
+    """Distinct from ProfileNotFoundError: the caller surfaces these as
+    different messages ('Invalid profile name' vs 'not found')."""
+    with pytest.raises(InvalidProfileNameError):
+        delete_profile("../../etc/passwd")
+
+
+def test_delete_profile_does_not_follow_a_name_out_of_the_store(
+    store: Path, tmp_path: Path
+) -> None:
+    """Belt-and-braces: even a name that somehow passed the regex must not be
+    able to unlink a file outside the store root."""
+    outsider = tmp_path / "outsider.md"
+    outsider.write_text("do not delete me", encoding="utf-8")
+    store.mkdir(parents=True, exist_ok=True)
+    with pytest.raises((InvalidProfileNameError, ProfileNotFoundError)):
+        delete_profile("../outsider")
+    assert outsider.exists()

--- a/test/utils/test_atomic_file.py
+++ b/test/utils/test_atomic_file.py
@@ -32,6 +32,7 @@ from cli_agent_orchestrator.utils.atomic_file import (
     _file_lock,
     _lock_path_for,
     locked_atomic_rewrite,
+    locked_atomic_write,
 )
 
 
@@ -520,3 +521,179 @@ def test_reentrant_same_target_raises_timeout_not_deadlock(tmp_path: Path) -> No
     # immediately afterward must succeed (proves no leaked lock).
     locked_atomic_rewrite(target, lambda existing: existing + "next\n")
     assert target.read_text(encoding="utf-8") == "base\nnext\n"
+
+
+# --------------------------------------------------------------------------
+# locked_atomic_write — the blind-write sibling
+# --------------------------------------------------------------------------
+
+
+def test_write_creates_file_when_missing(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "profile.md"
+
+    locked_atomic_write(target, "hello")
+
+    assert target.read_text(encoding="utf-8") == "hello"
+
+
+def test_write_replaces_existing_content_entirely(tmp_path: Path) -> None:
+    """Blind write, so the old content must not survive in any form."""
+    target = tmp_path / "profile.md"
+    target.write_text("old content that must vanish\n", encoding="utf-8")
+
+    locked_atomic_write(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_write_replaces_a_target_holding_undecodable_bytes(tmp_path: Path) -> None:
+    """The reason this helper exists.
+
+    ``locked_atomic_rewrite`` decodes the existing file before handing it to the
+    callback, so a target holding invalid UTF-8 raises ``UnicodeDecodeError``
+    and can never be repaired by the write that would have replaced it. A full
+    replace has no reason to read, so it must succeed.
+    """
+    target = tmp_path / "corrupt.md"
+    target.write_bytes(b"\xff\xfe not utf-8 \x80")
+
+    # Pin the contrast: the read-modify-write path genuinely cannot do this.
+    with pytest.raises(UnicodeDecodeError):
+        locked_atomic_rewrite(target, lambda existing: existing)
+
+    locked_atomic_write(target, "repaired")
+    assert target.read_text(encoding="utf-8") == "repaired"
+
+
+def test_write_preserves_an_existing_file_mode(tmp_path: Path) -> None:
+    """mkstemp creates at 0600; the publish must restore the target's mode."""
+    target = tmp_path / "profile.md"
+    target.write_text("base\n", encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    locked_atomic_write(target, "replaced\n")
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+def test_write_leaves_no_temp_files(tmp_path: Path) -> None:
+    target = tmp_path / "profile.md"
+
+    locked_atomic_write(target, "content")
+
+    leftovers = [p for p in tmp_path.iterdir() if ".tmp" in p.name]
+    assert leftovers == []
+
+
+def test_write_uses_the_same_lock_file_as_rewrite(tmp_path: Path) -> None:
+    """Both helpers must serialize against each other, not just themselves.
+
+    They share ``_lock_path_for``, so a rewrite and a blind write to the same
+    target contend on one lock. If they keyed differently, a memory-plugin
+    rewrite and a profile write to the same path could interleave.
+    """
+    target = tmp_path / "shared.md"
+    lock_path = _lock_path_for(target)
+
+    locked_atomic_write(target, "written\n")
+
+    assert lock_path.exists()
+    assert LOCK_DIR in lock_path.parents
+
+
+def test_write_serializes_concurrent_writers(tmp_path: Path) -> None:
+    """Two threads blind-writing the same target must produce one of the two
+    exact payloads, never a mix of both."""
+    target = tmp_path / "raced.md"
+    payload_a = "A" * 8192
+    payload_b = "B" * 8192
+    errors: list[BaseException] = []
+
+    def writer(content: str) -> None:
+        try:
+            locked_atomic_write(target, content)
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    t1 = threading.Thread(target=writer, args=(payload_a,))
+    t2 = threading.Thread(target=writer, args=(payload_b,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert errors == [], f"writers must not raise: {errors}"
+    final = target.read_text(encoding="utf-8")
+    assert final in (payload_a, payload_b), "file was torn between the two writers"
+
+
+def test_write_refuses_an_existing_target_when_overwrite_is_false(
+    tmp_path: Path,
+) -> None:
+    """The guard exists so a create-only caller (an HTTP POST wanting 409) can
+    rely on the helper rather than pre-checking exists() outside the lock."""
+    target = tmp_path / "taken.md"
+    target.write_text("original", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        locked_atomic_write(target, "replacement", overwrite=False)
+
+    assert target.read_text(encoding="utf-8") == "original"
+
+
+def test_write_creates_a_missing_target_when_overwrite_is_false(
+    tmp_path: Path,
+) -> None:
+    """overwrite=False must still permit the create case, otherwise it is
+    useless to a first-write caller."""
+    target = tmp_path / "fresh.md"
+    locked_atomic_write(target, "created", overwrite=False)
+    assert target.read_text(encoding="utf-8") == "created"
+
+
+def test_overwrite_false_check_happens_inside_the_lock(tmp_path: Path) -> None:
+    """Two concurrent creators must not both observe an absent file.
+
+    This is the regression test for the check living in the caller: an
+    exists() test outside the critical section lets both threads pass it, so
+    both write and the second silently clobbers the first. The barrier forces
+    them to contend on the same lock rather than relying on scheduling luck.
+    """
+    target = tmp_path / "contended.md"
+    arrived = threading.Barrier(2, timeout=5)
+    won: list[str] = []
+    rejected: list[str] = []
+    unexpected: list[BaseException] = []
+
+    def creator(tag: str) -> None:
+        arrived.wait()
+        try:
+            locked_atomic_write(target, tag, overwrite=False)
+            won.append(tag)
+        except FileExistsError:
+            rejected.append(tag)
+        except BaseException as exc:  # pragma: no cover - failure path
+            unexpected.append(exc)
+
+    t1 = threading.Thread(target=creator, args=("FIRST",))
+    t2 = threading.Thread(target=creator, args=("SECOND",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert unexpected == [], f"unexpected failures: {unexpected}"
+    assert len(won) == 1, f"exactly one creator must win, got {won}"
+    assert len(rejected) == 1, f"the loser must see FileExistsError, got {rejected}"
+    assert target.read_text(encoding="utf-8") == won[0], "the winner's content must survive"
+
+
+def test_write_times_out_when_the_lock_is_held(tmp_path: Path) -> None:
+    """Same bounded-wait contract as the rewrite path: a stuck holder surfaces
+    as a clear error rather than hanging the caller."""
+    target = tmp_path / "held.md"
+    lock_path = _lock_path_for(target)
+
+    with _file_lock(lock_path, timeout=5.0):
+        with pytest.raises(LockTimeoutError):
+            locked_atomic_write(target, "never lands", lock_timeout=0.2)


### PR DESCRIPTION
## What

Phase 3 of #510: consolidate local agent-store persistence into a single service, `services/profile_store.py`, so the write half of the profile HTTP surface has one place to call.

No new endpoints, no new CLI verbs, no UI. This is the service extraction that Phase 4's write endpoints sit on top of.

## Why

Profile persistence was spread across three sites with three different levels of guarantee:

| Site | What it did | Guard |
|---|---|---|
| `services/install_service.py::_download_agent` | `mkdir` + `write_text` into the store | own `_PROFILE_NAME_RE` |
| `cli/commands/install.py::_copy_local_profile_to_store` | `mkdir` + `write_text` into the store | duplicate `_PROFILE_NAME_RE` |
| `cli/commands/profile.py` | resolve-and-contain, hand-rolled twice (show/validate at ~L60, remove at ~L256) | inline `is_relative_to` |

So the store-path containment logic existed in three copies and both store writes were bare `write_text` calls with no locking. #518 would have added a fourth write path and another validation copy inside `api/main.py`.

This also lines up with #519 §2a, whose acceptance criteria require that "create/edit/validate go through existing services".

## What changed

**New `services/profile_store.py`** owns the `LOCAL_AGENT_STORE_DIR` boundary:

- `store_path(name)` — name to contained path, no existence requirement
- `write_profile(name, content, *, overwrite=False)` — atomic, inter-process-safe write
- `delete_profile(name)`
- `InvalidProfileNameError` / `ProfileExistsError` / `ProfileNotFoundError`

Every public function takes a **name**, never a caller-supplied path. That boundary is deliberate: `cli/commands/install.py` still does its own `Path(user_input)` resolution and hands this module only a validated stem, so `Path(user_input)` still never reaches the HTTP-reachable service layer. That property is what closed the recurring `py/path-injection` alerts (#49/#61), and I did not want to undo it — the existing comment in `install.py` says the duplicate regex is kept "deliberately: the CLI owes the service layer clean input", and that stays true.

**Callers now delegate:**

- `install_service.py:205` — store write for the URL download path
- `install.py:57` — store write for local-file import
- `profile.py:67` and `profile.py:265` — the two resolve-and-contain blocks
- `profile.py:279` — deletion

**New `locked_atomic_write` in `utils/atomic_file.py`**, the blind-write sibling of #492's `locked_atomic_rewrite`.

I originally routed profile writes through `locked_atomic_rewrite` with a callback that ignored its argument. That looks equivalent and is not: the RMW helper does `target.read_text(encoding=...)` before calling the callback, so a truncated download or a binary accidentally named `.md` raises `UnicodeDecodeError` and blocks the very re-install that would have repaired it. `main`'s bare `write_text` self-heals in that case. Probed both paths before and after:

```
locked_atomic_rewrite on undecodable target:  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff
bare write_text (main-equivalent):            SUCCEEDED
locked_atomic_write (this PR):                SUCCEEDED
```

Both entry points now share one `_atomic_publish`, so the lock, unique temp file, fsync, mode preservation and `os.replace` are identical between them. `locked_atomic_rewrite`'s behavior is unchanged for its four existing callers (`kiro_cli_memory.py:115`, `codex_memory.py:175`, `claude_code_memory.py:167`, `skill_injection.py:82`) — it still reads first, and still raises on an undecodable target, which is correct for read-modify-write.

**`overwrite` is enforced inside the lock.** `locked_atomic_write` takes `overwrite` (keyword-only, default `True`, so existing callers are unaffected) and does the `target.exists()` check within the critical section. My first version had that check in `write_profile`, outside the lock. Forced the race with a two-thread barrier:

```
before:  writers that believed they created it: 2 ['FIRST', 'SECOND']
         rejected with ProfileExistsError: []           <- both wrote, one silently clobbered
after:   won: ['SECOND']   rejected: ['FIRST']          <- exactly one winner
```

Not reachable today, since both call sites pass `overwrite=True`. It matters for Phase 4's `POST /agents/profiles`, which needs `overwrite=False` to answer 409 rather than overwrite a profile another caller just created.

For the same reason this module exposes **no** `profile_exists` helper. An existence check only means anything to a would-be writer if it runs inside the write's critical section, so a standalone predicate would mostly make the racy `if exists(): reject` sequence look supported. `overwrite=False` plus `ProfileExistsError` is the one supported way to ask for create-without-clobber, and `write_profile`'s docstring says so explicitly.

## On the repeated inline name guard

`_PROFILE_NAME_RE.fullmatch(...)` is copy-pasted into all three functions that join a name into a filesystem path, rather than factored into a `_validate_name()` helper. That is load-bearing, not an oversight: CodeQL's `py/path-injection` only recognises a barrier that guards the sink variable **in the same function** as the sink, so moving the guard into a helper drops the sanitiser and reopens the alert. Same constraint documented in `3e1a548` on the `feat/510-web-profile-management` branch, and the same one I hit on #523 with `_resolve_template_name`. There's a comment in the module saying so, so a future contributor doesn't "clean it up".

## Behavior changes, disclosed

This is mostly a refactor, but it is not a pure one. Four things a reviewer should see rather than discover:

**1. `cao profile remove` message change.** Names that fail the `[A-Za-z0-9_-]{1,64}` pattern but are still contained now report "Invalid profile name" where `main` said "not found in local store". Verified against both trees:

| name | main | this PR |
|---|---|---|
| `has space` | `not found in local store` | `Invalid profile name` |
| `has.dot` | `not found in local store` | `Invalid profile name` |
| 70 characters | `not found in local store` | `Invalid profile name` |
| `missing-ok` | `not found in local store` | `not found in local store` |

Exit code is unchanged. I think the new message is the more accurate diagnosis, but it is a change. The existing test asserted `"Invalid" in output or "not found"`, which is why it passed either way.

**2. Profile writes now create a lock file per profile name.** Under `LOCK_DIR` (`~/.aws/cli-agent-orchestrator/locks`), keyed by a hash of the resolved target path, one file per distinct profile name, persisting after the write. That's #492's documented design, now extended to the profile store.

**3. The store directory is no longer pre-created before the SSRF checks in `_download_agent`.** On `main`, `LOCAL_AGENT_STORE_DIR.mkdir(...)` was the first statement in the function, before URL validation, so a rejected URL still created the directory. Now the `mkdir` happens inside `locked_atomic_write`, which only runs after a successful fetch. Probed both trees with a URL that fails the very first check, so no socket is opened either way:

```
main    _download_agent("ftp://example.invalid/x.md")
        -> ValueError: Profile URL must use https://
        store directory exists afterwards: True

branch  same call, same ValueError
        store directory exists afterwards: False
```

Strictly less filesystem side effect on the rejection path, but it is a difference.

**4. `ProfileExistsError` is raised but not yet caught anywhere in production.** Both current call sites pass `overwrite=True`, so it cannot fire today. It exists because it is the contract Phase 4 needs. Happy to drop it and add it with the endpoint instead if you'd rather not carry unused surface.

## Explicitly out of scope

- `utils/agent_profiles.py` and its 26 test monkeypatches — that's the profile **load** path, a separate concern. Follow-up.
- `cao profile create`'s `--output-dir`, which defaults to `.` rather than the store. Changing that default is a real UX improvement and arguably a bug fix, but it needs a `--force`/clobber policy alongside it since template names are fixed. Separate PR so this one stays reviewable as a refactor.
- URL fetching, provider config injection in `install_agent`, template rendering.

## Testing

Full suite: **5,740 passed**, 34 skipped, 111 deselected, 1 xfailed.

Counts from `pytest --collect-only`, not inspection:

- `test/services/test_profile_store.py` — 25 new: name rejection (traversal, separators, absolute, empty, 65 chars), the 64-char inclusive boundary, guard-fires-before-disk-touch, create-parent-on-first-write, clobber refusal, `overwrite=True` replacement, corrupt-file replacement, no temp debris, concurrent writers, single-winner creation under a two-thread barrier, and the deletion paths.
- `test/utils/test_atomic_file.py` — 18 to 29 for `locked_atomic_write`: create, full replace, undecodable target, mode preservation, shared lock keying with `locked_atomic_rewrite`, concurrency, lock timeout, `overwrite=False` refusal, and that the refusal is serialized under the lock.
- Eleven existing monkeypatch sites move from `install_service` / `install` / `profile` to `profile_store`. The three in `test_profile_cmd.py` need **both** targets patched, because `profile.py` still reads the constant for two user-facing messages while `store_path` reads its own module reference.

`black --check` and `isort --check-only` clean. `mypy` clean on both changed source files.

## What comes next

- Phase 4: the write endpoints (`POST` / `PUT` / `DELETE /agents/profiles`), which is what this extraction is for.
- Separate PR: the `--output-dir` default plus a clobber policy.
- Phases 2 and 5 (the React surface) stay deferred until the backend is settled.

Ref #510. Builds on #523 (merged) and #492's `utils/atomic_file.py`.
