### PR TITLE
fix(kiro): auto-answer --trust-all-tools startup consent dialog

### DIFF
--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -346,11 +346,10 @@ class KiroCliProvider(BaseProvider):
         # Step 3: Wait for Kiro CLI to fully initialize and show the agent prompt.
         # Accept both IDLE and COMPLETED — some CLI versions show a startup
         # message that get_status() interprets as a completed response.
-        if not await wait_until_status(
-            self.terminal_id,
-            {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=float(get_server_settings()["provider_init_timeout"]),
-        ):
+        # _wait_ready_accepting_trust_dialog also auto-answers the
+        # --trust-all-tools startup consent dialog (see its docstring), which
+        # kiro-cli >= 2.1 shows in the default TUI *and* under --legacy-ui.
+        if not await self._wait_ready_accepting_trust_dialog():
             if yolo:
                 # Yolo already launched with --legacy-ui; no further fallback.
                 raise TimeoutError("Kiro CLI initialization timed out with --legacy-ui (yolo mode)")
@@ -378,15 +377,71 @@ class KiroCliProvider(BaseProvider):
             legacy_command = shlex.join(legacy_args)
             status_monitor.notify_input_sent(self.terminal_id)
             get_backend().send_keys(self.session_name, self.window_name, legacy_command)
-            if not await wait_until_status(
-                self.terminal_id,
-                {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-                timeout=float(get_server_settings()["provider_init_timeout"]),
-            ):
+            if not await self._wait_ready_accepting_trust_dialog():
                 raise TimeoutError("Kiro CLI initialization timed out with TUI and `--legacy-ui`")
 
         self._initialized = True
         return True
+
+    async def _wait_ready_accepting_trust_dialog(self) -> bool:
+        """Wait for the agent prompt, auto-answering the trust-all-tools dialog.
+
+        CAO always launches kiro-cli with ``--trust-all-tools`` (there is no
+        human at the terminal to answer per-tool permission prompts in headless
+        orchestration; CAO enforces tool scoping at its own profile/MCP layers).
+        Since kiro-cli 2.1, ``--trust-all-tools`` opens a one-time startup
+        consent dialog *before* the chat prompt is interactive:
+
+            ❯ No, exit
+              Yes, I accept
+              Yes, and don't ask again
+
+        The default TUI shows this dialog on kiro-cli 2.16.1 (verified), so the
+        earlier "force --legacy-ui to skip it" workaround no longer helps and
+        init just times out on the dialog. This helper is applied to the
+        ``--legacy-ui`` fallback path too, so if a kiro build shows the dialog
+        there as well it is handled without a version check. get_status()
+        already classifies the dialog as WAITING_USER_ANSWER, so here we wait
+        for that alongside IDLE/COMPLETED and, when it appears, select
+        **"Yes, I accept"** (Down, Enter) — the one-line-down option.
+        We deliberately do NOT pick "Yes, and don't ask again", which would
+        persist a trust-all-tools bypass into the user's kiro config; CAO's
+        acceptance is scoped to this ephemeral session only.
+
+        Returns:
+            True if the terminal reached IDLE or COMPLETED (dialog answered if
+            it was shown), False if it timed out before becoming ready.
+        """
+        init_timeout = float(get_server_settings()["provider_init_timeout"])
+        from cli_agent_orchestrator.services.status_monitor import status_monitor
+
+        ready = await wait_until_status(
+            self.terminal_id,
+            {
+                TerminalStatus.IDLE,
+                TerminalStatus.COMPLETED,
+                TerminalStatus.WAITING_USER_ANSWER,
+            },
+            timeout=init_timeout,
+        )
+        if not ready:
+            return False
+        if status_monitor.get_status(self.terminal_id) != TerminalStatus.WAITING_USER_ANSWER:
+            return True
+
+        # Trust-all-tools consent dialog is up: select "Yes, I accept".
+        logger.info(
+            "kiro_cli: answering --trust-all-tools startup consent dialog "
+            "with 'Yes, I accept' (session-scoped)"
+        )
+        backend = get_backend()
+        backend.send_special_key(self.session_name, self.window_name, "Down")
+        backend.send_special_key(self.session_name, self.window_name, "Enter")
+        return await wait_until_status(
+            self.terminal_id,
+            {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+            timeout=init_timeout,
+        )
 
     def get_status(self, output: str) -> TerminalStatus:
         """Get Kiro CLI status by analyzing terminal output.

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -136,6 +136,17 @@ TUI_PERMISSION_PATTERN = (
 # Must be anchored to bottom screen region (see get_status WAITING check) to avoid stale matches.
 TUI_TRUST_ALL_TOOLS_FOOTER = r"esc to cancel · ↑↓ to navigate · ↵ to select"
 
+# Distinctive consent-dialog body text. TUI_TRUST_ALL_TOOLS_FOOTER above is
+# kiro's GENERIC list-selector chrome — an update/login/onboarding selector
+# renders it identically — so before answering we require this trust-specific
+# line, and require the ❯ cursor to sit on "No, exit" so Down lands on
+# "Yes, I accept" (not "Yes, and don't ask again"). Anything else fails closed.
+TUI_TRUST_ALL_TOOLS_BODY = r"Kiro is running in trust all tools mode"
+TUI_TRUST_ALL_TOOLS_CURSOR = r"❯\s*No, exit"
+
+# Bottom pane lines scanned for the consent dialog (mirrors codex's window).
+STARTUP_PROMPT_BOTTOM_LINES = 15
+
 # =============================================================================
 # Error Detection
 # =============================================================================
@@ -402,16 +413,18 @@ class KiroCliProvider(BaseProvider):
         init just times out on the dialog. This helper is applied to the
         ``--legacy-ui`` fallback path too, so if a kiro build shows the dialog
         there as well it is handled without a version check. get_status()
-        already classifies the dialog as WAITING_USER_ANSWER, so here we wait
-        for that alongside IDLE/COMPLETED and, when it appears, select
-        **"Yes, I accept"** (Down, Enter) — the one-line-down option.
-        We deliberately do NOT pick "Yes, and don't ask again", which would
-        persist a trust-all-tools bypass into the user's kiro config; CAO's
-        acceptance is scoped to this ephemeral session only.
+        classifies the dialog as WAITING_USER_ANSWER off generic selector
+        chrome, so before answering we VERIFY the dialog body and the ❯ cursor
+        line (fail closed on anything else), then select **"Yes, I accept"**
+        (Down, Enter) — the one-line-down option. We deliberately do NOT pick
+        "Yes, and don't ask again", which would persist a trust-all-tools
+        bypass into the user's kiro config; CAO's acceptance is scoped to this
+        ephemeral session only.
 
         Returns:
             True if the terminal reached IDLE or COMPLETED (dialog answered if
-            it was shown), False if it timed out before becoming ready.
+            it was verified and shown), False if it timed out or a
+            WAITING_USER_ANSWER could not be verified as the consent dialog.
         """
         init_timeout = float(get_server_settings()["provider_init_timeout"])
         from cli_agent_orchestrator.services.status_monitor import status_monitor
@@ -428,15 +441,41 @@ class KiroCliProvider(BaseProvider):
         )
         if not ready:
             return False
+        # Ready-flap window: wait_until_status returned on WAITING_USER_ANSWER,
+        # but get_status is re-read here rather than trusted from the wait. If it
+        # has since flapped to IDLE/COMPLETED, treat the terminal as ready and do
+        # NOT send dialog keys (a blind Down+Enter into a live prompt would be a
+        # stray message). Low probability given the sticky latch, but explicit.
         if status_monitor.get_status(self.terminal_id) != TerminalStatus.WAITING_USER_ANSWER:
             return True
 
-        # Trust-all-tools consent dialog is up: select "Yes, I accept".
+        # WAITING_USER_ANSWER is classified from TUI_TRUST_ALL_TOOLS_FOOTER,
+        # which is kiro's GENERIC list-selector chrome. Verify the dialog BODY
+        # and the ❯ cursor position before answering — a blind Down+Enter on
+        # some other startup selector would pick an arbitrary option. Same
+        # fail-closed shape as codex's directory-trust check. On any mismatch,
+        # fall through to the normal timeout/fallback path.
+        backend = get_backend()
+        pane = strip_terminal_escapes(
+            re.sub(ANSI_CODE_PATTERN, "", backend.get_history(self.session_name, self.window_name))
+        )
+        bottom = "\n".join(pane.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        if not (
+            re.search(TUI_TRUST_ALL_TOOLS_BODY, bottom)
+            and re.search(TUI_TRUST_ALL_TOOLS_CURSOR, bottom)
+        ):
+            logger.warning(
+                "kiro_cli: WAITING_USER_ANSWER but the trust-all-tools consent "
+                "dialog (body + '❯ No, exit') was not verified; not answering"
+            )
+            return False
+
+        # Verified consent dialog: cursor on "No, exit", so Down lands on
+        # "Yes, I accept" (session-scoped — NOT "Yes, and don't ask again").
         logger.info(
             "kiro_cli: answering --trust-all-tools startup consent dialog "
             "with 'Yes, I accept' (session-scoped)"
         )
-        backend = get_backend()
         # Arm the PROCESSING latch before the keystrokes, like every other
         # send_special_key path, so answering the dialog isn't blocked by the
         # WAITING_USER_ANSWER we just observed.

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -20,6 +20,7 @@ The provider detects the following terminal states:
 import logging
 import re
 import shlex
+import time
 from typing import Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
@@ -415,6 +416,7 @@ class KiroCliProvider(BaseProvider):
         init_timeout = float(get_server_settings()["provider_init_timeout"])
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
+        start = time.monotonic()
         ready = await wait_until_status(
             self.terminal_id,
             {
@@ -435,12 +437,19 @@ class KiroCliProvider(BaseProvider):
             "with 'Yes, I accept' (session-scoped)"
         )
         backend = get_backend()
+        # Arm the PROCESSING latch before the keystrokes, like every other
+        # send_special_key path, so answering the dialog isn't blocked by the
+        # WAITING_USER_ANSWER we just observed.
+        status_monitor.notify_input_sent(self.terminal_id)
         backend.send_special_key(self.session_name, self.window_name, "Down")
         backend.send_special_key(self.session_name, self.window_name, "Enter")
+        # Bound the post-accept wait by the time already spent, so total startup
+        # stays within provider_init_timeout rather than up to 2x it.
+        remaining = max(0.0, init_timeout - (time.monotonic() - start))
         return await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-            timeout=init_timeout,
+            timeout=remaining,
         )
 
     def get_status(self, output: str) -> TerminalStatus:

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -19,6 +19,11 @@ def load_fixture(filename: str) -> str:
         return f.read()
 
 
+# Real active trust-all-tools consent dialog (body + '❯ No, exit' + footer),
+# used to satisfy the provider's verify-before-answer check.
+_TRUST_DIALOG_PANE = load_fixture("kiro_trust_all_tools_dialog_active.txt")
+
+
 class TestKiroCliProviderInitialization:
     """Test Kiro CLI provider initialization."""
 
@@ -296,6 +301,8 @@ class TestKiroCliProviderInitialization:
         # (after we answer) resolves to the prompt.
         mock_wait_status.side_effect = [True, True]
         mock_status_monitor.get_status.return_value = TerminalStatus.WAITING_USER_ANSWER
+        # The dialog must be VERIFIED from pane content before answering.
+        mock_tmux.return_value.get_history.return_value = _TRUST_DIALOG_PANE
         mock_load_profile.side_effect = FileNotFoundError("no profile")
 
         provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
@@ -309,6 +316,73 @@ class TestKiroCliProviderInitialization:
         assert special_keys == ["Down", "Enter"]
         # The PROCESSING latch must be armed before answering the dialog.
         mock_status_monitor.notify_input_sent.assert_called_with("test1234")
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.status_monitor.status_monitor")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
+    async def test_initialize_waiting_but_not_consent_dialog_fails_closed(
+        self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile, mock_status_monitor
+    ):
+        """A non-consent selector reported as WAITING_USER_ANSWER is NOT answered.
+
+        WAITING_USER_ANSWER is classified from kiro's generic list-selector
+        chrome, so any other startup selector (update/login/onboarding) would
+        share it. The pane content lacks the consent body + '❯ No, exit', so the
+        provider must send no keys and fall into the timeout/fallback path.
+        """
+        mock_wait_shell.return_value = True
+        # WAITING on first wait; the --legacy-ui fallback then times out too.
+        mock_wait_status.side_effect = [True, False]
+        mock_status_monitor.get_status.return_value = TerminalStatus.WAITING_USER_ANSWER
+        mock_tmux.return_value.get_history.return_value = (
+            "Update available! 2.16 -> 2.17\n❯ 1. Update now\n  2. Later\n"
+            "esc to cancel · ↑↓ to navigate · ↵ to select\n"
+        )
+        mock_load_profile.side_effect = FileNotFoundError("no profile")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        with pytest.raises(TimeoutError):
+            await provider.initialize()
+
+        # The unverified selector must never receive dialog keystrokes.
+        mock_tmux.return_value.send_special_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.status_monitor.status_monitor")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
+    async def test_initialize_dialog_answered_but_prompt_times_out_falls_back(
+        self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile, mock_status_monitor
+    ):
+        """Answering the dialog but never reaching the prompt triggers --legacy-ui.
+
+        First wait → WAITING (verified, answered); second (post-accept) wait
+        times out; the --legacy-ui relaunch's wait then succeeds.
+        """
+        mock_wait_shell.return_value = True
+        # main: WAITING (answered) → post-accept times out; legacy relaunch: IDLE.
+        mock_wait_status.side_effect = [True, False, True]
+        mock_status_monitor.get_status.side_effect = [
+            TerminalStatus.WAITING_USER_ANSWER,
+            TerminalStatus.IDLE,
+        ]
+        mock_tmux.return_value.get_history.return_value = _TRUST_DIALOG_PANE
+        mock_load_profile.side_effect = FileNotFoundError("no profile")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        result = await provider.initialize()
+
+        assert result is True
+        # Dialog answered (Down+Enter), then /exit + --legacy-ui relaunch.
+        special_keys = [c.args[2] for c in mock_tmux.return_value.send_special_key.call_args_list]
+        assert special_keys[:2] == ["Down", "Enter"]
+        commands = [c.args[2] for c in mock_tmux.return_value.send_keys.call_args_list]
+        assert "--legacy-ui" in commands[-1]
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.status_monitor.status_monitor")

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -275,6 +275,60 @@ class TestKiroCliProviderInitialization:
             "--model claude-opus-4.6 --agent developer",
         )
 
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.status_monitor.status_monitor")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
+    async def test_initialize_answers_trust_all_tools_dialog(
+        self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile, mock_status_monitor
+    ):
+        """--trust-all-tools startup dialog is auto-answered with 'Yes, I accept'.
+
+        kiro-cli >= 2.1 shows a consent dialog before the chat prompt. The
+        provider must detect WAITING_USER_ANSWER, send Down+Enter (select the
+        one-line-down 'Yes, I accept' option, NOT 'Yes, and don't ask again'),
+        then wait again for the prompt — without falling back to --legacy-ui.
+        """
+        mock_wait_shell.return_value = True
+        # First wait resolves to WAITING_USER_ANSWER (dialog up); second wait
+        # (after we answer) resolves to the prompt.
+        mock_wait_status.side_effect = [True, True]
+        mock_status_monitor.get_status.return_value = TerminalStatus.WAITING_USER_ANSWER
+        mock_load_profile.side_effect = FileNotFoundError("no profile")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        result = await provider.initialize()
+
+        assert result is True
+        # Exactly one launch — the dialog is answered in place, no /exit + relaunch.
+        assert mock_tmux.return_value.send_keys.call_count == 1
+        # "Yes, I accept" = one Down then Enter (two special keys total).
+        special_keys = [c.args[2] for c in mock_tmux.return_value.send_special_key.call_args_list]
+        assert special_keys == ["Down", "Enter"]
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.status_monitor.status_monitor")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.load_agent_profile")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.kiro_cli.get_backend")
+    async def test_initialize_no_dialog_sends_no_special_keys(
+        self, mock_tmux, mock_wait_status, mock_wait_shell, mock_load_profile, mock_status_monitor
+    ):
+        """When the terminal reaches IDLE directly, no dialog keys are sent."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_status_monitor.get_status.return_value = TerminalStatus.IDLE
+        mock_load_profile.side_effect = FileNotFoundError("no profile")
+
+        provider = KiroCliProvider("test1234", "test-session", "window-0", "developer")
+        result = await provider.initialize()
+
+        assert result is True
+        mock_tmux.return_value.send_special_key.assert_not_called()
+
     def test_initialization_with_different_agent_profiles(self):
         """Test initialization with various agent profile names."""
         test_profiles = ["developer", "code-reviewer", "test_agent", "agent123"]

--- a/test/providers/test_kiro_cli_unit.py
+++ b/test/providers/test_kiro_cli_unit.py
@@ -307,6 +307,8 @@ class TestKiroCliProviderInitialization:
         # "Yes, I accept" = one Down then Enter (two special keys total).
         special_keys = [c.args[2] for c in mock_tmux.return_value.send_special_key.call_args_list]
         assert special_keys == ["Down", "Enter"]
+        # The PROCESSING latch must be armed before answering the dialog.
+        mock_status_monitor.notify_input_sent.assert_called_with("test1234")
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.status_monitor.status_monitor")


### PR DESCRIPTION
## Problem

Launching a kiro-cli supervisor hangs and the client reports:

```
Error: Failed to connect to cao-server: HTTPConnectionPool(host='127.0.0.1', port=9889): Read timed out.
```

with the server log repeating:

```
wait_until_status [...]: timeout waiting for {idle, completed}
Kiro CLI TUI initialization timed out, retrying with --legacy-ui
... Failed to create terminal: Kiro CLI initialization timed out with TUI and `--legacy-ui`
```

### Root cause

CAO always launches kiro-cli with `--trust-all-tools` (headless orchestration has no human to answer per-tool permission prompts; CAO enforces tool scoping at its own profile/MCP allowlist layers). Since **kiro-cli 2.1**, that flag opens a one-time consent dialog *before* the chat prompt becomes interactive:

```
❯ No, exit
  Yes, I accept
  Yes, and don't ask again
```

`initialize()` only waited for `{IDLE, COMPLETED}`, so it sat on this dialog until `provider_init_timeout` elapsed. The existing "force `--legacy-ui` to skip the dialog" workaround was written for kiro-cli **2.0.1** and no longer helps — on **2.16.1** the dialog shows in the default TUI as well (reproduced directly).

Note this fires even for non-`--yolo`, restricted-tool launches (e.g. `--auto-approve` with `@cao-mcp-server, fs_read, fs_list`), because CAO passes `--trust-all-tools` on all kiro launches.

## Fix

`get_status()` classifies this dialog as `WAITING_USER_ANSWER`, so `initialize()` now waits for that state alongside `IDLE`/`COMPLETED`. When it appears, `_wait_ready_accepting_trust_dialog()`:

1. **Verifies the dialog before answering.** `WAITING_USER_ANSWER` is derived from kiro's generic list-selector chrome (`esc to cancel · ↑↓ to navigate · ↵ to select`), which an update/login/onboarding selector would share. So the pane is read and required to contain both the consent body (`Kiro is running in trust all tools mode`) and the cursor line (`❯ No, exit`). Anything else fails closed into the normal timeout/`--legacy-ui` path — never a blind keystroke on an unknown selector. Same shape as the codex directory-trust check.
2. **Answers session-scoped.** With the cursor pinned on `No, exit`, `Down`+`Enter` selects **"Yes, I accept"** — deliberately not "Yes, and don't ask again", which would persist a trust-all-tools bypass into the user's kiro config. The `PROCESSING` latch is armed first (`notify_input_sent`), matching every other `send_special_key` path.
3. **Bounds startup.** The post-accept wait uses the remaining init budget, so total startup stays within `provider_init_timeout` rather than up to 2×.

Applied to both the default-TUI launch and the `--legacy-ui` fallback.

## Verification

- **End-to-end** on kiro-cli 2.16.1: `cao launch --agents code_supervisor --auto-approve` now reaches idle in ~8s instead of timing out. Server log:
  ```
  wait_until_status [...]: waiting for {completed, idle, waiting_user_answer}
  status changed: waiting_user_answer
  kiro_cli: answering --trust-all-tools startup consent dialog with 'Yes, I accept' (session-scoped)
  wait_until_status [...]: waiting for {completed, idle}
  wait_until_status [...]: reached idle
  ```
- **Unit tests** added (against the real dialog fixture): verified-dialog accept path (`Down`+`Enter`, single launch, latch armed), no-dialog path (no keys sent), unverified-selector fail-closed path (no keys, times out), and answered-then-timeout `--legacy-ui` fallback.
- `pytest test/providers/ -m "not integration and not e2e"` → **1197 passed, 3 skipped, 1 xfailed**. `black`/`isort`/`mypy` clean.
