### PR TITLE
fix(launch): deliver the initial message via POST /sessions instead of a dropped second request

### DIFF
--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -1,7 +1,6 @@
 """Launch command for CLI Agent Orchestrator CLI."""
 
 import os
-import time
 
 import click
 import requests
@@ -52,6 +51,16 @@ _FORWARDED_ENV_PREFIX_ALLOWLIST = frozenset(
     }
 )
 _FORWARDED_ENV_MAX_VALUE_BYTES = 2048
+
+# How long the CLI allows for server-side provider init: the pre-attach
+# readiness poll on the non-headless path, and the init allowance folded into
+# the headless wait (where init now runs inside ``poll_until_done``'s window
+# rather than in a separate poll before a client-side send).
+_READINESS_WAIT_TIMEOUT = 120
+
+# How long the agent gets to finish MESSAGE on the headless non-async path,
+# on top of ``_READINESS_WAIT_TIMEOUT``.
+_HEADLESS_TASK_TIMEOUT = 300
 
 
 def _parse_env_pairs(pairs):
@@ -311,13 +320,45 @@ def launch(
         if resume_session_id:
             params["resume_session_id"] = resume_session_id
 
+        # Hand MESSAGE to the server rather than sending it ourselves.
+        # ``initial_message`` on ``POST /sessions`` puts the initial terminal on
+        # the existing deferred-init path (``session_service.create_session`` ->
+        # ``create_terminal(defer_init=True)``): the server responds as soon as
+        # the terminal record exists, then finishes provider init, delivers the
+        # message, and confirms/re-submits if the TUI swallowed it.
+        #
+        # The CLI used to create the session and then issue a SEPARATE
+        # ``POST /terminals/{id}/input``. Because ``POST /sessions`` ran the
+        # provider's full ``initialize()`` inline, a slow cold start outlived
+        # the client's read timeout: ``requests`` raised ``ReadTimeout``,
+        # ``launch`` reported "Failed to connect to cao-server", and that second
+        # request never happened — MESSAGE was silently dropped even though the
+        # session, the terminal and a healthy idle TUI all existed server-side,
+        # and nothing retried because from the server's point of view the launch
+        # had succeeded. Server-side delivery closes the window for every
+        # provider at once; ``cao launch`` was the last client still doing its
+        # own create-then-send (mcp_server and ops_mcp_server already pass
+        # ``initial_message``).
+        #
+        # Headless only: that is the path that used to send MESSAGE. A
+        # non-headless launch attaches instead and has never delivered MESSAGE,
+        # and deferring init there would make the pre-attach readiness poll
+        # below race the agent's first turn.
+        server_delivers_message = bool(message) and headless
+
         # Forwarded env vars travel in the JSON body so values (which may
         # contain secrets) don't end up in cao-server's HTTP access log.
-        # See issue #248.
-        request_timeout = get_server_settings()["mcp_request_timeout"]
-        post_kwargs: dict = {"params": params, "timeout": request_timeout}
+        # MESSAGE rides in the body for the same reason, plus URL-length. See
+        # issue #248 and ``CreateSessionBody``.
+        settings = get_server_settings()
+        post_kwargs: dict = {"params": params, "timeout": settings["mcp_request_timeout"]}
+        body: dict = {}
         if forwarded_env:
-            post_kwargs["json"] = {"env_vars": forwarded_env}
+            body["env_vars"] = forwarded_env
+        if server_delivers_message:
+            body["initial_message"] = message
+        if body:
+            post_kwargs["json"] = body
 
         response = requests.post(url, **post_kwargs)
         response.raise_for_status()
@@ -341,44 +382,41 @@ def launch(
             ready = wait_until_terminal_status(
                 terminal["id"],
                 {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-                timeout=120,
+                timeout=_READINESS_WAIT_TIMEOUT,
             )
             if not ready:
                 click.echo(
                     click.style(
-                        f"  Warning: {terminal['id']} did not reach idle within 120s — "
-                        "attaching anyway; input may be unreliable until init completes.",
+                        f"  Warning: {terminal['id']} did not reach idle within "
+                        f"{_READINESS_WAIT_TIMEOUT}s — attaching anyway; input may be "
+                        "unreliable until init completes.",
                         fg="yellow",
                     )
                 )
             get_backend().attach_session(terminal["session_name"])
         elif message:
-            ready = wait_until_terminal_status(
-                terminal["id"],
-                {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-                timeout=120,
-            )
-            if not ready:
-                raise click.ClickException(
-                    f"Conductor {terminal['id']} did not become ready within 120s"
-                )
-            request_timeout = get_server_settings()["mcp_request_timeout"]
-            response = requests.post(
-                f"{API_BASE_URL}/terminals/{terminal['id']}/input",
-                params={"message": message},
-                timeout=request_timeout,
-            )
-            response.raise_for_status()
-            time.sleep(3)
+            # Nothing to send: the server took MESSAGE in the create body above
+            # and owns init, delivery and re-submission. There is also nothing
+            # left to wait for before delivery — waiting for IDLE here is what
+            # used to gate a send that no longer happens.
             if is_async:
-                click.echo(f"Message sent to {terminal['name']}. Running in background.")
+                click.echo(
+                    f"Message accepted for {terminal['name']}; the server delivers it "
+                    "once provider init completes. Running in background."
+                )
                 return
-            poll_until_done(terminal["id"], timeout=300)
-            request_timeout = get_server_settings()["mcp_request_timeout"]
+            # Provider init now happens inside this wait instead of in a
+            # separate readiness poll before the send, so the budget covers
+            # both. A deferred terminal reports UNKNOWN until init finishes,
+            # which ``poll_until_done`` deliberately does not count as "started"
+            # — it returns only once the agent has been observed working.
+            poll_until_done(
+                terminal["id"], timeout=_READINESS_WAIT_TIMEOUT + _HEADLESS_TASK_TIMEOUT
+            )
             output_resp = requests.get(
                 f"{API_BASE_URL}/terminals/{terminal['id']}/output",
                 params={"mode": "last"},
-                timeout=request_timeout,
+                timeout=settings["mcp_request_timeout"],
             )
             output_resp.raise_for_status()
             output = output_resp.json().get("output", "")

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -76,17 +76,25 @@ def _is_waiting_on_user(terminal_id: str) -> bool:
     caller's ``RequestException`` handler, which reports "Failed to connect to
     cao-server" — untrue here, since the poll above just talked to it.
 
-    ``RequestException`` alone is sufficient breadth, including for a non-JSON
-    body: ``requests.exceptions.JSONDecodeError`` subclasses both it and
-    ``ValueError``, and has since requests 2.27 — comfortably below this
-    project's ``requests>=2.32.0`` floor.
+    An *unparseable* body is covered by the except:
+    ``requests.exceptions.JSONDecodeError`` subclasses ``RequestException`` (and
+    ``ValueError``) and has since requests 2.27, below this project's
+    ``requests>=2.32.0`` floor. A body that parses but isn't an object is not —
+    ``[].get`` raises ``AttributeError``, which is no kind of
+    ``RequestException`` — so the shape is checked rather than assumed. Without
+    that check a 200 carrying a JSON array, string or ``null`` escapes to the
+    caller's generic handler and aborts the launch with ``exit 1`` *after* the
+    session exists, leaving it orphaned in tmux: the precise failure this
+    function's local except is here to prevent.
     """
     try:
         resp = requests.get(f"{API_BASE_URL}/terminals/{terminal_id}", timeout=5.0)
         if resp.status_code == 200:
-            # bool(): ``resp.json()`` is Any, so the comparison is too, and this
-            # function is annotated ``-> bool``.
-            return bool(resp.json().get("status") == TerminalStatus.WAITING_USER_ANSWER.value)
+            payload = resp.json()
+            if isinstance(payload, dict):
+                # bool(): ``payload.get`` is Any, so the comparison is too, and
+                # this function is annotated ``-> bool``.
+                return bool(payload.get("status") == TerminalStatus.WAITING_USER_ANSWER.value)
     except requests.exceptions.RequestException:
         pass
     return False

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -1,7 +1,6 @@
 """Launch command for CLI Agent Orchestrator CLI."""
 
 import os
-import time
 
 import click
 import requests
@@ -51,6 +50,16 @@ _FORWARDED_ENV_PREFIX_ALLOWLIST = frozenset(
     }
 )
 _FORWARDED_ENV_MAX_VALUE_BYTES = 2048
+
+# How long the CLI allows for server-side provider init: the pre-attach
+# readiness poll on the non-headless path, and the init allowance folded into
+# the headless wait (where init now runs inside ``poll_until_done``'s window
+# rather than in a separate poll before a client-side send).
+_READINESS_WAIT_TIMEOUT = 120
+
+# How long the agent gets to finish MESSAGE on the headless non-async path,
+# on top of ``_READINESS_WAIT_TIMEOUT``.
+_HEADLESS_TASK_TIMEOUT = 300
 
 
 def _parse_env_pairs(pairs):
@@ -296,13 +305,45 @@ def launch(
         if memory:
             params["memory_manager"] = "true"
 
+        # Hand MESSAGE to the server rather than sending it ourselves.
+        # ``initial_message`` on ``POST /sessions`` puts the initial terminal on
+        # the existing deferred-init path (``session_service.create_session`` ->
+        # ``create_terminal(defer_init=True)``): the server responds as soon as
+        # the terminal record exists, then finishes provider init, delivers the
+        # message, and confirms/re-submits if the TUI swallowed it.
+        #
+        # The CLI used to create the session and then issue a SEPARATE
+        # ``POST /terminals/{id}/input``. Because ``POST /sessions`` ran the
+        # provider's full ``initialize()`` inline, a slow cold start outlived
+        # the client's read timeout: ``requests`` raised ``ReadTimeout``,
+        # ``launch`` reported "Failed to connect to cao-server", and that second
+        # request never happened — MESSAGE was silently dropped even though the
+        # session, the terminal and a healthy idle TUI all existed server-side,
+        # and nothing retried because from the server's point of view the launch
+        # had succeeded. Server-side delivery closes the window for every
+        # provider at once; ``cao launch`` was the last client still doing its
+        # own create-then-send (mcp_server and ops_mcp_server already pass
+        # ``initial_message``).
+        #
+        # Headless only: that is the path that used to send MESSAGE. A
+        # non-headless launch attaches instead and has never delivered MESSAGE,
+        # and deferring init there would make the pre-attach readiness poll
+        # below race the agent's first turn.
+        server_delivers_message = bool(message) and headless
+
         # Forwarded env vars travel in the JSON body so values (which may
         # contain secrets) don't end up in cao-server's HTTP access log.
-        # See issue #248.
-        request_timeout = get_server_settings()["mcp_request_timeout"]
-        post_kwargs: dict = {"params": params, "timeout": request_timeout}
+        # MESSAGE rides in the body for the same reason, plus URL-length. See
+        # issue #248 and ``CreateSessionBody``.
+        settings = get_server_settings()
+        post_kwargs: dict = {"params": params, "timeout": settings["mcp_request_timeout"]}
+        body: dict = {}
         if forwarded_env:
-            post_kwargs["json"] = {"env_vars": forwarded_env}
+            body["env_vars"] = forwarded_env
+        if server_delivers_message:
+            body["initial_message"] = message
+        if body:
+            post_kwargs["json"] = body
 
         response = requests.post(url, **post_kwargs)
         response.raise_for_status()
@@ -326,44 +367,41 @@ def launch(
             ready = wait_until_terminal_status(
                 terminal["id"],
                 {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-                timeout=120,
+                timeout=_READINESS_WAIT_TIMEOUT,
             )
             if not ready:
                 click.echo(
                     click.style(
-                        f"  Warning: {terminal['id']} did not reach idle within 120s — "
-                        "attaching anyway; input may be unreliable until init completes.",
+                        f"  Warning: {terminal['id']} did not reach idle within "
+                        f"{_READINESS_WAIT_TIMEOUT}s — attaching anyway; input may be "
+                        "unreliable until init completes.",
                         fg="yellow",
                     )
                 )
             get_backend().attach_session(terminal["session_name"])
         elif message:
-            ready = wait_until_terminal_status(
-                terminal["id"],
-                {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
-                timeout=120,
-            )
-            if not ready:
-                raise click.ClickException(
-                    f"Conductor {terminal['id']} did not become ready within 120s"
-                )
-            request_timeout = get_server_settings()["mcp_request_timeout"]
-            response = requests.post(
-                f"{API_BASE_URL}/terminals/{terminal['id']}/input",
-                params={"message": message},
-                timeout=request_timeout,
-            )
-            response.raise_for_status()
-            time.sleep(3)
+            # Nothing to send: the server took MESSAGE in the create body above
+            # and owns init, delivery and re-submission. There is also nothing
+            # left to wait for before delivery — waiting for IDLE here is what
+            # used to gate a send that no longer happens.
             if is_async:
-                click.echo(f"Message sent to {terminal['name']}. Running in background.")
+                click.echo(
+                    f"Message accepted for {terminal['name']}; the server delivers it "
+                    "once provider init completes. Running in background."
+                )
                 return
-            poll_until_done(terminal["id"], timeout=300)
-            request_timeout = get_server_settings()["mcp_request_timeout"]
+            # Provider init now happens inside this wait instead of in a
+            # separate readiness poll before the send, so the budget covers
+            # both. A deferred terminal reports UNKNOWN until init finishes,
+            # which ``poll_until_done`` deliberately does not count as "started"
+            # — it returns only once the agent has been observed working.
+            poll_until_done(
+                terminal["id"], timeout=_READINESS_WAIT_TIMEOUT + _HEADLESS_TASK_TIMEOUT
+            )
             output_resp = requests.get(
                 f"{API_BASE_URL}/terminals/{terminal['id']}/output",
                 params={"mode": "last"},
-                timeout=request_timeout,
+                timeout=settings["mcp_request_timeout"],
             )
             output_resp.raise_for_status()
             output = output_resp.json().get("output", "")

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -63,6 +63,35 @@ _READINESS_WAIT_TIMEOUT = 120
 _HEADLESS_TASK_TIMEOUT = 300
 
 
+def _is_waiting_on_user(terminal_id: str) -> bool:
+    """Return True when the terminal's live status is WAITING_USER_ANSWER.
+
+    Read separately because ``wait_until_terminal_status`` reports only whether
+    one of its target statuses was reached, not which one, and the pre-attach
+    poll accepts three.
+
+    Best-effort by design: this only decides which advisory line to print before
+    attaching, so a transport blip must not turn a successful launch into a
+    ``ClickException``. Hence the local except rather than letting it reach the
+    caller's ``RequestException`` handler, which reports "Failed to connect to
+    cao-server" — untrue here, since the poll above just talked to it.
+
+    ``RequestException`` alone is sufficient breadth, including for a non-JSON
+    body: ``requests.exceptions.JSONDecodeError`` subclasses both it and
+    ``ValueError``, and has since requests 2.27 — comfortably below this
+    project's ``requests>=2.32.0`` floor.
+    """
+    try:
+        resp = requests.get(f"{API_BASE_URL}/terminals/{terminal_id}", timeout=5.0)
+        if resp.status_code == 200:
+            # bool(): ``resp.json()`` is Any, so the comparison is too, and this
+            # function is annotated ``-> bool``.
+            return bool(resp.json().get("status") == TerminalStatus.WAITING_USER_ANSWER.value)
+    except requests.exceptions.RequestException:
+        pass
+    return False
+
+
 def _parse_env_pairs(pairs):
     """Parse repeated ``KEY=VALUE`` entries into a dict, validating each.
 
@@ -374,6 +403,21 @@ def launch(
         # silently drops keystrokes. See issue #220. The wait is advisory:
         # if it times out we still attach so the user can inspect the
         # half-initialized session rather than orphan it in tmux.
+        #
+        # WAITING_USER_ANSWER counts as settled here, not as a stall. A provider
+        # can finish initializing on a screen that legitimately needs the
+        # operator — Codex's first-run login menu is the case that forced this —
+        # and such a screen never becomes IDLE on its own, so waiting for IDLE
+        # burned the full ``_READINESS_WAIT_TIMEOUT`` and then blamed init for a
+        # pane that was simply waiting for a human. Safe because non-headless
+        # ``POST /sessions`` initializes synchronously (no ``initial_message``,
+        # see ``server_delivers_message`` above), so by the time this poll runs
+        # every provider's startup handler has already returned: a
+        # WAITING_USER_ANSWER here is a settled prompt, not a dialog caught
+        # mid-dismissal. If non-headless init is ever deferred, this poll would
+        # race the startup handler and attaching early would resize the pty
+        # mid-init — issue #220 again — so that change must gate attach on init
+        # completion rather than reuse this set.
         if not headless:
             # Align the CLI's backend singleton with the running server.
             # Without this, ``cao-server --terminal herdr`` + no config.json
@@ -381,7 +425,11 @@ def launch(
             sync_backend_from_server()
             ready = wait_until_terminal_status(
                 terminal["id"],
-                {TerminalStatus.IDLE, TerminalStatus.COMPLETED},
+                {
+                    TerminalStatus.IDLE,
+                    TerminalStatus.COMPLETED,
+                    TerminalStatus.WAITING_USER_ANSWER,
+                },
                 timeout=_READINESS_WAIT_TIMEOUT,
             )
             if not ready:
@@ -390,6 +438,15 @@ def launch(
                         f"  Warning: {terminal['id']} did not reach idle within "
                         f"{_READINESS_WAIT_TIMEOUT}s — attaching anyway; input may be "
                         "unreliable until init completes.",
+                        fg="yellow",
+                    )
+                )
+            elif _is_waiting_on_user(terminal["id"]):
+                click.echo(
+                    click.style(
+                        f"  {terminal['id']} is waiting for an answer in the pane "
+                        "(a first-run sign-in, for example) — complete it after "
+                        "attaching.",
                         fg="yellow",
                     )
                 )

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1035,44 +1035,8 @@ class CodexProvider(BaseProvider):
             command = f"{command} {developer_instructions_fragment}"
         return command
 
-    async def _handle_trust_prompt(
-        self,
-        idle_gap: Optional[float] = None,
-        outer_timeout: Optional[float] = None,
-    ) -> None:
+    async def _handle_trust_prompt(self, timeout: float = 20.0) -> None:
         """Dismiss startup prompts that block readiness.
-
-        Args:
-            idle_gap: Seconds with no new prompt before startup is considered
-                settled. Defaults to the ``startup_prompt_handler_timeout``
-                setting. Per that setting's contract this is an IDLE GAP, not a
-                total budget: it is reset every time a prompt is answered, and
-                it only starts counting once at least one prompt has been
-                handled. Mirrors ``kimi_cli``/``antigravity_cli``.
-            outer_timeout: Hard cap on total time this handler may run.
-                Defaults to the ``provider_init_timeout`` setting, which is
-                what that setting documents itself as bounding.
-
-        Before this split, ``startup_prompt_handler_timeout`` was used as a
-        FIXED TOTAL budget here, contradicting its documented semantics: an
-        operator who lowered it to make another provider settle faster silently
-        capped codex's whole handler, so a dialog rendered after the gap was
-        never dismissed. ``initialize()`` treats WAITING_USER_ANSWER as success,
-        so the undismissed dialog then made ``send_input`` raise
-        ``TerminalInputBlockedError`` and the initial message was never
-        delivered.
-
-        Every backend call here (get_history/send_keys/send_special_key) is a
-        blocking subprocess exec, and this loop makes one per second for up to
-        ``timeout`` seconds. cao-server runs a SINGLE event loop, so leaving
-        them loop-side froze every other concurrent request — including every
-        other terminal's own init — for the duration. They are offloaded to
-        threads for the same reason claude_code's startup handler was in #451
-        and kimi_cli/antigravity_cli/copilot_cli's were in #494. Codex is not
-        the last such gap — kiro_cli, opencode_cli and cursor_cli still make
-        loop-side backend calls in ``initialize()`` — but it is the slowest
-        init of the group, so a concurrent fan-out of codex launches is where
-        the self-inflicted queueing showed up first.
 
         Handles two classes of blocking dialog in a single poll loop:
 
@@ -1087,112 +1051,28 @@ class CodexProvider(BaseProvider):
            Dismissed with '3'+Enter ("Skip until next version"). A blind Enter
            would select "1. Update now" (global npm install).
         """
-        if idle_gap is None:
-            idle_gap = float(get_server_settings()["startup_prompt_handler_timeout"])
-        if outer_timeout is None:
-            outer_timeout = float(get_server_settings()["provider_init_timeout"])
-        outer_deadline = time.monotonic() + outer_timeout
-        last_prompt_time = time.monotonic()
-        any_prompt_handled = False
+        start_time = time.time()
         trust_dismissed = False
         update_dismissed = False
-        while True:
-            now = time.monotonic()
-            if now >= outer_deadline:
-                break
-            if any_prompt_handled and now - last_prompt_time >= idle_gap:
-                # No new prompt within the idle gap — startup settled.
-                return
-            output = await asyncio.to_thread(
-                get_backend().get_history, self.session_name, self.window_name
-            )
+        while time.time() - start_time < timeout:
+            output = get_backend().get_history(self.session_name, self.window_name)
             if not output:
                 await asyncio.sleep(1.0)
                 continue
 
             clean_output = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", output))
 
-            bottom_region = "\n".join(clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-            has_login = bool(
-                re.search(LOGIN_MENU_PATTERN, bottom_region)
-                and re.search(LOGIN_MENU_FOOTER, bottom_region)
-            )
-
-            # The v1 trust check is the only one of the four signatures matched
-            # against the WHOLE capture rather than ``bottom_region``, so on its own
-            # it fires on trust copy sitting anywhere in scrollback — text the login
-            # gate below cannot see. Ungated, the handler would press Enter into a
-            # live login menu and *then* log that it was leaving that menu for the
-            # operator: the keystroke selects a sign-in method, so the pane leaves
-            # the set ``initialize()`` waits on ({IDLE, COMPLETED,
-            # WAITING_USER_ANSWER}) and a recoverable "operator must authenticate"
-            # becomes a TimeoutError and teardown. (Measured as PROCESSING on the
-            # API-key option; the OAuth option was not exercised.)
-            #
-            # So the gate has to separate a LIVE v1 dialog from stale v1 copy, and
-            # position is what separates them — hence ``v1_is_live``. Suppressing on
-            # ``has_login`` alone would be wrong in the other direction: a genuine v1
-            # dialog stacked over a live login menu satisfies BOTH ``has_login`` and
-            # ``has_dialog``, so neither this branch nor the login exit could fire and
-            # the handler would live-lock to its outer cap — reproducing, in that one
-            # frame class, the exact stall this commit's sibling exists to remove.
-            #
-            # Where the asymmetry actually lies: this branch's TRIGGER is the only
-            # whole-capture match in the loop (the final conjunct below), while
-            # liveness and every term of ``has_dialog`` are confined to
-            # ``bottom_region`` — including ``_has_update_dialog_in_bottom``, which
-            # takes the same 15-line slice internally. So the whole capture decides
-            # only *whether trust copy exists at all*; position inside the bottom
-            # region decides whether it is live.
-            #
-            # Presence in ``bottom_region`` is not enough to call a v1 dialog live: it
-            # would still answer trust copy sitting in the last 15 lines ABOVE a live
-            # menu, which is the original bug with a smaller window rather than a
-            # closed one. POSITION settles it — Codex draws the active modal last, so
-            # the lower block is the one on screen. Hence "live" means the v1 copy
-            # appears below the menu text, which is also why the shared footer is no
-            # use here: ``LOGIN_MENU_FOOTER is TRUST_PROMPT_FOOTER``, so the footer
-            # cannot attribute itself to either block.
-            # Both sides take the LAST occurrence, and that symmetry is the whole
-            # correctness argument. Comparing the FIRST v1 match against the LAST menu
-            # match misreads a frame carrying stale v1 copy above the menu AND a live
-            # v1 dialog below it: the stale copy wins the comparison, ``v1_is_live``
-            # goes false, and because ``has_dialog`` shares that predicate the login
-            # exit fires with a live dialog on screen — the exact failure ``not
-            # has_dialog`` exists to prevent. Only the lowest occurrence of each block
-            # can be the one currently drawn, so only those two may be compared.
-            _v1_all = list(re.finditer(TRUST_PROMPT_PATTERN, bottom_region))
-            _v1_match = _v1_all[-1] if _v1_all else None
-            _menu_matches = list(re.finditer(LOGIN_MENU_PATTERN, bottom_region))
-            # Offsets are only comparable because both matches come from
-            # ``bottom_region``. Sourcing either from ``clean_output`` would compare
-            # positions in two different strings and silently produce nonsense.
-            #
-            # ``is not None`` rather than ``bool()``: mypy narrows the Optional through
-            # the former only, and ``.start()`` below needs the narrowing.
-            v1_is_live = _v1_match is not None and (
-                # Short-circuits before the index, which is only safe to take when
-                # has_login held (it requires a menu match in this same region).
-                not has_login
-                or _v1_match.start() > _menu_matches[-1].start()
-            )
-            if (
-                not trust_dismissed
-                and (v1_is_live or not has_login)
-                and re.search(TRUST_PROMPT_PATTERN, clean_output)
-            ):
+            if not trust_dismissed and re.search(TRUST_PROMPT_PATTERN, clean_output):
                 from cli_agent_orchestrator.services.status_monitor import status_monitor
 
                 logger.info("Codex workspace trust prompt (v1) detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
-                await asyncio.to_thread(
-                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
-                )
+                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 trust_dismissed = True
-                any_prompt_handled = True
-                last_prompt_time = time.monotonic()  # reset idle timer
                 await asyncio.sleep(1.0)
                 continue
+
+            bottom_region = "\n".join(clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
 
             if (
                 not trust_dismissed
@@ -1203,12 +1083,8 @@ class CodexProvider(BaseProvider):
 
                 logger.info("Codex workspace trust prompt (v2) detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
-                await asyncio.to_thread(
-                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
-                )
+                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 trust_dismissed = True
-                any_prompt_handled = True
-                last_prompt_time = time.monotonic()  # reset idle timer
                 await asyncio.sleep(1.0)
                 continue
 
@@ -1219,21 +1095,11 @@ class CodexProvider(BaseProvider):
                     "Codex update-available dialog detected, selecting " "'Skip until next version'"
                 )
                 status_monitor.notify_input_sent(self.terminal_id)
-                await asyncio.to_thread(
-                    get_backend().send_keys,
-                    self.session_name,
-                    self.window_name,
-                    "3",
-                    enter_count=0,
-                )
+                get_backend().send_keys(self.session_name, self.window_name, "3", enter_count=0)
                 # TUI rendering latency: '3' highlights the menu item, Enter confirms.
                 await asyncio.sleep(0.3)
-                await asyncio.to_thread(
-                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
-                )
+                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
                 update_dismissed = True
-                any_prompt_handled = True
-                last_prompt_time = time.monotonic()  # reset idle timer
                 await asyncio.sleep(1.0)
                 continue
 
@@ -1241,65 +1107,14 @@ class CodexProvider(BaseProvider):
             # dialog is active. The welcome banner alone is insufficient — it
             # renders as normal startup chrome BEFORE a late update dialog appears.
             has_idle = _has_startup_idle_composer(clean_output)
-            # ``v1_is_live`` rather than a bare presence test, so ONE notion of
-            # liveness governs both the dismissal above and this blocking check.
-            # With two notions they disagreed exactly where it hurt: stale v1 copy
-            # above a live menu was (correctly) too stale to dismiss, yet still
-            # counted here as a blocking dialog — so neither the dismissal nor the
-            # login exit could fire and the handler burned its whole cap, which at
-            # the 60s default against a 30s ``mcp_request_timeout`` is this PR's own
-            # P1 again. Sharing the predicate is what makes the invariant hold:
-            # every term in ``has_dialog`` has a dismissal arm that can actually
-            # fire on it.
-            #
-            # This only changes behaviour when a login menu is present. Without one,
-            # ``not has_login`` makes ``v1_is_live`` true whenever the copy is in
-            # ``bottom_region``, which is the previous meaning exactly — so the
-            # ``has_idle`` exit below still sees a live trust dialog as blocking.
             has_dialog = (
-                v1_is_live
+                re.search(TRUST_PROMPT_PATTERN, bottom_region)
                 or (
                     re.search(TRUST_PROMPT_PATTERN_V2, bottom_region)
                     and re.search(TRUST_PROMPT_FOOTER, bottom_region)
                 )
                 or _has_update_dialog_in_bottom(clean_output)
             )
-            # First-run login menu: this handler must NOT answer it (picking a
-            # sign-in method for the operator is not ours to do), but it is a
-            # settled startup state, and ``initialize()``'s next wait already
-            # accepts it as WAITING_USER_ANSWER. Without this branch it matches
-            # no exit condition — not a dismissable dialog, not the idle
-            # composer — so the loop ran to the outer cap and then logged
-            # "no prompt or welcome banner detected" about a screen that plainly
-            # showed one. With the default 60s cap and a 30s ``mcp_request_timeout``,
-            # a non-headless ``cao launch`` (which sends no initial_message, so
-            # ``POST /sessions`` initializes synchronously) had its client raise
-            # ReadTimeout before the operator could ever attach to authenticate.
-            # Still gated on ``not has_dialog``: a dialog stacked over the menu gets
-            # dismissed by a branch above first, and only then does this exit fire.
-            # Returning while one is still up would let ``initialize()`` succeed on
-            # WAITING_USER_ANSWER, and a delivery landing in that window is refused
-            # with ``TerminalInputBlockedError`` and dropped — the failure this
-            # handler's idle-gap split exists to prevent.
-            #
-            # "dismissed first" is load-bearing, and it is why the v1 term of
-            # ``has_dialog`` shares the dismissal's ``v1_is_live`` predicate. With two
-            # different notions of liveness, a live v1 dialog could satisfy
-            # ``has_dialog`` while being suppressed above as stale — neither branch
-            # fires and this loop live-locks to its cap. One predicate keeps the
-            # invariant that every term here has a dismissal arm able to fire on it.
-            #
-            # Stale copy is therefore not merely tolerated, it is invisible, whether it
-            # scrolled out of ``bottom_region`` entirely or still sits inside it above
-            # the menu. Both leave ``has_dialog`` false and this exit fires at once
-            # (measured: 0.00s, no keystroke, for either). Before the two predicates
-            # were unified, the second of those burned the whole cap.
-            if has_login and not has_dialog:
-                logger.info(
-                    "Codex first-run login menu detected — startup is settled, leaving the "
-                    "menu for the operator to answer"
-                )
-                return
             if has_idle and not has_dialog:
                 logger.info("Codex started — idle prompt visible, no blocking dialog")
                 return
@@ -1308,17 +1123,14 @@ class CodexProvider(BaseProvider):
 
         pane_tail = ""
         try:
-            output = await asyncio.to_thread(
-                get_backend().get_history, self.session_name, self.window_name
-            )
+            output = get_backend().get_history(self.session_name, self.window_name)
             if output:
                 pane_tail = "\n".join(output.splitlines()[-10:])
         except Exception:
             pass
         logger.error(
-            "Codex startup prompt handler hit its provider_init_timeout outer cap (%ss) — "
-            "no prompt or welcome banner detected. Pane tail:\n%s",
-            outer_timeout,
+            "Codex startup prompt handler timed out — no prompt or welcome banner detected. "
+            "Pane tail:\n%s",
             pane_tail,
         )
 
@@ -1332,10 +1144,8 @@ class CodexProvider(BaseProvider):
 
         # Capture the shell process name before launching codex — used later to
         # detect when codex has exited and the pane is back to a bare shell.
-        # Offloaded like the rest of this method's backend calls (#451): each is
-        # a blocking subprocess exec on cao-server's single shared event loop.
-        self.shell_baseline = await asyncio.to_thread(
-            get_backend().get_pane_current_command, self.session_name, self.window_name
+        self.shell_baseline = get_backend().get_pane_current_command(
+            self.session_name, self.window_name
         )
 
         # Send a warm-up command before launching codex.
@@ -1345,9 +1155,7 @@ class CodexProvider(BaseProvider):
         # external input that must be allowed to drive PROCESSING transitions
         # past any previously-latched ready state.
         status_monitor.notify_input_sent(self.terminal_id)
-        await asyncio.to_thread(
-            get_backend().send_keys, self.session_name, self.window_name, "echo ready"
-        )
+        get_backend().send_keys(self.session_name, self.window_name, "echo ready")
         await asyncio.sleep(2.0)
 
         # Build command with flags and agent profile (developer_instructions).
@@ -1357,22 +1165,10 @@ class CodexProvider(BaseProvider):
         #   caused by the shell_snapshot subprocess inheriting stdin.
         command = self._build_codex_command()
         status_monitor.notify_input_sent(self.terminal_id)
-        await asyncio.to_thread(
-            get_backend().send_keys, self.session_name, self.window_name, command
-        )
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
-        # Handle workspace trust prompt if it appears (new/untrusted directories).
-        # The handler's bounds now come from settings rather than a hard-coded
-        # 20.0 that could not be raised without a code change, so an operator on
-        # a slow or containerized host can widen them. It reads
-        # ``startup_prompt_handler_timeout`` itself as the IDLE GAP between
-        # consecutive prompts; ``provider_init_timeout`` (resolved above as
-        # ``init_timeout``) is passed as the hard outer cap. Keeping those two
-        # roles distinct is what those settings document, and matches
-        # kimi_cli/antigravity_cli/claude_code — so an operator who lowers the
-        # gap for one provider cannot silently truncate codex's whole handler
-        # and leave a late dialog undismissed.
-        await self._handle_trust_prompt(outer_timeout=float(init_timeout))
+        # Handle workspace trust prompt if it appears (new/untrusted directories)
+        await self._handle_trust_prompt(timeout=20.0)
 
         # WAITING_USER_ANSWER is included here specifically for the first-run login/auth
         # menu (see LOGIN_MENU_PATTERN's own comment) — an account with no credentials
@@ -1393,13 +1189,10 @@ class CodexProvider(BaseProvider):
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER},
-            timeout=float(init_timeout),
+            timeout=float(get_server_settings()["provider_init_timeout"]),
             polling_interval=1.0,
         ):
-            # Interpolated, not the old hard-coded "60 seconds": the bound is
-            # ``provider_init_timeout``, so an operator who changed it was told
-            # a number the code never used.
-            raise TimeoutError(f"Codex initialization timed out after {init_timeout}s")
+            raise TimeoutError("Codex initialization timed out after 60 seconds")
 
         self._initialized = True
         return True

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1175,6 +1175,10 @@ class CodexProvider(BaseProvider):
             # dialog is active. The welcome banner alone is insufficient — it
             # renders as normal startup chrome BEFORE a late update dialog appears.
             has_idle = _has_startup_idle_composer(clean_output)
+            has_login = bool(
+                re.search(LOGIN_MENU_PATTERN, bottom_region)
+                and re.search(LOGIN_MENU_FOOTER, bottom_region)
+            )
             has_dialog = (
                 re.search(TRUST_PROMPT_PATTERN, bottom_region)
                 or (
@@ -1183,6 +1187,28 @@ class CodexProvider(BaseProvider):
                 )
                 or _has_update_dialog_in_bottom(clean_output)
             )
+            # First-run login menu: this handler must NOT answer it (picking a
+            # sign-in method for the operator is not ours to do), but it is a
+            # settled startup state, and ``initialize()``'s next wait already
+            # accepts it as WAITING_USER_ANSWER. Without this branch it matches
+            # no exit condition — not a dismissable dialog, not the idle
+            # composer — so the loop ran to the outer cap and then logged
+            # "no prompt or welcome banner detected" about a screen that plainly
+            # showed one. With the default 60s cap and a 30s ``mcp_request_timeout``,
+            # a non-headless ``cao launch`` (which sends no initial_message, so
+            # ``POST /sessions`` initializes synchronously) had its client raise
+            # ReadTimeout before the operator could ever attach to authenticate.
+            # Still gated on ``not has_dialog``: a trust or update dialog stacked
+            # over the menu must be dismissed first, or ``initialize()`` would
+            # succeed on WAITING_USER_ANSWER and the next ``send_input`` would
+            # raise ``TerminalInputBlockedError`` — the exact failure this
+            # handler's idle-gap split exists to prevent.
+            if has_login and not has_dialog:
+                logger.info(
+                    "Codex first-run login menu detected — startup is settled, leaving the "
+                    "menu for the operator to answer"
+                )
+                return
             if has_idle and not has_dialog:
                 logger.info("Codex started — idle prompt visible, no blocking dialog")
                 return

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -644,6 +644,18 @@ class CodexProvider(BaseProvider):
     async def _handle_trust_prompt(self, timeout: float = 20.0) -> None:
         """Dismiss startup prompts that block readiness.
 
+        Every backend call here (get_history/send_keys/send_special_key) is a
+        blocking subprocess exec, and this loop makes one per second for up to
+        ``timeout`` seconds. cao-server runs a SINGLE event loop, so leaving
+        them loop-side froze every other concurrent request — including every
+        other terminal's own init — for the duration. They are offloaded to
+        threads for the same reason claude_code's startup handler was in #451
+        and kimi_cli/antigravity_cli/copilot_cli's were in #494. Codex is not
+        the last such gap — kiro_cli, opencode_cli and cursor_cli still make
+        loop-side backend calls in ``initialize()`` — but it is the slowest
+        init of the group, so a concurrent fan-out of codex launches is where
+        the self-inflicted queueing showed up first.
+
         Handles two classes of blocking dialog in a single poll loop:
 
         1. Workspace trust prompt (two variants):
@@ -661,7 +673,9 @@ class CodexProvider(BaseProvider):
         trust_dismissed = False
         update_dismissed = False
         while time.time() - start_time < timeout:
-            output = get_backend().get_history(self.session_name, self.window_name)
+            output = await asyncio.to_thread(
+                get_backend().get_history, self.session_name, self.window_name
+            )
             if not output:
                 await asyncio.sleep(1.0)
                 continue
@@ -673,7 +687,9 @@ class CodexProvider(BaseProvider):
 
                 logger.info("Codex workspace trust prompt (v1) detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 trust_dismissed = True
                 await asyncio.sleep(1.0)
                 continue
@@ -689,7 +705,9 @@ class CodexProvider(BaseProvider):
 
                 logger.info("Codex workspace trust prompt (v2) detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 trust_dismissed = True
                 await asyncio.sleep(1.0)
                 continue
@@ -701,10 +719,18 @@ class CodexProvider(BaseProvider):
                     "Codex update-available dialog detected, selecting " "'Skip until next version'"
                 )
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_keys(self.session_name, self.window_name, "3", enter_count=0)
+                await asyncio.to_thread(
+                    get_backend().send_keys,
+                    self.session_name,
+                    self.window_name,
+                    "3",
+                    enter_count=0,
+                )
                 # TUI rendering latency: '3' highlights the menu item, Enter confirms.
                 await asyncio.sleep(0.3)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 update_dismissed = True
                 await asyncio.sleep(1.0)
                 continue
@@ -729,7 +755,9 @@ class CodexProvider(BaseProvider):
 
         pane_tail = ""
         try:
-            output = get_backend().get_history(self.session_name, self.window_name)
+            output = await asyncio.to_thread(
+                get_backend().get_history, self.session_name, self.window_name
+            )
             if output:
                 pane_tail = "\n".join(output.splitlines()[-10:])
         except Exception:
@@ -750,8 +778,10 @@ class CodexProvider(BaseProvider):
 
         # Capture the shell process name before launching codex — used later to
         # detect when codex has exited and the pane is back to a bare shell.
-        self.shell_baseline = get_backend().get_pane_current_command(
-            self.session_name, self.window_name
+        # Offloaded like the rest of this method's backend calls (#451): each is
+        # a blocking subprocess exec on cao-server's single shared event loop.
+        self.shell_baseline = await asyncio.to_thread(
+            get_backend().get_pane_current_command, self.session_name, self.window_name
         )
 
         # Send a warm-up command before launching codex.
@@ -761,7 +791,9 @@ class CodexProvider(BaseProvider):
         # external input that must be allowed to drive PROCESSING transitions
         # past any previously-latched ready state.
         status_monitor.notify_input_sent(self.terminal_id)
-        get_backend().send_keys(self.session_name, self.window_name, "echo ready")
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, "echo ready"
+        )
         await asyncio.sleep(2.0)
 
         # Build command with flags and agent profile (developer_instructions).
@@ -771,10 +803,21 @@ class CodexProvider(BaseProvider):
         #   caused by the shell_snapshot subprocess inheriting stdin.
         command = self._build_codex_command()
         status_monitor.notify_input_sent(self.terminal_id)
-        get_backend().send_keys(self.session_name, self.window_name, command)
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, command
+        )
 
-        # Handle workspace trust prompt if it appears (new/untrusted directories)
-        await self._handle_trust_prompt(timeout=20.0)
+        # Handle workspace trust prompt if it appears (new/untrusted directories).
+        # Timeout comes from settings — matching kimi_cli / antigravity_cli /
+        # claude_code, which all read ``startup_prompt_handler_timeout`` — so an
+        # operator on a slow or containerized host can widen it. The hard-coded
+        # 20.0 could not be raised without a code change, and a cold start that
+        # renders its first frame later than that falls through to "startup
+        # prompt handler timed out" and has to be rescued by the
+        # wait_until_status below.
+        await self._handle_trust_prompt(
+            timeout=float(get_server_settings()["startup_prompt_handler_timeout"])
+        )
 
         # WAITING_USER_ANSWER is included here specifically for the first-run login/auth
         # menu (see LOGIN_MENU_PATTERN's own comment) — an account with no credentials
@@ -795,10 +838,13 @@ class CodexProvider(BaseProvider):
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER},
-            timeout=float(get_server_settings()["provider_init_timeout"]),
+            timeout=float(init_timeout),
             polling_interval=1.0,
         ):
-            raise TimeoutError("Codex initialization timed out after 60 seconds")
+            # Interpolated, not the old hard-coded "60 seconds": the bound is
+            # ``provider_init_timeout``, so an operator who changed it was told
+            # a number the code never used.
+            raise TimeoutError(f"Codex initialization timed out after {init_timeout}s")
 
         self._initialized = True
         return True

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1035,8 +1035,32 @@ class CodexProvider(BaseProvider):
             command = f"{command} {developer_instructions_fragment}"
         return command
 
-    async def _handle_trust_prompt(self, timeout: float = 20.0) -> None:
+    async def _handle_trust_prompt(
+        self,
+        idle_gap: Optional[float] = None,
+        outer_timeout: Optional[float] = None,
+    ) -> None:
         """Dismiss startup prompts that block readiness.
+
+        Args:
+            idle_gap: Seconds with no new prompt before startup is considered
+                settled. Defaults to the ``startup_prompt_handler_timeout``
+                setting. Per that setting's contract this is an IDLE GAP, not a
+                total budget: it is reset every time a prompt is answered, and
+                it only starts counting once at least one prompt has been
+                handled. Mirrors ``kimi_cli``/``antigravity_cli``.
+            outer_timeout: Hard cap on total time this handler may run.
+                Defaults to the ``provider_init_timeout`` setting, which is
+                what that setting documents itself as bounding.
+
+        Before this split, ``startup_prompt_handler_timeout`` was used as a
+        FIXED TOTAL budget here, contradicting its documented semantics: an
+        operator who lowered it to make another provider settle faster silently
+        capped codex's whole handler, so a dialog rendered after the gap was
+        never dismissed. ``initialize()`` treats WAITING_USER_ANSWER as success,
+        so the undismissed dialog then made ``send_input`` raise
+        ``TerminalInputBlockedError`` and the initial message was never
+        delivered.
 
         Every backend call here (get_history/send_keys/send_special_key) is a
         blocking subprocess exec, and this loop makes one per second for up to
@@ -1063,10 +1087,22 @@ class CodexProvider(BaseProvider):
            Dismissed with '3'+Enter ("Skip until next version"). A blind Enter
            would select "1. Update now" (global npm install).
         """
-        start_time = time.time()
+        if idle_gap is None:
+            idle_gap = float(get_server_settings()["startup_prompt_handler_timeout"])
+        if outer_timeout is None:
+            outer_timeout = float(get_server_settings()["provider_init_timeout"])
+        outer_deadline = time.monotonic() + outer_timeout
+        last_prompt_time = time.monotonic()
+        any_prompt_handled = False
         trust_dismissed = False
         update_dismissed = False
-        while time.time() - start_time < timeout:
+        while True:
+            now = time.monotonic()
+            if now >= outer_deadline:
+                break
+            if any_prompt_handled and now - last_prompt_time >= idle_gap:
+                # No new prompt within the idle gap — startup settled.
+                return
             output = await asyncio.to_thread(
                 get_backend().get_history, self.session_name, self.window_name
             )
@@ -1085,6 +1121,8 @@ class CodexProvider(BaseProvider):
                     get_backend().send_special_key, self.session_name, self.window_name, "Enter"
                 )
                 trust_dismissed = True
+                any_prompt_handled = True
+                last_prompt_time = time.monotonic()  # reset idle timer
                 await asyncio.sleep(1.0)
                 continue
 
@@ -1103,6 +1141,8 @@ class CodexProvider(BaseProvider):
                     get_backend().send_special_key, self.session_name, self.window_name, "Enter"
                 )
                 trust_dismissed = True
+                any_prompt_handled = True
+                last_prompt_time = time.monotonic()  # reset idle timer
                 await asyncio.sleep(1.0)
                 continue
 
@@ -1126,6 +1166,8 @@ class CodexProvider(BaseProvider):
                     get_backend().send_special_key, self.session_name, self.window_name, "Enter"
                 )
                 update_dismissed = True
+                any_prompt_handled = True
+                last_prompt_time = time.monotonic()  # reset idle timer
                 await asyncio.sleep(1.0)
                 continue
 
@@ -1157,8 +1199,9 @@ class CodexProvider(BaseProvider):
         except Exception:
             pass
         logger.error(
-            "Codex startup prompt handler timed out — no prompt or welcome banner detected. "
-            "Pane tail:\n%s",
+            "Codex startup prompt handler hit its provider_init_timeout outer cap (%ss) — "
+            "no prompt or welcome banner detected. Pane tail:\n%s",
+            outer_timeout,
             pane_tail,
         )
 
@@ -1202,16 +1245,17 @@ class CodexProvider(BaseProvider):
         )
 
         # Handle workspace trust prompt if it appears (new/untrusted directories).
-        # Timeout comes from settings — matching kimi_cli / antigravity_cli /
-        # claude_code, which all read ``startup_prompt_handler_timeout`` — so an
-        # operator on a slow or containerized host can widen it. The hard-coded
-        # 20.0 could not be raised without a code change, and a cold start that
-        # renders its first frame later than that falls through to "startup
-        # prompt handler timed out" and has to be rescued by the
-        # wait_until_status below.
-        await self._handle_trust_prompt(
-            timeout=float(get_server_settings()["startup_prompt_handler_timeout"])
-        )
+        # The handler's bounds now come from settings rather than a hard-coded
+        # 20.0 that could not be raised without a code change, so an operator on
+        # a slow or containerized host can widen them. It reads
+        # ``startup_prompt_handler_timeout`` itself as the IDLE GAP between
+        # consecutive prompts; ``provider_init_timeout`` (resolved above as
+        # ``init_timeout``) is passed as the hard outer cap. Keeping those two
+        # roles distinct is what those settings document, and matches
+        # kimi_cli/antigravity_cli/claude_code — so an operator who lowers the
+        # gap for one provider cannot silently truncate codex's whole handler
+        # and leave a late dialog undismissed.
+        await self._handle_trust_prompt(outer_timeout=float(init_timeout))
 
         # WAITING_USER_ANSWER is included here specifically for the first-run login/auth
         # menu (see LOGIN_MENU_PATTERN's own comment) — an account with no credentials

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1112,7 +1112,36 @@ class CodexProvider(BaseProvider):
 
             clean_output = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", output))
 
-            if not trust_dismissed and re.search(TRUST_PROMPT_PATTERN, clean_output):
+            bottom_region = "\n".join(clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+            has_login = bool(
+                re.search(LOGIN_MENU_PATTERN, bottom_region)
+                and re.search(LOGIN_MENU_FOOTER, bottom_region)
+            )
+
+            # ``not has_login`` is what keeps the invariant below honest. Alone among
+            # the four signatures this loop recognises, the v1 trust check matches the
+            # WHOLE capture rather than ``bottom_region`` — so it can fire on trust
+            # copy sitting anywhere in scrollback, including text the login gate
+            # cannot see. Without this gate the handler would press Enter into a live
+            # login menu and *then* log that it was leaving the menu for the operator,
+            # which is both a lie and worse than the stall being fixed here: the
+            # keystroke selects a sign-in method, so the pane leaves the login menu
+            # and therefore the set ``initialize()`` is waiting on ({IDLE, COMPLETED,
+            # WAITING_USER_ANSWER}) — measured as PROCESSING on the API-key option;
+            # the OAuth option was not exercised. Either way a recoverable "operator
+            # must authenticate" becomes a TimeoutError and teardown.
+            #
+            # Deliberately gated here rather than by bottom-anchoring the search:
+            # anchoring would change trust-v1 detection for every codex launch, and a
+            # genuine trust prompt may legitimately sit higher than the bottom 15
+            # lines. Reading it as "if the bottom of the screen is the login menu,
+            # then whatever trust text is in the buffer is not the active dialog"
+            # keeps this scoped to the case at hand.
+            if (
+                not trust_dismissed
+                and not has_login
+                and re.search(TRUST_PROMPT_PATTERN, clean_output)
+            ):
                 from cli_agent_orchestrator.services.status_monitor import status_monitor
 
                 logger.info("Codex workspace trust prompt (v1) detected, auto-accepting")
@@ -1125,8 +1154,6 @@ class CodexProvider(BaseProvider):
                 last_prompt_time = time.monotonic()  # reset idle timer
                 await asyncio.sleep(1.0)
                 continue
-
-            bottom_region = "\n".join(clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
 
             if (
                 not trust_dismissed
@@ -1175,10 +1202,6 @@ class CodexProvider(BaseProvider):
             # dialog is active. The welcome banner alone is insufficient — it
             # renders as normal startup chrome BEFORE a late update dialog appears.
             has_idle = _has_startup_idle_composer(clean_output)
-            has_login = bool(
-                re.search(LOGIN_MENU_PATTERN, bottom_region)
-                and re.search(LOGIN_MENU_FOOTER, bottom_region)
-            )
             has_dialog = (
                 re.search(TRUST_PROMPT_PATTERN, bottom_region)
                 or (

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1118,28 +1118,67 @@ class CodexProvider(BaseProvider):
                 and re.search(LOGIN_MENU_FOOTER, bottom_region)
             )
 
-            # ``not has_login`` is what keeps the invariant below honest. Alone among
-            # the four signatures this loop recognises, the v1 trust check matches the
-            # WHOLE capture rather than ``bottom_region`` — so it can fire on trust
-            # copy sitting anywhere in scrollback, including text the login gate
-            # cannot see. Without this gate the handler would press Enter into a live
-            # login menu and *then* log that it was leaving the menu for the operator,
-            # which is both a lie and worse than the stall being fixed here: the
-            # keystroke selects a sign-in method, so the pane leaves the login menu
-            # and therefore the set ``initialize()`` is waiting on ({IDLE, COMPLETED,
-            # WAITING_USER_ANSWER}) — measured as PROCESSING on the API-key option;
-            # the OAuth option was not exercised. Either way a recoverable "operator
-            # must authenticate" becomes a TimeoutError and teardown.
+            # The v1 trust check is the only one of the four signatures matched
+            # against the WHOLE capture rather than ``bottom_region``, so on its own
+            # it fires on trust copy sitting anywhere in scrollback — text the login
+            # gate below cannot see. Ungated, the handler would press Enter into a
+            # live login menu and *then* log that it was leaving that menu for the
+            # operator: the keystroke selects a sign-in method, so the pane leaves
+            # the set ``initialize()`` waits on ({IDLE, COMPLETED,
+            # WAITING_USER_ANSWER}) and a recoverable "operator must authenticate"
+            # becomes a TimeoutError and teardown. (Measured as PROCESSING on the
+            # API-key option; the OAuth option was not exercised.)
             #
-            # Deliberately gated here rather than by bottom-anchoring the search:
-            # anchoring would change trust-v1 detection for every codex launch, and a
-            # genuine trust prompt may legitimately sit higher than the bottom 15
-            # lines. Reading it as "if the bottom of the screen is the login menu,
-            # then whatever trust text is in the buffer is not the active dialog"
-            # keeps this scoped to the case at hand.
+            # So the gate has to separate a LIVE v1 dialog from stale v1 copy, and
+            # position is what separates them — hence ``v1_is_live``. Suppressing on
+            # ``has_login`` alone would be wrong in the other direction: a genuine v1
+            # dialog stacked over a live login menu satisfies BOTH ``has_login`` and
+            # ``has_dialog``, so neither this branch nor the login exit could fire and
+            # the handler would live-lock to its outer cap — reproducing, in that one
+            # frame class, the exact stall this commit's sibling exists to remove.
+            #
+            # Where the asymmetry actually lies: this branch's TRIGGER is the only
+            # whole-capture match in the loop (the final conjunct below), while
+            # liveness and every term of ``has_dialog`` are confined to
+            # ``bottom_region`` — including ``_has_update_dialog_in_bottom``, which
+            # takes the same 15-line slice internally. So the whole capture decides
+            # only *whether trust copy exists at all*; position inside the bottom
+            # region decides whether it is live.
+            #
+            # Presence in ``bottom_region`` is not enough to call a v1 dialog live: it
+            # would still answer trust copy sitting in the last 15 lines ABOVE a live
+            # menu, which is the original bug with a smaller window rather than a
+            # closed one. POSITION settles it — Codex draws the active modal last, so
+            # the lower block is the one on screen. Hence "live" means the v1 copy
+            # appears below the menu text, which is also why the shared footer is no
+            # use here: ``LOGIN_MENU_FOOTER is TRUST_PROMPT_FOOTER``, so the footer
+            # cannot attribute itself to either block.
+            # Both sides take the LAST occurrence, and that symmetry is the whole
+            # correctness argument. Comparing the FIRST v1 match against the LAST menu
+            # match misreads a frame carrying stale v1 copy above the menu AND a live
+            # v1 dialog below it: the stale copy wins the comparison, ``v1_is_live``
+            # goes false, and because ``has_dialog`` shares that predicate the login
+            # exit fires with a live dialog on screen — the exact failure ``not
+            # has_dialog`` exists to prevent. Only the lowest occurrence of each block
+            # can be the one currently drawn, so only those two may be compared.
+            _v1_all = list(re.finditer(TRUST_PROMPT_PATTERN, bottom_region))
+            _v1_match = _v1_all[-1] if _v1_all else None
+            _menu_matches = list(re.finditer(LOGIN_MENU_PATTERN, bottom_region))
+            # Offsets are only comparable because both matches come from
+            # ``bottom_region``. Sourcing either from ``clean_output`` would compare
+            # positions in two different strings and silently produce nonsense.
+            #
+            # ``is not None`` rather than ``bool()``: mypy narrows the Optional through
+            # the former only, and ``.start()`` below needs the narrowing.
+            v1_is_live = _v1_match is not None and (
+                # Short-circuits before the index, which is only safe to take when
+                # has_login held (it requires a menu match in this same region).
+                not has_login
+                or _v1_match.start() > _menu_matches[-1].start()
+            )
             if (
                 not trust_dismissed
-                and not has_login
+                and (v1_is_live or not has_login)
                 and re.search(TRUST_PROMPT_PATTERN, clean_output)
             ):
                 from cli_agent_orchestrator.services.status_monitor import status_monitor
@@ -1202,8 +1241,23 @@ class CodexProvider(BaseProvider):
             # dialog is active. The welcome banner alone is insufficient — it
             # renders as normal startup chrome BEFORE a late update dialog appears.
             has_idle = _has_startup_idle_composer(clean_output)
+            # ``v1_is_live`` rather than a bare presence test, so ONE notion of
+            # liveness governs both the dismissal above and this blocking check.
+            # With two notions they disagreed exactly where it hurt: stale v1 copy
+            # above a live menu was (correctly) too stale to dismiss, yet still
+            # counted here as a blocking dialog — so neither the dismissal nor the
+            # login exit could fire and the handler burned its whole cap, which at
+            # the 60s default against a 30s ``mcp_request_timeout`` is this PR's own
+            # P1 again. Sharing the predicate is what makes the invariant hold:
+            # every term in ``has_dialog`` has a dismissal arm that can actually
+            # fire on it.
+            #
+            # This only changes behaviour when a login menu is present. Without one,
+            # ``not has_login`` makes ``v1_is_live`` true whenever the copy is in
+            # ``bottom_region``, which is the previous meaning exactly — so the
+            # ``has_idle`` exit below still sees a live trust dialog as blocking.
             has_dialog = (
-                re.search(TRUST_PROMPT_PATTERN, bottom_region)
+                v1_is_live
                 or (
                     re.search(TRUST_PROMPT_PATTERN_V2, bottom_region)
                     and re.search(TRUST_PROMPT_FOOTER, bottom_region)
@@ -1221,11 +1275,25 @@ class CodexProvider(BaseProvider):
             # a non-headless ``cao launch`` (which sends no initial_message, so
             # ``POST /sessions`` initializes synchronously) had its client raise
             # ReadTimeout before the operator could ever attach to authenticate.
-            # Still gated on ``not has_dialog``: a trust or update dialog stacked
-            # over the menu must be dismissed first, or ``initialize()`` would
-            # succeed on WAITING_USER_ANSWER and the next ``send_input`` would
-            # raise ``TerminalInputBlockedError`` — the exact failure this
+            # Still gated on ``not has_dialog``: a dialog stacked over the menu gets
+            # dismissed by a branch above first, and only then does this exit fire.
+            # Returning while one is still up would let ``initialize()`` succeed on
+            # WAITING_USER_ANSWER, and a delivery landing in that window is refused
+            # with ``TerminalInputBlockedError`` and dropped — the failure this
             # handler's idle-gap split exists to prevent.
+            #
+            # "dismissed first" is load-bearing, and it is why the v1 term of
+            # ``has_dialog`` shares the dismissal's ``v1_is_live`` predicate. With two
+            # different notions of liveness, a live v1 dialog could satisfy
+            # ``has_dialog`` while being suppressed above as stale — neither branch
+            # fires and this loop live-locks to its cap. One predicate keeps the
+            # invariant that every term here has a dismissal arm able to fire on it.
+            #
+            # Stale copy is therefore not merely tolerated, it is invisible, whether it
+            # scrolled out of ``bottom_region`` entirely or still sits inside it above
+            # the menu. Both leave ``has_dialog`` false and this exit fires at once
+            # (measured: 0.00s, no keystroke, for either). Before the two predicates
+            # were unified, the second of those burned the whole cap.
             if has_login and not has_dialog:
                 logger.info(
                     "Codex first-run login menu detected — startup is settled, leaving the "

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1038,6 +1038,18 @@ class CodexProvider(BaseProvider):
     async def _handle_trust_prompt(self, timeout: float = 20.0) -> None:
         """Dismiss startup prompts that block readiness.
 
+        Every backend call here (get_history/send_keys/send_special_key) is a
+        blocking subprocess exec, and this loop makes one per second for up to
+        ``timeout`` seconds. cao-server runs a SINGLE event loop, so leaving
+        them loop-side froze every other concurrent request — including every
+        other terminal's own init — for the duration. They are offloaded to
+        threads for the same reason claude_code's startup handler was in #451
+        and kimi_cli/antigravity_cli/copilot_cli's were in #494. Codex is not
+        the last such gap — kiro_cli, opencode_cli and cursor_cli still make
+        loop-side backend calls in ``initialize()`` — but it is the slowest
+        init of the group, so a concurrent fan-out of codex launches is where
+        the self-inflicted queueing showed up first.
+
         Handles two classes of blocking dialog in a single poll loop:
 
         1. Workspace trust prompt (two variants):
@@ -1055,7 +1067,9 @@ class CodexProvider(BaseProvider):
         trust_dismissed = False
         update_dismissed = False
         while time.time() - start_time < timeout:
-            output = get_backend().get_history(self.session_name, self.window_name)
+            output = await asyncio.to_thread(
+                get_backend().get_history, self.session_name, self.window_name
+            )
             if not output:
                 await asyncio.sleep(1.0)
                 continue
@@ -1067,7 +1081,9 @@ class CodexProvider(BaseProvider):
 
                 logger.info("Codex workspace trust prompt (v1) detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 trust_dismissed = True
                 await asyncio.sleep(1.0)
                 continue
@@ -1083,7 +1099,9 @@ class CodexProvider(BaseProvider):
 
                 logger.info("Codex workspace trust prompt (v2) detected, auto-accepting")
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 trust_dismissed = True
                 await asyncio.sleep(1.0)
                 continue
@@ -1095,10 +1113,18 @@ class CodexProvider(BaseProvider):
                     "Codex update-available dialog detected, selecting " "'Skip until next version'"
                 )
                 status_monitor.notify_input_sent(self.terminal_id)
-                get_backend().send_keys(self.session_name, self.window_name, "3", enter_count=0)
+                await asyncio.to_thread(
+                    get_backend().send_keys,
+                    self.session_name,
+                    self.window_name,
+                    "3",
+                    enter_count=0,
+                )
                 # TUI rendering latency: '3' highlights the menu item, Enter confirms.
                 await asyncio.sleep(0.3)
-                get_backend().send_special_key(self.session_name, self.window_name, "Enter")
+                await asyncio.to_thread(
+                    get_backend().send_special_key, self.session_name, self.window_name, "Enter"
+                )
                 update_dismissed = True
                 await asyncio.sleep(1.0)
                 continue
@@ -1123,7 +1149,9 @@ class CodexProvider(BaseProvider):
 
         pane_tail = ""
         try:
-            output = get_backend().get_history(self.session_name, self.window_name)
+            output = await asyncio.to_thread(
+                get_backend().get_history, self.session_name, self.window_name
+            )
             if output:
                 pane_tail = "\n".join(output.splitlines()[-10:])
         except Exception:
@@ -1144,8 +1172,10 @@ class CodexProvider(BaseProvider):
 
         # Capture the shell process name before launching codex — used later to
         # detect when codex has exited and the pane is back to a bare shell.
-        self.shell_baseline = get_backend().get_pane_current_command(
-            self.session_name, self.window_name
+        # Offloaded like the rest of this method's backend calls (#451): each is
+        # a blocking subprocess exec on cao-server's single shared event loop.
+        self.shell_baseline = await asyncio.to_thread(
+            get_backend().get_pane_current_command, self.session_name, self.window_name
         )
 
         # Send a warm-up command before launching codex.
@@ -1155,7 +1185,9 @@ class CodexProvider(BaseProvider):
         # external input that must be allowed to drive PROCESSING transitions
         # past any previously-latched ready state.
         status_monitor.notify_input_sent(self.terminal_id)
-        get_backend().send_keys(self.session_name, self.window_name, "echo ready")
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, "echo ready"
+        )
         await asyncio.sleep(2.0)
 
         # Build command with flags and agent profile (developer_instructions).
@@ -1165,10 +1197,21 @@ class CodexProvider(BaseProvider):
         #   caused by the shell_snapshot subprocess inheriting stdin.
         command = self._build_codex_command()
         status_monitor.notify_input_sent(self.terminal_id)
-        get_backend().send_keys(self.session_name, self.window_name, command)
+        await asyncio.to_thread(
+            get_backend().send_keys, self.session_name, self.window_name, command
+        )
 
-        # Handle workspace trust prompt if it appears (new/untrusted directories)
-        await self._handle_trust_prompt(timeout=20.0)
+        # Handle workspace trust prompt if it appears (new/untrusted directories).
+        # Timeout comes from settings — matching kimi_cli / antigravity_cli /
+        # claude_code, which all read ``startup_prompt_handler_timeout`` — so an
+        # operator on a slow or containerized host can widen it. The hard-coded
+        # 20.0 could not be raised without a code change, and a cold start that
+        # renders its first frame later than that falls through to "startup
+        # prompt handler timed out" and has to be rescued by the
+        # wait_until_status below.
+        await self._handle_trust_prompt(
+            timeout=float(get_server_settings()["startup_prompt_handler_timeout"])
+        )
 
         # WAITING_USER_ANSWER is included here specifically for the first-run login/auth
         # menu (see LOGIN_MENU_PATTERN's own comment) — an account with no credentials
@@ -1189,10 +1232,13 @@ class CodexProvider(BaseProvider):
         if not await wait_until_status(
             self.terminal_id,
             {TerminalStatus.IDLE, TerminalStatus.COMPLETED, TerminalStatus.WAITING_USER_ANSWER},
-            timeout=float(get_server_settings()["provider_init_timeout"]),
+            timeout=float(init_timeout),
             polling_interval=1.0,
         ):
-            raise TimeoutError("Codex initialization timed out after 60 seconds")
+            # Interpolated, not the old hard-coded "60 seconds": the bound is
+            # ``provider_init_timeout``, so an operator who changed it was told
+            # a number the code never used.
+            raise TimeoutError(f"Codex initialization timed out after {init_timeout}s")
 
         self._initialized = True
         return True

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -295,9 +295,15 @@ def get_session(session_name: str) -> Dict:
         # single source of truth and is backend-aware (tmux push vs herdr
         # native), so derive it here rather than persisting a stale column.
         from cli_agent_orchestrator.services.status_monitor import status_monitor
+        from cli_agent_orchestrator.services.terminal_service import reported_status
 
         for terminal in terminals:
-            terminal["status"] = status_monitor.get_status(terminal["id"]).value
+            # reported_status keeps this in step with GET /terminals/{id}: a
+            # terminal whose accepted initial message has not been dispatched yet
+            # must not read IDLE/COMPLETED anywhere a client can see it (#566).
+            terminal["status"] = reported_status(
+                terminal["id"], status_monitor.get_status(terminal["id"])
+            ).value
         return {"session": session_data, "terminals": terminals}
 
     except Exception as e:

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -558,6 +558,34 @@ class StatusMonitor:
             except RuntimeError:
                 pass  # loop already closed during shutdown — the timer is moot
 
+    def output_generation(self, terminal_id: str) -> int:
+        """Return the terminal's current turn/output generation.
+
+        Exposes the counter #712 already maintains (``_capture_generation``) so a
+        caller can ask "has anything happened since this point?" rather than only
+        "what is the status now?". It advances in exactly two places:
+        ``notify_input_sent`` (a new turn began) and ``_process_chunk`` (real
+        output arrived). So a generation strictly greater than one sampled just
+        after dispatch means the terminal has produced output since that dispatch.
+
+        This exists because a status VALUE cannot carry that information.
+        ``notify_input_sent`` deliberately leaves ``_last_status`` alone while
+        arming the revert, so a ready status cached BEFORE a send is
+        indistinguishable from one earned after it — the defect PR #566 hit when
+        a pre-dispatch COMPLETED satisfied delivery confirmation instantly.
+
+        Read-only and lock-guarded. Returns 0 for an unknown terminal, which is
+        below any real generation and so never reads as "something happened".
+
+        NOT meaningful for event-inbox backends (herdr): they start no FIFO
+        reader, so ``_process_chunk`` never runs and this never advances from
+        output. ``get_status`` derives their status on demand instead, which is
+        why they have no staleness problem to solve and callers must not gate on
+        this for them.
+        """
+        with self._lock:
+            return self._capture_generation.get(terminal_id, 0)
+
     def notify_input_sent(self, terminal_id: str, *, assume_processing: bool = False) -> None:
         """Arm the next PROCESSING transition.
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -2054,27 +2054,46 @@ def _schedule_deferred_init(
                 effective_orchestration_type = orchestration_type or OrchestrationType.ASSIGN
                 # send_input is blocking tmux I/O — off the loop so it can't
                 # freeze the server for concurrent requests.
-                try:
-                    await asyncio.to_thread(
-                        send_input,
-                        terminal_id,
-                        initial_message,
-                        registry=registry,
-                        sender_id=caller_id,
-                        orchestration_type=effective_orchestration_type,
-                    )
-                finally:
-                    # The dispatch boundary, and the earliest point at which a
-                    # completion poller's evidence can be downstream of this send.
-                    # Released here rather than at the end of _run so a task that
-                    # finishes DURING _confirm_worker_started_or_resubmit is still
-                    # observable — holding the mark across the confirm/resubmit
-                    # window would hide a genuine early completion and strand the
-                    # poller until its timeout. In ``finally`` because a raising
-                    # send_input (TerminalInputBlockedError: the pane is parked on
-                    # a prompt) must also stop masking: the terminal is then
-                    # honestly WAITING_USER_ANSWER and the operator has to see it.
-                    _clear_initial_delivery_pending(terminal_id)
+                await asyncio.to_thread(
+                    send_input,
+                    terminal_id,
+                    initial_message,
+                    registry=registry,
+                    sender_id=caller_id,
+                    orchestration_type=effective_orchestration_type,
+                )
+                # The pending mark is deliberately NOT released here.
+                #
+                # Round-4 review (haofeif), P1. An earlier revision cleared it at
+                # this dispatch boundary, reasoning that a keystroke had been
+                # issued so a poller's evidence was now downstream of the send. It
+                # isn't. send_input only calls status_monitor.notify_input_sent(),
+                # which ARMS the next transition without changing the cached
+                # status, and no current provider enables
+                # assume_processing_on_dispatch. The status a poller reads right
+                # after this line is therefore still the pre-send IDLE, and stays
+                # that way until the agent's first output chunk is detected. The
+                # reviewer measured ~1.4s of it against a real worker; the
+                # regression test here reproduced 0.93s. Either way it is far
+                # longer than idle_stable_polls samples, so releasing at this line
+                # only moved the false-completion window from before the send to
+                # after it.
+                #
+                # _run's outer ``finally`` releases it instead, which is reached
+                # only after _confirm_worker_started_or_resubmit has observed a
+                # status in _DEFERRED_STARTED_STATUSES. That set includes
+                # COMPLETED, so holding the mark across the confirm window does
+                # NOT hide a genuine early completion (the concern that motivated
+                # releasing here): confirm returns as soon as the completion is
+                # visible, and the mark lifts with it.
+                #
+                # Cost of the change: when NO started status is ever observed the
+                # mark is now held for the confirm loop's whole budget
+                # (_DEFERRED_SUBMIT_CONFIRM_TIMEOUT x (1 + max resubmits) = ~32s)
+                # instead of being dropped at dispatch. That is inside `cao
+                # launch`'s 420s headless budget, and the worker is torn down at
+                # the end of it anyway, so UNKNOWN is the honest reading for a
+                # delivery we cannot confirm.
                 # Delivery can be silently dropped (Enter swallowed / paste lost)
                 # when the TUI isn't input-ready. Confirm the worker actually
                 # started and re-submit if not; if it never starts, surface the
@@ -2152,10 +2171,17 @@ def _schedule_deferred_init(
                 delete_worker=True,
             )
         finally:
-            # Safety net for every path that never reached the send at all —
-            # initialize() raising, or the loop being torn down — so a terminal
-            # can't be left permanently masked. Idempotent: the happy path has
-            # already cleared it at the dispatch boundary above.
+            # The single release point for every path, and on the happy path the
+            # first moment a completion poller's evidence is genuinely downstream
+            # of the send: reached only once _confirm_worker_started_or_resubmit
+            # has seen PROCESSING, COMPLETED or WAITING_USER_ANSWER.
+            #
+            # It also covers every abnormal exit, so a terminal can never be left
+            # permanently masked: initialize() raising, send_input raising
+            # TerminalInputBlockedError (the pane is parked on a prompt — the
+            # terminal is then honestly WAITING_USER_ANSWER and the operator has
+            # to see it), the worker never starting after all resubmits, or the
+            # loop being torn down. Idempotent, so double-clearing is harmless.
             _clear_initial_delivery_pending(terminal_id)
 
     try:

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -1950,6 +1950,50 @@ def redeliver_dropped_message(
     return False
 
 
+async def _wait_for_post_dispatch_start(
+    terminal_id: str,
+    dispatch_generation: Optional[int],
+    timeout: float,
+    polling_interval: float = 0.5,
+) -> bool:
+    """Wait for a started status that is EVIDENCE OF THIS TURN, not a cached one.
+
+    Round-6 review (haofeif), P1. ``wait_until_status`` returns on the first poll
+    whose value is in the target set, and a status VALUE cannot say when it was
+    earned. Provider startup output can legitimately parse as COMPLETED, which
+    then latches (``_STICKY_READY_STATUSES``), and ``send_input`` only ARMS the
+    next transition without touching the cached value. So a pre-dispatch
+    COMPLETED satisfied confirmation instantly -- measured at 0.008s against an
+    exact head -- releasing the pending-delivery mask before the new task had
+    emitted anything. Two earlier release points failed for the same underlying
+    reason: they keyed on a status value rather than on its recency.
+
+    ``dispatch_generation`` is ``status_monitor.output_generation()`` sampled just
+    after the send. Requiring the current generation to EXCEED it means real
+    output has landed since dispatch, because that counter advances only in
+    ``notify_input_sent`` (already included in the sample) and ``_process_chunk``
+    (real output arrived). That is the causal evidence the mask needs.
+
+    ``dispatch_generation=None`` disables the recency requirement, which is
+    necessary for event-inbox backends (herdr): they start no FIFO reader, so the
+    generation never advances from output and gating on it could never succeed --
+    the worker would burn every resubmit and then be torn down. They need no gate
+    anyway, because ``get_status`` derives their status on demand at call time, so
+    there is no cached value to go stale.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        status = status_monitor.get_status(terminal_id)
+        if status in _DEFERRED_STARTED_STATUSES and (
+            dispatch_generation is None
+            or status_monitor.output_generation(terminal_id) > dispatch_generation
+        ):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(polling_interval)
+
+
 async def _confirm_worker_started_or_resubmit(
     terminal_id: str,
     message: str,
@@ -1957,18 +2001,19 @@ async def _confirm_worker_started_or_resubmit(
     sender_id: Optional[str],
     orchestration_type: Optional[OrchestrationType],
     provider=None,
+    dispatch_generation: Optional[int] = None,
 ) -> bool:
     """Confirm a deferred-init worker began processing; re-submit if not.
 
-    Returns True once the terminal reaches a started status, False if it is
-    still stuck at IDLE after all resubmit attempts. Blocking tmux/DB I/O runs
-    off the loop via to_thread so concurrent deferred inits aren't frozen.
+    Returns True once the terminal reaches a started status EARNED AFTER dispatch
+    (see ``_wait_for_post_dispatch_start``), False if it never does after all
+    resubmit attempts. Blocking tmux/DB I/O runs off the loop via to_thread so
+    concurrent deferred inits aren't frozen.
     """
-    if await wait_until_status(
+    if await _wait_for_post_dispatch_start(
         terminal_id,
-        _DEFERRED_STARTED_STATUSES,
+        dispatch_generation,
         timeout=_DEFERRED_SUBMIT_CONFIRM_TIMEOUT,
-        polling_interval=0.5,
     ):
         return True
 
@@ -1988,11 +2033,12 @@ async def _confirm_worker_started_or_resubmit(
         )
         if already_started:
             return True
-        if await wait_until_status(
+        # Same recency requirement as the first wait: a resubmit that lands on a
+        # still-cached pre-dispatch COMPLETED must not read as success either.
+        if await _wait_for_post_dispatch_start(
             terminal_id,
-            _DEFERRED_STARTED_STATUSES,
+            dispatch_generation,
             timeout=_DEFERRED_SUBMIT_CONFIRM_TIMEOUT,
-            polling_interval=0.5,
         ):
             return True
 
@@ -2098,6 +2144,22 @@ def _schedule_deferred_init(
                 # when the TUI isn't input-ready. Confirm the worker actually
                 # started and re-submit if not; if it never starts, surface the
                 # failure so the supervisor re-routes instead of waiting forever.
+                # Sample the turn/output generation NOW, after send_input has run
+                # notify_input_sent (which bumps it once). Confirmation then
+                # requires the generation to exceed this, i.e. real output arrived
+                # after the send -- so a COMPLETED cached during provider startup
+                # can no longer read as this task starting.
+                #
+                # None for event-inbox backends (herdr): they run no FIFO reader,
+                # so the generation never advances from output and the requirement
+                # could never be met -- every resubmit would burn and the worker
+                # would be torn down. Their status is derived on demand instead, so
+                # there is no stale cached value for the gate to protect against.
+                dispatch_generation = (
+                    None
+                    if get_backend().supports_event_inbox()
+                    else status_monitor.output_generation(terminal_id)
+                )
                 started = await _confirm_worker_started_or_resubmit(
                     terminal_id,
                     initial_message,
@@ -2108,6 +2170,7 @@ def _schedule_deferred_init(
                     # must not silently drop back to the unguarded original type.
                     effective_orchestration_type,
                     provider=provider_instance,
+                    dispatch_generation=dispatch_generation,
                 )
                 if not started:
                     logger.error(

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -2199,7 +2199,18 @@ def _schedule_deferred_init(
     # the event loop first schedules _run instead of relying on it winning a race.
     if initial_message:
         _mark_initial_delivery_pending(terminal_id)
-    task = loop.create_task(_run())
+    # Only _run's finally can release the mark, so anything that prevents _run
+    # from ever running has to release it here. create_task raises RuntimeError
+    # if the loop closed between get_running_loop() above and this line (server
+    # teardown racing a create_terminal), and create_terminal's own exception
+    # cleanup does not know about this mark. Without this the terminal_id stays
+    # in the module-level set for the life of the process, reporting UNKNOWN for
+    # a terminal that is already gone.
+    try:
+        task = loop.create_task(_run())
+    except BaseException:
+        _clear_initial_delivery_pending(terminal_id)
+        raise
     _deferred_init_tasks.add(task)
     task.add_done_callback(_deferred_init_tasks.discard)
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -2216,10 +2216,23 @@ def _schedule_deferred_init(
     # _pending_initial_delivery is module state that dies with the process, so
     # there is nothing for it to leak into. Guarding it would mean a shutdown hook
     # for state that cannot outlive shutdown.
+    # BaseException rather than Exception is deliberate, and matches the rollback
+    # guards at :415 and :796. KeyboardInterrupt is one of the two realistic
+    # triggers named above and is not an Exception subclass, so narrowing this
+    # would skip the case it exists for. The bare ``raise`` leaves shutdown
+    # semantics intact — this only cleans up on the way past.
+    coro = _run()
     try:
-        task = loop.create_task(_run())
+        task = loop.create_task(coro)
     except BaseException:
-        _clear_initial_delivery_pending(terminal_id)
+        # The coroutine object exists but was never handed to a task, so close it
+        # or the interpreter warns "coroutine was never awaited" when it is GC'd.
+        coro.close()
+        # Only clear what this call may have set: with no initial_message no mark
+        # was taken, and an unconditional discard would be reaching for state this
+        # call does not own.
+        if initial_message:
+            _clear_initial_delivery_pending(terminal_id)
         raise
     _deferred_init_tasks.add(task)
     task.add_done_callback(_deferred_init_tasks.discard)

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -2199,13 +2199,23 @@ def _schedule_deferred_init(
     # the event loop first schedules _run instead of relying on it winning a race.
     if initial_message:
         _mark_initial_delivery_pending(terminal_id)
-    # Only _run's finally can release the mark, so anything that prevents _run
-    # from ever running has to release it here. create_task raises RuntimeError
-    # if the loop closed between get_running_loop() above and this line (server
-    # teardown racing a create_terminal), and create_terminal's own exception
-    # cleanup does not know about this mark. Without this the terminal_id stays
-    # in the module-level set for the life of the process, reporting UNKNOWN for
-    # a terminal that is already gone.
+    # Only _run's finally releases the mark, so a create_task that raises would
+    # leave it set with nothing left to clear it — create_terminal's own exception
+    # cleanup does not know about this mark. Cheap to close, so closed.
+    #
+    # Deliberately NOT claiming the obvious trigger: "the loop closed between the
+    # check above and this line" cannot happen. get_running_loop() only succeeds
+    # on the loop thread, so reaching here means we ARE the running loop, and
+    # loop.close() on a running loop raises "Cannot close a running event loop".
+    # What remains is the unglamorous set: _run() not being a coroutine
+    # (programming error), MemoryError, or a KeyboardInterrupt landing in the gap.
+    #
+    # Known and deliberately unguarded: after loop.stop(), create_task SUCCEEDS
+    # and the coroutine is never run, so the mark leaks with nothing raised for
+    # this to catch. That only arises while the loop is being torn down, and
+    # _pending_initial_delivery is module state that dies with the process, so
+    # there is nothing for it to leak into. Guarding it would mean a shutdown hook
+    # for state that cannot outlive shutdown.
     try:
         task = loop.create_task(_run())
     except BaseException:

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -178,6 +178,76 @@ _memory_injected_lock = threading.Lock()
 # silently leaving a worker uninitialized. Tasks drop themselves on completion.
 _deferred_init_tasks: set = set()
 
+# Terminals whose deferred initial message has been ACCEPTED but not yet
+# dispatched to the pane. Written on the event loop by _schedule_deferred_init,
+# read from worker threads by the status-reporting helpers below, hence the lock
+# (mirrors _memory_injected_lock above).
+_pending_initial_delivery: set = set()
+_pending_initial_delivery_lock = threading.Lock()
+
+# Statuses a poller may read as "there is nothing left to wait for". While an
+# initial message is still pending these are exactly the readings that must not
+# escape: see reported_status().
+_COMPLETABLE_STATUSES = (TerminalStatus.IDLE, TerminalStatus.COMPLETED)
+
+
+def _mark_initial_delivery_pending(terminal_id: str) -> None:
+    """Record that an accepted initial message has not been dispatched yet."""
+    with _pending_initial_delivery_lock:
+        _pending_initial_delivery.add(terminal_id)
+
+
+def _clear_initial_delivery_pending(terminal_id: str) -> None:
+    """Release the pending mark. Idempotent — every exit path may call it."""
+    with _pending_initial_delivery_lock:
+        _pending_initial_delivery.discard(terminal_id)
+
+
+def initial_delivery_pending(terminal_id: str) -> bool:
+    """True while an accepted initial message has not reached the pane yet."""
+    with _pending_initial_delivery_lock:
+        return terminal_id in _pending_initial_delivery
+
+
+def reported_status(terminal_id: str, status: TerminalStatus) -> TerminalStatus:
+    """Mask a completable status while the initial message is still undispatched.
+
+    PR #566 review (haofeif), P1. A client that polls for completion decides
+    "done" from the terminal's status alone, and every such poller needs the same
+    thing: evidence that is causally DOWNSTREAM of the send it is waiting on.
+    Provider startup does not qualify. On the deferred path the pane can sit at a
+    perfectly genuine IDLE for seconds after ``initialize()`` returns while
+    ``_schedule_deferred_init`` resolves shell_baseline and metadata and
+    ``send_input`` runs ``inject_memory_context`` — all strictly BEFORE any
+    keystroke is dispatched. A poller sampling that window sees a stable IDLE and
+    concludes the agent finished a task it was never given: the synchronous
+    ``cao launch`` printed empty output and exited 0.
+
+    Reporting UNKNOWN closes that window at the source, for every client at once,
+    rather than asking each one to remember to wait for a separate handshake.
+    UNKNOWN is the honest reading — the terminal exists but is not tracking the
+    task yet — and pollers already treat it as neither progress nor completion
+    (``utils.terminal.poll_until_done``, ``services.agent_step``), so no number
+    of pre-dispatch samples can satisfy an idle gate.
+
+    Deliberately NOT masked:
+
+    - **WAITING_USER_ANSWER / PROCESSING / ERROR.** Masking WAITING_USER_ANSWER
+      would hide a pane genuinely parked on a prompt, which is the one state an
+      operator has to see to clear it (and which ``send_input``'s own guard turns
+      into a TerminalInputBlockedError that releases the pending mark anyway).
+      Letting it through is harmless here: it flips a poller's "has started" flag
+      early, but with IDLE masked no idle streak can accumulate to act on it.
+    - **The internal callers of ``status_monitor.get_status``.** send_input's
+      ERROR/WAITING_USER_ANSWER guards, inbox/flow/memory services and the
+      deferred path's own retry loop all need the RAW state; masking there would
+      change delivery decisions, not just reporting. This is a reporting-layer
+      concern only, applied where a status crosses the API boundary.
+    """
+    if status in _COMPLETABLE_STATUSES and initial_delivery_pending(terminal_id):
+        return TerminalStatus.UNKNOWN
+    return status
+
 
 def inject_memory_context(
     first_message: str, terminal_id: str, frozen_memory: str | None = None
@@ -1984,14 +2054,27 @@ def _schedule_deferred_init(
                 effective_orchestration_type = orchestration_type or OrchestrationType.ASSIGN
                 # send_input is blocking tmux I/O — off the loop so it can't
                 # freeze the server for concurrent requests.
-                await asyncio.to_thread(
-                    send_input,
-                    terminal_id,
-                    initial_message,
-                    registry=registry,
-                    sender_id=caller_id,
-                    orchestration_type=effective_orchestration_type,
-                )
+                try:
+                    await asyncio.to_thread(
+                        send_input,
+                        terminal_id,
+                        initial_message,
+                        registry=registry,
+                        sender_id=caller_id,
+                        orchestration_type=effective_orchestration_type,
+                    )
+                finally:
+                    # The dispatch boundary, and the earliest point at which a
+                    # completion poller's evidence can be downstream of this send.
+                    # Released here rather than at the end of _run so a task that
+                    # finishes DURING _confirm_worker_started_or_resubmit is still
+                    # observable — holding the mark across the confirm/resubmit
+                    # window would hide a genuine early completion and strand the
+                    # poller until its timeout. In ``finally`` because a raising
+                    # send_input (TerminalInputBlockedError: the pane is parked on
+                    # a prompt) must also stop masking: the terminal is then
+                    # honestly WAITING_USER_ANSWER and the operator has to see it.
+                    _clear_initial_delivery_pending(terminal_id)
                 # Delivery can be silently dropped (Enter swallowed / paste lost)
                 # when the TUI isn't input-ready. Confirm the worker actually
                 # started and re-submit if not; if it never starts, surface the
@@ -2068,12 +2151,28 @@ def _schedule_deferred_init(
                 registry,
                 delete_worker=True,
             )
+        finally:
+            # Safety net for every path that never reached the send at all —
+            # initialize() raising, or the loop being torn down — so a terminal
+            # can't be left permanently masked. Idempotent: the happy path has
+            # already cleared it at the dispatch boundary above.
+            _clear_initial_delivery_pending(terminal_id)
 
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         logger.error(f"Deferred init for {terminal_id}: no running event loop; init skipped")
         return
+    # Mirrors _run's own ``if initial_message`` condition: defer_init is also used
+    # with no message at all (see the create_terminal call site), and there is
+    # nothing pending to mask on that path.
+    #
+    # Set here rather than inside _run so the mark is established by the time this
+    # function returns — the point at which the message has been accepted and the
+    # caller is free to start polling. That keeps the invariant independent of when
+    # the event loop first schedules _run instead of relying on it winning a race.
+    if initial_message:
+        _mark_initial_delivery_pending(terminal_id)
     task = loop.create_task(_run())
     _deferred_init_tasks.add(task)
     task.add_done_callback(_deferred_init_tasks.discard)
@@ -2086,7 +2185,7 @@ def get_terminal(terminal_id: str) -> Dict:
         if not metadata:
             raise ValueError(f"Terminal '{terminal_id}' not found")
 
-        status = status_monitor.get_status(terminal_id).value
+        status = reported_status(terminal_id, status_monitor.get_status(terminal_id)).value
 
         return {
             "id": metadata["id"],
@@ -2180,7 +2279,9 @@ def list_siblings(
         caller_id, prefix, caller_session=caller_session, cross_session=cross_session
     )
     for sibling in siblings:
-        sibling["status"] = status_monitor.get_status(sibling["id"]).value
+        sibling["status"] = reported_status(
+            sibling["id"], status_monitor.get_status(sibling["id"])
+        ).value
     return siblings
 
 

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from cli_agent_orchestrator.cli.commands.launch import _parse_env_pairs, launch
+from cli_agent_orchestrator.cli.commands.launch import (
+    _HEADLESS_TASK_TIMEOUT,
+    _READINESS_WAIT_TIMEOUT,
+    _parse_env_pairs,
+    launch,
+)
 
 # ── Backend auto-detection (issue #308) ──────────────────────────────
 
@@ -156,14 +161,20 @@ def test_launch_passes_explicit_kiro_engine():
 
 
 def test_launch_headless_message_sends_to_terminal():
-    """Test headless mode with message waits for IDLE then sends and polls for output."""
+    """Headless+message hands MESSAGE to the server in the create body, then polls.
+
+    Regression guard for caom-7it: the CLI used to create the session and then
+    issue a SEPARATE ``POST /terminals/{id}/input``. When provider init outlived
+    the client's read timeout on ``POST /sessions``, that second request never
+    happened and MESSAGE was silently dropped. There must be exactly ONE POST,
+    carrying ``initial_message``.
+    """
     runner = CliRunner()
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
         patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
-        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -196,9 +207,15 @@ def test_launch_headless_message_sends_to_terminal():
 
         assert result.exit_code == 0
         assert "task done" in result.output
-        mock_wait.assert_called_once()
-        # Two POST calls: create session + send message
-        assert mock_post.call_count == 2
+        # ONE POST: create session, with MESSAGE in the body. No follow-up
+        # /terminals/{id}/input — the server delivers it off the deferred-init
+        # path and re-submits if the TUI swallowed it.
+        assert mock_post.call_count == 1
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "do something"
+        assert "/input" not in str(mock_post.call_args)
+        # No client-side readiness gate either: the create response returns
+        # before init finishes (status UNKNOWN), and poll_until_done handles it.
+        mock_wait.assert_not_called()
 
 
 def test_launch_invalid_provider():
@@ -536,12 +553,20 @@ def test_launch_builtin_profile_resolves_role_defaults():
         assert "@cao-mcp-server" in params["allowed_tools"]
 
 
-def test_launch_headless_message_conductor_not_ready():
-    """Test headless+message raises when conductor does not become ready."""
+def test_launch_headless_message_does_not_gate_delivery_on_client_readiness():
+    """Headless+message must not abort just because the CLI never saw IDLE.
+
+    The old flow waited for IDLE client-side and raised "did not become ready"
+    before sending — a launch that hit that branch dropped MESSAGE outright even
+    though the terminal was alive and would have accepted it moments later. The
+    server now owns readiness, so a never-IDLE reading from the CLI's own poll
+    helper is irrelevant: MESSAGE is already in the create body.
+    """
     runner = CliRunner()
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
         mock_post.return_value.json.return_value = {
@@ -551,6 +576,14 @@ def test_launch_headless_message_conductor_not_ready():
         }
         mock_post.return_value.raise_for_status.return_value = None
         mock_wait.return_value = False
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "task done"}
+        mock_get.side_effect = [poll_resp, output_resp]
 
         result = runner.invoke(
             launch,
@@ -563,8 +596,9 @@ def test_launch_headless_message_conductor_not_ready():
             ],
         )
 
-        assert result.exit_code != 0
-        assert "did not become ready" in result.output
+        assert result.exit_code == 0
+        assert "did not become ready" not in result.output
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "do something"
 
 
 def test_launch_headless_message_poll_error_status():
@@ -575,7 +609,6 @@ def test_launch_headless_message_poll_error_status():
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
         patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
-        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -613,7 +646,6 @@ def test_launch_headless_message_poll_processing_then_completed():
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
         patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
-        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -1002,3 +1034,221 @@ def test_minimax_code_requires_workspace_access_confirmation():
     )
 
     assert "mcode" in PROVIDERS_REQUIRING_WORKSPACE_ACCESS
+
+
+# ── Server-side initial_message delivery (caom-7it) ────────────────────
+
+
+def _create_session_response():
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "session_name": "test-session",
+        "id": "test-terminal-id",
+        "name": "test-terminal",
+    }
+    return resp
+
+
+def test_launch_create_call_keeps_mcp_request_timeout():
+    """``POST /sessions`` stays on the ordinary ``mcp_request_timeout``.
+
+    Widening this instead of moving delivery server-side was the wrong fix: it
+    raises requests' CONNECT timeout as well (``timeout=`` is a single scalar,
+    so a dead server takes minutes to report), and it only helps callers that
+    happen to be this CLI. With ``initial_message`` in the body the server
+    returns before init even starts, so no widening is needed at all.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_server_settings") as mock_settings,
+    ):
+        mock_settings.return_value = {"mcp_request_timeout": 30}
+        mock_post.return_value = _create_session_response()
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "task done"}
+        mock_get.side_effect = [poll_resp, output_resp]
+
+        result = runner.invoke(
+            launch, ["--agents", "test-agent", "--headless", "--yolo", "do something"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_post.call_args.kwargs["timeout"] == 30
+        # The /output read is an ordinary request too.
+        assert mock_get.call_args_list[-1].kwargs["timeout"] == 30
+
+
+def test_launch_headless_message_travels_in_body_not_query_string():
+    """MESSAGE must not land in the URL: prompts are large (414 risk) and are
+    routinely captured verbatim in HTTP access logs and traces. Same reason
+    ``--env`` values were moved into the body in issue #248."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+    ):
+        mock_post.return_value = _create_session_response()
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": ""}
+        mock_get.side_effect = [poll_resp, output_resp]
+
+        result = runner.invoke(
+            launch, ["--agents", "test-agent", "--headless", "--yolo", "secret prompt"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "secret prompt"
+        assert "message" not in mock_post.call_args.kwargs["params"]
+        assert "secret prompt" not in str(mock_post.call_args.kwargs["params"])
+
+
+def test_launch_headless_message_shares_body_with_forwarded_env():
+    """``initial_message`` and ``env_vars`` are both body fields on
+    ``CreateSessionBody`` — passing both must not drop either."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+    ):
+        mock_post.return_value = _create_session_response()
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": ""}
+        mock_get.side_effect = [poll_resp, output_resp]
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--headless",
+                "--yolo",
+                "--env",
+                "AWS_PROFILE=dev",
+                "do something",
+            ],
+        )
+
+        assert result.exit_code == 0
+        body = mock_post.call_args.kwargs["json"]
+        assert body["initial_message"] == "do something"
+        assert body["env_vars"] == {"AWS_PROFILE": "dev"}
+
+
+def test_launch_async_returns_without_sending_input():
+    """``--async`` reports and returns. It must not fall back to a client-side
+    send, and it must not wait for IDLE first — the server delivers MESSAGE
+    once init completes."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch.poll_until_done") as mock_poll,
+    ):
+        mock_post.return_value = _create_session_response()
+
+        result = runner.invoke(
+            launch,
+            ["--agents", "test-agent", "--headless", "--async", "--yolo", "do something"],
+        )
+
+        assert result.exit_code == 0
+        assert "Running in background" in result.output
+        assert mock_post.call_count == 1
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "do something"
+        mock_wait.assert_not_called()
+        mock_poll.assert_not_called()
+        mock_get.assert_not_called()
+
+
+def test_launch_headless_no_message_omits_initial_message():
+    """A headless launch with no MESSAGE must not put the terminal on the
+    deferred-init path — it has nothing to deliver, and deferring would report
+    UNKNOWN instead of IDLE to a caller that expects a ready terminal."""
+    runner = CliRunner()
+
+    with patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post:
+        mock_post.return_value = _create_session_response()
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--headless", "--yolo"])
+
+        assert result.exit_code == 0
+        assert "json" not in mock_post.call_args.kwargs
+
+
+def test_launch_non_headless_does_not_defer_init():
+    """The attach path never sent MESSAGE and must not start now.
+
+    Deferring init here would leave the pre-attach readiness poll racing the
+    agent's first turn: the terminal reports UNKNOWN until init finishes and
+    then goes straight to PROCESSING, so the wait for IDLE would usually expire
+    and print a spurious "did not reach idle" warning before attaching.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
+        patch("cli_agent_orchestrator.cli.commands.launch.sync_backend_from_server"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+    ):
+        mock_post.return_value = _create_session_response()
+        mock_wait.return_value = True
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo", "do something"])
+
+        assert result.exit_code == 0
+        assert "json" not in mock_post.call_args.kwargs
+        assert mock_post.call_count == 1
+
+
+def test_launch_headless_poll_budget_covers_server_side_init():
+    """The wait budget must cover init as well as the task.
+
+    Init used to happen in a separate readiness poll BEFORE the client-side
+    send; it now runs inside this wait, so charging the task's own 300s for it
+    would silently shrink how long an agent gets to finish.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.poll_until_done") as mock_poll,
+    ):
+        mock_post.return_value = _create_session_response()
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "task done"}
+        mock_get.return_value = output_resp
+
+        result = runner.invoke(
+            launch, ["--agents", "test-agent", "--headless", "--yolo", "do something"]
+        )
+
+        assert result.exit_code == 0
+        mock_poll.assert_called_once_with(
+            "test-terminal-id", timeout=_READINESS_WAIT_TIMEOUT + _HEADLESS_TASK_TIMEOUT
+        )

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from cli_agent_orchestrator.cli.commands.launch import _parse_env_pairs, launch
+from cli_agent_orchestrator.cli.commands.launch import (
+    _HEADLESS_TASK_TIMEOUT,
+    _READINESS_WAIT_TIMEOUT,
+    _parse_env_pairs,
+    launch,
+)
 
 # ── Backend auto-detection (issue #308) ──────────────────────────────
 
@@ -156,14 +161,20 @@ def test_launch_passes_explicit_kiro_engine():
 
 
 def test_launch_headless_message_sends_to_terminal():
-    """Test headless mode with message waits for IDLE then sends and polls for output."""
+    """Headless+message hands MESSAGE to the server in the create body, then polls.
+
+    Regression guard for caom-7it: the CLI used to create the session and then
+    issue a SEPARATE ``POST /terminals/{id}/input``. When provider init outlived
+    the client's read timeout on ``POST /sessions``, that second request never
+    happened and MESSAGE was silently dropped. There must be exactly ONE POST,
+    carrying ``initial_message``.
+    """
     runner = CliRunner()
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
         patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
-        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -196,9 +207,15 @@ def test_launch_headless_message_sends_to_terminal():
 
         assert result.exit_code == 0
         assert "task done" in result.output
-        mock_wait.assert_called_once()
-        # Two POST calls: create session + send message
-        assert mock_post.call_count == 2
+        # ONE POST: create session, with MESSAGE in the body. No follow-up
+        # /terminals/{id}/input — the server delivers it off the deferred-init
+        # path and re-submits if the TUI swallowed it.
+        assert mock_post.call_count == 1
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "do something"
+        assert "/input" not in str(mock_post.call_args)
+        # No client-side readiness gate either: the create response returns
+        # before init finishes (status UNKNOWN), and poll_until_done handles it.
+        mock_wait.assert_not_called()
 
 
 def test_launch_invalid_provider():
@@ -536,12 +553,20 @@ def test_launch_builtin_profile_resolves_role_defaults():
         assert "@cao-mcp-server" in params["allowed_tools"]
 
 
-def test_launch_headless_message_conductor_not_ready():
-    """Test headless+message raises when conductor does not become ready."""
+def test_launch_headless_message_does_not_gate_delivery_on_client_readiness():
+    """Headless+message must not abort just because the CLI never saw IDLE.
+
+    The old flow waited for IDLE client-side and raised "did not become ready"
+    before sending — a launch that hit that branch dropped MESSAGE outright even
+    though the terminal was alive and would have accepted it moments later. The
+    server now owns readiness, so a never-IDLE reading from the CLI's own poll
+    helper is irrelevant: MESSAGE is already in the create body.
+    """
     runner = CliRunner()
 
     with (
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
     ):
         mock_post.return_value.json.return_value = {
@@ -551,6 +576,14 @@ def test_launch_headless_message_conductor_not_ready():
         }
         mock_post.return_value.raise_for_status.return_value = None
         mock_wait.return_value = False
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "task done"}
+        mock_get.side_effect = [poll_resp, output_resp]
 
         result = runner.invoke(
             launch,
@@ -563,8 +596,9 @@ def test_launch_headless_message_conductor_not_ready():
             ],
         )
 
-        assert result.exit_code != 0
-        assert "did not become ready" in result.output
+        assert result.exit_code == 0
+        assert "did not become ready" not in result.output
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "do something"
 
 
 def test_launch_headless_message_poll_error_status():
@@ -575,7 +609,6 @@ def test_launch_headless_message_poll_error_status():
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
         patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
-        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -613,7 +646,6 @@ def test_launch_headless_message_poll_processing_then_completed():
         patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
         patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
         patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
-        patch("cli_agent_orchestrator.cli.commands.launch.time.sleep"),
     ):
         mock_post.return_value.json.return_value = {
             "session_name": "test-session",
@@ -994,3 +1026,221 @@ def test_grok_cli_requires_workspace_access_confirmation():
     )
 
     assert "grok_cli" in PROVIDERS_REQUIRING_WORKSPACE_ACCESS
+
+
+# ── Server-side initial_message delivery (caom-7it) ────────────────────
+
+
+def _create_session_response():
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "session_name": "test-session",
+        "id": "test-terminal-id",
+        "name": "test-terminal",
+    }
+    return resp
+
+
+def test_launch_create_call_keeps_mcp_request_timeout():
+    """``POST /sessions`` stays on the ordinary ``mcp_request_timeout``.
+
+    Widening this instead of moving delivery server-side was the wrong fix: it
+    raises requests' CONNECT timeout as well (``timeout=`` is a single scalar,
+    so a dead server takes minutes to report), and it only helps callers that
+    happen to be this CLI. With ``initial_message`` in the body the server
+    returns before init even starts, so no widening is needed at all.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_server_settings") as mock_settings,
+    ):
+        mock_settings.return_value = {"mcp_request_timeout": 30}
+        mock_post.return_value = _create_session_response()
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "task done"}
+        mock_get.side_effect = [poll_resp, output_resp]
+
+        result = runner.invoke(
+            launch, ["--agents", "test-agent", "--headless", "--yolo", "do something"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_post.call_args.kwargs["timeout"] == 30
+        # The /output read is an ordinary request too.
+        assert mock_get.call_args_list[-1].kwargs["timeout"] == 30
+
+
+def test_launch_headless_message_travels_in_body_not_query_string():
+    """MESSAGE must not land in the URL: prompts are large (414 risk) and are
+    routinely captured verbatim in HTTP access logs and traces. Same reason
+    ``--env`` values were moved into the body in issue #248."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+    ):
+        mock_post.return_value = _create_session_response()
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": ""}
+        mock_get.side_effect = [poll_resp, output_resp]
+
+        result = runner.invoke(
+            launch, ["--agents", "test-agent", "--headless", "--yolo", "secret prompt"]
+        )
+
+        assert result.exit_code == 0
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "secret prompt"
+        assert "message" not in mock_post.call_args.kwargs["params"]
+        assert "secret prompt" not in str(mock_post.call_args.kwargs["params"])
+
+
+def test_launch_headless_message_shares_body_with_forwarded_env():
+    """``initial_message`` and ``env_vars`` are both body fields on
+    ``CreateSessionBody`` — passing both must not drop either."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+    ):
+        mock_post.return_value = _create_session_response()
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status.return_value = None
+        poll_resp.json.return_value = {"status": "completed"}
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": ""}
+        mock_get.side_effect = [poll_resp, output_resp]
+
+        result = runner.invoke(
+            launch,
+            [
+                "--agents",
+                "test-agent",
+                "--headless",
+                "--yolo",
+                "--env",
+                "AWS_PROFILE=dev",
+                "do something",
+            ],
+        )
+
+        assert result.exit_code == 0
+        body = mock_post.call_args.kwargs["json"]
+        assert body["initial_message"] == "do something"
+        assert body["env_vars"] == {"AWS_PROFILE": "dev"}
+
+
+def test_launch_async_returns_without_sending_input():
+    """``--async`` reports and returns. It must not fall back to a client-side
+    send, and it must not wait for IDLE first — the server delivers MESSAGE
+    once init completes."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch.poll_until_done") as mock_poll,
+    ):
+        mock_post.return_value = _create_session_response()
+
+        result = runner.invoke(
+            launch,
+            ["--agents", "test-agent", "--headless", "--async", "--yolo", "do something"],
+        )
+
+        assert result.exit_code == 0
+        assert "Running in background" in result.output
+        assert mock_post.call_count == 1
+        assert mock_post.call_args.kwargs["json"]["initial_message"] == "do something"
+        mock_wait.assert_not_called()
+        mock_poll.assert_not_called()
+        mock_get.assert_not_called()
+
+
+def test_launch_headless_no_message_omits_initial_message():
+    """A headless launch with no MESSAGE must not put the terminal on the
+    deferred-init path — it has nothing to deliver, and deferring would report
+    UNKNOWN instead of IDLE to a caller that expects a ready terminal."""
+    runner = CliRunner()
+
+    with patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post:
+        mock_post.return_value = _create_session_response()
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--headless", "--yolo"])
+
+        assert result.exit_code == 0
+        assert "json" not in mock_post.call_args.kwargs
+
+
+def test_launch_non_headless_does_not_defer_init():
+    """The attach path never sent MESSAGE and must not start now.
+
+    Deferring init here would leave the pre-attach readiness poll racing the
+    agent's first turn: the terminal reports UNKNOWN until init finishes and
+    then goes straight to PROCESSING, so the wait for IDLE would usually expire
+    and print a spurious "did not reach idle" warning before attaching.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend"),
+        patch("cli_agent_orchestrator.cli.commands.launch.sync_backend_from_server"),
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+    ):
+        mock_post.return_value = _create_session_response()
+        mock_wait.return_value = True
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo", "do something"])
+
+        assert result.exit_code == 0
+        assert "json" not in mock_post.call_args.kwargs
+        assert mock_post.call_count == 1
+
+
+def test_launch_headless_poll_budget_covers_server_side_init():
+    """The wait budget must cover init as well as the task.
+
+    Init used to happen in a separate readiness poll BEFORE the client-side
+    send; it now runs inside this wait, so charging the task's own 300s for it
+    would silently shrink how long an agent gets to finish.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get,
+        patch("cli_agent_orchestrator.cli.commands.launch.poll_until_done") as mock_poll,
+    ):
+        mock_post.return_value = _create_session_response()
+        output_resp = MagicMock()
+        output_resp.raise_for_status.return_value = None
+        output_resp.json.return_value = {"output": "task done"}
+        mock_get.return_value = output_resp
+
+        result = runner.invoke(
+            launch, ["--agents", "test-agent", "--headless", "--yolo", "do something"]
+        )
+
+        assert result.exit_code == 0
+        mock_poll.assert_called_once_with(
+            "test-terminal-id", timeout=_READINESS_WAIT_TIMEOUT + _HEADLESS_TASK_TIMEOUT
+        )

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -9,9 +9,11 @@ from click.testing import CliRunner
 from cli_agent_orchestrator.cli.commands.launch import (
     _HEADLESS_TASK_TIMEOUT,
     _READINESS_WAIT_TIMEOUT,
+    _is_waiting_on_user,
     _parse_env_pairs,
     launch,
 )
+from cli_agent_orchestrator.models.terminal import TerminalStatus
 
 # ── Backend auto-detection (issue #308) ──────────────────────────────
 
@@ -375,6 +377,143 @@ def test_launch_non_headless_attaches_even_if_wait_times_out():
         assert result.exit_code == 0
         assert "did not reach idle within 120s" in result.output
         mock_get_backend.return_value.attach_session.assert_called_once_with("test-session")
+
+
+# ── A screen that legitimately needs the operator is settled, not a stall ──
+#
+# A provider can finish init on a prompt only a human can answer (Codex's
+# first-run login menu is the case that forced this). Such a screen never
+# becomes IDLE on its own, so a readiness poll that accepts only
+# {IDLE, COMPLETED} burned the full _READINESS_WAIT_TIMEOUT and then blamed
+# init for a pane that was merely waiting — while telling the operator nothing
+# about the sign-in they had to complete.
+
+
+def test_readiness_poll_accepts_waiting_user_answer():
+    """WAITING_USER_ANSWER is in the pre-attach target set.
+
+    This is the assertion that matters: it pins the set itself, so narrowing it
+    back to {IDLE, COMPLETED} fails here rather than only showing up as a 120s
+    stall nothing in the suite waits around for.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch._is_waiting_on_user") as mock_waiting,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+        mock_waiting.return_value = False
+        mock_get_backend.return_value.attach_session.return_value = None
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
+
+        assert result.exit_code == 0
+        target_set = mock_wait.call_args[0][1]
+        assert TerminalStatus.WAITING_USER_ANSWER in target_set, (
+            "pre-attach poll must treat WAITING_USER_ANSWER as settled, or a "
+            f"first-run sign-in stalls for {_READINESS_WAIT_TIMEOUT}s; got {target_set}"
+        )
+        # The pre-existing members must survive the widening.
+        assert {TerminalStatus.IDLE, TerminalStatus.COMPLETED} <= target_set
+
+
+def test_launch_tells_the_operator_when_the_pane_awaits_an_answer():
+    """On a settled WAITING_USER_ANSWER the operator is told to finish it, not warned.
+
+    The "did not reach idle" warning would be actively wrong here: init did
+    finish, and the only thing outstanding is the human's answer.
+    """
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch._is_waiting_on_user") as mock_waiting,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+        mock_waiting.return_value = True
+        mock_get_backend.return_value.attach_session.return_value = None
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
+
+        assert result.exit_code == 0
+        assert "waiting for an answer in the pane" in result.output
+        assert "did not reach idle" not in result.output
+        mock_get_backend.return_value.attach_session.assert_called_once_with("test-session")
+
+
+def test_launch_stays_quiet_when_the_terminal_settles_idle():
+    """The new hint must not fire on the ordinary path."""
+    runner = CliRunner()
+
+    with (
+        patch("cli_agent_orchestrator.cli.commands.launch.requests.post") as mock_post,
+        patch("cli_agent_orchestrator.cli.commands.launch.get_backend") as mock_get_backend,
+        patch("cli_agent_orchestrator.cli.commands.launch.wait_until_terminal_status") as mock_wait,
+        patch("cli_agent_orchestrator.cli.commands.launch._is_waiting_on_user") as mock_waiting,
+    ):
+        mock_post.return_value.json.return_value = {
+            "session_name": "test-session",
+            "id": "test-terminal-id",
+            "name": "test-terminal",
+        }
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_wait.return_value = True
+        mock_waiting.return_value = False
+        mock_get_backend.return_value.attach_session.return_value = None
+
+        result = runner.invoke(launch, ["--agents", "test-agent", "--yolo"])
+
+        assert result.exit_code == 0
+        assert "waiting for an answer" not in result.output
+        assert "did not reach idle" not in result.output
+
+
+def test_is_waiting_on_user_reads_the_live_status():
+    """True only for WAITING_USER_ANSWER."""
+    with patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "status": TerminalStatus.WAITING_USER_ANSWER.value
+        }
+        assert _is_waiting_on_user("t1") is True
+
+        mock_get.return_value.json.return_value = {"status": TerminalStatus.IDLE.value}
+        assert _is_waiting_on_user("t1") is False
+
+
+def test_is_waiting_on_user_swallows_transport_errors():
+    """A blip must not turn a successful launch into "Failed to connect to cao-server".
+
+    This helper only decides which advisory line to print, and it runs inside the
+    command's ``RequestException`` handler — so letting one escape would report a
+    connection failure to a server the poll just finished talking to.
+    """
+    import requests as _requests
+
+    with patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get:
+        mock_get.side_effect = _requests.exceptions.ConnectionError("boom")
+        assert _is_waiting_on_user("t1") is False
+
+    with patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get:
+        mock_get.return_value.status_code = 500
+        assert _is_waiting_on_user("t1") is False
 
 
 def test_launch_workspace_confirmation_accepted():

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -516,6 +516,23 @@ def test_is_waiting_on_user_swallows_transport_errors():
         assert _is_waiting_on_user("t1") is False
 
 
+@pytest.mark.parametrize("payload", [[], ["a"], None, "waiting_user_answer", 3])
+def test_is_waiting_on_user_survives_a_200_that_is_not_a_json_object(payload):
+    """A parseable-but-non-object body must not abort the launch.
+
+    ``AttributeError`` from ``[].get`` is no kind of ``RequestException``, so
+    without the isinstance check it escapes this function, reaches the command's
+    generic handler, and exits 1 *after* ``POST /sessions`` has already created
+    the session — orphaning it in tmux, which is the exact outcome the local
+    except exists to prevent. Parametrized because each JSON scalar type reaches
+    ``.get`` by a different route.
+    """
+    with patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = payload
+        assert _is_waiting_on_user("t1") is False
+
+
 def test_launch_workspace_confirmation_accepted():
     """Test workspace confirmation is shown for claude_code provider and accepted."""
     runner = CliRunner()

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -511,8 +511,20 @@ def test_is_waiting_on_user_swallows_transport_errors():
         mock_get.side_effect = _requests.exceptions.ConnectionError("boom")
         assert _is_waiting_on_user("t1") is False
 
+
+@pytest.mark.parametrize("status_code", [201, 204, 400, 401, 404, 500, 503])
+def test_is_waiting_on_user_ignores_a_non_200_even_with_a_waiting_body(status_code):
+    """Only a 200 is believed — and the body must be a real dict to prove it.
+
+    Leaving ``json()`` as an unconfigured MagicMock would make this pass on the
+    isinstance guard alone, so deleting the status check would not fail any test.
+    A concrete waiting body is what makes the status check the thing under test.
+    """
     with patch("cli_agent_orchestrator.cli.commands.launch.requests.get") as mock_get:
-        mock_get.return_value.status_code = 500
+        mock_get.return_value.status_code = status_code
+        mock_get.return_value.json.return_value = {
+            "status": TerminalStatus.WAITING_USER_ANSWER.value
+        }
         assert _is_waiting_on_user("t1") is False
 
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -14,6 +14,11 @@ from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.codex import (
     APPROVAL_PROMPT_FOOTER,
+    LOGIN_MENU_FOOTER,
+    LOGIN_MENU_PATTERN,
+    STARTUP_PROMPT_BOTTOM_LINES,
+    TRUST_PROMPT_PATTERN,
+    TRUST_PROMPT_PATTERN_V2,
     CodexProvider,
     ProviderError,
     _find_response_marker,
@@ -2871,6 +2876,240 @@ class TestCodexProviderUpdateDialog:
         mock_tmux.return_value.send_special_key.assert_not_called()
         mock_tmux.return_value.send_keys.assert_not_called()
 
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_live_v1_dialog_over_a_login_menu_is_dismissed_not_live_locked(
+        self, mock_tmux, mock_error
+    ):
+        """A *live* v1 dialog stacked on the menu must still be answered.
+
+        This is why the v1 dismissal is bottom-anchored rather than simply
+        suppressed whenever ``has_login`` holds. Such a frame satisfies BOTH
+        ``has_login`` (menu text + footer in the bottom region) and ``has_dialog``
+        (the v1 copy), so under a ``not has_login`` gate neither the dismissal nor
+        the login exit could fire and the handler live-locked to its outer cap —
+        reproducing the very stall the login branch exists to remove, and in the
+        non-headless case the original ReadTimeout with it, since the handler's cap
+        is twice the client's request budget.
+
+        Asserting on the ORDER matters: dismiss first, then exit on the menu. That
+        is exactly what the login exit's ``not has_dialog`` comment claims happens.
+        """
+        stacked_live = (
+            "> 1. Sign in with ChatGPT\n"
+            "  2. Sign in with Device Code\n"
+            "  3. Provide your own API key\n"
+            "\n"
+            "  Do you trust this workspace?\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+        # Precondition: this frame really does set both predicates, or the test
+        # would be pinning nothing. Computed against the module's own patterns.
+        bottom = "\n".join(stacked_live.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        assert re.search(LOGIN_MENU_PATTERN, bottom) and re.search(LOGIN_MENU_FOOTER, bottom)
+        assert re.search(TRUST_PROMPT_PATTERN, bottom)
+
+        mock_tmux.return_value.get_history.side_effect = self._frames(
+            stacked_live, self.LOGIN_MENU_OUTPUT
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
+        # Did not run to the cap: the cap exit is the only thing that logs an error.
+        mock_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_trust_copy_above_a_live_menu_inside_the_window_is_not_answered(
+        self, mock_tmux, mock_error
+    ):
+        """Nearby stale trust copy is still stale — presence in the window isn't liveness.
+
+        Anchoring the v1 dismissal to ``bottom_region`` alone would only shrink the
+        scrollback exploit from "anywhere in the capture" to "the last 15 lines",
+        not close it. Position closes it: Codex draws the active modal last, so
+        trust copy ABOVE the menu text is history no matter how close it sits.
+
+        What distinguishes this from
+        ``test_live_v1_dialog_over_a_login_menu_is_dismissed_not_live_locked`` is the
+        ORDER of the two blocks — that fixture also carries an inert
+        "Do you trust this workspace?" line, which matches no pattern in this module,
+        so order is the only difference that any predicate can see. Reversing the
+        comparison therefore fails both, which is what pins the comparison rather
+        than mere containment.
+        """
+        trust_above = (
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+            "\n"
+            "> 1. Sign in with ChatGPT\n"
+            "  2. Sign in with Device Code\n"
+            "  3. Provide your own API key\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+        bottom = "\n".join(trust_above.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        # Both signatures are inside the window; only their ORDER differs from the
+        # live-dialog case. Without that assertion this test could pass by losing
+        # one of them to the 15-line cut.
+        assert re.search(TRUST_PROMPT_PATTERN, bottom), "v1 copy must be in the window"
+        assert re.search(LOGIN_MENU_PATTERN, bottom) and re.search(LOGIN_MENU_FOOTER, bottom)
+
+        mock_tmux.return_value.get_history.side_effect = self._frames(trust_above)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        started = time.monotonic()
+        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
+        elapsed = time.monotonic() - started
+
+        mock_tmux.return_value.send_special_key.assert_not_called()
+        mock_tmux.return_value.send_keys.assert_not_called()
+        # Sending nothing is only half of it. Asserting the keystroke alone let this
+        # test pass while the handler still burned its whole cap: the copy was too
+        # stale to dismiss, yet a bare presence test still counted it in
+        # ``has_dialog`` and blocked the login exit — so neither branch fired and, at
+        # the production 60s cap against a 30s client budget, this PR's own P1
+        # recurred in this frame class. Both assertions together are what pin it.
+        assert elapsed < 5.0, f"handler burned {elapsed:.1f}s instead of taking the login exit"
+        mock_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_v1_twin_login_exit_waits_for_a_dismissed_v1_dialog_to_clear(self, mock_tmux):
+        """``has_dialog`` must count a live v1 dialog, not just the v2 variant.
+
+        The v2 sibling of this test passes even with the v1 term removed from
+        ``has_dialog`` entirely — its fixture is a v2 frame, so the v2 term covers
+        for the v1 one. That left the v1 term unpinned: dropping it would let the
+        login exit fire on a frame where a just-answered v1 dialog is still
+        rendered, and since ``initialize()`` treats WAITING_USER_ANSWER as success,
+        a delivery landing in that window is refused with
+        ``TerminalInputBlockedError`` and dropped.
+
+        Frame 1 dismisses (the v1 copy is below the menu, so it is live). Frame 2
+        still shows it, and the handler must NOT take the login exit there.
+        Reaching frame 3 is the observable proof it kept waiting.
+        """
+        stacked_v1 = (
+            "> 1. Sign in with ChatGPT\n"
+            "  2. Sign in with Device Code\n"
+            "  3. Provide your own API key\n"
+            "\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+        bottom = "\n".join(stacked_v1.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        assert re.search(LOGIN_MENU_PATTERN, bottom) and re.search(LOGIN_MENU_FOOTER, bottom)
+        assert re.search(TRUST_PROMPT_PATTERN, bottom)
+        # No v2 signature anywhere, or the v2 term would cover for the v1 one and
+        # this test would pin nothing — which is the gap it exists to close.
+        assert not re.search(TRUST_PROMPT_PATTERN_V2, stacked_v1)
+
+        mock_tmux.return_value.get_history.side_effect = self._frames(
+            stacked_v1, stacked_v1, self._SETTLED
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
+        assert mock_tmux.return_value.get_history.call_count == 3, (
+            "login exit fired while a dismissed v1 dialog was still rendered "
+            f"(read {mock_tmux.return_value.get_history.call_count} frames, expected 3)"
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_stale_copy_above_and_live_dialog_below_dismisses(self, mock_tmux):
+        """Both sides of the position test must take the LAST occurrence.
+
+        Frame C: stale v1 copy above the menu AND a live v1 dialog below it. If the
+        v1 side takes the FIRST match while the menu side takes the LAST, the stale
+        copy wins the comparison, ``v1_is_live`` goes false, and — because
+        ``has_dialog`` shares that predicate — the login exit fires with a live
+        dialog still on screen. ``initialize()`` then succeeds on
+        WAITING_USER_ANSWER and the following ``send_input`` is refused with
+        ``TerminalInputBlockedError``, dropping the message: the exact failure ``not
+        has_dialog`` exists to prevent, and worse than the stall it replaced.
+
+        This frame does NOT discriminate ``_menu_matches[-1]`` from ``[0]`` — the last
+        v1 copy sits below both menu matches, so either index gives the same answer.
+        ``test_v1_copy_between_two_menu_renders_is_not_live`` covers that.
+        """
+        frame_c = (
+            "  $ grep 'allow Codex to work in this folder' audit.log\n"
+            "\n"
+            "> 1. Sign in with ChatGPT\n"
+            "  2. Sign in with Device Code\n"
+            "  3. Sign in with ChatGPT (retry)\n"
+            "\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+        bottom = "\n".join(frame_c.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        # The frame must genuinely contain the interleaving, or this pins nothing:
+        # two v1 occurrences straddling two menu occurrences.
+        assert len(list(re.finditer(TRUST_PROMPT_PATTERN, bottom))) == 2
+        assert len(list(re.finditer(LOGIN_MENU_PATTERN, bottom))) == 2
+        assert re.search(LOGIN_MENU_FOOTER, bottom)
+
+        mock_tmux.return_value.get_history.side_effect = self._frames(
+            frame_c, self.LOGIN_MENU_OUTPUT
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_v1_copy_between_two_menu_renders_is_not_live(self, mock_tmux):
+        """The menu side must take the LAST occurrence, not the first.
+
+        Frame: menu line, then v1 copy, then a second menu line. The lowest block is
+        the menu, so the v1 copy between them is stale and must not be answered.
+        Comparing against the FIRST menu match instead would put the v1 copy below it,
+        call it live, and press Enter into the menu.
+
+        This is the frame that discriminates ``_menu_matches[-1]`` from ``[0]``; the
+        stale-above/live-below test does not.
+        """
+        frame = (
+            "> 1. Sign in with ChatGPT\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. Sign in with ChatGPT\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+        bottom = "\n".join(frame.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        menus = list(re.finditer(LOGIN_MENU_PATTERN, bottom))
+        v1s = list(re.finditer(TRUST_PROMPT_PATTERN, bottom))
+        # The interleaving is the whole point: the last v1 must sit strictly between
+        # the first and last menu matches, or the two indices agree and this pins
+        # nothing.
+        assert len(menus) == 2 and len(v1s) == 1
+        assert menus[0].start() < v1s[-1].start() < menus[-1].start()
+
+        mock_tmux.return_value.get_history.side_effect = self._frames(frame)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_not_called()
+        mock_tmux.return_value.send_keys.assert_not_called()
+
     # ── ``has_login``'s conjunction is load-bearing in BOTH directions ──
     #
     # Since it now gates the v1 trust dismissal, a ``has_login`` that is too
@@ -2882,6 +3121,27 @@ class TestCodexProviderUpdateDialog:
     # where a real trust prompt must still be answered, and asserts it is.
 
     _SETTLED = "OpenAI Codex (v0.149.0)\n› \n"
+
+    @staticmethod
+    def _frames(*sequence):
+        """A ``get_history`` side effect that yields ``sequence``, then repeats the last.
+
+        Never use a bare list here. A plain ``side_effect`` list raises
+        ``StopIteration`` once exhausted, and this handler reads through
+        ``asyncio.to_thread`` — which cannot deliver ``StopIteration`` out of its
+        future, so the test HANGS instead of failing. That turns "a guard
+        regressed" into "the suite stopped", which is how a regression gets
+        mistaken for infrastructure flake. Repeating the final frame means an
+        unexpected extra read looks like a pane that stopped changing: the handler
+        runs to its ``outer_timeout`` and the test fails on its own assertion,
+        with its own message, in bounded time.
+        """
+        frames = list(sequence)
+
+        def _next(*_args, **_kwargs):
+            return frames.pop(0) if len(frames) > 1 else frames[0]
+
+        return _next
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
@@ -2899,7 +3159,7 @@ class TestCodexProviderUpdateDialog:
             "\n"
             "  Press enter to continue\n"
         )
-        mock_tmux.return_value.get_history.side_effect = [frame, self._SETTLED]
+        mock_tmux.return_value.get_history.side_effect = self._frames(frame, self._SETTLED)
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
@@ -2915,12 +3175,20 @@ class TestCodexProviderUpdateDialog:
         ``get_status`` requires both — so a trust prompt on the same screen must
         still be answered.
         """
+        # The v1 copy must sit ABOVE the menu line. With it below, ``v1_is_live`` is
+        # true on position alone and the dismissal fires whether or not the footer is
+        # required — which is how commit 5 silently un-covered this guard. Above the
+        # menu, a menu-only ``has_login`` suppresses the dismissal and this fails.
         frame = (
-            "  1. Sign in with ChatGPT\n"
             "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
             "  2. No, ask me to approve edits and commands\n"
+            "  1. Sign in with ChatGPT\n"
         )
-        mock_tmux.return_value.get_history.side_effect = [frame, self._SETTLED]
+        _bottom = "\n".join(frame.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        assert re.search(LOGIN_MENU_PATTERN, _bottom) and not re.search(
+            LOGIN_MENU_FOOTER, _bottom
+        ), "fixture must carry the menu pattern WITHOUT the footer"
+        mock_tmux.return_value.get_history.side_effect = self._frames(frame, self._SETTLED)
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
@@ -2943,7 +3211,7 @@ class TestCodexProviderUpdateDialog:
             + "\n  Do you trust this workspace?\n"
             + "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
         )
-        mock_tmux.return_value.get_history.side_effect = [frame, self._SETTLED]
+        mock_tmux.return_value.get_history.side_effect = self._frames(frame, self._SETTLED)
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
@@ -2996,8 +3264,18 @@ class TestCodexProviderUpdateDialog:
             "\n"
             "  Press enter to continue\n"
         )
-        settled = "OpenAI Codex (v0.149.0)\n› \n"
-        mock_tmux.return_value.get_history.side_effect = [stacked, stacked, settled]
+        # Precondition, asserted rather than asserted-in-prose: an earlier version of
+        # this test lost has_login to the 15-line window and passed regardless. The
+        # comment above documented that trap; this line is what actually defends
+        # against it, and it fails loudly if the fixture ever drifts.
+        _bottom = "\n".join(stacked.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+        assert re.search(LOGIN_MENU_PATTERN, _bottom) and re.search(
+            LOGIN_MENU_FOOTER, _bottom
+        ), "fixture no longer sets has_login; this test would pin nothing"
+
+        mock_tmux.return_value.get_history.side_effect = self._frames(
+            stacked, stacked, self._SETTLED
+        )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
         await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -3,9 +3,7 @@
 import os
 import re
 import shlex
-import time
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,11 +12,6 @@ from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.codex import (
     APPROVAL_PROMPT_FOOTER,
-    LOGIN_MENU_FOOTER,
-    LOGIN_MENU_PATTERN,
-    STARTUP_PROMPT_BOTTOM_LINES,
-    TRUST_PROMPT_PATTERN,
-    TRUST_PROMPT_PATTERN_V2,
     CodexProvider,
     ProviderError,
     _find_response_marker,
@@ -35,19 +28,6 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 def load_fixture(filename: str) -> str:
     with open(FIXTURES_DIR / filename, "r") as f:
         return f.read()
-
-
-def fake_clock(*values: float) -> SimpleNamespace:
-    """A stand-in for codex's ``time`` module yielding a fixed ``monotonic`` series.
-
-    Patch ``providers.codex.time`` with this rather than
-    ``providers.codex.time.monotonic``: ``codex.time`` IS the shared stdlib
-    module, so patching the attribute mutates it process-wide and asyncio's own
-    event loop — which calls ``time.monotonic()`` on every step — consumes the
-    ``side_effect`` sequence, raising StopIteration inside the loop instead of
-    in the code under test. Replacing the module reference keeps it local.
-    """
-    return SimpleNamespace(monotonic=MagicMock(side_effect=values))
 
 
 def read_developer_instructions_file(command: str) -> str:
@@ -2171,14 +2151,14 @@ class TestCodexProviderTrustPrompt:
 
     @pytest.mark.asyncio
     @patch(
-        "cli_agent_orchestrator.providers.codex.time",
-        new_callable=lambda: fake_clock(0.0, 0.0, 0.0),
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 20.0],
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_returns_on_v0149_idle_composer(
-        self, mock_backend, mock_error, mock_sleep, _fake_time
+        self, mock_backend, mock_error, mock_sleep, _mock_time
     ):
         mock_backend.return_value.get_history.return_value = (
             "OpenAI Codex (v0.149.0)\n"
@@ -2187,7 +2167,7 @@ class TestCodexProviderTrustPrompt:
         )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=20.0)
+        await provider._handle_trust_prompt(timeout=20.0)
 
         mock_backend.return_value.get_history.assert_called_once()
         mock_sleep.assert_not_awaited()
@@ -2197,14 +2177,14 @@ class TestCodexProviderTrustPrompt:
 
     @pytest.mark.asyncio
     @patch(
-        "cli_agent_orchestrator.providers.codex.time",
-        new_callable=lambda: fake_clock(0.0, 0.0, 0.0),
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 20.0],
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_returns_on_v0145_idle_composer(
-        self, mock_backend, mock_error, mock_sleep, _fake_time
+        self, mock_backend, mock_error, mock_sleep, _mock_time
     ):
         """Codex 0.145's placeholder composer is a ready state, not a timeout."""
         mock_backend.return_value.get_history.return_value = load_fixture(
@@ -2212,7 +2192,7 @@ class TestCodexProviderTrustPrompt:
         )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=20.0)
+        await provider._handle_trust_prompt(timeout=20.0)
 
         mock_backend.return_value.get_history.assert_called_once()
         mock_sleep.assert_not_awaited()
@@ -2222,14 +2202,14 @@ class TestCodexProviderTrustPrompt:
 
     @pytest.mark.asyncio
     @patch(
-        "cli_agent_orchestrator.providers.codex.time",
-        new_callable=lambda: fake_clock(0.0, 0.0, 0.0, 1.0, 2.0),
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 1.0, 2.0, 20.0],
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_waits_for_complete_v0145_composer_frame(
-        self, mock_backend, mock_error, mock_sleep, _fake_time
+        self, mock_backend, mock_error, mock_sleep, _mock_time
     ):
         """Chunked redraws are not ready until composer and footer are both visible."""
         fixture = load_fixture("codex_v0145_idle_output.txt")
@@ -2241,7 +2221,7 @@ class TestCodexProviderTrustPrompt:
         ]
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=20.0)
+        await provider._handle_trust_prompt(timeout=20.0)
 
         assert mock_backend.return_value.get_history.call_count == 3
         assert mock_sleep.await_count == 2
@@ -2295,20 +2275,19 @@ class TestCodexProviderTrustPrompt:
     )
     @pytest.mark.asyncio
     @patch(
-        # One poll (not ready), then the outer cap ends the loop.
-        "cli_agent_orchestrator.providers.codex.time",
-        new_callable=lambda: fake_clock(0.0, 0.0, 0.0, 20.0),
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 20.0],
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_does_not_treat_non_ready_output_as_idle(
-        self, mock_backend, mock_error, mock_sleep, _fake_time, output
+        self, mock_backend, mock_error, mock_sleep, _mock_time, output
     ):
         mock_backend.return_value.get_history.return_value = output
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=20.0)
+        await provider._handle_trust_prompt(timeout=20.0)
 
         mock_sleep.assert_awaited_once_with(1.0)
         mock_error.assert_called_once()
@@ -2330,7 +2309,7 @@ class TestCodexProviderTrustPrompt:
         )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=2.0)
+        await provider._handle_trust_prompt(timeout=2.0)
 
         mock_tmux.return_value.send_special_key.assert_called_once_with(
             "test-session", "window-0", "Enter"
@@ -2343,139 +2322,9 @@ class TestCodexProviderTrustPrompt:
         mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)\n› "
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=2.0)
+        await provider._handle_trust_prompt(timeout=2.0)
 
         mock_tmux.return_value.send_special_key.assert_not_called()
-
-    # ── startup_prompt_handler_timeout is an IDLE GAP, not a total budget ──
-    #
-    # The setting documents itself (settings_service.py) as the gap between
-    # consecutive startup prompts, reset each time one is answered, with total
-    # time bounded by provider_init_timeout. kimi_cli/antigravity_cli implement
-    # exactly that. Codex read it as a fixed total budget, so lowering the gap
-    # for another provider silently truncated codex's whole handler and left a
-    # late dialog undismissed -- and because initialize() accepts
-    # WAITING_USER_ANSWER as success, send_input then raised
-    # TerminalInputBlockedError and the initial message was never delivered.
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_small_idle_gap_does_not_truncate_the_handler(self, mock_backend, mock_sleep):
-        """A dialog rendered later than the idle gap is still dismissed.
-
-        Regression guard: with the gap used as a total budget, a 2s gap meant a
-        dialog first visible on the 4th poll was never answered.
-        """
-        blank = "OpenAI Codex (v0.98.0)\n"
-        trust = (
-            "> You are running Codex in /Users/test/project\n"
-            "\n"
-            "  Since this folder is version controlled, you may wish to "
-            "allow Codex to work in this folder without asking for approval.\n"
-            "\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-        )
-        mock_backend.return_value.get_history.side_effect = [blank, blank, blank, trust]
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        # Gap far shorter than the time the dialog takes to appear; the outer cap
-        # is what governs, so the handler must still be polling when it arrives.
-        with patch(
-            "cli_agent_orchestrator.providers.codex.time",
-            fake_clock(0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 60.0),
-        ):
-            await provider._handle_trust_prompt(idle_gap=2.0, outer_timeout=120.0)
-
-        mock_backend.return_value.send_special_key.assert_called_once_with(
-            "test-session", "window-0", "Enter"
-        )
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_idle_gap_resets_after_each_answered_prompt(self, mock_backend, mock_sleep):
-        """Answering the trust dialog restarts the gap, so a later update dialog
-        still gets dismissed rather than being cut off by the first gap."""
-        trust = (
-            "  Since this folder is version controlled, you may wish to "
-            "allow Codex to work in this folder without asking for approval.\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-        )
-        update = (
-            "✨ Update available! 0.142.5 -> 0.144.5\n"
-            "1. Update now (runs npm install -g @openai/codex)\n"
-            "2. Skip\n"
-            "3. Skip until next version\n"
-            "Press enter to continue\n"
-        )
-        mock_backend.return_value.get_history.side_effect = [trust, update, "quiet tail"]
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        # Poll 1 answers trust at t=10, which RESETS the gap; poll 2 at t=12 is
-        # only 2s past that reset, so it is still inside the 5s gap. Without the
-        # reset the gap would be measured from t=0 -- already 10s, past the 5s
-        # gap -- so the loop would have returned before ever seeing the update
-        # dialog. That asymmetry is what makes this a guard rather than a
-        # restatement of the happy path.
-        with patch(
-            "cli_agent_orchestrator.providers.codex.time",
-            fake_clock(0.0, 0.0, 10.0, 10.0, 12.0, 12.0, 100.0),
-        ):
-            await provider._handle_trust_prompt(idle_gap=5.0, outer_timeout=120.0)
-
-        # '3' + Enter dismisses the update dialog; a blind Enter would pick
-        # "1. Update now".
-        mock_backend.return_value.send_keys.assert_called_once_with(
-            "test-session", "window-0", "3", enter_count=0
-        )
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_idle_gap_ends_the_loop_once_startup_is_quiet(self, mock_backend, mock_sleep):
-        """After a prompt is answered, no new prompt within the gap returns —
-        the handler must not sit until the outer cap on a healthy start."""
-        trust = (
-            "  Since this folder is version controlled, you may wish to "
-            "allow Codex to work in this folder without asking for approval.\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-        )
-        mock_backend.return_value.get_history.return_value = trust
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        with patch(
-            "cli_agent_orchestrator.providers.codex.time",
-            fake_clock(0.0, 0.0, 0.0, 0.0, 10.0),
-        ):
-            await provider._handle_trust_prompt(idle_gap=5.0, outer_timeout=600.0)
-
-        # Returned on the gap, not the outer cap: only the one poll happened.
-        assert mock_backend.return_value.get_history.call_count == 1
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_bounds_default_to_their_documented_settings(self, mock_backend):
-        """idle_gap defaults to startup_prompt_handler_timeout and the outer cap
-        to provider_init_timeout — not both to the same setting."""
-        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)\n› "
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        with patch(
-            "cli_agent_orchestrator.providers.codex.get_server_settings",
-            return_value={
-                "startup_prompt_handler_timeout": 7.0,
-                "provider_init_timeout": 99.0,
-            },
-        ) as mock_settings:
-            with patch(
-                "cli_agent_orchestrator.providers.codex.time",
-                fake_clock(0.0, 0.0, 0.0),
-            ):
-                await provider._handle_trust_prompt()
-
-        assert mock_settings.called
 
     def test_get_status_trust_prompt_is_waiting_user_answer(self):
         """Test that trust prompt reports WAITING_USER_ANSWER, not PROCESSING."""
@@ -2770,7 +2619,7 @@ class TestCodexProviderUpdateDialog:
         ]
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=5.0)
+        await provider._handle_trust_prompt(timeout=5.0)
 
         mock_tmux.return_value.send_keys.assert_any_call(
             "test-session", "window-0", "3", enter_count=0
@@ -2784,512 +2633,10 @@ class TestCodexProviderUpdateDialog:
         mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.142.5)\n› "
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=2.0)
+        await provider._handle_trust_prompt(timeout=2.0)
 
         mock_tmux.return_value.send_keys.assert_not_called()
         mock_tmux.return_value.send_special_key.assert_not_called()
-
-    # ── The first-run login menu is a settled state, not a stall ──
-    #
-    # It is neither a dismissable dialog nor the idle composer, so before this it
-    # matched no exit condition and the handler ran to its outer cap. That cap is
-    # ``provider_init_timeout`` (60s by default) while a non-headless ``cao launch``
-    # sends no ``initial_message`` — so ``POST /sessions`` initializes synchronously
-    # against the client's ``mcp_request_timeout`` (30s), and the client raised
-    # ReadTimeout before the operator could attach and authenticate.
-
-    LOGIN_MENU_OUTPUT = (
-        "  Welcome to Codex, OpenAI's command-line coding agent\n"
-        "\n"
-        "  Sign in with ChatGPT to use Codex as part of your paid plan\n"
-        "  or connect an API key for usage-based billing\n"
-        "\n"
-        "> 1. Sign in with ChatGPT\n"
-        "     Usage included with Plus, Pro, Business, and Enterprise plans\n"
-        "\n"
-        "  2. Sign in with Device Code\n"
-        "     Sign in from another device with a one-time code\n"
-        "\n"
-        "  3. Provide your own API key\n"
-        "     Pay for what you use\n"
-        "\n"
-        "  Press enter to continue\n"
-    )
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.logger.error")
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_handle_trust_prompt_returns_on_login_menu(self, mock_tmux, mock_error):
-        """The handler returns promptly, having sent nothing, and logs no error.
-
-        Returning matters because ``initialize()``'s next ``wait_until_status``
-        already accepts this state as WAITING_USER_ANSWER — every second spent
-        here is spent against a client budget half the size of the outer cap.
-        Sending nothing matters more: choosing a sign-in method on the operator's
-        behalf is not this handler's call. The outer cap is set high here so a
-        timeout exit cannot be mistaken for a pass.
-        """
-        mock_tmux.return_value.get_history.return_value = self.LOGIN_MENU_OUTPUT
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        started = time.monotonic()
-        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
-        elapsed = time.monotonic() - started
-
-        assert elapsed < 5.0, f"handler waited {elapsed:.1f}s on a settled login menu"
-        mock_tmux.return_value.send_keys.assert_not_called()
-        mock_tmux.return_value.send_special_key.assert_not_called()
-        # The old behaviour ended in "no prompt or welcome banner detected" —
-        # about a screen that plainly showed one.
-        mock_error.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_trust_v1_does_not_fire_on_scrollback_above_a_live_login_menu(self, mock_tmux):
-        """Stale trust copy in scrollback must not make the handler answer the menu.
-
-        The v1 trust check is the only one of the four signatures matched against
-        the whole capture rather than ``bottom_region``, so before the ``not
-        has_login`` gate it could fire on text the login exit could not see. The
-        handler would then press Enter — selecting a sign-in method for the
-        operator — and log that it was leaving the menu alone, in that order.
-
-        The consequence is worse than the stall this branch fixes: the keystroke
-        selects a sign-in method, so the pane leaves the login menu and with it the
-        set ``initialize()`` waits on ({IDLE, COMPLETED, WAITING_USER_ANSWER}) —
-        measured as PROCESSING on the API-key option, with the OAuth option not
-        exercised. Either way the session is torn down on a TimeoutError instead
-        of waiting for the operator to authenticate.
-
-        One scrollback line is enough to demonstrate it, which is why the gate is
-        worth having even though no natural Codex sequence produces that line
-        today (the login menu renders *before* the trust prompt).
-        """
-        contaminated = (
-            "  $ echo 'allow Codex to work in this folder' >> notes.txt\n" + self.LOGIN_MENU_OUTPUT
-        )
-        mock_tmux.return_value.get_history.return_value = contaminated
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_not_called()
-        mock_tmux.return_value.send_keys.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.logger.error")
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_live_v1_dialog_over_a_login_menu_is_dismissed_not_live_locked(
-        self, mock_tmux, mock_error
-    ):
-        """A *live* v1 dialog stacked on the menu must still be answered.
-
-        This is why the v1 dismissal is bottom-anchored rather than simply
-        suppressed whenever ``has_login`` holds. Such a frame satisfies BOTH
-        ``has_login`` (menu text + footer in the bottom region) and ``has_dialog``
-        (the v1 copy), so under a ``not has_login`` gate neither the dismissal nor
-        the login exit could fire and the handler live-locked to its outer cap —
-        reproducing the very stall the login branch exists to remove, and in the
-        non-headless case the original ReadTimeout with it, since the handler's cap
-        is twice the client's request budget.
-
-        Asserting on the ORDER matters: dismiss first, then exit on the menu. That
-        is exactly what the login exit's ``not has_dialog`` comment claims happens.
-        """
-        stacked_live = (
-            "> 1. Sign in with ChatGPT\n"
-            "  2. Sign in with Device Code\n"
-            "  3. Provide your own API key\n"
-            "\n"
-            "  Do you trust this workspace?\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-            "\n"
-            "  Press enter to continue\n"
-        )
-        # Precondition: this frame really does set both predicates, or the test
-        # would be pinning nothing. Computed against the module's own patterns.
-        bottom = "\n".join(stacked_live.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-        assert re.search(LOGIN_MENU_PATTERN, bottom) and re.search(LOGIN_MENU_FOOTER, bottom)
-        assert re.search(TRUST_PROMPT_PATTERN, bottom)
-
-        mock_tmux.return_value.get_history.side_effect = self._frames(
-            stacked_live, self.LOGIN_MENU_OUTPUT
-        )
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
-        # Did not run to the cap: the cap exit is the only thing that logs an error.
-        mock_error.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.logger.error")
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_trust_copy_above_a_live_menu_inside_the_window_is_not_answered(
-        self, mock_tmux, mock_error
-    ):
-        """Nearby stale trust copy is still stale — presence in the window isn't liveness.
-
-        Anchoring the v1 dismissal to ``bottom_region`` alone would only shrink the
-        scrollback exploit from "anywhere in the capture" to "the last 15 lines",
-        not close it. Position closes it: Codex draws the active modal last, so
-        trust copy ABOVE the menu text is history no matter how close it sits.
-
-        What distinguishes this from
-        ``test_live_v1_dialog_over_a_login_menu_is_dismissed_not_live_locked`` is the
-        ORDER of the two blocks — that fixture also carries an inert
-        "Do you trust this workspace?" line, which matches no pattern in this module,
-        so order is the only difference that any predicate can see. Reversing the
-        comparison therefore fails both, which is what pins the comparison rather
-        than mere containment.
-        """
-        trust_above = (
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-            "\n"
-            "> 1. Sign in with ChatGPT\n"
-            "  2. Sign in with Device Code\n"
-            "  3. Provide your own API key\n"
-            "\n"
-            "  Press enter to continue\n"
-        )
-        bottom = "\n".join(trust_above.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-        # Both signatures are inside the window; only their ORDER differs from the
-        # live-dialog case. Without that assertion this test could pass by losing
-        # one of them to the 15-line cut.
-        assert re.search(TRUST_PROMPT_PATTERN, bottom), "v1 copy must be in the window"
-        assert re.search(LOGIN_MENU_PATTERN, bottom) and re.search(LOGIN_MENU_FOOTER, bottom)
-
-        mock_tmux.return_value.get_history.side_effect = self._frames(trust_above)
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        started = time.monotonic()
-        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
-        elapsed = time.monotonic() - started
-
-        mock_tmux.return_value.send_special_key.assert_not_called()
-        mock_tmux.return_value.send_keys.assert_not_called()
-        # Sending nothing is only half of it. Asserting the keystroke alone let this
-        # test pass while the handler still burned its whole cap: the copy was too
-        # stale to dismiss, yet a bare presence test still counted it in
-        # ``has_dialog`` and blocked the login exit — so neither branch fired and, at
-        # the production 60s cap against a 30s client budget, this PR's own P1
-        # recurred in this frame class. Both assertions together are what pin it.
-        assert elapsed < 5.0, f"handler burned {elapsed:.1f}s instead of taking the login exit"
-        mock_error.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_v1_twin_login_exit_waits_for_a_dismissed_v1_dialog_to_clear(self, mock_tmux):
-        """``has_dialog`` must count a live v1 dialog, not just the v2 variant.
-
-        The v2 sibling of this test passes even with the v1 term removed from
-        ``has_dialog`` entirely — its fixture is a v2 frame, so the v2 term covers
-        for the v1 one. That left the v1 term unpinned: dropping it would let the
-        login exit fire on a frame where a just-answered v1 dialog is still
-        rendered, and since ``initialize()`` treats WAITING_USER_ANSWER as success,
-        a delivery landing in that window is refused with
-        ``TerminalInputBlockedError`` and dropped.
-
-        Frame 1 dismisses (the v1 copy is below the menu, so it is live). Frame 2
-        still shows it, and the handler must NOT take the login exit there.
-        Reaching frame 3 is the observable proof it kept waiting.
-        """
-        stacked_v1 = (
-            "> 1. Sign in with ChatGPT\n"
-            "  2. Sign in with Device Code\n"
-            "  3. Provide your own API key\n"
-            "\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-            "\n"
-            "  Press enter to continue\n"
-        )
-        bottom = "\n".join(stacked_v1.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-        assert re.search(LOGIN_MENU_PATTERN, bottom) and re.search(LOGIN_MENU_FOOTER, bottom)
-        assert re.search(TRUST_PROMPT_PATTERN, bottom)
-        # No v2 signature anywhere, or the v2 term would cover for the v1 one and
-        # this test would pin nothing — which is the gap it exists to close.
-        assert not re.search(TRUST_PROMPT_PATTERN_V2, stacked_v1)
-
-        mock_tmux.return_value.get_history.side_effect = self._frames(
-            stacked_v1, stacked_v1, self._SETTLED
-        )
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
-        assert mock_tmux.return_value.get_history.call_count == 3, (
-            "login exit fired while a dismissed v1 dialog was still rendered "
-            f"(read {mock_tmux.return_value.get_history.call_count} frames, expected 3)"
-        )
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_stale_copy_above_and_live_dialog_below_dismisses(self, mock_tmux):
-        """Both sides of the position test must take the LAST occurrence.
-
-        Frame C: stale v1 copy above the menu AND a live v1 dialog below it. If the
-        v1 side takes the FIRST match while the menu side takes the LAST, the stale
-        copy wins the comparison, ``v1_is_live`` goes false, and — because
-        ``has_dialog`` shares that predicate — the login exit fires with a live
-        dialog still on screen. ``initialize()`` then succeeds on
-        WAITING_USER_ANSWER and the following ``send_input`` is refused with
-        ``TerminalInputBlockedError``, dropping the message: the exact failure ``not
-        has_dialog`` exists to prevent, and worse than the stall it replaced.
-
-        This frame does NOT discriminate ``_menu_matches[-1]`` from ``[0]`` — the last
-        v1 copy sits below both menu matches, so either index gives the same answer.
-        ``test_v1_copy_between_two_menu_renders_is_not_live`` covers that.
-        """
-        frame_c = (
-            "  $ grep 'allow Codex to work in this folder' audit.log\n"
-            "\n"
-            "> 1. Sign in with ChatGPT\n"
-            "  2. Sign in with Device Code\n"
-            "  3. Sign in with ChatGPT (retry)\n"
-            "\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-            "\n"
-            "  Press enter to continue\n"
-        )
-        bottom = "\n".join(frame_c.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-        # The frame must genuinely contain the interleaving, or this pins nothing:
-        # two v1 occurrences straddling two menu occurrences.
-        assert len(list(re.finditer(TRUST_PROMPT_PATTERN, bottom))) == 2
-        assert len(list(re.finditer(LOGIN_MENU_PATTERN, bottom))) == 2
-        assert re.search(LOGIN_MENU_FOOTER, bottom)
-
-        mock_tmux.return_value.get_history.side_effect = self._frames(
-            frame_c, self.LOGIN_MENU_OUTPUT
-        )
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_v1_copy_between_two_menu_renders_is_not_live(self, mock_tmux):
-        """The menu side must take the LAST occurrence, not the first.
-
-        Frame: menu line, then v1 copy, then a second menu line. The lowest block is
-        the menu, so the v1 copy between them is stale and must not be answered.
-        Comparing against the FIRST menu match instead would put the v1 copy below it,
-        call it live, and press Enter into the menu.
-
-        This is the frame that discriminates ``_menu_matches[-1]`` from ``[0]``; the
-        stale-above/live-below test does not.
-        """
-        frame = (
-            "> 1. Sign in with ChatGPT\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. Sign in with ChatGPT\n"
-            "\n"
-            "  Press enter to continue\n"
-        )
-        bottom = "\n".join(frame.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-        menus = list(re.finditer(LOGIN_MENU_PATTERN, bottom))
-        v1s = list(re.finditer(TRUST_PROMPT_PATTERN, bottom))
-        # The interleaving is the whole point: the last v1 must sit strictly between
-        # the first and last menu matches, or the two indices agree and this pins
-        # nothing.
-        assert len(menus) == 2 and len(v1s) == 1
-        assert menus[0].start() < v1s[-1].start() < menus[-1].start()
-
-        mock_tmux.return_value.get_history.side_effect = self._frames(frame)
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_not_called()
-        mock_tmux.return_value.send_keys.assert_not_called()
-
-    # ── ``has_login``'s conjunction is load-bearing in BOTH directions ──
-    #
-    # Since it now gates the v1 trust dismissal, a ``has_login`` that is too
-    # EAGER suppresses a dismissal that should happen — the mirror of the
-    # scrollback bug above, and not covered by tests that only check the login
-    # exit. It is easy to be too eager by accident: ``LOGIN_MENU_FOOTER`` IS
-    # ``TRUST_PROMPT_FOOTER``, so a footer-only ``has_login`` reads True on any
-    # frame carrying "Press enter to continue". Each test below feeds a frame
-    # where a real trust prompt must still be answered, and asserts it is.
-
-    _SETTLED = "OpenAI Codex (v0.149.0)\n› \n"
-
-    @staticmethod
-    def _frames(*sequence):
-        """A ``get_history`` side effect that yields ``sequence``, then repeats the last.
-
-        Never use a bare list here. A plain ``side_effect`` list raises
-        ``StopIteration`` once exhausted, and this handler reads through
-        ``asyncio.to_thread`` — which cannot deliver ``StopIteration`` out of its
-        future, so the test HANGS instead of failing. That turns "a guard
-        regressed" into "the suite stopped", which is how a regression gets
-        mistaken for infrastructure flake. Repeating the final frame means an
-        unexpected extra read looks like a pane that stopped changing: the handler
-        runs to its ``outer_timeout`` and the test fails on its own assertion,
-        with its own message, in bounded time.
-        """
-        frames = list(sequence)
-
-        def _next(*_args, **_kwargs):
-            return frames.pop(0) if len(frames) > 1 else frames[0]
-
-        return _next
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_shared_footer_alone_does_not_suppress_trust_dismissal(self, mock_tmux):
-        """The footer is shared with the trust prompt, so it cannot imply a login menu.
-
-        Kills a ``has_login`` weakened to the footer alone: this frame has the
-        footer and the v1 trust copy but no menu text, so the trust prompt must
-        still be auto-accepted.
-        """
-        frame = (
-            "  Do you trust this workspace?\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-            "\n"
-            "  Press enter to continue\n"
-        )
-        mock_tmux.return_value.get_history.side_effect = self._frames(frame, self._SETTLED)
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_menu_text_without_the_footer_does_not_suppress_trust_dismissal(self, mock_tmux):
-        """Kills a ``has_login`` weakened to the menu pattern alone.
-
-        A menu line with no footer is not a live login menu — Codex's own
-        ``get_status`` requires both — so a trust prompt on the same screen must
-        still be answered.
-        """
-        # The v1 copy must sit ABOVE the menu line. With it below, ``v1_is_live`` is
-        # true on position alone and the dismissal fires whether or not the footer is
-        # required — which is how commit 5 silently un-covered this guard. Above the
-        # menu, a menu-only ``has_login`` suppresses the dismissal and this fails.
-        frame = (
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-            "  1. Sign in with ChatGPT\n"
-        )
-        _bottom = "\n".join(frame.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-        assert re.search(LOGIN_MENU_PATTERN, _bottom) and not re.search(
-            LOGIN_MENU_FOOTER, _bottom
-        ), "fixture must carry the menu pattern WITHOUT the footer"
-        mock_tmux.return_value.get_history.side_effect = self._frames(frame, self._SETTLED)
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_login_menu_only_in_scrollback_does_not_suppress_trust_dismissal(self, mock_tmux):
-        """Kills a ``has_login`` matched against the whole capture.
-
-        ``has_login`` must stay bottom-anchored. A login menu that has scrolled
-        out of the bottom region is history, not a live prompt, so a trust dialog
-        at the bottom must still be dismissed — otherwise the gate that fixes the
-        scrollback bug above reintroduces it with the roles reversed.
-        """
-        frame = (
-            self.LOGIN_MENU_OUTPUT
-            + "\n".join(f"  build step {i}" for i in range(20))
-            + "\n  Do you trust this workspace?\n"
-            + "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-        )
-        mock_tmux.return_value.get_history.side_effect = self._frames(frame, self._SETTLED)
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
-
-        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_login_menu_does_not_short_circuit_a_stacked_trust_dialog(self, mock_tmux):
-        """A trust dialog rendered over the login menu is still dismissed first.
-
-        This is the hazard in returning early on a recognized-but-unanswerable
-        screen: ``initialize()`` treats WAITING_USER_ANSWER as success, so exiting
-        with a trust dialog still up would make the following ``send_input`` raise
-        ``TerminalInputBlockedError`` and drop the initial message — the exact
-        failure the idle-gap split in this PR exists to prevent. Hence the login
-        exit is gated on no dismissable dialog being present.
-        """
-        # A single stacked frame does NOT exercise the guard: the dismissal branch
-        # is earlier in the loop and ``continue``s, so the login check is never
-        # reached on that iteration. The guard decides something only on a LATER
-        # iteration, once the dialog has been answered but is still on screen — a
-        # rendering lag after Enter. Hence the same frame twice.
-        #
-        # Trust is not the only arm that gets there: ``has_dialog``'s third term is
-        # the same predicate as the update branch's condition, so a still-rendered
-        # update dialog reaches the guard once ``update_dismissed`` is set. Trust
-        # is used here because it is the cheaper frame to build.
-        #
-        # Both signatures must also land inside the 15-line bottom region, or
-        # ``has_login`` is False and the guard is never reached: an earlier version
-        # of this test appended the dialog to the full-height menu, which pushed
-        # "Sign in with ChatGPT" out of the window and passed whether the guard
-        # existed or not. This frame is 10 lines, so all of it is in the window:
-        # has_login holds, and so do BOTH trust signatures — TRUST_PROMPT_PATTERN
-        # via the option-1 line ("allow Codex to work in this folder") and the v2
-        # pattern with its footer — so has_dialog stays True on frame 2 either way.
-        #
-        # Condensed rather than observed — this is a defensive guard for frame
-        # interleavings the TUI controls, not a transcript of one.
-        stacked = (
-            "> 1. Sign in with ChatGPT\n"
-            "  2. Sign in with Device Code\n"
-            "  3. Provide your own API key\n"
-            "\n"
-            "  Do you trust the contents of this directory?\n"
-            "\n"
-            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
-            "  2. No, ask me to approve edits and commands\n"
-            "\n"
-            "  Press enter to continue\n"
-        )
-        # Precondition, asserted rather than asserted-in-prose: an earlier version of
-        # this test lost has_login to the 15-line window and passed regardless. The
-        # comment above documented that trap; this line is what actually defends
-        # against it, and it fails loudly if the fixture ever drifts.
-        _bottom = "\n".join(stacked.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
-        assert re.search(LOGIN_MENU_PATTERN, _bottom) and re.search(
-            LOGIN_MENU_FOOTER, _bottom
-        ), "fixture no longer sets has_login; this test would pin nothing"
-
-        mock_tmux.return_value.get_history.side_effect = self._frames(
-            stacked, stacked, self._SETTLED
-        )
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
-
-        # Frame 1 dismissed the dialog.
-        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
-        # Frame 2 still shows it. The handler must NOT take the login exit there —
-        # if it does, initialize() succeeds on WAITING_USER_ANSWER with a live
-        # dialog and the next send_input raises TerminalInputBlockedError. Reaching
-        # frame 3 is the observable proof it kept waiting.
-        assert mock_tmux.return_value.get_history.call_count == 3, (
-            "handler returned while a dismissable dialog was still on screen "
-            f"(read {mock_tmux.return_value.get_history.call_count} frames, expected 3)"
-        )
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
@@ -3362,7 +2709,7 @@ class TestCodexProviderUpdateDialog:
         ]
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(outer_timeout=10.0)
+        await provider._handle_trust_prompt(timeout=10.0)
 
         # Trust was dismissed with Enter
         mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
@@ -4778,70 +4125,3 @@ class TestCodexProviderBlocksOrchestratedInputWhileWaitingUserAnswer:
         mock_tmux.send_keys.assert_not_called()
         mock_notify.assert_called_once()
         assert mock_notify.call_args.kwargs["delete_worker"] is False
-
-
-class TestCodexInitConfiguredTimeouts:
-    """Codex init timeouts must come from settings, not hard-coded literals."""
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_server_settings")
-    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_initialize_passes_provider_init_timeout_as_the_outer_cap(
-        self, mock_backend, mock_wait_shell, mock_wait_status, mock_settings
-    ):
-        """The handler's hard cap is ``provider_init_timeout``, not the idle gap.
-
-        Both bounds come from settings rather than a hard-coded 20.0, so an
-        operator on a slow/containerized host can widen them without a code
-        change. But they are DIFFERENT settings doing different jobs:
-        ``startup_prompt_handler_timeout`` is the idle gap (read inside the
-        handler) and ``provider_init_timeout`` is the outer cap passed here.
-        Passing the gap as the total budget — as this call used to — meant
-        lowering the gap for another provider silently truncated codex's whole
-        handler, leaving a late dialog undismissed.
-        """
-        mock_settings.return_value = {
-            "provider_init_timeout": 60,
-            "startup_prompt_handler_timeout": 45,
-        }
-        mock_wait_shell.return_value = True
-        mock_wait_status.return_value = True
-        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        with patch.object(provider, "_handle_trust_prompt", new_callable=AsyncMock) as mock_trust:
-            await provider.initialize()
-
-        # The gap (45) must NOT be what bounds the handler's total run.
-        mock_trust.assert_awaited_once_with(outer_timeout=60.0)
-
-    @pytest.mark.asyncio
-    @patch("cli_agent_orchestrator.providers.codex.get_server_settings")
-    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
-    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_init_timeout_error_reports_the_configured_bound(
-        self, mock_backend, mock_wait_shell, mock_wait_status, mock_settings
-    ):
-        """The init-timeout message must name the timeout actually applied.
-
-        The bound is ``provider_init_timeout``, but the message was hard-coded
-        to "60 seconds" — so an operator who raised or lowered the setting was
-        told a number the code never used.
-        """
-        mock_settings.return_value = {
-            "provider_init_timeout": 150,
-            "startup_prompt_handler_timeout": 20,
-        }
-        mock_wait_shell.return_value = True
-        mock_wait_status.return_value = False  # never reaches a ready status
-        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        with patch.object(provider, "_handle_trust_prompt", new_callable=AsyncMock):
-            with pytest.raises(TimeoutError, match="150"):
-                await provider.initialize()
-
-        assert mock_wait_status.await_args.kwargs["timeout"] == 150.0

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -4125,3 +4125,63 @@ class TestCodexProviderBlocksOrchestratedInputWhileWaitingUserAnswer:
         mock_tmux.send_keys.assert_not_called()
         mock_notify.assert_called_once()
         assert mock_notify.call_args.kwargs["delete_worker"] is False
+
+
+class TestCodexInitConfiguredTimeouts:
+    """Codex init timeouts must come from settings, not hard-coded literals."""
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_server_settings")
+    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_initialize_uses_configured_startup_prompt_timeout(
+        self, mock_backend, mock_wait_shell, mock_wait_status, mock_settings
+    ):
+        """The trust-prompt budget comes from settings, not a hard-coded 20.0.
+
+        An operator on a slow/containerized host must be able to widen it via
+        ``startup_prompt_handler_timeout`` without a code change.
+        """
+        mock_settings.return_value = {
+            "provider_init_timeout": 60,
+            "startup_prompt_handler_timeout": 45,
+        }
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with patch.object(provider, "_handle_trust_prompt", new_callable=AsyncMock) as mock_trust:
+            await provider.initialize()
+
+        mock_trust.assert_awaited_once_with(timeout=45.0)
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_server_settings")
+    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_init_timeout_error_reports_the_configured_bound(
+        self, mock_backend, mock_wait_shell, mock_wait_status, mock_settings
+    ):
+        """The init-timeout message must name the timeout actually applied.
+
+        The bound is ``provider_init_timeout``, but the message was hard-coded
+        to "60 seconds" — so an operator who raised or lowered the setting was
+        told a number the code never used.
+        """
+        mock_settings.return_value = {
+            "provider_init_timeout": 150,
+            "startup_prompt_handler_timeout": 20,
+        }
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = False  # never reaches a ready status
+        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with patch.object(provider, "_handle_trust_prompt", new_callable=AsyncMock):
+            with pytest.raises(TimeoutError, match="150"):
+                await provider.initialize()
+
+        assert mock_wait_status.await_args.kwargs["timeout"] == 150.0

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -4,6 +4,7 @@ import os
 import re
 import shlex
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,6 +29,19 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 def load_fixture(filename: str) -> str:
     with open(FIXTURES_DIR / filename, "r") as f:
         return f.read()
+
+
+def fake_clock(*values: float) -> SimpleNamespace:
+    """A stand-in for codex's ``time`` module yielding a fixed ``monotonic`` series.
+
+    Patch ``providers.codex.time`` with this rather than
+    ``providers.codex.time.monotonic``: ``codex.time`` IS the shared stdlib
+    module, so patching the attribute mutates it process-wide and asyncio's own
+    event loop — which calls ``time.monotonic()`` on every step — consumes the
+    ``side_effect`` sequence, raising StopIteration inside the loop instead of
+    in the code under test. Replacing the module reference keeps it local.
+    """
+    return SimpleNamespace(monotonic=MagicMock(side_effect=values))
 
 
 def read_developer_instructions_file(command: str) -> str:
@@ -2151,14 +2165,14 @@ class TestCodexProviderTrustPrompt:
 
     @pytest.mark.asyncio
     @patch(
-        "cli_agent_orchestrator.providers.codex.time.time",
-        side_effect=[0.0, 0.0, 20.0],
+        "cli_agent_orchestrator.providers.codex.time",
+        new_callable=lambda: fake_clock(0.0, 0.0, 0.0),
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_returns_on_v0149_idle_composer(
-        self, mock_backend, mock_error, mock_sleep, _mock_time
+        self, mock_backend, mock_error, mock_sleep, _fake_time
     ):
         mock_backend.return_value.get_history.return_value = (
             "OpenAI Codex (v0.149.0)\n"
@@ -2167,7 +2181,7 @@ class TestCodexProviderTrustPrompt:
         )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=20.0)
+        await provider._handle_trust_prompt(outer_timeout=20.0)
 
         mock_backend.return_value.get_history.assert_called_once()
         mock_sleep.assert_not_awaited()
@@ -2177,14 +2191,14 @@ class TestCodexProviderTrustPrompt:
 
     @pytest.mark.asyncio
     @patch(
-        "cli_agent_orchestrator.providers.codex.time.time",
-        side_effect=[0.0, 0.0, 20.0],
+        "cli_agent_orchestrator.providers.codex.time",
+        new_callable=lambda: fake_clock(0.0, 0.0, 0.0),
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_returns_on_v0145_idle_composer(
-        self, mock_backend, mock_error, mock_sleep, _mock_time
+        self, mock_backend, mock_error, mock_sleep, _fake_time
     ):
         """Codex 0.145's placeholder composer is a ready state, not a timeout."""
         mock_backend.return_value.get_history.return_value = load_fixture(
@@ -2192,7 +2206,7 @@ class TestCodexProviderTrustPrompt:
         )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=20.0)
+        await provider._handle_trust_prompt(outer_timeout=20.0)
 
         mock_backend.return_value.get_history.assert_called_once()
         mock_sleep.assert_not_awaited()
@@ -2202,14 +2216,14 @@ class TestCodexProviderTrustPrompt:
 
     @pytest.mark.asyncio
     @patch(
-        "cli_agent_orchestrator.providers.codex.time.time",
-        side_effect=[0.0, 0.0, 1.0, 2.0, 20.0],
+        "cli_agent_orchestrator.providers.codex.time",
+        new_callable=lambda: fake_clock(0.0, 0.0, 0.0, 1.0, 2.0),
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_waits_for_complete_v0145_composer_frame(
-        self, mock_backend, mock_error, mock_sleep, _mock_time
+        self, mock_backend, mock_error, mock_sleep, _fake_time
     ):
         """Chunked redraws are not ready until composer and footer are both visible."""
         fixture = load_fixture("codex_v0145_idle_output.txt")
@@ -2221,7 +2235,7 @@ class TestCodexProviderTrustPrompt:
         ]
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=20.0)
+        await provider._handle_trust_prompt(outer_timeout=20.0)
 
         assert mock_backend.return_value.get_history.call_count == 3
         assert mock_sleep.await_count == 2
@@ -2275,19 +2289,20 @@ class TestCodexProviderTrustPrompt:
     )
     @pytest.mark.asyncio
     @patch(
-        "cli_agent_orchestrator.providers.codex.time.time",
-        side_effect=[0.0, 0.0, 20.0],
+        # One poll (not ready), then the outer cap ends the loop.
+        "cli_agent_orchestrator.providers.codex.time",
+        new_callable=lambda: fake_clock(0.0, 0.0, 0.0, 20.0),
     )
     @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
     @patch("cli_agent_orchestrator.providers.codex.logger.error")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_handle_trust_prompt_does_not_treat_non_ready_output_as_idle(
-        self, mock_backend, mock_error, mock_sleep, _mock_time, output
+        self, mock_backend, mock_error, mock_sleep, _fake_time, output
     ):
         mock_backend.return_value.get_history.return_value = output
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=20.0)
+        await provider._handle_trust_prompt(outer_timeout=20.0)
 
         mock_sleep.assert_awaited_once_with(1.0)
         mock_error.assert_called_once()
@@ -2309,7 +2324,7 @@ class TestCodexProviderTrustPrompt:
         )
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=2.0)
+        await provider._handle_trust_prompt(outer_timeout=2.0)
 
         mock_tmux.return_value.send_special_key.assert_called_once_with(
             "test-session", "window-0", "Enter"
@@ -2322,9 +2337,139 @@ class TestCodexProviderTrustPrompt:
         mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)\n› "
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=2.0)
+        await provider._handle_trust_prompt(outer_timeout=2.0)
 
         mock_tmux.return_value.send_special_key.assert_not_called()
+
+    # ── startup_prompt_handler_timeout is an IDLE GAP, not a total budget ──
+    #
+    # The setting documents itself (settings_service.py) as the gap between
+    # consecutive startup prompts, reset each time one is answered, with total
+    # time bounded by provider_init_timeout. kimi_cli/antigravity_cli implement
+    # exactly that. Codex read it as a fixed total budget, so lowering the gap
+    # for another provider silently truncated codex's whole handler and left a
+    # late dialog undismissed -- and because initialize() accepts
+    # WAITING_USER_ANSWER as success, send_input then raised
+    # TerminalInputBlockedError and the initial message was never delivered.
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_small_idle_gap_does_not_truncate_the_handler(self, mock_backend, mock_sleep):
+        """A dialog rendered later than the idle gap is still dismissed.
+
+        Regression guard: with the gap used as a total budget, a 2s gap meant a
+        dialog first visible on the 4th poll was never answered.
+        """
+        blank = "OpenAI Codex (v0.98.0)\n"
+        trust = (
+            "> You are running Codex in /Users/test/project\n"
+            "\n"
+            "  Since this folder is version controlled, you may wish to "
+            "allow Codex to work in this folder without asking for approval.\n"
+            "\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+        )
+        mock_backend.return_value.get_history.side_effect = [blank, blank, blank, trust]
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        # Gap far shorter than the time the dialog takes to appear; the outer cap
+        # is what governs, so the handler must still be polling when it arrives.
+        with patch(
+            "cli_agent_orchestrator.providers.codex.time",
+            fake_clock(0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 60.0),
+        ):
+            await provider._handle_trust_prompt(idle_gap=2.0, outer_timeout=120.0)
+
+        mock_backend.return_value.send_special_key.assert_called_once_with(
+            "test-session", "window-0", "Enter"
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_idle_gap_resets_after_each_answered_prompt(self, mock_backend, mock_sleep):
+        """Answering the trust dialog restarts the gap, so a later update dialog
+        still gets dismissed rather than being cut off by the first gap."""
+        trust = (
+            "  Since this folder is version controlled, you may wish to "
+            "allow Codex to work in this folder without asking for approval.\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+        )
+        update = (
+            "✨ Update available! 0.142.5 -> 0.144.5\n"
+            "1. Update now (runs npm install -g @openai/codex)\n"
+            "2. Skip\n"
+            "3. Skip until next version\n"
+            "Press enter to continue\n"
+        )
+        mock_backend.return_value.get_history.side_effect = [trust, update, "quiet tail"]
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        # Poll 1 answers trust at t=10, which RESETS the gap; poll 2 at t=12 is
+        # only 2s past that reset, so it is still inside the 5s gap. Without the
+        # reset the gap would be measured from t=0 -- already 10s, past the 5s
+        # gap -- so the loop would have returned before ever seeing the update
+        # dialog. That asymmetry is what makes this a guard rather than a
+        # restatement of the happy path.
+        with patch(
+            "cli_agent_orchestrator.providers.codex.time",
+            fake_clock(0.0, 0.0, 10.0, 10.0, 12.0, 12.0, 100.0),
+        ):
+            await provider._handle_trust_prompt(idle_gap=5.0, outer_timeout=120.0)
+
+        # '3' + Enter dismisses the update dialog; a blind Enter would pick
+        # "1. Update now".
+        mock_backend.return_value.send_keys.assert_called_once_with(
+            "test-session", "window-0", "3", enter_count=0
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_idle_gap_ends_the_loop_once_startup_is_quiet(self, mock_backend, mock_sleep):
+        """After a prompt is answered, no new prompt within the gap returns —
+        the handler must not sit until the outer cap on a healthy start."""
+        trust = (
+            "  Since this folder is version controlled, you may wish to "
+            "allow Codex to work in this folder without asking for approval.\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+        )
+        mock_backend.return_value.get_history.return_value = trust
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with patch(
+            "cli_agent_orchestrator.providers.codex.time",
+            fake_clock(0.0, 0.0, 0.0, 0.0, 10.0),
+        ):
+            await provider._handle_trust_prompt(idle_gap=5.0, outer_timeout=600.0)
+
+        # Returned on the gap, not the outer cap: only the one poll happened.
+        assert mock_backend.return_value.get_history.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_bounds_default_to_their_documented_settings(self, mock_backend):
+        """idle_gap defaults to startup_prompt_handler_timeout and the outer cap
+        to provider_init_timeout — not both to the same setting."""
+        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)\n› "
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with patch(
+            "cli_agent_orchestrator.providers.codex.get_server_settings",
+            return_value={
+                "startup_prompt_handler_timeout": 7.0,
+                "provider_init_timeout": 99.0,
+            },
+        ) as mock_settings:
+            with patch(
+                "cli_agent_orchestrator.providers.codex.time",
+                fake_clock(0.0, 0.0, 0.0),
+            ):
+                await provider._handle_trust_prompt()
+
+        assert mock_settings.called
 
     def test_get_status_trust_prompt_is_waiting_user_answer(self):
         """Test that trust prompt reports WAITING_USER_ANSWER, not PROCESSING."""
@@ -2619,7 +2764,7 @@ class TestCodexProviderUpdateDialog:
         ]
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=5.0)
+        await provider._handle_trust_prompt(outer_timeout=5.0)
 
         mock_tmux.return_value.send_keys.assert_any_call(
             "test-session", "window-0", "3", enter_count=0
@@ -2633,7 +2778,7 @@ class TestCodexProviderUpdateDialog:
         mock_tmux.return_value.get_history.return_value = "OpenAI Codex (v0.142.5)\n› "
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=2.0)
+        await provider._handle_trust_prompt(outer_timeout=2.0)
 
         mock_tmux.return_value.send_keys.assert_not_called()
         mock_tmux.return_value.send_special_key.assert_not_called()
@@ -2709,7 +2854,7 @@ class TestCodexProviderUpdateDialog:
         ]
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        await provider._handle_trust_prompt(timeout=10.0)
+        await provider._handle_trust_prompt(outer_timeout=10.0)
 
         # Trust was dismissed with Enter
         mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
@@ -4135,13 +4280,19 @@ class TestCodexInitConfiguredTimeouts:
     @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
     @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
-    async def test_initialize_uses_configured_startup_prompt_timeout(
+    async def test_initialize_passes_provider_init_timeout_as_the_outer_cap(
         self, mock_backend, mock_wait_shell, mock_wait_status, mock_settings
     ):
-        """The trust-prompt budget comes from settings, not a hard-coded 20.0.
+        """The handler's hard cap is ``provider_init_timeout``, not the idle gap.
 
-        An operator on a slow/containerized host must be able to widen it via
-        ``startup_prompt_handler_timeout`` without a code change.
+        Both bounds come from settings rather than a hard-coded 20.0, so an
+        operator on a slow/containerized host can widen them without a code
+        change. But they are DIFFERENT settings doing different jobs:
+        ``startup_prompt_handler_timeout`` is the idle gap (read inside the
+        handler) and ``provider_init_timeout`` is the outer cap passed here.
+        Passing the gap as the total budget — as this call used to — meant
+        lowering the gap for another provider silently truncated codex's whole
+        handler, leaving a late dialog undismissed.
         """
         mock_settings.return_value = {
             "provider_init_timeout": 60,
@@ -4155,7 +4306,8 @@ class TestCodexInitConfiguredTimeouts:
         with patch.object(provider, "_handle_trust_prompt", new_callable=AsyncMock) as mock_trust:
             await provider.initialize()
 
-        mock_trust.assert_awaited_once_with(timeout=45.0)
+        # The gap (45) must NOT be what bounds the handler's total run.
+        mock_trust.assert_awaited_once_with(outer_timeout=60.0)
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.get_server_settings")

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2871,6 +2871,85 @@ class TestCodexProviderUpdateDialog:
         mock_tmux.return_value.send_special_key.assert_not_called()
         mock_tmux.return_value.send_keys.assert_not_called()
 
+    # ── ``has_login``'s conjunction is load-bearing in BOTH directions ──
+    #
+    # Since it now gates the v1 trust dismissal, a ``has_login`` that is too
+    # EAGER suppresses a dismissal that should happen — the mirror of the
+    # scrollback bug above, and not covered by tests that only check the login
+    # exit. It is easy to be too eager by accident: ``LOGIN_MENU_FOOTER`` IS
+    # ``TRUST_PROMPT_FOOTER``, so a footer-only ``has_login`` reads True on any
+    # frame carrying "Press enter to continue". Each test below feeds a frame
+    # where a real trust prompt must still be answered, and asserts it is.
+
+    _SETTLED = "OpenAI Codex (v0.149.0)\n› \n"
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_shared_footer_alone_does_not_suppress_trust_dismissal(self, mock_tmux):
+        """The footer is shared with the trust prompt, so it cannot imply a login menu.
+
+        Kills a ``has_login`` weakened to the footer alone: this frame has the
+        footer and the v1 trust copy but no menu text, so the trust prompt must
+        still be auto-accepted.
+        """
+        frame = (
+            "  Do you trust this workspace?\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+        mock_tmux.return_value.get_history.side_effect = [frame, self._SETTLED]
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_menu_text_without_the_footer_does_not_suppress_trust_dismissal(self, mock_tmux):
+        """Kills a ``has_login`` weakened to the menu pattern alone.
+
+        A menu line with no footer is not a live login menu — Codex's own
+        ``get_status`` requires both — so a trust prompt on the same screen must
+        still be answered.
+        """
+        frame = (
+            "  1. Sign in with ChatGPT\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+        )
+        mock_tmux.return_value.get_history.side_effect = [frame, self._SETTLED]
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_login_menu_only_in_scrollback_does_not_suppress_trust_dismissal(self, mock_tmux):
+        """Kills a ``has_login`` matched against the whole capture.
+
+        ``has_login`` must stay bottom-anchored. A login menu that has scrolled
+        out of the bottom region is history, not a live prompt, so a trust dialog
+        at the bottom must still be dismissed — otherwise the gate that fixes the
+        scrollback bug above reintroduces it with the roles reversed.
+        """
+        frame = (
+            self.LOGIN_MENU_OUTPUT
+            + "\n".join(f"  build step {i}" for i in range(20))
+            + "\n  Do you trust this workspace?\n"
+            + "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+        )
+        mock_tmux.return_value.get_history.side_effect = [frame, self._SETTLED]
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
+
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_login_menu_does_not_short_circuit_a_stacked_trust_dialog(self, mock_tmux):

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2954,3 +2954,63 @@ class TestCodexProviderBlocksOrchestratedInputWhileWaitingUserAnswer:
         mock_tmux.send_keys.assert_not_called()
         mock_notify.assert_called_once()
         assert mock_notify.call_args.kwargs["delete_worker"] is False
+
+
+class TestCodexInitConfiguredTimeouts:
+    """Codex init timeouts must come from settings, not hard-coded literals."""
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_server_settings")
+    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_initialize_uses_configured_startup_prompt_timeout(
+        self, mock_backend, mock_wait_shell, mock_wait_status, mock_settings
+    ):
+        """The trust-prompt budget comes from settings, not a hard-coded 20.0.
+
+        An operator on a slow/containerized host must be able to widen it via
+        ``startup_prompt_handler_timeout`` without a code change.
+        """
+        mock_settings.return_value = {
+            "provider_init_timeout": 60,
+            "startup_prompt_handler_timeout": 45,
+        }
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with patch.object(provider, "_handle_trust_prompt", new_callable=AsyncMock) as mock_trust:
+            await provider.initialize()
+
+        mock_trust.assert_awaited_once_with(timeout=45.0)
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_server_settings")
+    @patch("cli_agent_orchestrator.providers.codex.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.codex.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_init_timeout_error_reports_the_configured_bound(
+        self, mock_backend, mock_wait_shell, mock_wait_status, mock_settings
+    ):
+        """The init-timeout message must name the timeout actually applied.
+
+        The bound is ``provider_init_timeout``, but the message was hard-coded
+        to "60 seconds" — so an operator who raised or lowered the setting was
+        told a number the code never used.
+        """
+        mock_settings.return_value = {
+            "provider_init_timeout": 150,
+            "startup_prompt_handler_timeout": 20,
+        }
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = False  # never reaches a ready status
+        mock_backend.return_value.get_history.return_value = "OpenAI Codex (v0.98.0)"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with patch.object(provider, "_handle_trust_prompt", new_callable=AsyncMock):
+            with pytest.raises(TimeoutError, match="150"):
+                await provider.initialize()
+
+        assert mock_wait_status.await_args.kwargs["timeout"] == 150.0

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -3,6 +3,7 @@
 import os
 import re
 import shlex
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2782,6 +2783,118 @@ class TestCodexProviderUpdateDialog:
 
         mock_tmux.return_value.send_keys.assert_not_called()
         mock_tmux.return_value.send_special_key.assert_not_called()
+
+    # ── The first-run login menu is a settled state, not a stall ──
+    #
+    # It is neither a dismissable dialog nor the idle composer, so before this it
+    # matched no exit condition and the handler ran to its outer cap. That cap is
+    # ``provider_init_timeout`` (60s by default) while a non-headless ``cao launch``
+    # sends no ``initial_message`` — so ``POST /sessions`` initializes synchronously
+    # against the client's ``mcp_request_timeout`` (30s), and the client raised
+    # ReadTimeout before the operator could attach and authenticate.
+
+    LOGIN_MENU_OUTPUT = (
+        "  Welcome to Codex, OpenAI's command-line coding agent\n"
+        "\n"
+        "  Sign in with ChatGPT to use Codex as part of your paid plan\n"
+        "  or connect an API key for usage-based billing\n"
+        "\n"
+        "> 1. Sign in with ChatGPT\n"
+        "     Usage included with Plus, Pro, Business, and Enterprise plans\n"
+        "\n"
+        "  2. Sign in with Device Code\n"
+        "     Sign in from another device with a one-time code\n"
+        "\n"
+        "  3. Provide your own API key\n"
+        "     Pay for what you use\n"
+        "\n"
+        "  Press enter to continue\n"
+    )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_handle_trust_prompt_returns_on_login_menu(self, mock_tmux, mock_error):
+        """The handler returns promptly, having sent nothing, and logs no error.
+
+        Returning matters because ``initialize()``'s next ``wait_until_status``
+        already accepts this state as WAITING_USER_ANSWER — every second spent
+        here is spent against a client budget half the size of the outer cap.
+        Sending nothing matters more: choosing a sign-in method on the operator's
+        behalf is not this handler's call. The outer cap is set high here so a
+        timeout exit cannot be mistaken for a pass.
+        """
+        mock_tmux.return_value.get_history.return_value = self.LOGIN_MENU_OUTPUT
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        started = time.monotonic()
+        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 5.0, f"handler waited {elapsed:.1f}s on a settled login menu"
+        mock_tmux.return_value.send_keys.assert_not_called()
+        mock_tmux.return_value.send_special_key.assert_not_called()
+        # The old behaviour ended in "no prompt or welcome banner detected" —
+        # about a screen that plainly showed one.
+        mock_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_login_menu_does_not_short_circuit_a_stacked_trust_dialog(self, mock_tmux):
+        """A trust dialog rendered over the login menu is still dismissed first.
+
+        This is the hazard in returning early on a recognized-but-unanswerable
+        screen: ``initialize()`` treats WAITING_USER_ANSWER as success, so exiting
+        with a trust dialog still up would make the following ``send_input`` raise
+        ``TerminalInputBlockedError`` and drop the initial message — the exact
+        failure the idle-gap split in this PR exists to prevent. Hence the login
+        exit is gated on no dismissable dialog being present.
+        """
+        # A single stacked frame does NOT exercise the guard: the trust branch is
+        # earlier in the loop and ``continue``s, so the login check is never
+        # reached on that iteration. The guard only decides anything on a LATER
+        # iteration, once ``trust_dismissed`` is set but the dialog is still on
+        # screen — a rendering lag after Enter. Hence the same frame twice.
+        #
+        # Both signatures must also land inside the 15-line bottom region, or
+        # ``has_login`` is False and the guard is never reached: an earlier version
+        # of this test appended the dialog to the full-height menu, which pushed
+        # "Sign in with ChatGPT" out of the window and passed whether the guard
+        # existed or not. This frame is 10 lines, so all of it is in the window:
+        # has_login holds, and so do BOTH trust signatures — TRUST_PROMPT_PATTERN
+        # via the option-1 line ("allow Codex to work in this folder") and the v2
+        # pattern with its footer — so has_dialog stays True on frame 2 either way.
+        #
+        # Condensed rather than observed — this is a defensive guard for frame
+        # interleavings the TUI controls, not a transcript of one.
+        stacked = (
+            "> 1. Sign in with ChatGPT\n"
+            "  2. Sign in with Device Code\n"
+            "  3. Provide your own API key\n"
+            "\n"
+            "  Do you trust the contents of this directory?\n"
+            "\n"
+            "› 1. Yes, allow Codex to work in this folder without asking for approval\n"
+            "  2. No, ask me to approve edits and commands\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+        settled = "OpenAI Codex (v0.149.0)\n› \n"
+        mock_tmux.return_value.get_history.side_effect = [stacked, stacked, settled]
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=30.0, outer_timeout=30.0)
+
+        # Frame 1 dismissed the dialog.
+        mock_tmux.return_value.send_special_key.assert_any_call("test-session", "window-0", "Enter")
+        # Frame 2 still shows it. The handler must NOT take the login exit there —
+        # if it does, initialize() succeeds on WAITING_USER_ANSWER with a live
+        # dialog and the next send_input raises TerminalInputBlockedError. Reaching
+        # frame 3 is the observable proof it kept waiting.
+        assert mock_tmux.return_value.get_history.call_count == 3, (
+            "handler returned while a dismissable dialog was still on screen "
+            f"(read {mock_tmux.return_value.get_history.call_count} frames, expected 3)"
+        )
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.wait_until_status")

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2840,6 +2840,39 @@ class TestCodexProviderUpdateDialog:
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_trust_v1_does_not_fire_on_scrollback_above_a_live_login_menu(self, mock_tmux):
+        """Stale trust copy in scrollback must not make the handler answer the menu.
+
+        The v1 trust check is the only one of the four signatures matched against
+        the whole capture rather than ``bottom_region``, so before the ``not
+        has_login`` gate it could fire on text the login exit could not see. The
+        handler would then press Enter — selecting a sign-in method for the
+        operator — and log that it was leaving the menu alone, in that order.
+
+        The consequence is worse than the stall this branch fixes: the keystroke
+        selects a sign-in method, so the pane leaves the login menu and with it the
+        set ``initialize()`` waits on ({IDLE, COMPLETED, WAITING_USER_ANSWER}) —
+        measured as PROCESSING on the API-key option, with the OAuth option not
+        exercised. Either way the session is torn down on a TimeoutError instead
+        of waiting for the operator to authenticate.
+
+        One scrollback line is enough to demonstrate it, which is why the gate is
+        worth having even though no natural Codex sequence produces that line
+        today (the login menu renders *before* the trust prompt).
+        """
+        contaminated = (
+            "  $ echo 'allow Codex to work in this folder' >> notes.txt\n" + self.LOGIN_MENU_OUTPUT
+        )
+        mock_tmux.return_value.get_history.return_value = contaminated
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(idle_gap=20.0, outer_timeout=30.0)
+
+        mock_tmux.return_value.send_special_key.assert_not_called()
+        mock_tmux.return_value.send_keys.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
     async def test_login_menu_does_not_short_circuit_a_stacked_trust_dialog(self, mock_tmux):
         """A trust dialog rendered over the login menu is still dismissed first.
 
@@ -2850,11 +2883,16 @@ class TestCodexProviderUpdateDialog:
         failure the idle-gap split in this PR exists to prevent. Hence the login
         exit is gated on no dismissable dialog being present.
         """
-        # A single stacked frame does NOT exercise the guard: the trust branch is
-        # earlier in the loop and ``continue``s, so the login check is never
-        # reached on that iteration. The guard only decides anything on a LATER
-        # iteration, once ``trust_dismissed`` is set but the dialog is still on
-        # screen — a rendering lag after Enter. Hence the same frame twice.
+        # A single stacked frame does NOT exercise the guard: the dismissal branch
+        # is earlier in the loop and ``continue``s, so the login check is never
+        # reached on that iteration. The guard decides something only on a LATER
+        # iteration, once the dialog has been answered but is still on screen — a
+        # rendering lag after Enter. Hence the same frame twice.
+        #
+        # Trust is not the only arm that gets there: ``has_dialog``'s third term is
+        # the same predicate as the update branch's condition, so a still-rendered
+        # update dialog reaches the guard once ``update_dismissed`` is set. Trust
+        # is used here because it is the cheaper frame to build.
         #
         # Both signatures must also land inside the 15-line bottom region, or
         # ``has_login`` is False and the guard is never reached: an earlier version

--- a/test/providers/test_startup_handler_nonblocking.py
+++ b/test/providers/test_startup_handler_nonblocking.py
@@ -22,16 +22,6 @@ Two layers, parameterized across the four handlers:
 ClaudeCodeProvider._handle_startup_prompts is deliberately excluded from both
 layers: PR #451 (which converts it) is open/changes-requested, not merged, as
 of this test.
-
-``CodexProvider._handle_trust_prompt`` and ``CodexProvider.initialize`` were
-added later (caom-7it), for the same reason and against the same property. Codex
-is not the last remaining gap — kiro_cli, opencode_cli and cursor_cli still make
-loop-side backend calls in ``initialize()`` — but it has the slowest init of the
-group, so its stall was the one that showed up under a concurrent fan-out.
-``initialize`` is covered as well as the handler because its OWN send_keys /
-get_pane_current_command calls are blocking subprocess execs too, not just the
-prompt poll; it gets its own layer (2b) because a tick count cannot measure a
-coroutine that awaits a fixed ``asyncio.sleep`` of its own.
 """
 
 import asyncio
@@ -42,7 +32,6 @@ import pytest
 
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.antigravity_cli import AntigravityCliProvider
-from cli_agent_orchestrator.providers.codex import CodexProvider
 from cli_agent_orchestrator.providers.copilot_cli import CopilotCliProvider
 from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 
@@ -52,17 +41,6 @@ from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 # directly on the event-loop thread.
 _BLOCKING_CALL_SECONDS = 0.05
 _TICKER_INTERVAL_SECONDS = 0.01
-
-# Blocking latency and threshold for the LONGEST-GAP probe (layer 2b). Larger
-# than _BLOCKING_CALL_SECONDS so the two outcomes sit far apart: offloaded, the
-# worst gap stays near the ticker interval (0.01s) and must clear a 10x jitter
-# margin; left on the loop, the gap is at least the full 0.2s blocking call.
-_MAX_GAP_BLOCKING_SECONDS = 0.2
-_MAX_ACCEPTABLE_GAP_SECONDS = 0.1
-
-# A codex frame showing the idle composer and no blocking dialog, so
-# _handle_trust_prompt returns after a single poll.
-_CODEX_READY_FRAME = "OpenAI Codex (v0.145.0)\n› Explain this codebase\n  gpt-5.6-sol high · /tmp\n"
 
 
 def _blocking_history(ready_output: str):
@@ -91,12 +69,6 @@ async def _run_with_heartbeat_probe(handler_coro) -> int:
     a worker thread. Zero would mean the handler's "blocking" call actually
     ran on the event-loop thread and starved everything else -- the exact
     pathology issue #494 (and PR #451 before it) fixes.
-
-    The zero reading is load-bearing and depends on the ticker NOT having run
-    yet: ``create_task`` only schedules it, so a handler that never yields
-    starves it before its very first tick. Do not "warm up" the ticker before
-    ``await handler_coro`` -- that makes the count non-zero unconditionally and
-    silently voids every case below.
     """
     ticks = 0
     stop = asyncio.Event()
@@ -118,58 +90,6 @@ async def _run_with_heartbeat_probe(handler_coro) -> int:
         except asyncio.CancelledError:
             pass
     return ticks
-
-
-async def _run_with_max_gap_probe(handler_coro) -> tuple[int, float]:
-    """Like ``_run_with_heartbeat_probe``, but returns ``(ticks, worst gap)``.
-
-    For coroutines that ``await`` on their own for reasons unrelated to the
-    offload -- ``CodexProvider.initialize()``'s fixed ``asyncio.sleep(2.0)``
-    shell warm-up -- the tick COUNT proves nothing: the loop ticks during those
-    sleeps whether or not the backend calls are offloaded. The LONGEST interval
-    between two ticks does prove it, because it measures the stall itself and
-    is therefore bounded by the size of the largest un-offloaded call rather
-    than by the coroutine's total runtime.
-
-    Unlike the tick-count probe, this one deliberately brackets the handler
-    with ticks:
-
-    * At least one tick BEFORE it runs, so ``last`` is anchored -- otherwise a
-      stall that happens before the ticker's first tick goes unmeasured.
-    * At least one tick AFTER it returns, because a gap is only recorded when
-      the ticker resumes -- a handler that blocks and then returns without ever
-      suspending would otherwise look gap-free because the cancel lands first.
-    """
-    ticks = 0
-    max_gap = 0.0
-    stop = asyncio.Event()
-
-    async def _ticker() -> None:
-        nonlocal ticks, max_gap
-        last = time.monotonic()
-        while not stop.is_set():
-            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
-            now = time.monotonic()
-            max_gap = max(max_gap, now - last)
-            last = now
-            ticks += 1
-
-    ticker_task = asyncio.create_task(_ticker())
-    try:
-        while ticks < 1:
-            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
-        await handler_coro
-        settled = ticks
-        while ticks == settled:
-            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
-    finally:
-        stop.set()
-        ticker_task.cancel()
-        try:
-            await ticker_task
-        except asyncio.CancelledError:
-            pass
-    return ticks, max_gap
 
 
 async def _kimi_handler_run() -> int:
@@ -224,50 +144,6 @@ async def _copilot_shell_ready_run() -> int:
         )
 
 
-async def _codex_trust_prompt_run() -> int:
-    """CodexProvider._handle_trust_prompt: one poll, idle composer, no dialog."""
-    provider = CodexProvider("t1", "sess", "win")
-    mock_backend = MagicMock()
-    mock_backend.get_history.side_effect = _blocking_history(_CODEX_READY_FRAME)
-    with patch("cli_agent_orchestrator.providers.codex.get_backend", return_value=mock_backend):
-        return await _run_with_heartbeat_probe(provider._handle_trust_prompt(outer_timeout=5.0))
-
-
-async def _codex_initialize_run() -> tuple[int, float]:
-    """CodexProvider.initialize: its OWN backend calls, not just the prompt poll.
-
-    ``get_pane_current_command`` and both ``send_keys`` calls are blocking
-    subprocess execs as well. Stubbed at the longer
-    ``_MAX_GAP_BLOCKING_SECONDS`` because this case is measured by worst gap
-    (layer 3), not tick count -- ``initialize()`` awaits a fixed
-    ``asyncio.sleep`` warm-up that ticks the ticker either way.
-    """
-
-    def _blocking(*_args, **_kwargs):
-        time.sleep(_MAX_GAP_BLOCKING_SECONDS)
-
-    def _blocking_pane_command(*_args, **_kwargs) -> str:
-        time.sleep(_MAX_GAP_BLOCKING_SECONDS)
-        return "zsh"
-
-    mock_backend = MagicMock()
-    mock_backend.send_keys.side_effect = _blocking
-    mock_backend.get_pane_current_command.side_effect = _blocking_pane_command
-    mock_backend.get_history.return_value = _CODEX_READY_FRAME
-
-    provider = CodexProvider("t1", "sess", "win")
-    with (
-        patch("cli_agent_orchestrator.providers.codex.get_backend", return_value=mock_backend),
-        patch(
-            "cli_agent_orchestrator.providers.codex.get_server_settings",
-            return_value={"provider_init_timeout": 60, "startup_prompt_handler_timeout": 20},
-        ),
-        patch("cli_agent_orchestrator.providers.codex.wait_for_shell", return_value=True),
-        patch("cli_agent_orchestrator.providers.codex.wait_until_status", return_value=True),
-    ):
-        return await _run_with_max_gap_probe(provider.initialize())
-
-
 # ---------------------------------------------------------------------------
 # Layer 1: structural pin -- must be real coroutine functions.
 # ---------------------------------------------------------------------------
@@ -277,7 +153,6 @@ _COROUTINE_TARGETS = [
     ("antigravity:_handle_startup_dialog", AntigravityCliProvider._handle_startup_dialog),
     ("copilot:_accept_trust_prompts", CopilotCliProvider._accept_trust_prompts),
     ("copilot:_wait_for_shell_ready", CopilotCliProvider._wait_for_shell_ready),
-    ("codex:_handle_trust_prompt", CodexProvider._handle_trust_prompt),
 ]
 
 
@@ -295,7 +170,6 @@ _HEARTBEAT_CASES = [
     ("antigravity:_handle_startup_dialog", _antigravity_handler_run),
     ("copilot:_accept_trust_prompts", _copilot_trust_run),
     ("copilot:_wait_for_shell_ready", _copilot_shell_ready_run),
-    ("codex:_handle_trust_prompt", _codex_trust_prompt_run),
 ]
 
 
@@ -304,33 +178,6 @@ _HEARTBEAT_CASES = [
 async def test_handler_does_not_starve_event_loop(name, run_case):
     ticks = await run_case()
     assert ticks > 0, f"{name}: event loop starved while its backend call was in flight"
-
-
-# ---------------------------------------------------------------------------
-# Layer 2b: longest-gap probe -- for coroutines whose own awaits tick the
-# ticker regardless of whether their backend calls are offloaded.
-#
-# ``CodexProvider.initialize()`` awaits a fixed ``asyncio.sleep(2.0)`` shell
-# warm-up, so layer 2's tick COUNT would pass even with every backend call left
-# on the event loop. The metric that survives is the LONGEST interval between
-# two ticks: it measures the stall itself, so it is bounded by the size of the
-# largest un-offloaded call rather than by the coroutine's total runtime.
-# ---------------------------------------------------------------------------
-
-_MAX_GAP_CASES = [
-    ("codex:initialize", _codex_initialize_run),
-]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("name,run_case", _MAX_GAP_CASES, ids=[c[0] for c in _MAX_GAP_CASES])
-async def test_handler_never_stalls_the_loop_for_a_full_backend_call(name, run_case):
-    ticks, max_gap = await run_case()
-    assert ticks > 0, f"{name}: ticker never sampled"
-    assert max_gap < _MAX_ACCEPTABLE_GAP_SECONDS, (
-        f"{name}: event loop stalled for {max_gap:.3f}s "
-        f"(a {_MAX_GAP_BLOCKING_SECONDS}s backend call ran on the loop thread)"
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/test/providers/test_startup_handler_nonblocking.py
+++ b/test/providers/test_startup_handler_nonblocking.py
@@ -230,7 +230,7 @@ async def _codex_trust_prompt_run() -> int:
     mock_backend = MagicMock()
     mock_backend.get_history.side_effect = _blocking_history(_CODEX_READY_FRAME)
     with patch("cli_agent_orchestrator.providers.codex.get_backend", return_value=mock_backend):
-        return await _run_with_heartbeat_probe(provider._handle_trust_prompt(timeout=5.0))
+        return await _run_with_heartbeat_probe(provider._handle_trust_prompt(outer_timeout=5.0))
 
 
 async def _codex_initialize_run() -> tuple[int, float]:

--- a/test/providers/test_startup_handler_nonblocking.py
+++ b/test/providers/test_startup_handler_nonblocking.py
@@ -22,6 +22,16 @@ Two layers, parameterized across the four handlers:
 ClaudeCodeProvider._handle_startup_prompts is deliberately excluded from both
 layers: PR #451 (which converts it) is open/changes-requested, not merged, as
 of this test.
+
+``CodexProvider._handle_trust_prompt`` and ``CodexProvider.initialize`` were
+added later (caom-7it), for the same reason and against the same property. Codex
+is not the last remaining gap — kiro_cli, opencode_cli and cursor_cli still make
+loop-side backend calls in ``initialize()`` — but it has the slowest init of the
+group, so its stall was the one that showed up under a concurrent fan-out.
+``initialize`` is covered as well as the handler because its OWN send_keys /
+get_pane_current_command calls are blocking subprocess execs too, not just the
+prompt poll; it gets its own layer (2b) because a tick count cannot measure a
+coroutine that awaits a fixed ``asyncio.sleep`` of its own.
 """
 
 import asyncio
@@ -32,6 +42,7 @@ import pytest
 
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.antigravity_cli import AntigravityCliProvider
+from cli_agent_orchestrator.providers.codex import CodexProvider
 from cli_agent_orchestrator.providers.copilot_cli import CopilotCliProvider
 from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 
@@ -41,6 +52,17 @@ from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 # directly on the event-loop thread.
 _BLOCKING_CALL_SECONDS = 0.05
 _TICKER_INTERVAL_SECONDS = 0.01
+
+# Blocking latency and threshold for the LONGEST-GAP probe (layer 2b). Larger
+# than _BLOCKING_CALL_SECONDS so the two outcomes sit far apart: offloaded, the
+# worst gap stays near the ticker interval (0.01s) and must clear a 10x jitter
+# margin; left on the loop, the gap is at least the full 0.2s blocking call.
+_MAX_GAP_BLOCKING_SECONDS = 0.2
+_MAX_ACCEPTABLE_GAP_SECONDS = 0.1
+
+# A codex frame showing the idle composer and no blocking dialog, so
+# _handle_trust_prompt returns after a single poll.
+_CODEX_READY_FRAME = "OpenAI Codex (v0.145.0)\n› Explain this codebase\n  gpt-5.6-sol high · /tmp\n"
 
 
 def _blocking_history(ready_output: str):
@@ -69,6 +91,12 @@ async def _run_with_heartbeat_probe(handler_coro) -> int:
     a worker thread. Zero would mean the handler's "blocking" call actually
     ran on the event-loop thread and starved everything else -- the exact
     pathology issue #494 (and PR #451 before it) fixes.
+
+    The zero reading is load-bearing and depends on the ticker NOT having run
+    yet: ``create_task`` only schedules it, so a handler that never yields
+    starves it before its very first tick. Do not "warm up" the ticker before
+    ``await handler_coro`` -- that makes the count non-zero unconditionally and
+    silently voids every case below.
     """
     ticks = 0
     stop = asyncio.Event()
@@ -90,6 +118,58 @@ async def _run_with_heartbeat_probe(handler_coro) -> int:
         except asyncio.CancelledError:
             pass
     return ticks
+
+
+async def _run_with_max_gap_probe(handler_coro) -> tuple[int, float]:
+    """Like ``_run_with_heartbeat_probe``, but returns ``(ticks, worst gap)``.
+
+    For coroutines that ``await`` on their own for reasons unrelated to the
+    offload -- ``CodexProvider.initialize()``'s fixed ``asyncio.sleep(2.0)``
+    shell warm-up -- the tick COUNT proves nothing: the loop ticks during those
+    sleeps whether or not the backend calls are offloaded. The LONGEST interval
+    between two ticks does prove it, because it measures the stall itself and
+    is therefore bounded by the size of the largest un-offloaded call rather
+    than by the coroutine's total runtime.
+
+    Unlike the tick-count probe, this one deliberately brackets the handler
+    with ticks:
+
+    * At least one tick BEFORE it runs, so ``last`` is anchored -- otherwise a
+      stall that happens before the ticker's first tick goes unmeasured.
+    * At least one tick AFTER it returns, because a gap is only recorded when
+      the ticker resumes -- a handler that blocks and then returns without ever
+      suspending would otherwise look gap-free because the cancel lands first.
+    """
+    ticks = 0
+    max_gap = 0.0
+    stop = asyncio.Event()
+
+    async def _ticker() -> None:
+        nonlocal ticks, max_gap
+        last = time.monotonic()
+        while not stop.is_set():
+            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
+            now = time.monotonic()
+            max_gap = max(max_gap, now - last)
+            last = now
+            ticks += 1
+
+    ticker_task = asyncio.create_task(_ticker())
+    try:
+        while ticks < 1:
+            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
+        await handler_coro
+        settled = ticks
+        while ticks == settled:
+            await asyncio.sleep(_TICKER_INTERVAL_SECONDS)
+    finally:
+        stop.set()
+        ticker_task.cancel()
+        try:
+            await ticker_task
+        except asyncio.CancelledError:
+            pass
+    return ticks, max_gap
 
 
 async def _kimi_handler_run() -> int:
@@ -144,6 +224,50 @@ async def _copilot_shell_ready_run() -> int:
         )
 
 
+async def _codex_trust_prompt_run() -> int:
+    """CodexProvider._handle_trust_prompt: one poll, idle composer, no dialog."""
+    provider = CodexProvider("t1", "sess", "win")
+    mock_backend = MagicMock()
+    mock_backend.get_history.side_effect = _blocking_history(_CODEX_READY_FRAME)
+    with patch("cli_agent_orchestrator.providers.codex.get_backend", return_value=mock_backend):
+        return await _run_with_heartbeat_probe(provider._handle_trust_prompt(timeout=5.0))
+
+
+async def _codex_initialize_run() -> tuple[int, float]:
+    """CodexProvider.initialize: its OWN backend calls, not just the prompt poll.
+
+    ``get_pane_current_command`` and both ``send_keys`` calls are blocking
+    subprocess execs as well. Stubbed at the longer
+    ``_MAX_GAP_BLOCKING_SECONDS`` because this case is measured by worst gap
+    (layer 3), not tick count -- ``initialize()`` awaits a fixed
+    ``asyncio.sleep`` warm-up that ticks the ticker either way.
+    """
+
+    def _blocking(*_args, **_kwargs):
+        time.sleep(_MAX_GAP_BLOCKING_SECONDS)
+
+    def _blocking_pane_command(*_args, **_kwargs) -> str:
+        time.sleep(_MAX_GAP_BLOCKING_SECONDS)
+        return "zsh"
+
+    mock_backend = MagicMock()
+    mock_backend.send_keys.side_effect = _blocking
+    mock_backend.get_pane_current_command.side_effect = _blocking_pane_command
+    mock_backend.get_history.return_value = _CODEX_READY_FRAME
+
+    provider = CodexProvider("t1", "sess", "win")
+    with (
+        patch("cli_agent_orchestrator.providers.codex.get_backend", return_value=mock_backend),
+        patch(
+            "cli_agent_orchestrator.providers.codex.get_server_settings",
+            return_value={"provider_init_timeout": 60, "startup_prompt_handler_timeout": 20},
+        ),
+        patch("cli_agent_orchestrator.providers.codex.wait_for_shell", return_value=True),
+        patch("cli_agent_orchestrator.providers.codex.wait_until_status", return_value=True),
+    ):
+        return await _run_with_max_gap_probe(provider.initialize())
+
+
 # ---------------------------------------------------------------------------
 # Layer 1: structural pin -- must be real coroutine functions.
 # ---------------------------------------------------------------------------
@@ -153,6 +277,7 @@ _COROUTINE_TARGETS = [
     ("antigravity:_handle_startup_dialog", AntigravityCliProvider._handle_startup_dialog),
     ("copilot:_accept_trust_prompts", CopilotCliProvider._accept_trust_prompts),
     ("copilot:_wait_for_shell_ready", CopilotCliProvider._wait_for_shell_ready),
+    ("codex:_handle_trust_prompt", CodexProvider._handle_trust_prompt),
 ]
 
 
@@ -170,6 +295,7 @@ _HEARTBEAT_CASES = [
     ("antigravity:_handle_startup_dialog", _antigravity_handler_run),
     ("copilot:_accept_trust_prompts", _copilot_trust_run),
     ("copilot:_wait_for_shell_ready", _copilot_shell_ready_run),
+    ("codex:_handle_trust_prompt", _codex_trust_prompt_run),
 ]
 
 
@@ -178,6 +304,33 @@ _HEARTBEAT_CASES = [
 async def test_handler_does_not_starve_event_loop(name, run_case):
     ticks = await run_case()
     assert ticks > 0, f"{name}: event loop starved while its backend call was in flight"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2b: longest-gap probe -- for coroutines whose own awaits tick the
+# ticker regardless of whether their backend calls are offloaded.
+#
+# ``CodexProvider.initialize()`` awaits a fixed ``asyncio.sleep(2.0)`` shell
+# warm-up, so layer 2's tick COUNT would pass even with every backend call left
+# on the event loop. The metric that survives is the LONGEST interval between
+# two ticks: it measures the stall itself, so it is bounded by the size of the
+# largest un-offloaded call rather than by the coroutine's total runtime.
+# ---------------------------------------------------------------------------
+
+_MAX_GAP_CASES = [
+    ("codex:initialize", _codex_initialize_run),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,run_case", _MAX_GAP_CASES, ids=[c[0] for c in _MAX_GAP_CASES])
+async def test_handler_never_stalls_the_loop_for_a_full_backend_call(name, run_case):
+    ticks, max_gap = await run_case()
+    assert ticks > 0, f"{name}: ticker never sampled"
+    assert max_gap < _MAX_ACCEPTABLE_GAP_SECONDS, (
+        f"{name}: event loop stalled for {max_gap:.3f}s "
+        f"(a {_MAX_GAP_BLOCKING_SECONDS}s backend call ran on the loop thread)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -148,7 +148,7 @@ class TestRedeliverDroppedMessageHelper:
 class TestConfirmWorkerStartedOrResubmit:
     async def test_started_on_first_confirm_no_resubmit(self):
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=True)),
+            patch.object(ts, "_wait_for_post_dispatch_start", new=AsyncMock(return_value=True)),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
         ):
@@ -163,7 +163,9 @@ class TestConfirmWorkerStartedOrResubmit:
         # First confirm fails, box shows our text (Enter swallowed) → bare Enter,
         # second confirm succeeds.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(
+                ts, "_wait_for_post_dispatch_start", new=AsyncMock(side_effect=[False, True])
+            ),
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
@@ -178,7 +180,9 @@ class TestConfirmWorkerStartedOrResubmit:
     async def test_full_redeliver_when_box_empty(self):
         # First confirm fails, box empty (paste dropped) → re-deliver full msg.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(
+                ts, "_wait_for_post_dispatch_start", new=AsyncMock(side_effect=[False, True])
+            ),
             patch.object(ts, "_message_visible_in_box", return_value=False),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
@@ -195,7 +199,7 @@ class TestConfirmWorkerStartedOrResubmit:
     async def test_returns_false_when_worker_never_starts(self):
         # Every confirm fails through all resubmit attempts.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
+            patch.object(ts, "_wait_for_post_dispatch_start", new=AsyncMock(return_value=False)),
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key"),
             patch.object(ts, "send_input"),
@@ -210,7 +214,7 @@ class TestConfirmWorkerStartedOrResubmit:
         # returns True without calling send_input or send_special_key.
         provider = MagicMock(supports_direct_status_probe=True)
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
+            patch.object(ts, "_wait_for_post_dispatch_start", new=AsyncMock(return_value=False)),
             patch.object(ts, "_worker_is_started_direct", return_value=True),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
@@ -231,7 +235,9 @@ class TestConfirmWorkerStartedOrResubmit:
         # Direct probe returns False → continues to existing resubmit logic.
         provider = MagicMock(supports_direct_status_probe=True)
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(
+                ts, "_wait_for_post_dispatch_start", new=AsyncMock(side_effect=[False, True])
+            ),
             patch.object(ts, "_worker_is_started_direct", return_value=False),
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key") as key,
@@ -254,7 +260,9 @@ class TestConfirmWorkerStartedOrResubmit:
         # invoked; falls through to existing resubmit logic.
         provider = MagicMock(supports_direct_status_probe=False)
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(
+                ts, "_wait_for_post_dispatch_start", new=AsyncMock(side_effect=[False, True])
+            ),
             patch.object(ts, "_worker_is_started_direct") as probe,
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key"),
@@ -274,7 +282,9 @@ class TestConfirmWorkerStartedOrResubmit:
     async def test_provider_none_skips_direct_probe(self):
         # The existing None-provider path still works unchanged.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(
+                ts, "_wait_for_post_dispatch_start", new=AsyncMock(side_effect=[False, True])
+            ),
             patch.object(ts, "_worker_is_started_direct") as probe,
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key"),

--- a/test/services/test_session_service.py
+++ b/test/services/test_session_service.py
@@ -861,6 +861,56 @@ class TestSessionOwnershipIntegration:
                     delete_session(second.session_name)
 
 
+class TestGetSessionMasksPendingDelivery:
+    """#566: the masking WIRING here, not just ``reported_status`` in isolation.
+
+    ``TestReportedStatusMasking`` pins the function; nothing pinned that
+    ``get_session`` actually calls it. Deleting the call left 162 tests passing
+    (gutosantos82's mutation check), so the whole invariant -- a terminal whose
+    accepted initial message is undelivered must never read completable anywhere a
+    client can see it -- rested on an unguarded call site. ``GET /sessions/{name}``
+    is one of the three outward surfaces, reached by ``examples/fleet/panel`` and
+    by ``ops_mcp_server.get_session_info``.
+    """
+
+    @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_pending_delivery_is_masked_in_the_session_listing(
+        self, mock_get_backend, mock_list_terminals
+    ):
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+        from cli_agent_orchestrator.services import terminal_service
+
+        mock_get_backend.return_value.session_exists.return_value = True
+        mock_get_backend.return_value.list_sessions.return_value = [
+            {"id": "cao-test", "name": "Test Session"}
+        ]
+        mock_list_terminals.return_value = [
+            {"id": "pend1234", "session": "cao-test"},
+            {"id": "free5678", "session": "cao-test"},
+        ]
+
+        fake_monitor = MagicMock()
+        fake_monitor.get_status.return_value = TerminalStatus.IDLE
+
+        # Only pend1234 has an undelivered initial message.
+        with (
+            patch.object(terminal_service, "_pending_initial_delivery", {"pend1234"}),
+            patch("cli_agent_orchestrator.services.status_monitor.status_monitor", fake_monitor),
+        ):
+            result = get_session("cao-test")
+
+        by_id = {term["id"]: term["status"] for term in result["terminals"]}
+        assert by_id["pend1234"] == TerminalStatus.UNKNOWN.value, (
+            "get_session reported a completable status for a terminal whose initial "
+            "message has not been dispatched -- the mask is not wired into this surface, "
+            "so a client polling GET /sessions/{name} can still conclude 'done'"
+        )
+        assert (
+            by_id["free5678"] == TerminalStatus.IDLE.value
+        ), "masking leaked to a terminal with no pending delivery; it is per-terminal"
+
+
 class TestGetSession:
     """Tests for get_session function."""
 

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3569,6 +3569,56 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
 
 
 
+class TestPendingMarkNeverLeaks:
+    """The mark is module-level state, so a leak poisons a terminal_id for the
+    life of the process: every later GET /terminals/{id} reports UNKNOWN for a
+    terminal that may already be deleted. Only ``_run``'s finally releases it,
+    so any path that stops ``_run`` from running must release it directly.
+
+    Found by adversarial review of the round-4 fix. Pre-existing since the mask
+    was introduced rather than new to that commit, but it is this mechanism's
+    defect either way.
+    """
+
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_create_task_raising_does_not_leak_the_mark(self, mock_meta):
+        import asyncio
+
+        from cli_agent_orchestrator.services.terminal_service import (
+            _schedule_deferred_init,
+            initial_delivery_pending,
+        )
+
+        TERMINAL_ID = "1eak1eak"
+        mock_meta.return_value = None
+
+        class ClosedLoop:
+            """A loop that accepted get_running_loop() then closed underneath us."""
+
+            def create_task(self, coro):
+                coro.close()  # avoid an un-awaited-coroutine warning
+                raise RuntimeError("Event loop is closed")
+
+        provider_instance = AsyncMock()
+        provider_instance.shell_baseline = None
+
+        assert not initial_delivery_pending(TERMINAL_ID)
+        with patch.object(asyncio, "get_running_loop", return_value=ClosedLoop()):
+            with pytest.raises(RuntimeError, match="Event loop is closed"):
+                _schedule_deferred_init(
+                    provider_instance,
+                    TERMINAL_ID,
+                    "do the task",
+                    OrchestrationType.ASSIGN,
+                    None,
+                )
+        assert not initial_delivery_pending(TERMINAL_ID), (
+            "the pending mark leaked: create_task raised after the mark was set, so "
+            "_run never ran and its finally never released it — this terminal_id now "
+            "reports UNKNOWN forever"
+        )
+
+
 class TestReportedStatusMasking:
     """The masking matrix ``reported_status`` documents, pinned.
 

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3570,6 +3570,48 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
         )
 
 
+class TestListSiblingsMasksPendingDelivery:
+    """#566: the masking WIRING in list_siblings, not ``reported_status`` alone.
+
+    The existing sibling tests use empty sibling lists, so deleting the
+    ``reported_status`` call left 130 tests passing (gutosantos82's mutation
+    check). ``list_siblings`` is one of the three outward surfaces, and it is the
+    one a supervisor reads to decide whether a sibling is finished -- an unmasked
+    IDLE there invites a caller to treat an undelivered worker as done.
+    """
+
+    @patch("cli_agent_orchestrator.services.terminal_service.list_siblings_by_group_prefix")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_pending_delivery_is_masked_for_siblings(self, mock_meta, mock_by_prefix):
+        from cli_agent_orchestrator.services import terminal_service
+        from cli_agent_orchestrator.services.terminal_service import list_siblings
+
+        mock_meta.return_value = {"group": ["root", "child"], "tmux_session": "cao-session"}
+        mock_by_prefix.return_value = [
+            {"id": "pend1234", "group": ["root", "child"], "metadata": None},
+            {"id": "free5678", "group": ["root", "child"], "metadata": None},
+        ]
+
+        fake_monitor = MagicMock()
+        fake_monitor.get_status.return_value = TerminalStatus.COMPLETED
+
+        with (
+            patch.object(terminal_service, "_pending_initial_delivery", {"pend1234"}),
+            patch.object(terminal_service, "status_monitor", fake_monitor),
+        ):
+            siblings = list_siblings("caller99")
+
+        by_id = {s["id"]: s["status"] for s in siblings}
+        assert by_id["pend1234"] == TerminalStatus.UNKNOWN.value, (
+            "list_siblings reported COMPLETED for a sibling whose initial message has "
+            "not been dispatched -- a supervisor would treat an undelivered worker as "
+            "finished"
+        )
+        assert (
+            by_id["free5678"] == TerminalStatus.COMPLETED.value
+        ), "masking leaked to a sibling with no pending delivery; it is per-terminal"
+
+
 class TestConfirmationRequiresPostDispatchEvidence:
     """Round-6 review (haofeif), P1: a cached pre-dispatch COMPLETED is not evidence.
 
@@ -3683,15 +3725,20 @@ class TestPendingMarkNeverLeaks:
         TERMINAL_ID = "1eak1eak"
         mock_meta.return_value = None
 
+        captured = {}
+
         class RefusingLoop:
             """Stands in for any create_task failure, not for a closed loop.
 
             Deliberately does NOT close the coroutine: a real loop doesn't either,
             and the production guard is what has to close it. Leaving that to the
-            fake would hide an un-awaited-coroutine warning in real use.
+            fake would hide an un-awaited-coroutine warning in real use. The
+            coroutine is captured so the assertion below can check production
+            closed it, rather than inferring that from a GC-timed warning.
             """
 
             def create_task(self, coro):
+                captured["coro"] = coro
                 raise RuntimeError("create_task refused")
 
         provider_instance = AsyncMock()
@@ -3707,6 +3754,16 @@ class TestPendingMarkNeverLeaks:
                     OrchestrationType.ASSIGN,
                     None,
                 )
+        # A closed coroutine has cr_frame is None; a never-started, never-closed one
+        # does not. Deterministic, unlike asserting on the un-awaited RuntimeWarning
+        # that pytest only surfaces as a non-failing PytestUnraisableExceptionWarning
+        # at GC -- which is why deleting production's coro.close() used to fail
+        # nothing (gutosantos82).
+        assert captured["coro"].cr_frame is None, (
+            "the orphaned coroutine was left open: create_task raised after _run() was "
+            "constructed, so nothing will ever await it and the interpreter warns "
+            "'coroutine was never awaited' when it is collected"
+        )
         assert not initial_delivery_pending(TERMINAL_ID), (
             "the pending mark leaked: create_task raised after the mark was set, so "
             "_run never ran and its finally never released it, leaving this "

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3598,10 +3598,14 @@ class TestPendingMarkNeverLeaks:
         mock_meta.return_value = None
 
         class RefusingLoop:
-            """Stands in for any create_task failure, not for a closed loop."""
+            """Stands in for any create_task failure, not for a closed loop.
+
+            Deliberately does NOT close the coroutine: a real loop doesn't either,
+            and the production guard is what has to close it. Leaving that to the
+            fake would hide an un-awaited-coroutine warning in real use.
+            """
 
             def create_task(self, coro):
-                coro.close()  # avoid an un-awaited-coroutine warning
                 raise RuntimeError("create_task refused")
 
         provider_instance = AsyncMock()

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3146,3 +3146,360 @@ class TestDeferredInitWaitingUserAnswerSurvival:
         mock_tmux.send_keys.assert_not_called()
         mock_notify.assert_called_once()
         assert mock_notify.call_args.kwargs["delete_worker"] is False
+
+
+class TestDeferredDeliveryNotCompletableBeforeDispatch:
+    """PR #566 review (haofeif), BLOCKING P1: the synchronous headless
+    ``cao launch`` path must not be able to return before the initial message
+    has actually been dispatched.
+
+    ``launch``'s ``poll_until_done`` starts the moment the deferred
+    ``POST /sessions`` returns, so its ``observed_working`` evidence is not
+    causally downstream of the send. Provider startup on its own reports
+    WAITING_USER_ANSWER (kiro-cli's consent dialog is the common case), which
+    flips ``observed_working=True``; once ``initialize()`` finishes the pane
+    reads IDLE while ``_schedule_deferred_init`` still has to resolve
+    shell_baseline and metadata and then run ``inject_memory_context`` inside
+    ``send_input`` (a curated-memory lookup widens that to seconds). Three IDLE
+    samples inside that window and the CLI returns, reads empty output, and
+    exits 0 with the task never delivered.
+
+    The invariant under test is the ordering one, not a wall-clock one: while an
+    initial delivery is still pending, the terminal must not report a
+    *completable* status, so no number of samples taken before dispatch can
+    satisfy the idle gate.
+    """
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service._notify_caller_of_deferred_failure")
+    @patch("cli_agent_orchestrator.services.terminal_service.update_terminal_shell_command")
+    @patch(
+        "cli_agent_orchestrator.services.terminal_service._confirm_worker_started_or_resubmit",
+        new_callable=AsyncMock,
+    )
+    @patch("cli_agent_orchestrator.services.terminal_service.send_input")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    async def test_poll_until_done_cannot_return_before_initial_send_is_issued(
+        self,
+        mock_meta,
+        mock_status_monitor,
+        mock_send_input,
+        mock_confirm_started,
+        mock_update_shell,
+        mock_notify,
+    ):
+        """The reviewer's reproduction, driven through the real reporting path.
+
+        Real ``_schedule_deferred_init``, real ``terminal_service.get_terminal``
+        (the status every client polls), and the real ``poll_until_done`` the CLI
+        calls, run concurrently against one valid startup sequence:
+        WAITING_USER_ANSWER while initializing, then IDLE, then PROCESSING once
+        the message is dispatched.
+
+        Against the unfixed head this fails: ``poll_until_done`` returns while
+        ``dispatched`` is still False. The polling interval is compressed only to
+        keep the test fast — what makes the bug reproduce is that the
+        pre-dispatch IDLE window outlasts ``idle_stable_polls`` samples, which is
+        exactly the real-world condition.
+        """
+        import asyncio
+        import threading
+        import time as _time
+
+        from cli_agent_orchestrator.services.terminal_service import (
+            _deferred_init_tasks,
+            _schedule_deferred_init,
+            get_terminal,
+        )
+        from cli_agent_orchestrator.utils.terminal import poll_until_done
+
+        TERMINAL_ID = "abcd1234"
+        INIT_SECONDS = 0.10
+        PRE_DISPATCH_SECONDS = 0.60
+        POST_DISPATCH_WORK_SECONDS = 0.10
+        POLL_INTERVAL = 0.02
+
+        mock_meta.return_value = {
+            "id": TERMINAL_ID,
+            "tmux_window": "developer-abcd",
+            "tmux_session": "cao-session",
+            "provider": "kiro_cli",
+            "agent_profile": "developer",
+            "caller_id": None,
+            "allowed_tools": None,
+            "engine": None,
+            "group": None,
+            "metadata": None,
+            "last_active": datetime.now(),
+        }
+
+        init_done = threading.Event()
+        dispatched = threading.Event()
+        dispatched_at = {}
+
+        def fake_get_status(terminal_id):
+            # One valid startup sequence, then one ordinary turn:
+            #   WAITING_USER_ANSWER (consent dialog, real startup activity but
+            #   NOT evidence the assigned task was picked up)
+            #     -> IDLE (init finished; nothing dispatched yet)
+            #       -> PROCESSING (the agent is working on the delivered task)
+            #         -> IDLE (turn finished, the only legitimate exit)
+            if dispatched.is_set():
+                if _time.monotonic() - dispatched_at["t"] < POST_DISPATCH_WORK_SECONDS:
+                    return TerminalStatus.PROCESSING
+                return TerminalStatus.IDLE
+            if init_done.is_set():
+                return TerminalStatus.IDLE
+            return TerminalStatus.WAITING_USER_ANSWER
+
+        mock_status_monitor.get_status.side_effect = fake_get_status
+
+        def fake_send_input(terminal_id, message, **kwargs):
+            # Stands in for send_input's pre-dispatch work — most of it
+            # inject_memory_context — before any keystroke reaches the pane.
+            _time.sleep(PRE_DISPATCH_SECONDS)
+            dispatched_at["t"] = _time.monotonic()
+            dispatched.set()
+            return True
+
+        mock_send_input.side_effect = fake_send_input
+        mock_confirm_started.return_value = True
+
+        async def fake_initialize():
+            await asyncio.sleep(INIT_SECONDS)
+            init_done.set()
+            return True
+
+        provider_instance = AsyncMock()
+        provider_instance.initialize.side_effect = fake_initialize
+        provider_instance.shell_baseline = None
+
+        # Route the CLI's status poll through the real server-side reporting
+        # path instead of a scripted list, so this test pins the behaviour of
+        # get_terminal rather than a restatement of the fixture.
+        def fake_requests_get(url, **kwargs):
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"status": get_terminal(TERMINAL_ID)["status"]}
+            return resp
+
+        before_tasks = set(_deferred_init_tasks)
+        _schedule_deferred_init(
+            provider_instance, TERMINAL_ID, "do the task", OrchestrationType.ASSIGN, None
+        )
+        (task,) = set(_deferred_init_tasks) - before_tasks
+
+        dispatched_when_poll_returned = {}
+
+        def run_poll():
+            with patch("cli_agent_orchestrator.utils.terminal.requests.get", fake_requests_get):
+                poll_until_done(
+                    TERMINAL_ID,
+                    timeout=30.0,
+                    polling_interval=POLL_INTERVAL,
+                )
+            dispatched_when_poll_returned["value"] = dispatched.is_set()
+
+        await asyncio.gather(task, asyncio.to_thread(run_poll))
+
+        mock_notify.assert_not_called()
+        assert dispatched.is_set(), "fixture bug: the initial send never ran"
+        assert dispatched_when_poll_returned["value"] is True, (
+            "poll_until_done returned before the initial message was dispatched — "
+            "the synchronous `cao launch` would print empty output and exit 0 "
+            "with the task never delivered"
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service._notify_caller_of_deferred_failure")
+    @patch("cli_agent_orchestrator.services.terminal_service.update_terminal_shell_command")
+    @patch(
+        "cli_agent_orchestrator.services.terminal_service._confirm_worker_started_or_resubmit",
+        new_callable=AsyncMock,
+    )
+    @patch("cli_agent_orchestrator.services.terminal_service.send_input")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    async def test_mask_is_released_at_dispatch_not_after_delivery_confirmation(
+        self,
+        mock_meta,
+        mock_status_monitor,
+        mock_send_input,
+        mock_confirm_started,
+        mock_update_shell,
+        mock_notify,
+    ):
+        """The mask must be released when the send is ISSUED, not when
+        ``_confirm_worker_started_or_resubmit`` finishes.
+
+        Holding it across the confirm/resubmit window would swap this bug for its
+        mirror image: a short task can finish while that window is still open, and
+        a poller masked for the whole of it would sit through a completion that
+        already happened — stranded until its own timeout. The dispatch boundary is
+        the narrowest mark that still makes the poller's evidence causal.
+
+        Fails if ``_clear_initial_delivery_pending`` is moved to the end of
+        ``_run`` (or into the outer ``finally`` alone): the poll then cannot
+        return until confirmation is over.
+        """
+        import asyncio
+        import threading
+        import time as _time
+
+        from cli_agent_orchestrator.services.terminal_service import (
+            _deferred_init_tasks,
+            _schedule_deferred_init,
+            get_terminal,
+        )
+        from cli_agent_orchestrator.utils.terminal import poll_until_done
+
+        TERMINAL_ID = "beef5678"
+        POST_DISPATCH_WORK_SECONDS = 0.10
+        CONFIRM_SECONDS = 1.50
+        POLL_INTERVAL = 0.02
+
+        mock_meta.return_value = {
+            "id": TERMINAL_ID,
+            "tmux_window": "developer-beef",
+            "tmux_session": "cao-session",
+            "provider": "kiro_cli",
+            "agent_profile": "developer",
+            "caller_id": None,
+            "allowed_tools": None,
+            "engine": None,
+            "group": None,
+            "metadata": None,
+            "last_active": datetime.now(),
+        }
+
+        dispatched = threading.Event()
+        confirm_finished = threading.Event()
+        dispatched_at = {}
+
+        def fake_get_status(terminal_id):
+            if not dispatched.is_set():
+                return TerminalStatus.IDLE
+            if _time.monotonic() - dispatched_at["t"] < POST_DISPATCH_WORK_SECONDS:
+                return TerminalStatus.PROCESSING
+            return TerminalStatus.IDLE
+
+        mock_status_monitor.get_status.side_effect = fake_get_status
+
+        def fake_send_input(terminal_id, message, **kwargs):
+            dispatched_at["t"] = _time.monotonic()
+            dispatched.set()
+            return True
+
+        mock_send_input.side_effect = fake_send_input
+
+        async def fake_confirm(*args, **kwargs):
+            # A probe-capable provider's verification, plus the pickup grace the
+            # resubmit path waits out. The agent's turn completes inside it.
+            await asyncio.sleep(CONFIRM_SECONDS)
+            confirm_finished.set()
+            return True
+
+        mock_confirm_started.side_effect = fake_confirm
+
+        provider_instance = AsyncMock()
+        provider_instance.initialize.return_value = True
+        provider_instance.shell_baseline = None
+
+        def fake_requests_get(url, **kwargs):
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"status": get_terminal(TERMINAL_ID)["status"]}
+            return resp
+
+        before_tasks = set(_deferred_init_tasks)
+        _schedule_deferred_init(
+            provider_instance, TERMINAL_ID, "do the task", OrchestrationType.ASSIGN, None
+        )
+        (task,) = set(_deferred_init_tasks) - before_tasks
+
+        observed = {}
+
+        def run_poll():
+            with patch("cli_agent_orchestrator.utils.terminal.requests.get", fake_requests_get):
+                poll_until_done(TERMINAL_ID, timeout=30.0, polling_interval=POLL_INTERVAL)
+            observed["dispatched"] = dispatched.is_set()
+            observed["confirm_finished"] = confirm_finished.is_set()
+
+        await asyncio.gather(task, asyncio.to_thread(run_poll))
+
+        mock_notify.assert_not_called()
+        assert observed["dispatched"] is True, "poll returned before dispatch (the P1 itself)"
+        assert observed["confirm_finished"] is False, (
+            "poll_until_done did not return until delivery confirmation had finished — "
+            "the pending mark is being held past the dispatch boundary, so a task that "
+            "completes during the confirm/resubmit window is invisible to the caller"
+        )
+
+
+class TestReportedStatusMasking:
+    """The masking matrix ``reported_status`` documents, pinned.
+
+    Which statuses are masked is the whole safety argument: mask too little and
+    the #566 P1 is back; mask too much and a pane parked on a real prompt, or a
+    dead provider, becomes invisible to the operator who has to act on it.
+    """
+
+    def _pending(self, terminal_id):
+        from cli_agent_orchestrator.services import terminal_service
+
+        return patch.object(terminal_service, "_pending_initial_delivery", {terminal_id})
+
+    @pytest.mark.parametrize(
+        "raw",
+        [TerminalStatus.IDLE, TerminalStatus.COMPLETED],
+    )
+    def test_completable_statuses_are_masked_while_delivery_pending(self, raw):
+        from cli_agent_orchestrator.services.terminal_service import reported_status
+
+        with self._pending("aaaa1111"):
+            assert reported_status("aaaa1111", raw) is TerminalStatus.UNKNOWN
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            TerminalStatus.WAITING_USER_ANSWER,
+            TerminalStatus.PROCESSING,
+            TerminalStatus.ERROR,
+            TerminalStatus.UNKNOWN,
+        ],
+    )
+    def test_actionable_statuses_are_never_masked(self, raw):
+        """WAITING_USER_ANSWER in particular: masking it would hide the one state
+        an operator must see to unblock the pane, and send_input's own guard
+        converts it into a TerminalInputBlockedError that releases the mark."""
+        from cli_agent_orchestrator.services.terminal_service import reported_status
+
+        with self._pending("aaaa1111"):
+            assert reported_status("aaaa1111", raw) is raw
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            TerminalStatus.IDLE,
+            TerminalStatus.COMPLETED,
+            TerminalStatus.WAITING_USER_ANSWER,
+            TerminalStatus.PROCESSING,
+            TerminalStatus.ERROR,
+            TerminalStatus.UNKNOWN,
+        ],
+    )
+    def test_nothing_is_masked_once_no_delivery_is_pending(self, raw):
+        """The mask is scoped to the pending window only — the ordinary steady
+        state of every terminal must be reported verbatim."""
+        from cli_agent_orchestrator.services.terminal_service import reported_status
+
+        assert reported_status("aaaa1111", raw) is raw
+
+    def test_mask_is_per_terminal_not_global(self):
+        """A pending delivery on one terminal must not mask a sibling's IDLE."""
+        from cli_agent_orchestrator.services.terminal_service import reported_status
+
+        with self._pending("aaaa1111"):
+            assert reported_status("aaaa1111", TerminalStatus.IDLE) is TerminalStatus.UNKNOWN
+            assert reported_status("bbbb2222", TerminalStatus.IDLE) is TerminalStatus.IDLE

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3570,6 +3570,91 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
         )
 
 
+class TestConfirmationRequiresPostDispatchEvidence:
+    """Round-6 review (haofeif), P1: a cached pre-dispatch COMPLETED is not evidence.
+
+    Provider startup output can legitimately parse as COMPLETED, which then latches
+    (``_STICKY_READY_STATUSES``), and ``send_input`` only ARMS the next transition
+    without touching the cached value. Confirmation therefore used to succeed
+    instantly on a status earned BEFORE the send -- measured at 0.008s on an exact
+    head -- releasing the pending-delivery mask before the task emitted anything.
+
+    Every prior test in this area seeded IDLE and produced COMPLETED afterwards, so
+    none of them could see this. These seed the completion FIRST.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pre_dispatch_completed_does_not_confirm_the_send(self):
+        """The reviewer's case: COMPLETED cached before dispatch, no new output."""
+        from cli_agent_orchestrator.services.terminal_service import (
+            _wait_for_post_dispatch_start,
+        )
+
+        fake_monitor = MagicMock()
+        # Status is COMPLETED throughout, and the generation NEVER advances --
+        # exactly the shape of a completion left over from provider startup.
+        fake_monitor.get_status.return_value = TerminalStatus.COMPLETED
+        fake_monitor.output_generation.return_value = 7
+
+        with patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor):
+            confirmed = await _wait_for_post_dispatch_start(
+                "abcd1234", dispatch_generation=7, timeout=0.25, polling_interval=0.05
+            )
+
+        assert confirmed is False, (
+            "confirmation accepted a COMPLETED cached before dispatch: the generation "
+            "never advanced, so no output arrived for this task, yet the send read as "
+            "started and the delivery mask would clear on the previous turn's result"
+        )
+
+    @pytest.mark.asyncio
+    async def test_post_dispatch_output_does_confirm(self):
+        """The discriminating half: same status, but the generation advanced."""
+        from cli_agent_orchestrator.services.terminal_service import (
+            _wait_for_post_dispatch_start,
+        )
+
+        fake_monitor = MagicMock()
+        fake_monitor.get_status.return_value = TerminalStatus.COMPLETED
+        fake_monitor.output_generation.return_value = 8  # real output landed
+
+        with patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor):
+            confirmed = await _wait_for_post_dispatch_start(
+                "abcd1234", dispatch_generation=7, timeout=0.25, polling_interval=0.05
+            )
+
+        assert confirmed is True, (
+            "a COMPLETED with an advanced generation IS this turn's completion and "
+            "must confirm -- otherwise a genuine fast turn burns every resubmit and "
+            "the worker is torn down"
+        )
+
+    @pytest.mark.asyncio
+    async def test_event_inbox_backends_are_not_gated_on_generation(self):
+        """herdr runs no FIFO reader, so the generation never advances from output.
+
+        Gating it would make confirmation unsatisfiable and tear down working
+        workers. ``dispatch_generation=None`` opts out, and their status is derived
+        on demand so there is no stale cached value to defend against.
+        """
+        from cli_agent_orchestrator.services.terminal_service import (
+            _wait_for_post_dispatch_start,
+        )
+
+        fake_monitor = MagicMock()
+        fake_monitor.get_status.return_value = TerminalStatus.COMPLETED
+        fake_monitor.output_generation.return_value = 0  # never advances for herdr
+
+        with patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor):
+            confirmed = await _wait_for_post_dispatch_start(
+                "abcd1234", dispatch_generation=None, timeout=0.25, polling_interval=0.05
+            )
+
+        assert (
+            confirmed is True
+        ), "an event-inbox backend was gated on a generation it can never advance"
+
+
 class TestPendingMarkNeverLeaks:
     """Only ``_run``'s finally releases the mark, so a ``create_task`` that raises
     would leave it set with nothing left to clear it.

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3422,9 +3422,10 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
 
         # wait_until_status imports the singleton at call time, so patching
         # terminal_service.status_monitor alone would not reach the confirm loop.
-        with patch(
-            "cli_agent_orchestrator.services.status_monitor.status_monitor", fake_monitor
-        ), patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor):
+        with (
+            patch("cli_agent_orchestrator.services.status_monitor.status_monitor", fake_monitor),
+            patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor),
+        ):
             before_tasks = set(_deferred_init_tasks)
             _schedule_deferred_init(
                 provider_instance, TERMINAL_ID, "do the task", OrchestrationType.ASSIGN, None
@@ -3433,9 +3434,9 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
             await asyncio.gather(task, asyncio.to_thread(run_poll))
 
         assert dispatched.is_set(), "fixture bug: the initial send never ran"
-        assert "t" in first_processing_at, (
-            "fixture bug: the agent never reached PROCESSING, so the test proves nothing"
-        )
+        assert (
+            "t" in first_processing_at
+        ), "fixture bug: the agent never reached PROCESSING, so the test proves nothing"
         assert poll_returned_at["t"] > first_processing_at["t"], (
             "poll_until_done returned before the first post-dispatch PROCESSING signal — "
             "it completed on the stale pre-send IDLE that survives send_input()'s return, "
@@ -3548,9 +3549,10 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
                 poll_until_done(TERMINAL_ID, timeout=30.0, polling_interval=POLL_INTERVAL)
             elapsed["t"] = _time.monotonic() - started
 
-        with patch(
-            "cli_agent_orchestrator.services.status_monitor.status_monitor", fake_monitor
-        ), patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor):
+        with (
+            patch("cli_agent_orchestrator.services.status_monitor.status_monitor", fake_monitor),
+            patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor),
+        ):
             before_tasks = set(_deferred_init_tasks)
             _schedule_deferred_init(
                 provider_instance, TERMINAL_ID, "do the task", OrchestrationType.ASSIGN, None
@@ -3566,7 +3568,6 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
             f"{COMPLETION_LAG:.2f}s after dispatch — the mask is stranding a genuine "
             "early completion"
         )
-
 
 
 class TestPendingMarkNeverLeaks:

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3314,34 +3314,158 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.terminal_service._notify_caller_of_deferred_failure")
     @patch("cli_agent_orchestrator.services.terminal_service.update_terminal_shell_command")
-    @patch(
-        "cli_agent_orchestrator.services.terminal_service._confirm_worker_started_or_resubmit",
-        new_callable=AsyncMock,
-    )
+    @patch("cli_agent_orchestrator.services.terminal_service.redeliver_dropped_message")
     @patch("cli_agent_orchestrator.services.terminal_service.send_input")
-    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
-    async def test_mask_is_released_at_dispatch_not_after_delivery_confirmation(
-        self,
-        mock_meta,
-        mock_status_monitor,
-        mock_send_input,
-        mock_confirm_started,
-        mock_update_shell,
-        mock_notify,
+    async def test_poll_cannot_complete_on_the_stale_post_dispatch_idle(
+        self, mock_meta, mock_send_input, mock_redeliver, mock_update_shell, mock_notify
     ):
-        """The mask must be released when the send is ISSUED, not when
-        ``_confirm_worker_started_or_resubmit`` finishes.
+        """Round-4 review (haofeif), P1: issuing the send is not evidence of it.
 
-        Holding it across the confirm/resubmit window would swap this bug for its
-        mirror image: a short task can finish while that window is still open, and
-        a poller masked for the whole of it would sit through a completion that
-        already happened — stranded until its own timeout. The dispatch boundary is
-        the narrowest mark that still makes the poller's evidence causal.
+        An earlier revision released the mask when ``send_input()`` returned, on
+        the reasoning that a keystroke had been dispatched so a poller's evidence
+        was now causal. It isn't. ``send_input`` only calls
+        ``notify_input_sent()``, which arms the next transition without touching
+        the cached status, and no provider enables
+        ``assume_processing_on_dispatch`` — so the reading right after dispatch is
+        still the pre-send IDLE, for as long as it takes the agent's first output
+        chunk to be detected (~1.4s measured against the real scheduler).
 
-        Fails if ``_clear_initial_delivery_pending`` is moved to the end of
-        ``_run`` (or into the outer ``finally`` alone): the poll then cannot
-        return until confirmation is over.
+        This runs the REAL ``_confirm_worker_started_or_resubmit`` against a status
+        fixture with that post-dispatch IDLE lag, and fails on the head that
+        released at the dispatch boundary: ``poll_until_done`` returned 0.93s
+        before the first PROCESSING signal ever appeared.
+        """
+        import asyncio
+        import threading
+        import time as _time
+
+        from cli_agent_orchestrator.services.terminal_service import (
+            _deferred_init_tasks,
+            _schedule_deferred_init,
+            get_terminal,
+        )
+        from cli_agent_orchestrator.utils.terminal import poll_until_done
+
+        TERMINAL_ID = "abcd1234"
+        INIT_SECONDS = 0.10
+        PRE_DISPATCH_SECONDS = 0.20
+        POST_DISPATCH_IDLE_LAG = 0.60
+        POST_DISPATCH_WORK_SECONDS = 3.00
+        POLL_INTERVAL = 0.02
+
+        mock_meta.return_value = {
+            "id": TERMINAL_ID,
+            "tmux_window": "developer-abcd",
+            "tmux_session": "cao-session",
+            "provider": "kiro_cli",
+            "agent_profile": "developer",
+            "caller_id": None,
+            "allowed_tools": None,
+            "engine": None,
+            "group": None,
+            "metadata": None,
+            "last_active": datetime.now(),
+        }
+
+        init_done = threading.Event()
+        dispatched = threading.Event()
+        dispatched_at = {}
+        first_processing_at = {}
+
+        def fake_get_status(terminal_id):
+            if dispatched.is_set():
+                elapsed = _time.monotonic() - dispatched_at["t"]
+                if elapsed < POST_DISPATCH_IDLE_LAG:
+                    return TerminalStatus.IDLE  # the stale pre-send reading
+                if elapsed < POST_DISPATCH_IDLE_LAG + POST_DISPATCH_WORK_SECONDS:
+                    first_processing_at.setdefault("t", _time.monotonic())
+                    return TerminalStatus.PROCESSING
+                return TerminalStatus.IDLE
+            if init_done.is_set():
+                return TerminalStatus.IDLE
+            return TerminalStatus.WAITING_USER_ANSWER
+
+        fake_monitor = MagicMock()
+        fake_monitor.get_status.side_effect = fake_get_status
+
+        def fake_send_input(terminal_id, message, **kwargs):
+            _time.sleep(PRE_DISPATCH_SECONDS)
+            dispatched_at["t"] = _time.monotonic()
+            dispatched.set()
+            return True
+
+        mock_send_input.side_effect = fake_send_input
+        mock_redeliver.return_value = False
+
+        async def fake_initialize():
+            await asyncio.sleep(INIT_SECONDS)
+            init_done.set()
+            return True
+
+        provider_instance = AsyncMock()
+        provider_instance.initialize.side_effect = fake_initialize
+        provider_instance.shell_baseline = None
+
+        def fake_requests_get(url, **kwargs):
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"status": get_terminal(TERMINAL_ID)["status"]}
+            return resp
+
+        poll_returned_at = {}
+
+        def run_poll():
+            with patch("cli_agent_orchestrator.utils.terminal.requests.get", fake_requests_get):
+                poll_until_done(TERMINAL_ID, timeout=30.0, polling_interval=POLL_INTERVAL)
+            poll_returned_at["t"] = _time.monotonic()
+
+        # wait_until_status imports the singleton at call time, so patching
+        # terminal_service.status_monitor alone would not reach the confirm loop.
+        with patch(
+            "cli_agent_orchestrator.services.status_monitor.status_monitor", fake_monitor
+        ), patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor):
+            before_tasks = set(_deferred_init_tasks)
+            _schedule_deferred_init(
+                provider_instance, TERMINAL_ID, "do the task", OrchestrationType.ASSIGN, None
+            )
+            (task,) = set(_deferred_init_tasks) - before_tasks
+            await asyncio.gather(task, asyncio.to_thread(run_poll))
+
+        assert dispatched.is_set(), "fixture bug: the initial send never ran"
+        assert "t" in first_processing_at, (
+            "fixture bug: the agent never reached PROCESSING, so the test proves nothing"
+        )
+        assert poll_returned_at["t"] > first_processing_at["t"], (
+            "poll_until_done returned before the first post-dispatch PROCESSING signal — "
+            "it completed on the stale pre-send IDLE that survives send_input()'s return, "
+            "so `cao launch` exits 0 with empty output while the agent is about to start"
+        )
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service._notify_caller_of_deferred_failure")
+    @patch("cli_agent_orchestrator.services.terminal_service.update_terminal_shell_command")
+    @patch("cli_agent_orchestrator.services.terminal_service.redeliver_dropped_message")
+    @patch("cli_agent_orchestrator.services.terminal_service.send_input")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    async def test_a_genuine_early_completion_is_not_hidden_by_the_mask(
+        self, mock_meta, mock_send_input, mock_redeliver, mock_update_shell, mock_notify
+    ):
+        """The mirror-image regression, pinned with the REAL confirm loop.
+
+        Replaces an earlier test that asserted the mask had to be released at the
+        dispatch boundary. That test's premise was a fixture artifact: it mocked
+        ``_confirm_worker_started_or_resubmit`` as a flat 1.5s sleep that returned
+        True regardless of status, so holding the mark across it necessarily
+        stranded the poller. The real function's first action is
+        ``wait_until_status(_DEFERRED_STARTED_STATUSES, polling_interval=0.5)``,
+        and that set contains COMPLETED — so it returns as soon as a completion is
+        visible, and the mark lifts with it.
+
+        Here a turn finishes without the pipeline ever publishing PROCESSING
+        (IDLE -> COMPLETED directly), which is the case that release point existed
+        to protect. The poll must still return promptly rather than sit out the
+        confirm window.
         """
         import asyncio
         import threading
@@ -3355,8 +3479,8 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
         from cli_agent_orchestrator.utils.terminal import poll_until_done
 
         TERMINAL_ID = "beef5678"
-        POST_DISPATCH_WORK_SECONDS = 0.10
-        CONFIRM_SECONDS = 1.50
+        INIT_SECONDS = 0.10
+        COMPLETION_LAG = 0.30
         POLL_INTERVAL = 0.02
 
         mock_meta.return_value = {
@@ -3373,18 +3497,22 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
             "last_active": datetime.now(),
         }
 
+        init_done = threading.Event()
         dispatched = threading.Event()
-        confirm_finished = threading.Event()
         dispatched_at = {}
+        saw_processing = {"value": False}
 
         def fake_get_status(terminal_id):
-            if not dispatched.is_set():
+            if dispatched.is_set():
+                if _time.monotonic() - dispatched_at["t"] < COMPLETION_LAG:
+                    return TerminalStatus.IDLE
+                return TerminalStatus.COMPLETED  # never PROCESSING
+            if init_done.is_set():
                 return TerminalStatus.IDLE
-            if _time.monotonic() - dispatched_at["t"] < POST_DISPATCH_WORK_SECONDS:
-                return TerminalStatus.PROCESSING
-            return TerminalStatus.IDLE
+            return TerminalStatus.WAITING_USER_ANSWER
 
-        mock_status_monitor.get_status.side_effect = fake_get_status
+        fake_monitor = MagicMock()
+        fake_monitor.get_status.side_effect = fake_get_status
 
         def fake_send_input(terminal_id, message, **kwargs):
             dispatched_at["t"] = _time.monotonic()
@@ -3392,49 +3520,53 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
             return True
 
         mock_send_input.side_effect = fake_send_input
+        mock_redeliver.return_value = False
 
-        async def fake_confirm(*args, **kwargs):
-            # A probe-capable provider's verification, plus the pickup grace the
-            # resubmit path waits out. The agent's turn completes inside it.
-            await asyncio.sleep(CONFIRM_SECONDS)
-            confirm_finished.set()
+        async def fake_initialize():
+            await asyncio.sleep(INIT_SECONDS)
+            init_done.set()
             return True
 
-        mock_confirm_started.side_effect = fake_confirm
-
         provider_instance = AsyncMock()
-        provider_instance.initialize.return_value = True
+        provider_instance.initialize.side_effect = fake_initialize
         provider_instance.shell_baseline = None
 
         def fake_requests_get(url, **kwargs):
             resp = MagicMock()
             resp.raise_for_status.return_value = None
-            resp.json.return_value = {"status": get_terminal(TERMINAL_ID)["status"]}
+            status = get_terminal(TERMINAL_ID)["status"]
+            if status == TerminalStatus.PROCESSING.value:
+                saw_processing["value"] = True
+            resp.json.return_value = {"status": status}
             return resp
 
-        before_tasks = set(_deferred_init_tasks)
-        _schedule_deferred_init(
-            provider_instance, TERMINAL_ID, "do the task", OrchestrationType.ASSIGN, None
-        )
-        (task,) = set(_deferred_init_tasks) - before_tasks
-
-        observed = {}
+        elapsed = {}
 
         def run_poll():
+            started = _time.monotonic()
             with patch("cli_agent_orchestrator.utils.terminal.requests.get", fake_requests_get):
                 poll_until_done(TERMINAL_ID, timeout=30.0, polling_interval=POLL_INTERVAL)
-            observed["dispatched"] = dispatched.is_set()
-            observed["confirm_finished"] = confirm_finished.is_set()
+            elapsed["t"] = _time.monotonic() - started
 
-        await asyncio.gather(task, asyncio.to_thread(run_poll))
+        with patch(
+            "cli_agent_orchestrator.services.status_monitor.status_monitor", fake_monitor
+        ), patch("cli_agent_orchestrator.services.terminal_service.status_monitor", fake_monitor):
+            before_tasks = set(_deferred_init_tasks)
+            _schedule_deferred_init(
+                provider_instance, TERMINAL_ID, "do the task", OrchestrationType.ASSIGN, None
+            )
+            (task,) = set(_deferred_init_tasks) - before_tasks
+            await asyncio.gather(task, asyncio.to_thread(run_poll))
 
-        mock_notify.assert_not_called()
-        assert observed["dispatched"] is True, "poll returned before dispatch (the P1 itself)"
-        assert observed["confirm_finished"] is False, (
-            "poll_until_done did not return until delivery confirmation had finished — "
-            "the pending mark is being held past the dispatch boundary, so a task that "
-            "completes during the confirm/resubmit window is invisible to the caller"
+        assert (
+            saw_processing["value"] is False
+        ), "fixture bug: this must exercise the no-PROCESSING path"
+        assert elapsed["t"] < 3.0, (
+            f"poll_until_done took {elapsed['t']:.2f}s for a turn that completed "
+            f"{COMPLETION_LAG:.2f}s after dispatch — the mask is stranding a genuine "
+            "early completion"
         )
+
 
 
 class TestReportedStatusMasking:

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -3570,14 +3570,19 @@ class TestDeferredDeliveryNotCompletableBeforeDispatch:
 
 
 class TestPendingMarkNeverLeaks:
-    """The mark is module-level state, so a leak poisons a terminal_id for the
-    life of the process: every later GET /terminals/{id} reports UNKNOWN for a
-    terminal that may already be deleted. Only ``_run``'s finally releases it,
-    so any path that stops ``_run`` from running must release it directly.
+    """Only ``_run``'s finally releases the mark, so a ``create_task`` that raises
+    would leave it set with nothing left to clear it.
 
-    Found by adversarial review of the round-4 fix. Pre-existing since the mask
-    was introduced rather than new to that commit, but it is this mechanism's
-    defect either way.
+    Scope, stated honestly because the tempting version of this claim is false:
+    the trigger is NOT a closed loop. ``get_running_loop()`` only succeeds on the
+    loop thread, so reaching ``create_task`` means we are the running loop, and
+    closing a running loop raises. The reachable triggers are ``_run()`` not being
+    a coroutine, MemoryError, or a KeyboardInterrupt in the gap. This pins the
+    invariant rather than any one of them.
+
+    Not covered, by choice: after ``loop.stop()`` ``create_task`` succeeds and the
+    coroutine never runs, leaking the mark with nothing raised. That is
+    loop-teardown only, and this is module state that dies with the process.
     """
 
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
@@ -3592,19 +3597,19 @@ class TestPendingMarkNeverLeaks:
         TERMINAL_ID = "1eak1eak"
         mock_meta.return_value = None
 
-        class ClosedLoop:
-            """A loop that accepted get_running_loop() then closed underneath us."""
+        class RefusingLoop:
+            """Stands in for any create_task failure, not for a closed loop."""
 
             def create_task(self, coro):
                 coro.close()  # avoid an un-awaited-coroutine warning
-                raise RuntimeError("Event loop is closed")
+                raise RuntimeError("create_task refused")
 
         provider_instance = AsyncMock()
         provider_instance.shell_baseline = None
 
         assert not initial_delivery_pending(TERMINAL_ID)
-        with patch.object(asyncio, "get_running_loop", return_value=ClosedLoop()):
-            with pytest.raises(RuntimeError, match="Event loop is closed"):
+        with patch.object(asyncio, "get_running_loop", return_value=RefusingLoop()):
+            with pytest.raises(RuntimeError, match="create_task refused"):
                 _schedule_deferred_init(
                     provider_instance,
                     TERMINAL_ID,
@@ -3614,8 +3619,8 @@ class TestPendingMarkNeverLeaks:
                 )
         assert not initial_delivery_pending(TERMINAL_ID), (
             "the pending mark leaked: create_task raised after the mark was set, so "
-            "_run never ran and its finally never released it — this terminal_id now "
-            "reports UNKNOWN forever"
+            "_run never ran and its finally never released it, leaving this "
+            "terminal_id reporting UNKNOWN with nothing able to clear it"
         )
 
 


### PR DESCRIPTION
## Problem

`cao launch --agents <worker> <message>` created the session, then delivered the message as a **separate** `POST /terminals/{id}/input`. When provider init outlives the client's read timeout that second request never fires, and the message is silently dropped — the worker sits idle with a healthy TUI and no task. Reproduced on codex workers in a mixed fan-out.

## Approach

`POST /sessions` already accepts `initial_message`, and `session_service.create_session` sets `defer_init=initial_message is not None`, so the server owns init, delivery and resubmit after the response returns. `mcp_server` and `ops_mcp_server` already use this; `cao launch` was the last client that didn't.

`launch.py` now sends `initial_message` in the create body (alongside `env_vars`, keeping secrets out of the HTTP access log) and **deletes** the client-side `/input` POST, the pre-send readiness wait, and the settling `sleep`. One delivery ships. The create call returns to `mcp_request_timeout`; `_create_session_timeout` / `_effective_init_timeout` / `_CREATE_OVERHEAD_MARGIN` are gone.

## The hard part: making the deferred terminal safe to poll

Deferring delivery means a client can poll *before* the task is delivered. Three review rounds each found the same class of hole — a release point keyed on a status **value** rather than on when that value was earned:

1. **Release when `send_input()` returns.** Holed: `send_input` only calls `notify_input_sent()`, which arms the next transition without touching the cached status. A poller reads the stale pre-send IDLE for ~1s. Reproduced returning 0.93s before the first PROCESSING signal.
2. **Release after `_confirm_worker_started_or_resubmit`.** Holed by @haofeif: `_DEFERRED_STARTED_STATUSES` contains `COMPLETED`, and provider startup output can latch one *before* dispatch. Confirmation succeeded in 0.008s on a status earned before the send.
3. **Release on post-dispatch evidence** — current. `status_monitor` gains one read-only accessor, `output_generation()`, exposing the `_capture_generation` counter #712 already maintains. It advances only in `notify_input_sent` (new turn) and `_process_chunk` (real output). `_run` samples it after the send; confirmation requires a started status **and** a strictly greater generation. A cached pre-dispatch `COMPLETED` can no longer confirm.

While held, `reported_status()` masks IDLE/COMPLETED as `UNKNOWN` at the three outward surfaces only (`get_terminal`, `list_siblings`, the session listing). WAITING_USER_ANSWER / PROCESSING / ERROR and every internal `status_monitor` caller keep the raw state.

**Event-inbox backends (herdr) are exempt** via `dispatch_generation=None`. They start no FIFO reader, so the generation never advances from output and gating them would make confirmation unsatisfiable — every resubmit burned, then teardown of a working worker. They need no gate: `get_status` derives their status on demand, so nothing is cached to go stale.

## Scope note

Delivery is deferred on the **headless** path only (`bool(message) and headless`). Deferring on the attach path would race the pre-attach readiness poll against the agent's first turn. Covered by `test_launch_non_headless_does_not_defer_init`.

## Split

The Codex startup work that was here — idle-gap redefinition, first-run login-menu liveness, trust-copy positioning, and the event-loop offload — is now #731. It shares no files with this PR and is independently reviewable.

## Verification

- **306 passed** across `test_launch.py`, `test_terminal_service_full.py`, `test_session_service.py`, `test_deferred_submit_verification.py`, `test_status_monitor.py`.
- Mutation-tested: removing the generation clause fails the pre-dispatch test while its two siblings still pass; removing `coro.close()` or bypassing `reported_status` at either call site fails exactly the three tests written for them.
- The masking wiring at `session_service.get_session` and `list_siblings` is now pinned — previously deleting either call left 162 and 130 tests passing respectively.
- `black --check` / `isort --check-only` clean.
