### PR TITLE
fix(memory): route memory plugins through the backend abstraction (fixes silent no-op on herdr)

### DIFF
--- a/src/cli_agent_orchestrator/plugins/builtin/claude_code_memory.py
+++ b/src/cli_agent_orchestrator/plugins/builtin/claude_code_memory.py
@@ -15,8 +15,8 @@ import asyncio
 import logging
 from pathlib import Path
 
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import get_terminal_metadata
-from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.plugins import PostCreateTerminalEvent, hook
 from cli_agent_orchestrator.plugins.base import CaoPlugin
 from cli_agent_orchestrator.services.memory_service import MemoryService
@@ -109,7 +109,7 @@ class ClaudeCodeMemoryPlugin(CaoPlugin):
     # helpers
 
     def _resolve_working_directory(self, event: PostCreateTerminalEvent) -> str | None:
-        """Look up the tmux pane's working directory for the terminal."""
+        """Look up the pane's working directory for the terminal via backend."""
 
         metadata = get_terminal_metadata(event.terminal_id)
         if metadata is None:
@@ -120,7 +120,7 @@ class ClaudeCodeMemoryPlugin(CaoPlugin):
         if not session_name or not window_name:
             return None
 
-        return tmux_client.get_pane_working_directory(session_name, window_name)
+        return get_backend().get_pane_working_directory(session_name, window_name)
 
     def _validated_target_path(self, working_directory: str) -> Path:
         """Return <cwd>/.claude/CLAUDE.md, rejecting paths that escape the cwd.

--- a/src/cli_agent_orchestrator/plugins/builtin/codex_memory.py
+++ b/src/cli_agent_orchestrator/plugins/builtin/codex_memory.py
@@ -22,8 +22,8 @@ import asyncio
 import logging
 from pathlib import Path
 
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import get_terminal_metadata
-from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.plugins import PostCreateTerminalEvent, hook
 from cli_agent_orchestrator.plugins.base import CaoPlugin
 from cli_agent_orchestrator.services.memory_service import MemoryService
@@ -115,7 +115,7 @@ class CodexMemoryPlugin(CaoPlugin):
     # helpers
 
     def _resolve_working_directory(self, event: PostCreateTerminalEvent) -> str | None:
-        """Look up the tmux pane's working directory for the terminal."""
+        """Look up the pane's working directory for the terminal via backend."""
 
         metadata = get_terminal_metadata(event.terminal_id)
         if metadata is None:
@@ -126,7 +126,7 @@ class CodexMemoryPlugin(CaoPlugin):
         if not session_name or not window_name:
             return None
 
-        return tmux_client.get_pane_working_directory(session_name, window_name)
+        return get_backend().get_pane_working_directory(session_name, window_name)
 
     def _validated_target_path(self, working_directory: str) -> Path:
         """Return <cwd>/AGENTS.md, rejecting paths that escape the cwd.

--- a/src/cli_agent_orchestrator/plugins/builtin/kiro_cli_memory.py
+++ b/src/cli_agent_orchestrator/plugins/builtin/kiro_cli_memory.py
@@ -28,8 +28,8 @@ import asyncio
 import logging
 from pathlib import Path
 
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.clients.database import get_terminal_metadata
-from cli_agent_orchestrator.clients.tmux import tmux_client
 from cli_agent_orchestrator.plugins import PostCreateTerminalEvent, hook
 from cli_agent_orchestrator.plugins.base import CaoPlugin
 from cli_agent_orchestrator.services.memory_service import MemoryService
@@ -125,7 +125,7 @@ class KiroCliMemoryPlugin(CaoPlugin):
     # helpers
 
     def _resolve_working_directory(self, event: PostCreateTerminalEvent) -> str | None:
-        """Look up the tmux pane's working directory for the terminal."""
+        """Look up the pane's working directory for the terminal via backend."""
 
         metadata = get_terminal_metadata(event.terminal_id)
         if metadata is None:
@@ -136,7 +136,7 @@ class KiroCliMemoryPlugin(CaoPlugin):
         if not session_name or not window_name:
             return None
 
-        return tmux_client.get_pane_working_directory(session_name, window_name)
+        return get_backend().get_pane_working_directory(session_name, window_name)
 
     def _validated_target_path(self, working_directory: str) -> Path:
         """Return <cwd>/.kiro/steering/cao-memory.md, rejecting escape attempts.

--- a/test/plugins/builtin/test_claude_code_memory.py
+++ b/test/plugins/builtin/test_claude_code_memory.py
@@ -58,7 +58,9 @@ async def test_writes_memory_block_on_post_create_terminal(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
 
     class FakeMemoryService:
@@ -108,7 +110,9 @@ async def test_replaces_existing_memory_block_on_rerun(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
 
     class FakeMemoryService:
@@ -147,7 +151,9 @@ async def test_skips_write_when_memory_context_empty(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.MemoryService",
@@ -180,7 +186,9 @@ async def test_disabled_memory_writes_nothing(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.services.settings_service.is_memory_enabled",
@@ -212,7 +220,9 @@ async def test_memory_fetch_failure_is_logged_not_raised(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
 
     class ExplodingMemoryService:
@@ -289,7 +299,9 @@ async def test_path_containment_guard_rejects_escape(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(real_cwd)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(real_cwd)}
+        )(),
     )
 
     class FakeMemoryService:
@@ -355,7 +367,11 @@ async def test_missing_working_dir_does_not_escape_handler(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: "/nonexistent-cao-dir-xyz123/sub"})(),
+        lambda: type(
+            "FakeBackend",
+            (),
+            {"get_pane_working_directory": lambda self, s, w: "/nonexistent-cao-dir-xyz123/sub"},
+        )(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.MemoryService",

--- a/test/plugins/builtin/test_claude_code_memory.py
+++ b/test/plugins/builtin/test_claude_code_memory.py
@@ -499,3 +499,62 @@ def test_write_block_two_concurrent_writers_neither_loses_the_other(tmp_path: Pa
     assert final.count(END_MARKER) == 1
     assert "Hand-written content." in final, "surrounding user content must survive"
     assert ("from-agent-a" in final) or ("from-agent-b" in final)
+
+
+@pytest.mark.asyncio
+async def test_writes_via_configured_backend_not_tmux_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression: the cwd lookup must go through the CONFIGURED backend.
+
+    The plugin used to call ``tmux_client.get_pane_working_directory`` directly,
+    so on a non-tmux backend (herdr) the lookup returned None and CLAUDE.md was
+    silently never written. This drives the real backend registry via
+    ``set_backend`` instead of patching the plugin's ``get_backend`` name, so a
+    plugin that bypasses the abstraction never consults this backend and fails
+    the write assertion below.
+    """
+
+    from cli_agent_orchestrator.backends.registry import set_backend
+
+    resolved_for: list[tuple[str, str]] = []
+
+    class RecordingBackend:
+        """Stands in for a non-tmux backend (e.g. HerdrBackend)."""
+
+        def get_pane_working_directory(self, session: str, window: str) -> str:
+            resolved_for.append((session, window))
+            return str(tmp_path)
+
+    set_backend(RecordingBackend())
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_terminal_metadata",
+        lambda terminal_id: {
+            "tmux_session": "cao-test-session",
+            "tmux_window": "developer-abcd",
+            "id": terminal_id,
+        },
+    )
+
+    class FakeMemoryService:
+        def get_memory_context_for_terminal(self, terminal_id: str) -> str:
+            return "<cao-memory>\n## Context\n- routed via backend\n</cao-memory>"
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.MemoryService",
+        lambda: FakeMemoryService(),
+    )
+
+    plugin = ClaudeCodeMemoryPlugin()
+    await plugin.setup()
+    await plugin.on_post_create_terminal(_event())
+    await plugin.teardown()
+
+    # The configured backend was actually consulted, with the metadata identifiers.
+    assert resolved_for == [("cao-test-session", "developer-abcd")]
+
+    # And CLAUDE.md landed under the cwd that backend reported.
+    target = tmp_path / ".claude" / "CLAUDE.md"
+    assert target.exists(), "CLAUDE.md must be written on a non-tmux backend"
+    assert "routed via backend" in target.read_text(encoding="utf-8")

--- a/test/plugins/builtin/test_claude_code_memory.py
+++ b/test/plugins/builtin/test_claude_code_memory.py
@@ -57,8 +57,8 @@ async def test_writes_memory_block_on_post_create_terminal(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
 
     class FakeMemoryService:
@@ -107,8 +107,8 @@ async def test_replaces_existing_memory_block_on_rerun(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
 
     class FakeMemoryService:
@@ -146,8 +146,8 @@ async def test_skips_write_when_memory_context_empty(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.MemoryService",
@@ -179,8 +179,8 @@ async def test_disabled_memory_writes_nothing(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.services.settings_service.is_memory_enabled",
@@ -211,8 +211,8 @@ async def test_memory_fetch_failure_is_logged_not_raised(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
 
     class ExplodingMemoryService:
@@ -288,8 +288,8 @@ async def test_path_containment_guard_rejects_escape(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(real_cwd),
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(real_cwd)})(),
     )
 
     class FakeMemoryService:
@@ -354,8 +354,8 @@ async def test_missing_working_dir_does_not_escape_handler(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: "/nonexistent-cao-dir-xyz123/sub",
+        "cli_agent_orchestrator.plugins.builtin.claude_code_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: "/nonexistent-cao-dir-xyz123/sub"})(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.claude_code_memory.MemoryService",

--- a/test/plugins/builtin/test_codex_memory.py
+++ b/test/plugins/builtin/test_codex_memory.py
@@ -56,7 +56,9 @@ async def test_writes_memory_block_on_post_create_terminal(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
 
     class FakeMemoryService:
@@ -104,7 +106,9 @@ async def test_replaces_existing_memory_block_on_rerun(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
 
     class FakeMemoryService:
@@ -143,7 +147,9 @@ async def test_skips_write_when_memory_context_empty(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.MemoryService",
@@ -177,7 +183,9 @@ async def test_disabled_memory_writes_nothing(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.services.settings_service.is_memory_enabled",
@@ -209,7 +217,9 @@ async def test_memory_fetch_failure_is_logged_not_raised(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)}
+        )(),
     )
 
     class ExplodingMemoryService:
@@ -282,7 +292,9 @@ async def test_path_containment_guard_rejects_escape(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(real_cwd)})(),
+        lambda: type(
+            "FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(real_cwd)}
+        )(),
     )
 
     class FakeMemoryService:
@@ -343,7 +355,11 @@ async def test_missing_working_dir_does_not_escape_handler(
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
-        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: "/nonexistent-cao-dir-xyz123/sub"})(),
+        lambda: type(
+            "FakeBackend",
+            (),
+            {"get_pane_working_directory": lambda self, s, w: "/nonexistent-cao-dir-xyz123/sub"},
+        )(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.MemoryService",

--- a/test/plugins/builtin/test_codex_memory.py
+++ b/test/plugins/builtin/test_codex_memory.py
@@ -55,8 +55,8 @@ async def test_writes_memory_block_on_post_create_terminal(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.codex_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
 
     class FakeMemoryService:
@@ -103,8 +103,8 @@ async def test_replaces_existing_memory_block_on_rerun(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.codex_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
 
     class FakeMemoryService:
@@ -142,8 +142,8 @@ async def test_skips_write_when_memory_context_empty(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.codex_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.MemoryService",
@@ -176,8 +176,8 @@ async def test_disabled_memory_writes_nothing(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.codex_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.services.settings_service.is_memory_enabled",
@@ -208,8 +208,8 @@ async def test_memory_fetch_failure_is_logged_not_raised(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.codex_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(tmp_path)})(),
     )
 
     class ExplodingMemoryService:
@@ -281,8 +281,8 @@ async def test_path_containment_guard_rejects_escape(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.codex_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(real_cwd),
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: str(real_cwd)})(),
     )
 
     class FakeMemoryService:
@@ -342,8 +342,8 @@ async def test_missing_working_dir_does_not_escape_handler(
         },
     )
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.codex_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: "/nonexistent-cao-dir-xyz123/sub",
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_backend",
+        lambda: type("FakeBackend", (), {"get_pane_working_directory": lambda self, s, w: "/nonexistent-cao-dir-xyz123/sub"})(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.codex_memory.MemoryService",

--- a/test/plugins/builtin/test_codex_memory.py
+++ b/test/plugins/builtin/test_codex_memory.py
@@ -486,3 +486,62 @@ def test_write_block_two_concurrent_writers_neither_loses_the_other(tmp_path: Pa
     assert final.count(END_MARKER) == 1
     assert "Hand-written content." in final, "surrounding user content must survive"
     assert ("from-agent-a" in final) or ("from-agent-b" in final)
+
+
+@pytest.mark.asyncio
+async def test_writes_via_configured_backend_not_tmux_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression: the cwd lookup must go through the CONFIGURED backend.
+
+    The plugin used to call ``tmux_client.get_pane_working_directory`` directly,
+    so on a non-tmux backend (herdr) the lookup returned None and AGENTS.md was
+    silently never written. This drives the real backend registry via
+    ``set_backend`` instead of patching the plugin's ``get_backend`` name, so a
+    plugin that bypasses the abstraction never consults this backend and fails
+    the write assertion below.
+    """
+
+    from cli_agent_orchestrator.backends.registry import set_backend
+
+    resolved_for: list[tuple[str, str]] = []
+
+    class RecordingBackend:
+        """Stands in for a non-tmux backend (e.g. HerdrBackend)."""
+
+        def get_pane_working_directory(self, session: str, window: str) -> str:
+            resolved_for.append((session, window))
+            return str(tmp_path)
+
+    set_backend(RecordingBackend())
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.get_terminal_metadata",
+        lambda terminal_id: {
+            "tmux_session": "cao-test-session",
+            "tmux_window": "developer-abcd",
+            "id": terminal_id,
+        },
+    )
+
+    class FakeMemoryService:
+        def get_memory_context_for_terminal(self, terminal_id: str) -> str:
+            return "<cao-memory>\n## Context\n- routed via backend\n</cao-memory>"
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.plugins.builtin.codex_memory.MemoryService",
+        lambda: FakeMemoryService(),
+    )
+
+    plugin = CodexMemoryPlugin()
+    await plugin.setup()
+    await plugin.on_post_create_terminal(_event())
+    await plugin.teardown()
+
+    # The configured backend was actually consulted, with the metadata identifiers.
+    assert resolved_for == [("cao-test-session", "developer-abcd")]
+
+    # And AGENTS.md landed under the cwd that backend reported.
+    target = tmp_path / "AGENTS.md"
+    assert target.exists(), "AGENTS.md must be written on a non-tmux backend"
+    assert "routed via backend" in target.read_text(encoding="utf-8")

--- a/test/plugins/builtin/test_kiro_cli_memory.py
+++ b/test/plugins/builtin/test_kiro_cli_memory.py
@@ -416,3 +416,62 @@ def test_concurrent_steering_writes_never_collide_on_temp_file(tmp_path: Path) -
     assert final.count("</cao-memory>") == 1
     leftovers = [p for p in target.parent.iterdir() if p.suffix == ".tmp"]
     assert leftovers == []
+
+
+@pytest.mark.asyncio
+async def test_writes_via_configured_backend_not_tmux_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression: the cwd lookup must go through the CONFIGURED backend.
+
+    The plugin used to call ``tmux_client.get_pane_working_directory`` directly,
+    so on a non-tmux backend (herdr) the lookup returned None and the steering
+    file was silently never written. This drives the real backend registry via
+    ``set_backend`` instead of patching the plugin's ``get_backend`` name, so a
+    plugin that bypasses the abstraction never consults this backend and fails
+    the write assertion below.
+    """
+
+    from cli_agent_orchestrator.backends.registry import set_backend
+
+    resolved_for: list[tuple[str, str]] = []
+
+    class RecordingBackend:
+        """Stands in for a non-tmux backend (e.g. HerdrBackend)."""
+
+        def get_pane_working_directory(self, session: str, window: str) -> str:
+            resolved_for.append((session, window))
+            return str(tmp_path)
+
+    set_backend(RecordingBackend())
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.get_terminal_metadata",
+        lambda terminal_id: {
+            "tmux_session": "cao-test-session",
+            "tmux_window": "developer-abcd",
+            "id": terminal_id,
+        },
+    )
+
+    class FakeMemoryService:
+        def get_memory_context_for_terminal(self, terminal_id: str) -> str:
+            return "<cao-memory>\n## Context\n- routed via backend\n</cao-memory>"
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.MemoryService",
+        lambda: FakeMemoryService(),
+    )
+
+    plugin = KiroCliMemoryPlugin()
+    await plugin.setup()
+    await plugin.on_post_create_terminal(_event())
+    await plugin.teardown()
+
+    # The configured backend was actually consulted, with the metadata identifiers.
+    assert resolved_for == [("cao-test-session", "developer-abcd")]
+
+    # And the steering file landed under the cwd that backend reported.
+    target = tmp_path / STEERING_SUBDIR / MEMORY_FILENAME
+    assert target.exists(), "steering file must be written on a non-tmux backend"
+    assert "routed via backend" in target.read_text(encoding="utf-8")

--- a/test/plugins/builtin/test_kiro_cli_memory.py
+++ b/test/plugins/builtin/test_kiro_cli_memory.py
@@ -32,9 +32,15 @@ def _install_metadata_and_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
             "id": terminal_id,
         },
     )
+
+    # Mock get_backend() to return a fake backend with get_pane_working_directory
+    class FakeBackend:
+        def get_pane_working_directory(self, session: str, window: str) -> str:
+            return str(tmp_path)
+
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(tmp_path),
+        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.get_backend",
+        lambda: FakeBackend(),
     )
 
 
@@ -256,9 +262,15 @@ async def test_path_containment_guard_rejects_symlink_escape(
             "id": terminal_id,
         },
     )
+
+    # Mock get_backend() to return a fake backend with get_pane_working_directory
+    class FakeBackend:
+        def get_pane_working_directory(self, session: str, window: str) -> str:
+            return str(real_cwd)
+
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: str(real_cwd),
+        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.get_backend",
+        lambda: FakeBackend(),
     )
 
     class FakeMemoryService:
@@ -307,9 +319,15 @@ async def test_missing_working_dir_does_not_escape_handler(
             "id": terminal_id,
         },
     )
+
+    # Mock get_backend() to return a fake backend with get_pane_working_directory
+    class FakeBackend:
+        def get_pane_working_directory(self, session: str, window: str) -> str:
+            return "/nonexistent-cao-dir-xyz123/sub"
+
     monkeypatch.setattr(
-        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.tmux_client.get_pane_working_directory",
-        lambda session, window: "/nonexistent-cao-dir-xyz123/sub",
+        "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.get_backend",
+        lambda: FakeBackend(),
     )
     monkeypatch.setattr(
         "cli_agent_orchestrator.plugins.builtin.kiro_cli_memory.MemoryService",


### PR DESCRIPTION
Closes #553

## Problem

The three built-in memory plugins resolve the terminal's working directory by
calling the tmux client directly, bypassing the backend abstraction:

```python
return tmux_client.get_pane_working_directory(session_name, window_name)
```

On the `herdr` backend that call returns `None`, so `_resolve_working_directory`
returns `None`, the hook early-returns, and the memory/steering file is **never
written**. Agents silently lose curated memory injection.

It fails silently — the only trace is a `logger.error` from the tmux client that
reads like an unrelated tmux problem:

```
Failed to get working directory for cao-herdr-trial-1:conductor-b55e:
No objects found: session_name='cao-herdr-trial-1'
```

Affected (all in `_resolve_working_directory`):

- `plugins/builtin/kiro_cli_memory.py`
- `plugins/builtin/codex_memory.py`
- `plugins/builtin/claude_code_memory.py`

`HerdrBackend.get_pane_working_directory` implements this correctly already — it
was simply never called.

## Fix

Route through the abstraction, matching the existing idiom in
`services/terminal_service.py::get_working_directory`:

```python
return get_backend().get_pane_working_directory(session_name, window_name)
```

Plus removal of the now-unused `tmux_client` import from each plugin. No other
behaviour changes; metadata keys keep their historical `tmux_*` names (those are
DB column names, out of scope here).

## Verification

Live against herdr 0.7.5 (protocol 17), driving the real plugin hook on a real
herdr terminal with only the plugin code differing:

| Code | Resolved cwd | Steering file |
|---|---|---|
| before | `None` | **absent** |
| after | `/private/tmp/livecheck` | **written** |

Reproduced independently for all three plugins — `.kiro/steering/cao-memory.md`,
`AGENTS.md`, and `.claude/CLAUDE.md` each written at the correct path with the
expected content.

**No tmux regression.** `TmuxBackend.get_pane_working_directory` is a one-line
delegation to the same `TmuxClient` method, and `get_backend()` lazy-initialises
via `BackendFactory` whose default is `tmux` — so the default path is unchanged.
`test/plugins/` is green with `CAO_TERMINAL_BACKEND=tmux`.

**New regression tests** (one per plugin): `test_writes_via_configured_backend_not_tmux_directly`
drives the real backend registry via `set_backend()` rather than patching each
plugin's `get_backend` name — so a plugin that reverts to calling `tmux_client`
never consults the configured backend and the test fails. Verified failing on the
reintroduced bug in all three plugins, and passing on the fix.

The pre-existing mocks were also re-pointed from `tmux_client` to `get_backend`,
since continuing to mock the old layer would re-enshrine the bug.

- `uv run pytest test/plugins/` → **90 passed**
- `uv run pytest test/plugins/ test/backends/` → **257 passed**
- `test/services/ test/backends/` → failure set **identical to pristine `main`**
  (pre-existing, from the optional `ag-ui-protocol` dep not being installed)
- `black` + `isort` clean

> Note for reviewers running the suite from a git worktree: if the worktree has no
> `.venv` of its own, an unpinned `uv run` resolves the package from the parent
> checkout via the editable `.pth` and reports spurious
> `module ... has no attribute 'get_backend'` failures. Pin
> `PYTHONPATH=<worktree>/src`. CI checks out a single tree, so it is unaffected.

## Completeness

Every `get_pane_working_directory` caller in `src/` now goes through
`get_backend()` (`terminal_service.py:944,1360`, `providers/copilot_cli.py:157`,
and these three plugins). No `tmux_client` references remain anywhere under
`src/cli_agent_orchestrator/plugins/`.

## Out of scope

The three `_resolve_working_directory` helpers are now byte-identical triplicates.
That duplication is pre-existing on `main` (the whole handler shape is
triplicated), and extracting a shared helper would turn a 9-line bugfix into a
cross-plugin refactor that buries the change. Happy to file a follow-up issue for
the extraction if maintainers want it.
