### PR TITLE
fix(deps): force fast-uri 3.1.5 in aidlc-portfolio examples

### DIFF
--- a/examples/aidlc-portfolio/bun.lock
+++ b/examples/aidlc-portfolio/bun.lock
@@ -14,6 +14,9 @@
       },
     },
   },
+  "overrides": {
+    "fast-uri": "^3.1.5",
+  },
   "packages": {
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -25,7 +28,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/examples/aidlc-portfolio/package.json
+++ b/examples/aidlc-portfolio/package.json
@@ -16,5 +16,8 @@
   "devDependencies": {
     "@types/bun": "^1.3.10",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.5"
   }
 }

--- a/examples/aidlc-portfolio/skills/aidlc-portfolio/bun.lock
+++ b/examples/aidlc-portfolio/skills/aidlc-portfolio/bun.lock
@@ -10,12 +10,15 @@
       },
     },
   },
+  "overrides": {
+    "fast-uri": "^3.1.5",
+  },
   "packages": {
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/examples/aidlc-portfolio/skills/aidlc-portfolio/package.json
+++ b/examples/aidlc-portfolio/skills/aidlc-portfolio/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "yaml": "^2.8.1"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.5"
   }
 }


### PR DESCRIPTION
Closes #551.

Clears Trivy code-scanning alerts #193 and #194 — `fast-uri@3.1.4` is vulnerable to CVE-2026-18446 (HIGH), a parser-differential where a backslash-based authority introducer (`\\`, `/\`, `\/`) yields a different host than Node's WHATWG `URL`.

## Change

Adds `"overrides": { "fast-uri": "^3.1.5" }` to both example `package.json` files and regenerates the lockfiles:

- `examples/aidlc-portfolio/`
- `examples/aidlc-portfolio/skills/aidlc-portfolio/`

## Why an override, not `bun update fast-uri`

The issue suggested `bun update fast-uri`. That doesn't work here — it promotes `fast-uri` to a *direct* dependency at `^4.1.2` and leaves ajv's nested copy pinned at the vulnerable `3.1.4` under an `ajv/fast-uri` lockfile key, so the alert would have stayed open. The override forces the transitive resolution instead. Staying on the 3.x line keeps it within ajv's declared `^3.0.1` range.

## Verification

- No `fast-uri@3.1.4` remains in either lockfile; both resolve `3.1.5`.
- `bun run check` in `examples/aidlc-portfolio` passes: `tsc --noEmit` clean, 29/29 tests.

Exposure was low — both hits are in example projects, not the shipped `cli-agent-orchestrator` package, and `fast-uri` is reached only via ajv's JSON-schema `$ref`/`$id` resolution rather than any host-based security decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)