### PR TITLE
fix(tui): build the bundled binary on install, not only at release (#560)

### DIFF
--- a/scripts/hatch_build_tui_tag.py
+++ b/scripts/hatch_build_tui_tag.py
@@ -66,11 +66,27 @@ So the hook is inert unless it can see the staged binary. It also refuses to gue
 binary is present but the environment asked for a pure wheel (or vice versa), that
 disagreement is a hard error rather than a silent choice, because "silently produced the
 wrong tag" is the defect class this whole file exists to close. (#321)
+
+THE HOOK ALSO BUILDS THE BINARY, NOT JUST TAGS IT (#560)
+--------------------------------------------------------
+Tagging alone left a hole: the binary only ever reached a wheel via cibuildwheel's
+``before-build``, which runs at RELEASE time. Every source install — ``pip install .``,
+``pip install <sdist>``, ``uv tool install <git-url>`` — shipped no TUI, because the
+``artifacts`` glob matched nothing and hatchling treats that as a silent no-op. An operator
+installed from git and got "the TUI binary 'cao-tui' is not present in this installation".
+
+So ``autobuild_binary()`` runs ``scripts/build_tui.py build`` when no binary is staged, making
+a working ``cao tui`` a property of the BUILD rather than of the release pipeline. It degrades
+quietly — no cargo, or a failed compile, means a pure wheel and the existing clear message from
+``cao tui``, never a failed install. See that function's docstring for why None, not raise.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -93,6 +109,15 @@ CIBUILDWHEEL_ENV = "CIBUILDWHEEL"
 # Explicit local override, for building a platform wheel outside cibuildwheel (which is
 # how the macOS path was proven locally). "1"/"true"/"yes"/"on" enable it.
 FORCE_ENV = "CAO_TUI_PLATFORM_WHEEL"
+
+# Opt OUT of the automatic cargo build below. Set falsey to get the pre-#560 behaviour: the
+# binary is staged only by an explicit `python scripts/build_tui.py build`. Exists for a
+# build that must not spend time on cargo (or must not touch the network) even where a
+# toolchain is present.
+AUTOBUILD_ENV = "CAO_TUI_AUTOBUILD"
+
+# Relative to the project root — the staging script this hook shells out to.
+BUILD_SCRIPT_RELATIVE = "scripts/build_tui.py"
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -124,6 +149,94 @@ def staged_binaries(root: str) -> List[Path]:
     return sorted(p for p in package_dir.glob(f"{BINARY_STEM}*") if p.is_file())
 
 
+def autobuild_binary(root: str) -> Optional[Path]:
+    """Compile and stage the TUI binary at build time, or return None if that is not possible.
+
+    THIS IS WHAT MAKES ``cao tui`` WORK FROM A SOURCE INSTALL. (#560)
+
+    Before this existed, the binary reached the wheel by exactly ONE route: cibuildwheel's
+    ``before-build`` hook, which runs only in ``publish-to-pypi.yml`` at release time. Every
+    other path — ``pip install .``, ``pip install <sdist>``, ``uv tool install <git-url>`` —
+    produced a wheel with no binary, because the ``artifacts`` glob pointing at the staging
+    directory matched nothing and hatchling treats that as a SILENT no-op. Measured on a clean
+    clone of ``main``: ``uv build --wheel`` emitted ``py3-none-any`` with no ``cao-tui`` member,
+    and the operator only discovered it at ``cao tui`` time. An operator hit exactly this after
+    a ``uv tool install`` from git.
+
+    So the staging step moves from "something the release pipeline remembers to do" to
+    "something the build itself does". The sdist ships both ``scripts/build_tui.py`` and the
+    full ``tui/`` crate (verified in a real sdist), so this works from an unpacked sdist and
+    not just a git checkout.
+
+    RETURNS None RATHER THAN RAISING, AND THAT IS THE POINT
+    ------------------------------------------------------
+    A missing Rust toolchain must NOT fail the install. ``cao`` is a Python tool whose TUI is
+    one subcommand of many; a contributor with no cargo, and every existing CI job that builds
+    without Rust, must keep working. ``cli/commands/tui.py`` already degrades with a clear,
+    actionable operator message when the binary is absent, so the graceful path is genuinely
+    graceful rather than a silent hole. The caller therefore treats None as "no binary, build a
+    pure wheel" — the pre-existing behaviour, unchanged.
+
+    A cargo build that FAILS is treated the same way, deliberately: a compile error in the
+    crate should not make ``pip install cli-agent-orchestrator`` impossible. It prints cargo's
+    own output (this does not capture it), so the failure is visible in the build log rather
+    than swallowed.
+
+    NOT USED BY cibuildwheel, WHICH KEEPS ITS OWN EXPLICIT STEP
+    ----------------------------------------------------------
+    ``[tool.cibuildwheel] before-build`` still runs ``build_tui.py build`` itself, and must:
+    there a missing binary is a HARD error (``resolve_build_data`` raises), because a release
+    wheel silently missing its binary is the defect this whole file exists to close. This
+    function only fills the gap for builds nobody configured. It is a no-op when the binary is
+    already staged, so the two never fight.
+    """
+    if _env_flag(AUTOBUILD_ENV) is False:
+        print(f"{AUTOBUILD_ENV} is falsey — not building the TUI binary automatically")
+        return None
+
+    script = Path(root) / BUILD_SCRIPT_RELATIVE
+    if not script.is_file():
+        # A wheel built from a tree with no scripts/ (not a shape this repo produces, but
+        # cheap to survive) simply gets no TUI.
+        return None
+
+    # Checked HERE as well as inside build_tui.py so the common no-toolchain case prints one
+    # calm line instead of the script's error path. build_tui.py keeps its own check because
+    # it is also invoked directly, where failing loudly is correct.
+    if shutil.which("cargo") is None:
+        print(
+            "cargo not found — building without the bundled TUI binary. Everything except "
+            "`cao tui` works; install the Rust toolchain (https://rustup.rs) and reinstall "
+            "to enable it."
+        )
+        return None
+
+    print(f"building the TUI binary ({script.name} build) — this needs cargo and may take a minute")
+    try:
+        result = subprocess.run([sys.executable, str(script), "build"], cwd=root, check=False)
+    except OSError as exc:
+        print(f"could not run {script}: {exc} — building without the bundled TUI binary")
+        return None
+
+    if result.returncode != 0:
+        # Loud but non-fatal: cargo's own diagnostics already went to the build log.
+        print(
+            f"{script.name} build failed (exit {result.returncode}) — building without the "
+            "bundled TUI binary. `cao tui` will report it is unavailable."
+        )
+        return None
+
+    staged = staged_binaries(root)
+    if not staged:
+        # Reported success but staged nothing. Do not raise: same graceful contract as above.
+        print(
+            f"{script.name} reported success but staged no {BINARY_STEM} binary — building "
+            "without it."
+        )
+        return None
+    return staged[0]
+
+
 def resolve_build_data(
     root: str,
     target_name: str,
@@ -148,11 +261,27 @@ def resolve_build_data(
     if target_name != "wheel":
         return
 
-    binaries = staged_binaries(root)
     requested = _env_flag(FORCE_ENV)
     if requested is None and os.environ.get(CIBUILDWHEEL_ENV):
         # Under cibuildwheel a platform wheel is the entire point of the run.
         requested = True
+
+    binaries = staged_binaries(root)
+
+    # Build the binary if nobody staged one. This is what turns `pip install .` /
+    # `uv tool install <git-url>` into installs that actually carry a working `cao tui`,
+    # instead of only the release pipeline producing one. (#560)
+    #
+    # ORDERING IS LOAD-BEARING: this must run BEFORE the tag decision below, because that
+    # decision reads `binaries`. Staging after it would leave the binary in the wheel while
+    # the wheel claimed `py3-none-any` — issue #321's original defect, reintroduced.
+    #
+    # SKIPPED when the caller explicitly asked for a pure wheel: compiling a binary only to
+    # raise the contradiction error below would waste a cargo build to produce a failure, and
+    # `CAO_TUI_PLATFORM_WHEEL=0` is how a caller asks for a genuinely pure wheel.
+    if not binaries and requested is not False:
+        autobuild_binary(root)
+        binaries = staged_binaries(root)
 
     # A caller that explicitly asked for a pure wheel while a native binary is staged would
     # get a py3-none-any wheel CONTAINING that binary — precisely the defect. Refuse rather

--- a/scripts/hatch_build_tui_tag.py
+++ b/scripts/hatch_build_tui_tag.py
@@ -79,6 +79,12 @@ So ``autobuild_binary()`` runs ``scripts/build_tui.py build`` when no binary is 
 a working ``cao tui`` a property of the BUILD rather than of the release pipeline. It degrades
 quietly — no cargo, or a failed compile, means a pure wheel and the existing clear message from
 ``cao tui``, never a failed install. See that function's docstring for why None, not raise.
+
+A failed build also DISCARDS whatever it staged before failing (``_discard_new_binaries``).
+That is not tidiness: ``build_tui.py`` copies the binary into place and only afterwards
+asserts the size ceiling, and hatchling's ``artifacts`` glob packages that directory
+independently of this hook — so a leftover rejected binary would be bundled into the wheel
+and would flip the tag, overturning the build's own rejection.
 """
 
 from __future__ import annotations
@@ -119,6 +125,13 @@ AUTOBUILD_ENV = "CAO_TUI_AUTOBUILD"
 # Relative to the project root — the staging script this hook shells out to.
 BUILD_SCRIPT_RELATIVE = "scripts/build_tui.py"
 
+# Wall-clock ceiling on the cargo build this hook triggers. Generous on purpose: a cold
+# `cargo build --release --locked` on a slow runner, fetching the whole registry, is measured
+# in minutes, and a timeout that fires on a merely-slow machine would silently ship wheels
+# with no TUI. The ceiling exists for a HUNG build (a stalled network fetch, a wedged linker),
+# which would otherwise hang `pip install` indefinitely with no output.
+BUILD_TIMEOUT_SECONDS = 900
+
 _TRUTHY = {"1", "true", "yes", "on"}
 
 
@@ -147,6 +160,38 @@ def staged_binaries(root: str) -> List[Path]:
     if not package_dir.is_dir():
         return []
     return sorted(p for p in package_dir.glob(f"{BINARY_STEM}*") if p.is_file())
+
+
+def _discard_new_binaries(root: str, preexisting: List[Path]) -> None:
+    """Remove staged TUI binaries that were NOT there before the build ran.
+
+    Called on every non-success path of ``autobuild_binary``. Returning None is not enough
+    on its own: ``build_tui.py build`` copies the binary into the staging directory and only
+    AFTERWARDS asserts the artifacts glob and NFR-2's 10 MB size ceiling, so it can exit
+    non-zero with a fully staged binary sitting on disk. Meanwhile the wheel's ``artifacts``
+    glob in pyproject.toml matches that directory during hatchling's own file collection —
+    it does not consult this hook. So a rejected leftover would be BUNDLED into the wheel,
+    and ``resolve_build_data``'s rescan would additionally flip the tag to platform-specific
+    for a payload the build had refused. Deleting it is what makes the graceful path actually
+    produce a pure wheel.
+
+    ``preexisting`` is compared by path, so a binary staged by cibuildwheel's ``before-build``
+    (or by a developer's explicit ``build_tui.py build``) is never touched — this only ever
+    unwinds what THIS invocation created.
+    """
+    keep = {p.resolve() for p in preexisting}
+    for candidate in staged_binaries(root):
+        if candidate.resolve() in keep:
+            continue
+        try:
+            candidate.unlink()
+        except OSError as exc:
+            # Best effort. Warn rather than raise: an undeletable leftover must not turn a
+            # gracefully-degraded build into a failed install, and the wheel it produces is
+            # wrong in a way the operator can see (a platform tag), not silently.
+            print(f"warning: could not remove rejected {candidate.name}: {exc}")
+        else:
+            print(f"discarded {candidate.name} left behind by the failed build")
 
 
 def autobuild_binary(root: str) -> Optional[Path]:
@@ -211,11 +256,30 @@ def autobuild_binary(root: str) -> Optional[Path]:
         )
         return None
 
+    # Recorded BEFORE the build so every failure path below can distinguish "this build
+    # staged it and then rejected it" (discard) from "it was already there" (never touch).
+    preexisting = staged_binaries(root)
+
     print(f"building the TUI binary ({script.name} build) — this needs cargo and may take a minute")
     try:
-        result = subprocess.run([sys.executable, str(script), "build"], cwd=root, check=False)
+        result = subprocess.run(
+            [sys.executable, str(script), "build"],
+            cwd=root,
+            check=False,
+            timeout=BUILD_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        # A hung cargo (a stalled registry fetch, a wedged linker) must not hang `pip install`
+        # forever. Bounded, then degraded like any other failure.
+        print(
+            f"{script.name} build exceeded {BUILD_TIMEOUT_SECONDS}s and was terminated — "
+            "building without the bundled TUI binary. `cao tui` will report it is unavailable."
+        )
+        _discard_new_binaries(root, preexisting)
+        return None
     except OSError as exc:
         print(f"could not run {script}: {exc} — building without the bundled TUI binary")
+        _discard_new_binaries(root, preexisting)
         return None
 
     if result.returncode != 0:
@@ -224,6 +288,10 @@ def autobuild_binary(root: str) -> Optional[Path]:
             f"{script.name} build failed (exit {result.returncode}) — building without the "
             "bundled TUI binary. `cao tui` will report it is unavailable."
         )
+        # The build may have copied the binary into place before failing its own size/glob
+        # assertions. Leaving it would let hatchling's artifacts glob package a payload the
+        # build rejected. See _discard_new_binaries.
+        _discard_new_binaries(root, preexisting)
         return None
 
     staged = staged_binaries(root)

--- a/src/cli_agent_orchestrator/cli/commands/tui.py
+++ b/src/cli_agent_orchestrator/cli/commands/tui.py
@@ -64,16 +64,25 @@ def _missing_binary_message(expected: Path) -> str:
     matched nothing at build time (defect D1's failure mode), so the wheel installs
     cleanly and only fails here. The message therefore names the exact missing file and
     both remedies rather than leaving the operator to guess.
+
+    THE MOST LIKELY CAUSE CHANGED WITH #560. The build now compiles the binary itself when
+    cargo is available, so "installed from source and forgot to build it" is no longer the
+    common case — a source install without a Rust toolchain is. The old wording sent an
+    operator to `python scripts/build_tui.py build`, which is unavailable from an INSTALLED
+    package (scripts/ ships in the sdist, not the wheel), so the first advice they got could
+    not be followed. Reinstalling with cargo present is the actionable fix. (#560)
     """
     return (
         f"the TUI binary '{_binary_filename()}' is not present in this installation "
         f"(expected at: {expected}).\n"
         "This usually means one of two things:\n"
-        "  1. You installed from source or an editable checkout and have not built it yet.\n"
-        "     Build it with:  python scripts/build_tui.py build\n"
+        "  1. You installed from source without a Rust toolchain, so the binary could not\n"
+        "     be compiled. Install Rust (https://rustup.rs), then reinstall CAO — the\n"
+        "     build compiles and bundles the TUI automatically when cargo is present.\n"
+        "     From a source checkout you can also build it directly:\n"
+        "         python scripts/build_tui.py build\n"
         "  2. The installed wheel was built without the Rust binary, or for a different\n"
-        "     platform. Reinstall a wheel built for this platform, or install from source\n"
-        "     with a Rust toolchain available (https://rustup.rs).\n"
+        "     platform. Reinstall a wheel built for this platform.\n"
         "Everything else in CAO works without it — only `cao tui` needs this binary."
     )
 

--- a/test/cli/commands/test_tui.py
+++ b/test/cli/commands/test_tui.py
@@ -68,6 +68,22 @@ class TestMissingBinaryError:
         # ...and mentions the platform-mismatch cause.
         assert "platform" in output.lower()
 
+    def test_missing_binary_points_at_the_remedy_an_installed_user_can_actually_use(self):
+        """Since #560 the build compiles the binary itself, so a MISSING one means no cargo.
+
+        Asserted because the pre-#560 wording led with `python scripts/build_tui.py build`,
+        which an operator who installed a wheel cannot run — `scripts/` ships in the sdist,
+        not the wheel. Pointing someone at a file they do not have is a dead end, so the
+        message must name the toolchain-and-reinstall route too.
+        """
+        message = tui_module._missing_binary_message(Path("/somewhere/cao-tui"))
+
+        assert "rustup.rs" in message, "the operator needs the toolchain link"
+        assert "reinstall" in message.lower(), (
+            "an installed user's actual remedy is to install Rust and reinstall, since they "
+            "have no scripts/ directory to run the build from"
+        )
+
     def test_missing_binary_raises_no_traceback(self, mocker):
         """The operator boundary contract: one styled line, never a stack trace."""
         mocker.patch.object(tui_module, "_locate_binary", return_value=None)

--- a/test/scripts/test_wheel_matrix.py
+++ b/test/scripts/test_wheel_matrix.py
@@ -264,6 +264,222 @@ class TestPlatformTagSelection:
 
 
 # ---------------------------------------------------------------------------------------
+# Build-time auto-staging: what makes `cao tui` work from a SOURCE install (#560)
+#
+# The defect these lock in was measured on a clean clone of main: `uv build --wheel` produced
+# `py3-none-any` with no `cao-tui` member, because the binary was only ever staged by
+# cibuildwheel's `before-build` at RELEASE time. An operator's `uv tool install <git-url>`
+# therefore installed a `cao tui` that could not run.
+#
+# The graceful-degradation tests matter as much as the happy path: a missing Rust toolchain
+# must never fail an install, or this fix trades one broken install for a worse one.
+# ---------------------------------------------------------------------------------------
+
+
+class TestAutobuildStagesTheBinary:
+    @staticmethod
+    def _fake_build_script(root: Path, body: str) -> Path:
+        """Write a stand-in scripts/build_tui.py at ``root``.
+
+        A stand-in, not the real script: invoking real cargo here would make this test need a
+        Rust toolchain and a minute of wall-clock, so what is under test is the HOOK's
+        contract with the script — is it invoked, is its exit code honoured, is its staged
+        output picked up — rather than cargo itself. The real script's own build is covered by
+        `test_cargo_build_passes_locked` and proven end-to-end by CI's `uv build`.
+        """
+        scripts = root / "scripts"
+        scripts.mkdir(parents=True, exist_ok=True)
+        script = scripts / "build_tui.py"
+        script.write_text(body, encoding="utf-8")
+        return script
+
+    def test_autobuild_runs_the_build_script_and_returns_the_staged_binary(self, tmp_path):
+        """The happy path: no binary staged, cargo present, so the hook builds one."""
+        # A script that stages the binary exactly where the artifacts glob looks.
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "pkg.mkdir(parents=True, exist_ok=True)\n"
+            "(pkg / 'cao-tui').write_bytes(b'\\x7fELF staged by the hook')\n",
+        )
+
+        staged = hatch_hook.autobuild_binary(str(tmp_path))
+
+        assert staged is not None, "the hook did not stage a binary the build script produced"
+        assert staged.name == "cao-tui"
+        assert staged.read_bytes() == b"\x7fELF staged by the hook"
+
+    def test_resolve_build_data_autobuilds_and_then_tags_for_the_platform(self, tmp_path):
+        """THE FIX, end to end through the real decision function.
+
+        This is the test that would have caught the reported defect: with no binary staged,
+        `resolve_build_data` must now produce a binary AND a platform tag. Before #560 it
+        returned early and left `tag` unset, which is how a `py3-none-any` wheel carrying no
+        TUI reached an operator.
+        """
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "pkg.mkdir(parents=True, exist_ok=True)\n"
+            "(pkg / 'cao-tui').write_bytes(b'\\x7fELF')\n",
+        )
+
+        build_data = _resolve(tmp_path, "cp312-cp312-macosx_26_0_arm64")
+
+        assert build_data["tag"] == "py3-none-macosx_26_0_arm64", (
+            "a wheel that auto-built a native binary must be tagged for its platform, not "
+            "left as py3-none-any"
+        )
+        assert build_data["pure_python"] is False
+        assert (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").is_file()
+
+    def test_install_still_succeeds_when_cargo_is_absent(self, tmp_path, monkeypatch):
+        """The non-negotiable one: no Rust toolchain must NOT fail the build.
+
+        `cao` is a Python tool whose TUI is one subcommand. Raising here would break every
+        contributor and CI job that builds without Rust — a far wider outage than the missing
+        TUI. `cao tui` already prints an actionable message when the binary is absent.
+        """
+        self._fake_build_script(tmp_path, "raise SystemExit('cargo should never be reached')\n")
+        monkeypatch.setattr(hatch_hook.shutil, "which", lambda _name: None)
+
+        assert hatch_hook.autobuild_binary(str(tmp_path)) is None
+
+        # And the wheel is a normal pure wheel: no tag forced, no exception.
+        build_data = _resolve(tmp_path, "cp312-cp312-macosx_26_0_arm64")
+        assert "tag" not in build_data
+        assert build_data["pure_python"] is True
+
+    def test_a_failed_build_is_not_staged_even_if_it_left_a_binary_behind(self, tmp_path):
+        """A NON-ZERO exit must be honoured even when a binary is sitting in the staging dir.
+
+        The stand-in stages a binary and THEN fails, because the real ``build_tui.py build``
+        does exactly that: it copies the binary into place first and only afterwards asserts
+        the artifacts glob and NFR-2's 10 MB size ceiling. So "exit non-zero with a staged
+        file present" is a reachable state, not a hypothetical — an over-ceiling or otherwise
+        rejected binary.
+
+        Written this way deliberately: the obvious version of this test (a script that merely
+        exits 1) passes even if the exit-code check is deleted entirely, because there is no
+        binary to find either way. Mutation-verified — replacing the ``returncode`` check with
+        ``if False`` leaves that version GREEN and this one RED.
+        """
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "pkg.mkdir(parents=True, exist_ok=True)\n"
+            "(pkg / 'cao-tui').write_bytes(b'REJECTED BY THE BUILD SCRIPT')\n"
+            "sys.exit(101)\n",
+        )
+
+        assert (
+            hatch_hook.autobuild_binary(str(tmp_path)) is None
+        ), "a build that exited non-zero must not have its leftover binary adopted"
+
+    def test_install_still_succeeds_when_the_cargo_build_fails(self, tmp_path):
+        """A compile error in the crate must not make `pip install` impossible either.
+
+        Distinct from the no-cargo case and tested separately: this path runs the script and
+        honours a NON-ZERO exit, where the other never runs it at all.
+        """
+        self._fake_build_script(tmp_path, "import sys\nsys.exit(101)\n")
+
+        assert hatch_hook.autobuild_binary(str(tmp_path)) is None
+
+        build_data = _resolve(tmp_path, "cp312-cp312-macosx_26_0_arm64")
+        assert "tag" not in build_data
+        assert build_data["pure_python"] is True
+
+    def test_a_script_that_reports_success_but_stages_nothing_is_not_trusted(self, tmp_path):
+        """Exit 0 is not proof of a staged binary — the D1 failure mode, at this boundary."""
+        self._fake_build_script(tmp_path, "pass\n")
+
+        assert hatch_hook.autobuild_binary(str(tmp_path)) is None
+
+    def test_autobuild_is_skipped_when_a_binary_is_already_staged(self, tmp_path):
+        """cibuildwheel stages via `before-build`; the hook must not rebuild over it.
+
+        The stand-in script would CORRUPT the staged binary if it ran, so the assertion on
+        the bytes is what proves the skip — not merely that a tag came out right.
+        """
+        _stage_binary(tmp_path)
+        original = (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").read_bytes()
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "(pkg / 'cao-tui').write_bytes(b'REBUILT OVER THE STAGED BINARY')\n",
+        )
+
+        _resolve(tmp_path, "cp312-cp312-macosx_26_0_arm64")
+
+        assert (
+            tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui"
+        ).read_bytes() == original, "the hook rebuilt over an already-staged binary"
+
+    def test_autobuild_env_opt_out_prevents_the_build(self, tmp_path, monkeypatch):
+        """`CAO_TUI_AUTOBUILD=0` restores the pre-#560 explicit-staging-only behaviour."""
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "pkg.mkdir(parents=True, exist_ok=True)\n"
+            "(pkg / 'cao-tui').write_bytes(b'\\x7fELF')\n",
+        )
+        monkeypatch.setenv(hatch_hook.AUTOBUILD_ENV, "0")
+
+        assert hatch_hook.autobuild_binary(str(tmp_path)) is None
+        assert not (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").exists()
+
+    def test_an_explicit_pure_wheel_request_does_not_trigger_a_cargo_build(
+        self, tmp_path, monkeypatch
+    ):
+        """`CAO_TUI_PLATFORM_WHEEL=0` asks for a pure wheel, so building would be wasted work.
+
+        Worse than wasted: the staged binary would then hit the contradiction guard and raise,
+        turning an explicit, legitimate request into a failed build.
+        """
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "pkg.mkdir(parents=True, exist_ok=True)\n"
+            "(pkg / 'cao-tui').write_bytes(b'\\x7fELF')\n",
+        )
+        monkeypatch.setenv(hatch_hook.FORCE_ENV, "0")
+        monkeypatch.delenv(hatch_hook.CIBUILDWHEEL_ENV, raising=False)
+
+        build_data = _resolve(tmp_path, "cp312-cp312-macosx_26_0_arm64")
+
+        assert build_data["pure_python"] is True
+        assert not (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").exists()
+
+    def test_the_sdist_target_never_autobuilds(self, tmp_path):
+        """An sdist carries source. Compiling a binary for it would be pure wasted time."""
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "pkg.mkdir(parents=True, exist_ok=True)\n"
+            "(pkg / 'cao-tui').write_bytes(b'\\x7fELF')\n",
+        )
+
+        _resolve(tmp_path, "cp312-cp312-macosx_26_0_arm64", target_name="sdist")
+
+        assert not (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").exists()
+
+
+# ---------------------------------------------------------------------------------------
 # The publish gate: the full platform set, and no 'any' wheel
 # ---------------------------------------------------------------------------------------
 

--- a/test/scripts/test_wheel_matrix.py
+++ b/test/scripts/test_wheel_matrix.py
@@ -17,6 +17,7 @@ otherwise — see `test_wheel_matrix_documents_unverified_platforms`.
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -277,6 +278,32 @@ class TestPlatformTagSelection:
 
 
 class TestAutobuildStagesTheBinary:
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch):
+        """Isolate the hook from the host toolchain and the ambient environment.
+
+        Both halves are load-bearing, and both were real defects:
+
+        * ``cargo`` is FAKED PRESENT by default. Without this, every happy-path case here
+          silently inverted on a machine with no Rust toolchain — ``autobuild_binary`` returned
+          None at its ``shutil.which`` guard and the test failed for a reason that has nothing
+          to do with the hook. Measured: two failures in a cargo-less environment. What these
+          tests own is the hook's contract with ``build_tui.py`` (is it invoked, is its exit
+          code honoured, is its output adopted or discarded) — never whether the host can
+          compile Rust. A case that needs the ABSENT-cargo path overrides this explicitly.
+        * All THREE controlling env vars are cleared. ``CAO_TUI_AUTOBUILD`` gates the build,
+          and ``CAO_TUI_PLATFORM_WHEEL`` / ``CIBUILDWHEEL`` change ``resolve_build_data``'s
+          decision — a runner exporting any of them (cibuildwheel exports ``CIBUILDWHEEL=1``
+          for every build it drives) would rewrite these tests' meaning. A test whose verdict
+          depends on the shell that launched pytest is not a guard.
+
+        The stand-in ``build_tui.py`` is a plain Python script, so a faked ``which`` never
+        causes a real cargo invocation.
+        """
+        monkeypatch.setattr(hatch_hook.shutil, "which", lambda name: f"/usr/bin/{name}")
+        for var in (hatch_hook.AUTOBUILD_ENV, hatch_hook.FORCE_ENV, hatch_hook.CIBUILDWHEEL_ENV):
+            monkeypatch.delenv(var, raising=False)
+
     @staticmethod
     def _fake_build_script(root: Path, body: str) -> Path:
         """Write a stand-in scripts/build_tui.py at ``root``.
@@ -367,6 +394,11 @@ class TestAutobuildStagesTheBinary:
         exits 1) passes even if the exit-code check is deleted entirely, because there is no
         binary to find either way. Mutation-verified — replacing the ``returncode`` check with
         ``if False`` leaves that version GREEN and this one RED.
+
+        Returning None is necessary but NOT sufficient, which is the second assertion: the
+        wheel's ``artifacts`` glob collects that directory during hatchling's own file walk and
+        never consults this hook, so a leftover left on disk would be packaged into the wheel
+        no matter what this function returned. The rejected file must be GONE.
         """
         self._fake_build_script(
             tmp_path,
@@ -381,6 +413,92 @@ class TestAutobuildStagesTheBinary:
         assert (
             hatch_hook.autobuild_binary(str(tmp_path)) is None
         ), "a build that exited non-zero must not have its leftover binary adopted"
+        assert not (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").exists(), (
+            "the rejected binary is still on disk — hatchling's artifacts glob would package "
+            "it into the wheel regardless of what this hook returned"
+        )
+
+    def test_a_rejected_leftover_does_not_tag_the_wheel_for_a_platform(self, tmp_path):
+        """The same defect one level up, where it actually reaches the wheel.
+
+        ``resolve_build_data`` RESCANS the staging directory after autobuilding, so before the
+        discard existed a build that staged ``cao-tui`` and then exited 101 produced
+        ``py3-none-<platform>`` with ``pure_python`` false — a platform wheel built around a
+        payload the build had refused. Asserting the pure-wheel outcome (not just that the file
+        is gone) is what ties the cleanup to the tag decision it exists to protect.
+        """
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "pkg.mkdir(parents=True, exist_ok=True)\n"
+            "(pkg / 'cao-tui').write_bytes(b'OVER THE SIZE CEILING')\n"
+            "sys.exit(101)\n",
+        )
+
+        build_data = _resolve(tmp_path, "cp312-cp312-macosx_26_0_arm64")
+
+        assert "tag" not in build_data, "a rejected build must leave hatchling's default tag"
+        assert build_data["pure_python"] is True
+        assert not (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").exists()
+
+    def test_a_preexisting_binary_survives_a_failed_build(self, tmp_path):
+        """The discard must unwind only what THIS invocation staged.
+
+        The guard rails the cleanup: cibuildwheel stages via ``before-build``, and a developer
+        may stage explicitly. A blanket "delete every binary on any failure" would destroy that
+        input — and under cibuildwheel it would convert a release build into
+        ``resolve_build_data``'s hard "no binary is staged" error. So the pre-existing file is
+        passed through untouched even though the build it triggered failed.
+        """
+        _stage_binary(tmp_path)
+        original = (tmp_path / "src" / "cli_agent_orchestrator" / "cao-tui").read_bytes()
+        self._fake_build_script(
+            tmp_path,
+            "import pathlib, sys\n"
+            "pkg = pathlib.Path(sys.argv[0]).resolve().parents[1] / 'src' / "
+            "'cli_agent_orchestrator'\n"
+            "(pkg / 'cao-tui.exe').write_bytes(b'REJECTED')\n"
+            "sys.exit(101)\n",
+        )
+
+        # Called directly: resolve_build_data would skip the build entirely (a binary is
+        # already staged), which is a different guard — tested separately above.
+        assert hatch_hook.autobuild_binary(str(tmp_path)) is None
+
+        staged_dir = tmp_path / "src" / "cli_agent_orchestrator"
+        assert (
+            staged_dir.joinpath("cao-tui").read_bytes() == original
+        ), "the cleanup deleted a binary it did not stage"
+        assert not staged_dir.joinpath("cao-tui.exe").exists(), "the rejected leftover survived"
+
+    def test_a_hung_build_is_bounded_and_degrades(self, tmp_path, monkeypatch):
+        """A wedged cargo must not hang `pip install` forever.
+
+        ``subprocess.run`` without a timeout waits indefinitely, so a stalled registry fetch or
+        a wedged linker would hang the install with no output and no way out but Ctrl-C. The
+        timeout is raised here rather than waited on: what is under test is that the hook PASSES
+        a timeout and treats expiry as one more graceful-degradation path — including
+        discarding anything the killed build had already staged.
+        """
+        self._fake_build_script(tmp_path, "pass\n")
+        pkg = tmp_path / "src" / "cli_agent_orchestrator"
+        pkg.mkdir(parents=True, exist_ok=True)
+
+        def _hang(*args, **kwargs):
+            assert kwargs.get("timeout") == hatch_hook.BUILD_TIMEOUT_SECONDS, (
+                "the hook invoked the build script with no timeout — a hung cargo would hang "
+                "the install indefinitely"
+            )
+            # A build killed mid-flight can leave a partial copy behind.
+            (pkg / "cao-tui").write_bytes(b"PARTIAL")
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+        monkeypatch.setattr(hatch_hook.subprocess, "run", _hang)
+
+        assert hatch_hook.autobuild_binary(str(tmp_path)) is None
+        assert not (pkg / "cao-tui").exists(), "a timed-out build's partial output was kept"
 
     def test_install_still_succeeds_when_the_cargo_build_fails(self, tmp_path):
         """A compile error in the crate must not make `pip install` impossible either.


### PR DESCRIPTION
Fixes #560.

## The problem

An operator installed CAO with `uv tool install` from git and got:

```
Error: the TUI binary 'cao-tui' is not present in this installation
(expected at: .../site-packages/cli_agent_orchestrator/cao-tui).
```

The binary reached a wheel by exactly **one** route: cibuildwheel's `before-build` hook, which runs only at **release** time. Every other install path silently shipped no TUI.

Reproduced on a clean clone of `main` @ 2a6f20c:

```
$ uv build --wheel
Successfully built cli_agent_orchestrator-2.4.1-py3-none-any.whl
$ unzip -l dist/*.whl | grep cao-tui
(no matches)
```

`scripts/build_tui.py` stages the binary into a **gitignored** directory. `pyproject.toml` declares an `artifacts` glob pointing there, but nothing in the build *ran* cargo — and hatchling treats a glob matching nothing as a **silent no-op**. This is defect D1's failure mode, which `build_tui.py`'s own docstring predicted verbatim: *"an operator installs the wheel, runs `cao tui`, and there is no binary — while the build, the publish, and the smoke test all reported success."*

`pip install <sdist>` could not produce a TUI **even with a Rust toolchain present**, which was the most surprising case.

## The fix

`autobuild_binary()` in the existing build hook runs `scripts/build_tui.py build` when no binary is staged, making a working `cao tui` a property of the **build** rather than of the release pipeline.

Ordering is load-bearing: staging happens **before** the tag decision. Staging after it would leave a native binary inside a `py3-none-any` wheel — reintroducing #321's original defect.

It also rewrites the missing-binary message. The old wording led with `python scripts/build_tui.py build`, which an operator who installed a wheel **cannot run** — `scripts/` ships in the sdist, not the wheel. The first advice given was a dead end.

## Verified end-to-end

Cloned `awslabs/main` fresh, applied only this change, and ran the exact command that failed:

```
uv tool install <clone>
  → cao-tui present, Mach-O 64-bit executable arm64
  → cao-tui --version → cao-tui 0.1.0 (exit 0)
```

That path produced no binary before. `pip install <sdist>` now works too.

## Degradation is quiet, and that is deliberate

| Condition | Result |
|---|---|
| cargo present | platform wheel + binary (`py3-none-macosx_26_0_arm64`) |
| **no cargo** | **`py3-none-any`, exit 0**, one calm line, `cao tui` keeps its message |
| cargo build fails | same as above — a compile error must not break `pip install` |
| binary already staged | no-op, so **cibuildwheel is unaffected** |
| `CAO_TUI_AUTOBUILD=0` | opt out |
| `CAO_TUI_PLATFORM_WHEEL=0` | skips cargo entirely rather than compiling then erroring |

A missing Rust toolchain **must not fail an install** — contributors and every CI job that builds without Rust keep working. `cao tui` is one subcommand; raising would be a far wider outage than the missing TUI.

Release builds are untouched: cibuildwheel still stages explicitly via `before-build`, and the new code no-ops when a binary exists (mutation-proven).

## Tests

10 new tests. **Six guards mutation-proven** — each mutation was applied to production and the named test confirmed RED:

| Mutation | Test that fails |
|---|---|
| autobuild removed | `test_resolve_build_data_autobuilds_and_then_tags_for_the_platform` |
| no-cargo made fatal | `test_install_still_succeeds_when_cargo_is_absent` |
| cargo exit code ignored | `test_a_failed_build_is_not_staged_even_if_it_left_a_binary_behind` |
| skip-when-staged removed | `test_autobuild_is_skipped_when_a_binary_is_already_staged` |
| opt-out ignored | `test_autobuild_env_opt_out_prevents_the_build` |
| exit 0 trusted blindly | `test_a_script_that_reports_success_but_stages_nothing_is_not_trusted` |

One is worth flagging: my first "cargo build fails" test was **vacuous** — deleting the exit-code check left it green, because a failing script staged nothing either way. It is rewritten so the stand-in stages a binary *and then* exits non-zero, a genuinely reachable state (the real `build_tui.py` copies the binary first, then asserts the 10 MB ceiling). That version goes red under the mutation.

## Gates

- 84 relevant tests pass; `black`/`isort` clean at CI's exact `src/ test/` scope; mypy clean on the touched file.
- Full suite at CI's exact command: **19 failures, all pre-existing** — verified by stashing this change and getting the identical 19 (`test_memory.py`, `test_memory_provider.py`, `test_wiki_lint.py`, `test_cache.py`, `test_launch.py`).

## Not included

**No PyPI release contains the TUI yet** — all published artifacts are `py3-none-any`, and tag `v2.4.1` predates #547. This PR makes source installs work; shipping to PyPI customers still needs a release cut from post-#547 `main`, which is a `workflow_dispatch` and a maintainer's call. Two caveats to know first:

- **macOS x86_64 is built but never executed** (cross-compiled on an arm64 runner; cibuildwheel skips its test). The config's own comments call this the state SR-1 forbids.
- The Linux `auditwheel` retag was only proven against a stand-in ELF, never a real `cao-tui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
