### PR TITLE
fix: enable mouse scrolling in CAO tmux sessions

### DIFF
--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -190,6 +190,13 @@ class TmuxClient:
                 x=220,
                 y=50,
             )
+            # Keep mouse-wheel input inside tmux.  With mouse mode disabled,
+            # tmux forwards wheel events to the foreground application as Up/
+            # Down keys, which makes shells and agent TUIs navigate their
+            # command history instead of entering copy mode to scroll output.
+            # This is a session option, so it does not change the user's other
+            # tmux sessions or their global tmux configuration.
+            session.set_option("mouse", "on")
             logger.info(
                 f"Created tmux session: {session_name} with window: {window_name} in directory: {working_directory}"
             )

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -61,6 +61,7 @@ class TestCreateSession:
 
         assert result == "my-window"
         tmux.server.new_session.assert_called_once()
+        mock_session.set_option.assert_called_once_with("mouse", "on")
 
     def test_create_session_window_name_none(self, tmux, tmp_path):
         mock_window = MagicMock()


### PR DESCRIPTION
## Summary
- Enable tmux mouse mode for newly created CAO sessions.
- Cover the session option with a tmux-client regression test.

## Root cause
With tmux mouse mode disabled, wheel input is forwarded to the foreground TUI as Up/Down keys, causing command-history navigation instead of scrollback.

## Validation
- `uv run pytest test/clients/test_tmux_client.py -q`