### PR TITLE
fix(tmux): retry libtmux listing parse failures instead of surfacing them as "not found"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+
+### Fixed
+
+- tmux listing parse failures are retried once and reported as a distinct condition instead of surfacing as a bare `ValueError` that reads like "session not found" one layer up. libtmux 0.53.1+ zips `parse_output`'s fields with `strict=True`, so any short row (a pane or session vanishing mid-listing, or trailing fields tmux omits) raised `ValueError: zip() argument 2 is shorter than argument 1` — which propagated through `server.sessions`/`window.panes`, blocked launches outright, and left the pipe-liveness watchdog unable to tell a genuinely-gone session from a transient parse failure. Adds `TmuxLookupError` and routes the listing reads in `clients/tmux.py` through a single retry-and-classify wrapper; a failed `create_session` no longer leaves an orphaned tmux session that blocks relaunching the same name. Also caps `libtmux<0.53.1`, the last release that zips non-strict (caom-anv)
+
 ## [2.4.1] - 2026-08-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,19 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "uvicorn[standard]>=0.24.0",
     "websockets>=12.0",
-    "libtmux>=0.51.0",
+    # Upper bound: libtmux 0.53.1 rewrote `neo.parse_output` to zip a fixed
+    # 125-name format list against each row's values with `strict=True`, so any
+    # row short of 125 values (a pane/session vanishing mid-listing, or a
+    # trailing field a given tmux build omits) raises
+    # ValueError('zip() argument 2 is shorter than argument 1') instead of
+    # degrading. 0.53.0 is the last release that zips non-strict; every release
+    # from 0.53.1 through 0.62.0 has it. Verified by inspecting `libtmux/neo.py`
+    # in every wheel in that range. clients/tmux.py wraps every listing call so
+    # a parse failure is a retryable TmuxLookupError rather than a fake
+    # "session not found" — this bound is the belt to that suspenders, keeping
+    # the broken releases from arriving silently on another machine. Raise it
+    # once upstream zips non-strict or pads short rows.
+    "libtmux>=0.51.0,<0.53.1",
     "click>=8.2.0",
     "python-dotenv>=1.2.2",
     "python-frontmatter>=1.1.0",

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -7,9 +7,12 @@ import shlex
 import subprocess
 import time
 import uuid
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional, TypeVar
 
 import libtmux
+from libtmux.pane import Pane
+from libtmux.session import Session
+from libtmux.window import Window
 
 from cli_agent_orchestrator.constants import (
     BRACKETED_PASTE_INCOMPATIBLE_SHELLS,
@@ -23,12 +26,222 @@ from cli_agent_orchestrator.utils.terminal import validate_tmux_name
 
 logger = logging.getLogger(__name__)
 
+_T = TypeVar("_T")
+
+
+class TmuxLookupError(RuntimeError):
+    """A tmux listing could not be read, so the answer is UNKNOWN — not "absent".
+
+    libtmux >= 0.53.1 parses ``list-sessions`` / ``list-windows`` / ``list-panes``
+    output with ``dict(zip(formats, values, strict=True))`` (``libtmux/neo.py``,
+    ``parse_output``) against a fixed 125-name format list, stripping only ONE
+    trailing empty field. Any row that yields fewer than 125 values — a
+    session/window/pane that disappears mid-listing, or a trailing field this
+    tmux build simply omits — raises ``ValueError('zip() argument 2 is shorter
+    than argument 1')`` instead of degrading. Under load (many concurrent CAO
+    sessions polling the same tmux server) that race fires constantly.
+
+    This exception exists so the failure cannot masquerade as a missing session.
+    Everything else in this module signals a *genuine* absence with a plain
+    ``ValueError`` (or ``None`` / ``False`` / ``[]`` for the query-style
+    methods), so a caller that needs to tell "the session is really gone" from
+    "we could not look" catches ``TmuxLookupError`` explicitly. It is
+    deliberately NOT a subclass of ``ValueError``: an ``except ValueError``
+    written for the not-found case must not swallow it.
+
+    Treat it as transient and retryable — ``TmuxClient`` already retries the
+    read once before raising.
+    """
+
 
 class TmuxClient:
     """Simplified tmux client for basic operations."""
 
     def __init__(self) -> None:
         self.server = libtmux.Server()
+
+    # ── libtmux listing boundary ─────────────────────────────────────────
+    #
+    # Every read that makes libtmux shell out to `list-sessions` /
+    # `list-windows` / `list-panes` goes through _read_listing() below, so a
+    # transient parse failure (see TmuxLookupError) becomes a distinct,
+    # retryable, non-fatal condition instead of a raw ValueError that reads
+    # like "not found" one layer up.
+
+    # Short pause before the single retry so the mid-listing race (a pane or
+    # session vanishing between tmux's enumeration and its output) has settled.
+    # Deliberately tiny: get_history() is called from the FIFO pipe-liveness
+    # watchdog loop, which must not be stalled by a slow retry.
+    _LISTING_RETRY_DELAY_S = 0.05
+
+    @classmethod
+    def _read_listing(cls, description: str, read: Callable[[], _T]) -> _T:
+        """Run one libtmux listing read, retrying ONCE on a parse failure.
+
+        ``read`` must contain nothing but libtmux attribute access / query
+        calls. That invariant is what lets us classify *any* ``ValueError``
+        escaping it as a libtmux parse failure rather than matching on
+        CPython's ``zip()`` message text (which is not part of any contract).
+        Callers therefore raise their own "not found" ``ValueError``s outside
+        the callable, never inside it.
+
+        Args:
+            description: What was being read, for the log/error message.
+            read: The libtmux read to perform.
+
+        Returns:
+            Whatever ``read`` returns.
+
+        Raises:
+            TmuxLookupError: The read failed to parse twice in a row.
+        """
+        try:
+            return read()
+        except ValueError as first_error:
+            logger.warning(
+                "tmux listing parse failed (%s): %s — retrying once", description, first_error
+            )
+
+        time.sleep(cls._LISTING_RETRY_DELAY_S)
+        try:
+            return read()
+        except ValueError as second_error:
+            raise TmuxLookupError(
+                f"Could not read tmux listing ({description}): {second_error}. "
+                "The tmux server output failed to parse twice; this is transient "
+                "and says nothing about whether the target still exists."
+            ) from second_error
+
+    def _find_session(self, session_name: str) -> Optional[Session]:
+        """Return the named session, or None if it is genuinely absent.
+
+        ``default=None`` is passed explicitly: libtmux's ``QueryList.get()``
+        raises ``ObjectDoesNotExist`` when nothing matches and no default is
+        given, and that exception type moved between libtmux releases
+        (``libtmux._internal.query_list`` on 0.51, ``libtmux.exc`` on 0.62).
+        Asking for ``None`` keeps genuine absence version-stable and keeps the
+        ``if not session:`` checks below meaningful.
+
+        Raises:
+            TmuxLookupError: The session listing could not be parsed.
+        """
+        return self._read_listing(
+            f"list-sessions for session '{session_name}'",
+            lambda: self.server.sessions.get(session_name=session_name, default=None),
+        )
+
+    def _find_window(
+        self, session: Session, session_name: str, window_name: str
+    ) -> Optional[Window]:
+        """Return the named window in ``session``, or None if genuinely absent.
+
+        Raises:
+            TmuxLookupError: The window listing could not be parsed.
+        """
+        return self._read_listing(
+            f"list-windows for '{session_name}:{window_name}'",
+            lambda: session.windows.get(window_name=window_name, default=None),
+        )
+
+    def _find_active_pane(
+        self, window: Window, session_name: str, window_name: str
+    ) -> Optional[Pane]:
+        """Return the window's active pane. ``Window.active_pane`` lists panes.
+
+        Raises:
+            TmuxLookupError: The pane listing could not be parsed.
+        """
+        return self._read_listing(
+            f"list-panes for '{session_name}:{window_name}'",
+            lambda: window.active_pane,
+        )
+
+    def _find_first_pane(self, window: Window, session_name: str, window_name: str) -> Pane:
+        """Return the window's first pane. ``Window.panes`` lists panes.
+
+        Raises:
+            TmuxLookupError: The pane listing could not be parsed.
+        """
+        return self._read_listing(
+            f"list-panes for '{session_name}:{window_name}'",
+            lambda: window.panes[0],
+        )
+
+    @staticmethod
+    def _kill_via_cli(session_name: str, window_name: Optional[str] = None) -> bool:
+        """Kill a session (or a single window) straight through the tmux CLI.
+
+        Deliberately bypasses libtmux: no listing is parsed, so this still
+        works when ``parse_output`` cannot read the server's output. That is
+        what stops a launch aborted by a parse failure from leaving a live
+        tmux session behind — the operator's retry would otherwise be blocked
+        by "Session already exists" with no usable terminal to attach to.
+
+        The target uses tmux's ``=`` exact-match prefix so a prefix collision
+        can never kill a *different* session.
+
+        Returns:
+            True if tmux reported the kill succeeded, False otherwise.
+        """
+        try:
+            target = f"={validate_tmux_name(session_name, 'session_name')}"
+            if window_name is not None:
+                target = f"{target}:{validate_tmux_name(window_name, 'window_name')}"
+        except ValueError as e:
+            logger.error("Cannot build tmux kill target: %s", e)
+            return False
+
+        command = "kill-window" if window_name is not None else "kill-session"
+        try:
+            result = subprocess.run(
+                ["tmux", command, "-t", target],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as e:
+            logger.error("Failed to run `tmux %s -t %s`: %s", command, target, e)
+            return False
+
+        if result.returncode == 0:
+            logger.info("Killed %s via tmux CLI: %s", command.split("-")[1], target)
+            return True
+        logger.warning(
+            "`tmux %s -t %s` failed (rc=%s): %s",
+            command,
+            target,
+            result.returncode,
+            (result.stderr or "").strip(),
+        )
+        return False
+
+    @staticmethod
+    def _has_session_via_cli(session_name: str) -> Optional[bool]:
+        """Parse-free ``tmux has-session`` probe used when a listing won't parse.
+
+        Returns:
+            True/False when tmux answered, None when we could not even ask
+            (invalid name, or the tmux binary is unavailable) — in which case
+            the caller must keep reporting "unknown" rather than "gone".
+        """
+        try:
+            target = f"={validate_tmux_name(session_name, 'session_name')}"
+        except ValueError as e:
+            logger.error("Cannot build tmux has-session target: %s", e)
+            return None
+        try:
+            result = subprocess.run(
+                ["tmux", "has-session", "-t", target],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as e:
+            logger.error("Failed to run `tmux has-session -t %s`: %s", target, e)
+            return None
+        # tmux exits non-zero both for "no such session" and "no server
+        # running"; both mean the session does not exist.
+        return result.returncode == 0
 
     # Kept as an alias so existing callers/tests referencing the class
     # attribute keep working; the canonical set lives in
@@ -181,21 +394,62 @@ class TmuxClient:
             # silently dropped. Starting at a larger size makes the attach
             # resize a no-op/shrink, which kiro handles correctly. All other
             # providers tolerate wider panes. See issue #216.
-            session = self.server.new_session(
-                session_name=session_name,
-                window_name=window_name,
-                start_directory=working_directory,
-                detach=True,
-                environment=environment,
-                x=220,
-                y=50,
-            )
+            try:
+                session = self.server.new_session(
+                    session_name=session_name,
+                    window_name=window_name,
+                    start_directory=working_directory,
+                    detach=True,
+                    environment=environment,
+                    x=220,
+                    y=50,
+                )
+            except ValueError as e:
+                # new_session() lists the server to build its Session object,
+                # so it can fail to PARSE output for a session tmux has
+                # ALREADY created (see TmuxLookupError). tmux refusing a
+                # duplicate name raises LibTmuxException, not ValueError, so a
+                # ValueError here means "our session may exist but we cannot
+                # see it". Tear it down through the parse-free CLI: otherwise
+                # the caller's rollback never fires (it only knows the session
+                # was created once this method RETURNS) and the retry is
+                # blocked by "Session already exists" with a dead pane.
+                logger.error(
+                    f"tmux listing failed while creating session {session_name}: {e} — "
+                    "removing any session tmux created before re-raising"
+                )
+                self._kill_via_cli(session_name)
+                raise TmuxLookupError(
+                    f"Could not read tmux listing while creating session "
+                    f"'{session_name}': {e}. Any partially created session has "
+                    "been removed; the launch can be retried with the same name."
+                ) from e
+
             logger.info(
                 f"Created tmux session: {session_name} with window: {window_name} in directory: {working_directory}"
             )
-            window_name_result = session.windows[0].name
-            if window_name_result is None:
-                raise ValueError(f"Window name is None for session {session_name}")
+            try:
+                window_name_result = self._read_listing(
+                    f"list-windows for new session '{session_name}'",
+                    lambda: session.windows[0].name,
+                )
+                if window_name_result is None:
+                    raise ValueError(f"Window name is None for session {session_name}")
+            except TmuxLookupError:
+                # Same half-state, one step later: the session is up but we
+                # cannot confirm its window. Use the parse-free CLI here too —
+                # session.kill() would need the very listing that just failed.
+                self._kill_via_cli(session_name)
+                raise
+            except Exception:
+                # Any other post-creation failure: the session exists and this
+                # method is about to raise, so nothing downstream will ever
+                # learn it needs cleaning up. Kill it here.
+                try:
+                    session.kill()
+                except Exception as kill_error:  # pragma: no cover - best effort
+                    logger.warning(f"Failed to roll back session {session_name}: {kill_error}")
+                raise
             return window_name_result
         except Exception as e:
             logger.error(f"Failed to create session {session_name}: {e}")
@@ -219,7 +473,7 @@ class TmuxClient:
         try:
             working_directory = self._resolve_and_validate_working_directory(working_directory)
 
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
@@ -474,15 +728,15 @@ class TmuxClient:
                 f"send_keys_via_paste: {session_name}:{window_name} - text length: {len(text)}"
             )
 
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._find_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
-            pane = window.active_pane
+            pane = self._find_active_pane(window, session_name, window_name)
             if pane:
                 buf_name = "cao_paste"
 
@@ -524,15 +778,15 @@ class TmuxClient:
         try:
             logger.info(f"send_special_key: {session_name}:{window_name} - key: {key}")
 
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._find_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
-            pane = window.active_pane
+            pane = self._find_active_pane(window, session_name, window_name)
             if pane:
                 pane.send_keys(key, enter=False)
                 logger.debug(f"Sent special key to {session_name}:{window_name}")
@@ -556,18 +810,28 @@ class TmuxClient:
             tail_lines: Number of lines to capture from end (default: TMUX_HISTORY_LINES)
             strip_escapes: If True, capture plain text without ANSI escape sequences
             full_history: If True, capture entire scrollback buffer (overrides tail_lines)
+
+        Raises:
+            ValueError: The session or window is genuinely gone.
+            TmuxLookupError: The tmux listing could not be parsed, so we cannot
+                say whether it is gone. This is the hot path for the parse race
+                — the FIFO pipe-liveness watchdog probes panes through here on
+                every tick, from every concurrent CAO session. The distinction
+                matters: the watchdog must not conclude a worker's pane has
+                stopped producing output (and a supervisor must not conclude
+                the worker finished) because a listing failed to parse.
         """
         try:
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._find_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
             # Use cmd to run capture-pane with -e (escape sequences) and -p (print) flags
-            pane = window.panes[0]
+            pane = self._find_first_pane(window, session_name, window_name)
             if full_history:
                 # "-S -" captures from the start of the scrollback buffer
                 flags = ["-p", "-S", "-"]
@@ -584,8 +848,15 @@ class TmuxClient:
             raise
 
     def list_sessions(self) -> List[Dict[str, str]]:
-        """List all tmux sessions."""
-        try:
+        """List all tmux sessions.
+
+        Raises:
+            TmuxLookupError: The listing could not be parsed. Deliberately NOT
+                degraded to an empty list — "we could not read the tmux server"
+                must never look like "there are no sessions".
+        """
+
+        def read() -> List[Dict[str, str]]:
             sessions: List[Dict[str, str]] = []
             for session in self.server.sessions:
                 # Check if session has attached clients
@@ -599,78 +870,143 @@ class TmuxClient:
                         "status": "active" if is_attached else "detached",
                     }
                 )
-
             return sessions
+
+        try:
+            return self._read_listing("list-sessions", read)
+        except TmuxLookupError:
+            raise
         except Exception as e:
             logger.error(f"Failed to list sessions: {e}")
             return []
 
     def get_session_windows(self, session_name: str) -> List[Dict[str, str]]:
-        """Get all windows in a session."""
+        """Get all windows in a session.
+
+        Returns an empty list when the session is genuinely absent.
+
+        Raises:
+            TmuxLookupError: The listing could not be parsed — not the same
+                thing as a session with no windows.
+        """
         try:
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 return []
 
-            windows: List[Dict[str, str]] = []
-            for window in session.windows:
-                window_name = window.name if window.name is not None else ""
-                windows.append({"name": window_name, "index": str(window.index)})
+            def read() -> List[Dict[str, str]]:
+                windows: List[Dict[str, str]] = []
+                for window in session.windows:
+                    window_name = window.name if window.name is not None else ""
+                    windows.append({"name": window_name, "index": str(window.index)})
+                return windows
 
-            return windows
+            return self._read_listing(f"list-windows for session '{session_name}'", read)
+        except TmuxLookupError:
+            raise
         except Exception as e:
             logger.error(f"Failed to get windows for session {session_name}: {e}")
             return []
 
     def kill_session(self, session_name: str) -> bool:
-        """Kill tmux session."""
+        """Kill tmux session.
+
+        Returns:
+            True if a session was killed, False if there was nothing to kill
+            (or the kill itself failed).
+
+        A listing parse failure does NOT return False here: "we could not look"
+        is not "nothing to kill", and swallowing it is exactly how a failed
+        launch leaves a live session that blocks the retry. The kill is retried
+        through the parse-free tmux CLI instead.
+        """
         try:
-            session = self.server.sessions.get(session_name=session_name)
-            if session:
-                session.kill()
-                logger.info(f"Killed tmux session: {session_name}")
-                return True
-            return False
+            session = self._find_session(session_name)
+            if session is None:
+                return False
+            self._read_listing(f"kill-session '{session_name}'", session.kill)
+            logger.info(f"Killed tmux session: {session_name}")
+            return True
+        except TmuxLookupError as e:
+            logger.warning(
+                f"tmux listing failed while killing session {session_name}: {e} — "
+                "falling back to the tmux CLI"
+            )
+            return self._kill_via_cli(session_name)
         except Exception as e:
             logger.error(f"Failed to kill session {session_name}: {e}")
             return False
 
     def kill_window(self, session_name: str, window_name: str) -> bool:
-        """Kill a specific tmux window within a session."""
+        """Kill a specific tmux window within a session.
+
+        Like ``kill_session``, a listing parse failure falls back to the
+        parse-free tmux CLI rather than reporting "nothing to kill".
+        """
         try:
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 return False
-            window = session.windows.get(window_name=window_name)
-            if window:
-                window.kill()
-                logger.info(f"Killed tmux window: {session_name}:{window_name}")
-                return True
-            return False
+            window = self._find_window(session, session_name, window_name)
+            if window is None:
+                return False
+            self._read_listing(f"kill-window '{session_name}:{window_name}'", window.kill)
+            logger.info(f"Killed tmux window: {session_name}:{window_name}")
+            return True
+        except TmuxLookupError as e:
+            logger.warning(
+                f"tmux listing failed while killing window {session_name}:{window_name}: {e} — "
+                "falling back to the tmux CLI"
+            )
+            return self._kill_via_cli(session_name, window_name)
         except Exception as e:
             logger.error(f"Failed to kill window {session_name}:{window_name}: {e}")
             return False
 
     def session_exists(self, session_name: str) -> bool:
-        """Check if session exists."""
+        """Check if session exists.
+
+        A listing parse failure must not answer False: callers use this both to
+        decide a session is gone AND to guard against creating a duplicate, so
+        a wrong False is the worst possible answer. On a parse failure we ask
+        tmux directly (``has-session``), which needs no listing parse.
+
+        Raises:
+            TmuxLookupError: The listing could not be parsed AND the direct
+                probe could not answer either — genuinely unknown.
+        """
         try:
-            session = self.server.sessions.get(session_name=session_name)
-            return session is not None
+            return self._find_session(session_name) is not None
+        except TmuxLookupError:
+            logger.warning(
+                "tmux listing failed for session %s — probing with `tmux has-session`",
+                session_name,
+            )
+            exists = self._has_session_via_cli(session_name)
+            if exists is None:
+                raise
+            return exists
         except Exception:
             return False
 
     def get_pane_working_directory(self, session_name: str, window_name: str) -> Optional[str]:
-        """Get the current working directory of a pane."""
+        """Get the current working directory of a pane.
+
+        Returns None when it cannot be determined — including on a listing
+        parse failure. None already means "unknown" for this method (it is what
+        an absent session/window returns too), so there is no "gone" claim to
+        get wrong; the failure is logged rather than raised.
+        """
         try:
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 return None
 
-            window = session.windows.get(window_name=window_name)
+            window = self._find_window(session, session_name, window_name)
             if not window:
                 return None
 
-            pane = window.active_pane
+            pane = self._find_active_pane(window, session_name, window_name)
             if pane:
                 # Get pane_current_path from tmux
                 result = pane.cmd("display-message", "-p", "#{pane_current_path}")
@@ -682,15 +1018,22 @@ class TmuxClient:
             return None
 
     def get_pane_current_command(self, session_name: str, window_name: str) -> Optional[str]:
-        """Get the current foreground command running in a pane."""
+        """Get the current foreground command running in a pane.
+
+        Returns None when it cannot be determined, including on a listing parse
+        failure. Its only caller
+        (``_pane_is_bracketed_paste_incompatible``) already treats None as
+        "assume a real TUI", the pre-existing safe default — so there is no
+        "gone" claim to get wrong here either.
+        """
         try:
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 return None
-            window = session.windows.get(window_name=window_name)
+            window = self._find_window(session, session_name, window_name)
             if not window:
                 return None
-            pane = window.active_pane
+            pane = self._find_active_pane(window, session_name, window_name)
             if pane:
                 result = pane.cmd("display-message", "-p", "#{pane_current_command}")
                 if result.stdout:
@@ -707,17 +1050,23 @@ class TmuxClient:
             session_name: Tmux session name
             window_name: Tmux window name
             file_path: Absolute path to log file
+
+        Raises:
+            ValueError: The session or window is genuinely gone.
+            TmuxLookupError: The tmux listing could not be parsed. Raised rather
+                than swallowed so the pipe-liveness watchdog's re-arm is retried
+                instead of being recorded as a permanent failure.
         """
         try:
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._find_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
-            pane = window.active_pane
+            pane = self._find_active_pane(window, session_name, window_name)
             if pane:
                 pane.cmd("pipe-pane", "-o", f"cat >> {shlex.quote(str(file_path))}")
                 logger.info(f"Started pipe-pane for {session_name}:{window_name} to {file_path}")
@@ -731,17 +1080,21 @@ class TmuxClient:
         Args:
             session_name: Tmux session name
             window_name: Tmux window name
+
+        Raises:
+            ValueError: The session or window is genuinely gone.
+            TmuxLookupError: The tmux listing could not be parsed.
         """
         try:
-            session = self.server.sessions.get(session_name=session_name)
+            session = self._find_session(session_name)
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window = session.windows.get(window_name=window_name)
+            window = self._find_window(session, session_name, window_name)
             if not window:
                 raise ValueError(f"Window '{window_name}' not found in session '{session_name}'")
 
-            pane = window.active_pane
+            pane = self._find_active_pane(window, session_name, window_name)
             if pane:
                 pane.cmd("pipe-pane")
                 logger.info(f"Stopped pipe-pane for {session_name}:{window_name}")

--- a/test/clients/test_tmux_lookup_error.py
+++ b/test/clients/test_tmux_lookup_error.py
@@ -1,0 +1,397 @@
+"""Tests for the libtmux listing boundary in TmuxClient (no real tmux required).
+
+Covers the `libtmux.neo.parse_output` failure mode: libtmux >= 0.53.1 zips a fixed
+125-name format list against a row's values with ``strict=True``, so any row
+short of 125 values raises ``ValueError('zip() argument 2 is shorter than
+argument 1')`` instead of degrading. A pane/session vanishing mid-listing does
+exactly that, and it used to surface as a raw ValueError — indistinguishable
+from this module's own "session not found" ValueError, and fatal to launches
+and to the FIFO pipe-liveness watchdog.
+"""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.clients.tmux import TmuxClient, TmuxLookupError
+
+# The exact message CPython's strict zip produces, i.e. what libtmux's
+# parse_output raises for a one-field-short row.
+ZIP_ERROR = "zip() argument 2 is shorter than argument 1"
+
+
+@pytest.fixture
+def tmux():
+    """Create a TmuxClient with a mocked libtmux.Server."""
+    with patch("cli_agent_orchestrator.clients.tmux.libtmux") as mock_libtmux:
+        mock_server = MagicMock()
+        mock_libtmux.Server.return_value = mock_server
+        client = TmuxClient()
+        client.server = mock_server
+        yield client
+
+
+def parse_failure(*, times: int, then=None):
+    """side_effect that raises the strict-zip ValueError ``times`` times."""
+    return [ValueError(ZIP_ERROR)] * times + ([then] if then is not None else [])
+
+
+def make_window(pane=None):
+    window = MagicMock()
+    if pane is not None:
+        window.active_pane = pane
+        window.panes = [pane]
+    return window
+
+
+# ── upstream behavior this module wraps ──────────────────────────────
+
+
+class TestUpstreamParseOutput:
+    """Pin the real libtmux failure, when the installed libtmux has that path.
+
+    Gated on ``parse_output``'s own source rather than on a version number: the
+    strict zip landed in 0.53.1, the whole ``parse_output`` /
+    ``get_output_format`` pair does not exist before 0.53.1, and
+    ``get_output_format`` grew parameters after it. The pinned dependency range
+    resolves a non-strict libtmux, so this normally skips — the wrapper itself
+    is exercised against a simulated failure by every other test in this file.
+    It exists so raising the bound over a still-broken release fails loudly here.
+    """
+
+    def test_one_field_short_row_raises_value_error(self):
+        neo = pytest.importorskip("libtmux.neo")
+        parse_output = getattr(neo, "parse_output", None)
+        get_output_format = getattr(neo, "get_output_format", None)
+        if parse_output is None or get_output_format is None:
+            pytest.skip("this libtmux predates the neo.parse_output listing parser")
+        if "strict=True" not in inspect.getsource(parse_output):
+            pytest.skip("this libtmux zips non-strict: parse_output degrades instead of raising")
+
+        # Every affected signature defaults to (list-panes, tmux 3.2a) and
+        # 0.53.1's takes no arguments at all, so call with none for portability.
+        separator = neo.FORMAT_SEPARATOR
+        formats, _ = get_output_format()
+
+        # A full-width row parses; one field short raises instead of degrading.
+        parse_output(separator.join(["x"] * len(formats)) + separator)
+        with pytest.raises(ValueError, match="shorter than"):
+            parse_output(separator.join(["x"] * (len(formats) - 1)) + separator)
+
+
+# ── _read_listing: retry once, then classify ─────────────────────────
+
+
+class TestReadListing:
+    def test_retries_once_and_succeeds(self):
+        read = MagicMock(side_effect=parse_failure(times=1, then="ok"))
+
+        assert TmuxClient._read_listing("list-panes", read) == "ok"
+        assert read.call_count == 2
+
+    def test_no_retry_when_first_read_succeeds(self):
+        read = MagicMock(return_value="ok")
+
+        assert TmuxClient._read_listing("list-panes", read) == "ok"
+        assert read.call_count == 1
+
+    def test_raises_lookup_error_after_second_failure(self):
+        read = MagicMock(side_effect=parse_failure(times=2))
+
+        with pytest.raises(TmuxLookupError) as excinfo:
+            TmuxClient._read_listing("list-panes", read)
+
+        # Bounded: exactly two attempts, never an unbounded loop.
+        assert read.call_count == 2
+        assert ZIP_ERROR in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, ValueError)
+
+    def test_lookup_error_is_not_a_value_error(self):
+        """The whole point: `except ValueError` for "not found" must not catch it."""
+        assert not issubclass(TmuxLookupError, ValueError)
+        assert issubclass(TmuxLookupError, RuntimeError)
+
+
+# ── get_history: the watchdog / status-polling hot path ──────────────
+
+
+class TestGetHistoryParseFailure:
+    def _wire(self, tmux, session_side_effect):
+        pane = MagicMock()
+        pane.cmd.return_value = MagicMock(stdout=["line one", "line two"])
+        window = make_window(pane)
+        session = MagicMock()
+        session.windows.get.return_value = window
+        tmux.server.sessions.get.side_effect = session_side_effect(session)
+        return pane
+
+    def test_one_field_short_row_does_not_abort_the_call(self, tmux):
+        """A transient parse failure retries and the probe still returns content."""
+        self._wire(tmux, lambda session: parse_failure(times=1, then=session))
+
+        assert tmux.get_history("ses", "win") == "line one\nline two"
+        assert tmux.server.sessions.get.call_count == 2
+
+    def test_persistent_parse_failure_raises_lookup_error(self, tmux):
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with pytest.raises(TmuxLookupError):
+            tmux.get_history("ses", "win")
+
+    def test_parse_failure_in_pane_listing_raises_lookup_error(self, tmux):
+        """`window.panes` is a listing too — not just `sessions`/`windows`."""
+        window = MagicMock()
+        type(window).panes = property(lambda self: (_ for _ in ()).throw(ValueError(ZIP_ERROR)))
+        session = MagicMock()
+        session.windows.get.return_value = window
+        tmux.server.sessions.get.return_value = session
+
+        with pytest.raises(TmuxLookupError):
+            tmux.get_history("ses", "win")
+
+
+# ── criterion 3: gone vs. could-not-look are distinguishable ─────────
+
+
+class TestGenuineAbsenceVersusParseFailure:
+    """Both outcomes pinned: a caller can always tell them apart."""
+
+    def test_missing_session_raises_plain_value_error(self, tmux):
+        tmux.server.sessions.get.return_value = None
+
+        with pytest.raises(ValueError, match="Session 'ses' not found") as excinfo:
+            tmux.get_history("ses", "win")
+        assert not isinstance(excinfo.value, TmuxLookupError)
+
+    def test_missing_window_raises_plain_value_error(self, tmux):
+        session = MagicMock()
+        session.windows.get.return_value = None
+        tmux.server.sessions.get.return_value = session
+
+        with pytest.raises(ValueError, match="Window 'win' not found") as excinfo:
+            tmux.get_history("ses", "win")
+        assert not isinstance(excinfo.value, TmuxLookupError)
+
+    def test_parse_failure_raises_lookup_error_not_value_error(self, tmux):
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with pytest.raises(TmuxLookupError) as excinfo:
+            tmux.get_history("ses", "win")
+        assert not isinstance(excinfo.value, ValueError)
+
+
+# ── session_exists: must never answer "gone" on a parse failure ──────
+
+
+class TestSessionExistsParseFailure:
+    def test_retry_recovers_without_touching_the_cli(self, tmux):
+        session = MagicMock()
+        tmux.server.sessions.get.side_effect = parse_failure(times=1, then=session)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            assert tmux.session_exists("ses") is True
+        mock_subprocess.run.assert_not_called()
+
+    def test_falls_back_to_has_session_for_a_live_session(self, tmux):
+        """The bug's worst answer: reporting a LIVE session as gone."""
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0, stderr="")
+            assert tmux.session_exists("ses") is True
+
+        assert mock_subprocess.run.call_args[0][0] == [
+            "tmux",
+            "has-session",
+            "-t",
+            "=ses",
+        ]
+
+    def test_falls_back_to_has_session_for_a_dead_session(self, tmux):
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=1, stderr="can't find session")
+            assert tmux.session_exists("ses") is False
+
+    def test_raises_when_neither_path_can_answer(self, tmux):
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.side_effect = OSError("no tmux binary")
+            with pytest.raises(TmuxLookupError):
+                tmux.session_exists("ses")
+
+    def test_unrelated_failure_still_returns_false(self, tmux):
+        """Pre-existing behavior for non-parse errors is unchanged."""
+        tmux.server.sessions.get.side_effect = RuntimeError("boom")
+
+        assert tmux.session_exists("ses") is False
+
+
+# ── criterion 4: no half-state left behind by a failed launch ────────
+
+
+class TestCreateSessionHalfState:
+    def test_parse_failure_in_new_session_removes_the_partial_session(self, tmux, tmp_path):
+        """tmux may have created the session before libtmux failed to parse it.
+
+        `launch_session` only learns a session was created once create_session
+        RETURNS, so its own rollback never fires here — without this cleanup the
+        retry is blocked by "Session already exists" with a dead pane.
+        """
+        tmux.server.new_session.side_effect = ValueError(ZIP_ERROR)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0, stderr="")
+            with pytest.raises(TmuxLookupError):
+                tmux.create_session("ses", "win", "tid1", str(tmp_path))
+
+        assert mock_subprocess.run.call_args[0][0] == [
+            "tmux",
+            "kill-session",
+            "-t",
+            "=ses",
+        ]
+
+    def test_parse_failure_reading_the_new_window_removes_the_session(self, tmux, tmp_path):
+        session = MagicMock()
+        type(session).windows = property(lambda self: (_ for _ in ()).throw(ValueError(ZIP_ERROR)))
+        tmux.server.new_session.return_value = session
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0, stderr="")
+            with pytest.raises(TmuxLookupError):
+                tmux.create_session("ses", "win", "tid1", str(tmp_path))
+
+        assert mock_subprocess.run.call_args[0][0] == [
+            "tmux",
+            "kill-session",
+            "-t",
+            "=ses",
+        ]
+
+    def test_transient_parse_failure_reading_the_new_window_still_succeeds(self, tmux, tmp_path):
+        window = MagicMock()
+        window.name = "win"
+        session = MagicMock()
+        windows = MagicMock()
+        windows.__getitem__.side_effect = [ValueError(ZIP_ERROR), window]
+        session.windows = windows
+        tmux.server.new_session.return_value = session
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            assert tmux.create_session("ses", "win", "tid1", str(tmp_path)) == "win"
+        mock_subprocess.run.assert_not_called()
+
+    def test_other_post_creation_failure_rolls_the_session_back(self, tmux, tmp_path):
+        """A None window name is not the parse bug, but still orphans a session."""
+        window = MagicMock()
+        window.name = None
+        session = MagicMock()
+        session.windows = [window]
+        tmux.server.new_session.return_value = session
+
+        with pytest.raises(ValueError, match="Window name is None"):
+            tmux.create_session("ses", "win", "tid1", str(tmp_path))
+
+        session.kill.assert_called_once()
+
+
+# ── kill paths: "could not look" is not "nothing to kill" ────────────
+
+
+class TestKillParseFailure:
+    def test_kill_session_falls_back_to_the_cli(self, tmux):
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0, stderr="")
+            assert tmux.kill_session("ses") is True
+
+        assert mock_subprocess.run.call_args[0][0] == [
+            "tmux",
+            "kill-session",
+            "-t",
+            "=ses",
+        ]
+
+    def test_kill_session_reports_absence_without_calling_the_cli(self, tmux):
+        tmux.server.sessions.get.return_value = None
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            assert tmux.kill_session("ses") is False
+        mock_subprocess.run.assert_not_called()
+
+    def test_kill_window_falls_back_to_the_cli(self, tmux):
+        session = MagicMock()
+        session.windows.get.side_effect = parse_failure(times=2)
+        tmux.server.sessions.get.return_value = session
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0, stderr="")
+            assert tmux.kill_window("ses", "win") is True
+
+        assert mock_subprocess.run.call_args[0][0] == [
+            "tmux",
+            "kill-window",
+            "-t",
+            "=ses:win",
+        ]
+
+    def test_cli_fallback_reports_failure_rather_than_success(self, tmux):
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=1, stderr="server not found")
+            assert tmux.kill_session("ses") is False
+
+    def test_cli_fallback_rejects_an_invalid_name(self, tmux):
+        tmux.server.sessions.get.side_effect = parse_failure(times=2)
+
+        with patch("cli_agent_orchestrator.clients.tmux.subprocess") as mock_subprocess:
+            assert tmux.kill_session("bad:name") is False
+        mock_subprocess.run.assert_not_called()
+
+
+# ── listing methods must not degrade to "empty" ──────────────────────
+
+
+class TestListingsDoNotDegradeToEmpty:
+    def test_list_sessions_raises_instead_of_returning_empty(self, tmux):
+        type(tmux.server).sessions = property(
+            lambda self: (_ for _ in ()).throw(ValueError(ZIP_ERROR))
+        )
+
+        with pytest.raises(TmuxLookupError):
+            tmux.list_sessions()
+
+    def test_list_sessions_retry_recovers(self, tmux):
+        session = MagicMock()
+        session.name = "ses"
+        session.attached_sessions = []
+        calls = {"n": 0}
+
+        def sessions(_self):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ValueError(ZIP_ERROR)
+            return [session]
+
+        type(tmux.server).sessions = property(sessions)
+
+        assert tmux.list_sessions() == [{"id": "ses", "name": "ses", "status": "detached"}]
+
+    def test_get_session_windows_raises_instead_of_returning_empty(self, tmux):
+        session = MagicMock()
+        type(session).windows = property(lambda self: (_ for _ in ()).throw(ValueError(ZIP_ERROR)))
+        tmux.server.sessions.get.return_value = session
+
+        with pytest.raises(TmuxLookupError):
+            tmux.get_session_windows("ses")
+
+    def test_get_session_windows_returns_empty_for_a_missing_session(self, tmux):
+        tmux.server.sessions.get.return_value = None
+
+        assert tmux.get_session_windows("ses") == []

--- a/uv.lock
+++ b/uv.lock
@@ -432,7 +432,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.14.0,<4.0.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jsonschema", specifier = ">=4.25" },
-    { name = "libtmux", specifier = ">=0.51.0" },
+    { name = "libtmux", specifier = ">=0.51.0,<0.53.1" },
     { name = "markdown-it-py", specifier = ">=4.0.0" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27.0" },


### PR DESCRIPTION
## Problem

libtmux 0.53.1+ builds `neo.parse_output`'s field map with `dict(zip(formats, values, strict=True))`, where `formats` has 125 entries. Any row yielding fewer values — a pane or session disappearing mid-listing, or trailing fields tmux omits — raises `ValueError: zip() argument 2 is shorter than argument 1` instead of degrading.

That propagates through `server.sessions` / `window.panes` and takes down CAO's tmux listing. Three concrete harms:

1. **It blocks launches.** `launch_session` fails outright with the raw zip error.
2. **It leaves a half-created session.** `create_session` reads `session.windows[0].name` *after* `server.new_session()` has already created the session, so a parse failure raises before `session_created = True` is set and the rollback `kill_session` never runs — leaving a registered tmux session with a dead pane. Retrying the same name is then rejected with "Session already exists". `kill_session` also swallowed the parse failure, so even a rollback that did fire could silently fail.
3. **It corrupts the completion signal, because the sentinel is overloaded.** `clients/tmux.py` already raises `ValueError` for genuinely-missing sessions, so a caller cannot distinguish "session gone" from "libtmux failed to parse a transient listing". The pipe-liveness watchdog (`fifo_reader._check_pipe_liveness` → `terminal_service._probe_pane` → `tmux_backend.get_history`) reads a transient parse failure as a definite answer.

Observed at scale on one host: **1201 occurrences across 164 sessions**, from several concurrent clients. It is a race, so it worsens under load — seen at load average 26–86 with 17–18 live tmux sessions.

## Fix

A single boundary wrapper, `TmuxClient._read_listing(description, read)`:

- run the listing read; on `ValueError`, log, pause 50 ms, and retry **once**
- on a second failure, raise `TmuxLookupError(RuntimeError)` chained from the original

The retry pause is deliberately small: `get_history()` is called from the watchdog loop, which must not stall.

`_read_listing` classifies *any* `ValueError` escaping the callable as a parse failure rather than matching on CPython's `zip()` message text, which is not part of any contract. That is sound because the callable contains nothing but libtmux attribute access — callers raise their own "not found" `ValueError`s outside it. The invariant is documented at the wrapper.

Also fixed: `create_session` now cleans up the tmux session it created before the failing read, so a relaunch of the same name is not blocked; and `kill_session` no longer reports "could not look" as `False`.

## The `libtmux<0.53.1` cap — happy to drop this if you'd prefer

I scanned every patch release from 0.50.0 to 0.62.0 by downloading the wheel and grepping `libtmux/neo.py`:

| versions | zip call |
|---|---|
| 0.50.0 – 0.53.0 | `strict=False` — degrades, no bug |
| 0.53.1 – 0.62.0 | `strict=True` — the bug |

So there is no working release above 0.53.0 to admit, and the previous `>=0.51.0` had no ceiling, which is how this arrived silently.

**The wrapper is the actual fix and works on any libtmux** — the cap only stops the bug reaching machines that haven't hit it yet. If you'd rather not carry an upper bound, say so and I'll drop it; the fix stands without it. Worth filing upstream that `parse_output` should zip non-strict or pad.

## Tests

New `test/clients/test_tmux_lookup_error.py` — 28 passed, 1 skipped. Covers a one-field-short row, retry-then-succeed, retry-then-fail, and that a genuine "not found" stays a `ValueError`.

`test/clients/`: 216 passed, 1 skipped. On `test/clients/ + test/services/` this branch gives 43 failed / 2186 passed against 43 failed / 2158 passed on plain `main` — identical failure count (all pre-existing, `ag-ui-protocol` not installed in my env), +28 passing. black/isort clean.
