### PR TITLE
fix(codex): detect the runtime approval prompt codex 0.147.0 actually renders

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -143,21 +143,55 @@ STARTUP_ACTIVITY_PATTERN = r"^\s*•[^\S\n]+\S"
 #     Press enter to confirm or esc to cancel
 #
 # It is NOT a box-drawn modal and carries no "[a] Accept"/"[d] Decline" keys: it
-# is a numbered menu with a `›` selection cursor, structurally identical to the
-# trust-v2, login, and update dialogs above -- hence the same question+footer
-# corroboration shape. The three question variants are the exec, apply_patch, and
-# permission-escalation approvals; all three block the TUI on a keystroke, and all
-# three are present in the 0.147.0 binary's string table.
+# is a numbered menu with a `›` selection cursor and a confirm footer.
 #
-# Left un-anchored to the `›` cursor line on purpose: the cursor moves between the
-# numbered options as the operator arrows around, so the question and the footer
-# are the only two positionally stable rows.
+# THE TITLE IS NOT THE HOOK. An earlier revision of this detector required one of
+# three enumerated question titles inside a fixed-height bottom window, and both
+# halves of that were wrong:
+#
+#   * The enumeration is incomplete, and cannot be completed. `strings` over the
+#     0.147.0 native binary turns up at least two more approval titles driving the
+#     same menu -- `Do you want to approve network access to "<host>"?` (emitted
+#     when features.network_proxy is on, with its own `Yes, and allow this host in
+#     ...` / `No, and block this host in the future` options) and `Approve app tool
+#     call?` -- so any title list is a list of the variants someone happened to
+#     have already seen.
+#   * The fixed window fails OPEN. The command preview between the title and the
+#     menu is the verbatim command, untruncated by the renderer, so a multi-line
+#     heredoc pushes the title out of any fixed row budget; the detector then found
+#     no title and returned IDLE for a hard-blocked pane, which is the dangerous
+#     direction to be wrong in.
+#
+# So detection is structural and bottom-up instead -- see
+# :func:`_has_approval_prompt_in_bottom`. These title patterns survive only as the
+# permissive NEGATIVE gate in STARTUP_BLOCKING_INPUT_PATTERN below, where an extra
+# match merely keeps the startup poll going and is therefore free; the network
+# title is folded in there for the same reason. Nothing positive is classified off
+# a title any more.
 APPROVAL_PROMPT_PATTERN = (
-    r"Would you like to (?:run the following command"
+    r"(?:Would you like to (?:run the following command"
     r"|make the following edits"
     r"|grant these permissions)\?"
+    r"|Do you want to approve network access to)"
 )
+# Rendered as `Press ` + `enter` + ` to confirm or ` + `esc` + ` to cancel`, with
+# the key names emitted as separately styled spans -- the whole sentence is not one
+# literal in the binary, so match the stable leading fragment only.
 APPROVAL_PROMPT_FOOTER = r"Press enter to confirm"
+# One numbered menu option: "› 1. Yes, proceed (y)", "  2. No, ... (esc)". The
+# selection cursor is optional here because it sits on exactly one option at a
+# time and moves as the operator arrows around.
+APPROVAL_MENU_OPTION_PATTERN = r"^[^\S\n]*(?:›[^\S\n]+)?\d+\.[^\S\n]+\S"
+# The selected option with its cursor flush at column 0, which is where Codex
+# draws every transcript gutter marker. This is the same left-margin argument
+# _modal_line_content makes for the boxed modal: quoted or continuation prose is
+# indented under its bullet, so a menu the model merely PASTED into its own reply
+# carries its cursor at column >= 2 and fails this while a live one passes.
+APPROVAL_MENU_CURSOR_PATTERN = r"^›[^\S\n]+\d+\.[^\S\n]+\S"
+# Minimum numbered options required above the footer. Two is the floor for a
+# genuine approval (accept and decline); requiring specific option COPY instead
+# would reintroduce exactly the enumeration fragility described above.
+APPROVAL_MENU_MIN_OPTIONS = 2
 
 # Codex's boxed command-approval modal:
 #   ╭─ Command Approval Required ─╮
@@ -493,29 +527,88 @@ def _has_approval_modal_in_bottom(clean_output: str) -> bool:
     return False
 
 
+def _has_approval_menu_above(lines: list[str], footer_idx: int) -> bool:
+    """Return True when a numbered selection menu sits above ``lines[footer_idx]``.
+
+    Walks UP from the footer collecting option lines, stopping at the first
+    :func:`_is_transcript_marker` — the prompt is one transcript cell, so the
+    menu must live inside it. Option lines are classified BEFORE the marker test
+    because the cursor line ("› 1. Yes, proceed (y)") itself matches
+    USER_PREFIX_PATTERN and would otherwise end the walk immediately.
+
+    Blank rows and the question/command-preview rows between the menu and the
+    title are stepped over rather than terminating the walk, which is what makes
+    the height of the command preview irrelevant.
+
+    Requires APPROVAL_MENU_MIN_OPTIONS options AND the selection cursor flush at
+    column 0 (see APPROVAL_MENU_CURSOR_PATTERN).
+    """
+    options = 0
+    cursor_at_margin = False
+    for index in range(footer_idx - 1, -1, -1):
+        line = lines[index]
+        if re.match(APPROVAL_MENU_OPTION_PATTERN, line):
+            options += 1
+            if re.match(APPROVAL_MENU_CURSOR_PATTERN, line):
+                cursor_at_margin = True
+            continue
+        if not line.strip():
+            continue
+        if _is_transcript_marker(line):
+            break
+    return options >= APPROVAL_MENU_MIN_OPTIONS and cursor_at_margin
+
+
 def _has_approval_prompt_in_bottom(clean_output: str) -> bool:
     """Return True when Codex's runtime approval prompt is active at the bottom.
 
-    This is the prompt codex-cli 0.147.0 actually renders (verified against a
-    live capture; see APPROVAL_PROMPT_PATTERN). Corroborates the question with
-    its footer inside the bottom region, exactly like the trust-v2, login, and
-    update dialogs — the prompt is a numbered menu of the same shape, so the
-    same guard against the copy surviving in scrollback applies.
+    This is the prompt codex-cli 0.147.0 actually renders (verified against three
+    live captures). Detection is STRUCTURAL and bottom-up — the numbered menu
+    plus its confirm footer, not the question title — for the two reasons set out
+    at APPROVAL_PROMPT_PATTERN: the title list cannot be completed, and a fixed
+    row budget fails open on a long command preview.
 
-    BLANK LINES ARE DROPPED before the region is taken. The prompt is ~10 rows
-    of question, command preview, and options separated by blank filler, and
-    ``tmux capture-pane`` pads the pane to its full height with empty rows, so a
-    raw 15-line tail can land entirely inside the padding and see neither half.
-    Compacting first is what :meth:`CodexProvider.get_status_from_screen`
-    already does to the pyte viewport, so this makes the buffer path agree with
-    the screen path rather than inventing a second rule.
+    Three guards, in the order they are cheapest to refute:
+
+    1. **Footer anchor.** The LAST line matching APPROVAL_PROMPT_FOOTER. Taking
+       the last, not the first, lets an already-answered prompt in scrollback be
+       ignored rather than shadow a live one below it.
+    2. **Nothing but chrome below the anchor** (:func:`_is_chrome_only`, shared
+       with the boxed-modal detector). A live prompt blocks the TUI, so it must
+       BE the bottom of the pane. This is the guard that rejects an ordinary
+       COMPLETED reply which happens to quote both the question and the footer
+       while a live composer and more prose sit underneath — the sticky
+       WAITING_USER_ANSWER that case used to latch would wedge a ready worker.
+    3. **A numbered menu directly above the anchor**
+       (:func:`_has_approval_menu_above`), bounded by transcript markers rather
+       than a line count, so an arbitrarily tall preview still resolves.
+
+    Deliberately NOT required: any particular question title, and any particular
+    option copy. The consequence is that this also fires on Codex's other
+    blocking numbered menus that share the confirm footer (the model picker, for
+    one). That is correct rather than tolerated — those panes are equally blocked
+    on a keystroke, and WAITING_USER_ANSWER is the right answer for them too.
+
+    Residual risk, disclosed: guard 3's column-0 cursor test is what separates a
+    live menu from one pasted into a reply, so a future renderer that indents the
+    cursor would fail open to IDLE. The three live captures in
+    test/providers/fixtures/ (codex_approval_{modal,edits,long_preview}_raw.txt)
+    pin the current rendering against that.
     """
-    rows = [line for line in clean_output.splitlines() if line.strip()]
-    bottom = "\n".join(rows[-STARTUP_PROMPT_BOTTOM_LINES:])
-    return (
-        re.search(APPROVAL_PROMPT_PATTERN, bottom) is not None
-        and re.search(APPROVAL_PROMPT_FOOTER, bottom) is not None
-    )
+    lines = clean_output.splitlines()
+
+    footer_idx = None
+    for index in range(len(lines) - 1, -1, -1):
+        if re.search(APPROVAL_PROMPT_FOOTER, lines[index]):
+            footer_idx = index
+            break
+    if footer_idx is None:
+        return False
+
+    if not all(_is_chrome_only(line) for line in lines[footer_idx + 1 :]):
+        return False
+
+    return _has_approval_menu_above(lines, footer_idx)
 
 
 def _has_startup_idle_composer(clean_output: str) -> bool:
@@ -1168,6 +1261,10 @@ class CodexProvider(BaseProvider):
         # Placed after the legacy modal check and before the idle classification,
         # for the same reason: the composer and status bar keep rendering while the
         # prompt is up, so the idle-prompt check cannot see the block.
+        #
+        # Structural, not title-driven: see _has_approval_prompt_in_bottom. Both
+        # this buffer path and get_status_from_screen's rendered-screen path reach
+        # it through this one call, so the two cannot disagree.
         if _has_approval_prompt_in_bottom(clean_output):
             return TerminalStatus.WAITING_USER_ANSWER
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -126,10 +126,52 @@ UPDATE_DIALOG_MENU_PATTERN = r"Skip until next version"
 UPDATE_DIALOG_FOOTER = TRUST_PROMPT_FOOTER
 STARTUP_PROMPT_BOTTOM_LINES = 15
 STARTUP_ACTIVITY_PATTERN = r"^\s*•[^\S\n]+\S"
-# Codex's boxed command-approval modal, e.g.
+# Codex's runtime approval prompt as actually rendered by codex-cli 0.147.0,
+# verified against a live tmux capture (test/providers/fixtures/
+# codex_approval_modal_raw.txt):
+#
+#     Would you like to run the following command?
+#
+#     Environment: local
+#
+#     $ mkdir -p /private/tmp/codex-work-567
+#
+#   › 1. Yes, proceed (y)
+#     2. Yes, and don't ask again for commands that start with `mkdir -p ...` (p)
+#     3. No, and tell Codex what to do differently (esc)
+#
+#     Press enter to confirm or esc to cancel
+#
+# It is NOT a box-drawn modal and carries no "[a] Accept"/"[d] Decline" keys: it
+# is a numbered menu with a `›` selection cursor, structurally identical to the
+# trust-v2, login, and update dialogs above -- hence the same question+footer
+# corroboration shape. The three question variants are the exec, apply_patch, and
+# permission-escalation approvals; all three block the TUI on a keystroke, and all
+# three are present in the 0.147.0 binary's string table.
+#
+# Left un-anchored to the `›` cursor line on purpose: the cursor moves between the
+# numbered options as the operator arrows around, so the question and the footer
+# are the only two positionally stable rows.
+APPROVAL_PROMPT_PATTERN = (
+    r"Would you like to (?:run the following command"
+    r"|make the following edits"
+    r"|grant these permissions)\?"
+)
+APPROVAL_PROMPT_FOOTER = r"Press enter to confirm"
+
+# Codex's boxed command-approval modal:
 #   ╭─ Command Approval Required ─╮
 #   │ [a] Accept  [d] Decline     │
 #   ╰─────────────────────────────╯
+# WARNING: this copy is NOT emitted by codex-cli 0.147.0. `strings` over the
+# vendored native binary finds zero occurrences of "Command Approval Required",
+# "] Accept", or "] Decline" -- the live prompt is APPROVAL_PROMPT_PATTERN above.
+# The two patterns are kept because this copy predates the numbered menu and is
+# already load-bearing in STARTUP_BLOCKING_INPUT_PATTERN below, so dropping them
+# would silently un-guard whichever older Codex builds still render it. Treat
+# _has_approval_modal_in_bottom as legacy/defensive: APPROVAL_PROMPT_PATTERN is
+# what fires on current Codex.
+#
 # Split into header and choice-key halves because the two paths that consume
 # them need different strictness. The startup path (_has_startup_idle_composer)
 # uses the permissive OR below as a NEGATIVE gate — any one token vetoes
@@ -163,7 +205,7 @@ MODAL_FRAME_CHARS = "─│╭╮╰╯├┤━┃┏┓┗┛┣┫═║╔�
 MODAL_FRAME_GLYPHS = frozenset(MODAL_FRAME_CHARS) - frozenset(" \t")
 STARTUP_BLOCKING_INPUT_PATTERN = (
     rf"(?:{APPROVAL_MODAL_HEADER_PATTERN}|{APPROVAL_MODAL_CHOICE_PATTERN}|"
-    rf"{TRUST_PROMPT_FOOTER})"
+    rf"{APPROVAL_PROMPT_PATTERN}|{APPROVAL_PROMPT_FOOTER}|{TRUST_PROMPT_FOOTER})"
 )
 STARTUP_IDLE_PLACEHOLDER_PATTERN = (
     rf"^\s*{IDLE_PROMPT_PATTERN}[^\S\n]+(?:"
@@ -345,76 +387,135 @@ def _modal_line_content(line: str) -> Optional[str]:
     return content
 
 
-def _has_active_spinner(lines: list) -> bool:
-    """Return True when any of ``lines`` carries Codex's live progress spinner."""
-    return any(re.search(TUI_PROGRESS_PATTERN, line) for line in lines)
+def _is_frame_padding(line: str) -> bool:
+    """Return True when ``line`` carries nothing but frame glyphs and padding.
+
+    True of a box's top/bottom rule ("╰────╯"), of an empty interior row
+    ("│      │"), and of a blank line (space is in ``MODAL_FRAME_CHARS``).
+    """
+    return not line.strip(MODAL_FRAME_CHARS)
+
+
+def _is_chrome_only(line: str) -> bool:
+    """Return True when ``line`` is frame or TUI chrome rather than content.
+
+    The union of what may legitimately sit BELOW a live modal: the box's own
+    closing rule and interior padding, blank filler, the empty composer line
+    ("›" with nothing typed), and the status-bar footer. Anything else -- a
+    prose bullet, a spinner, a typed draft -- is content, which means the
+    modal is no longer the bottom of the pane.
+
+    The empty-composer and footer cases are matched explicitly rather than
+    folded into :func:`_is_frame_padding` because neither ``›`` nor the footer
+    text reduces to empty under ``MODAL_FRAME_CHARS``.
+    """
+    if _is_frame_padding(line):
+        return True
+    if re.fullmatch(rf"\s*{IDLE_PROMPT_PATTERN}\s*", line):
+        return True
+    return re.search(TUI_FOOTER_PATTERN, line) is not None
+
+
+def _is_transcript_marker(line: str) -> bool:
+    """Return True when ``line`` opens a new transcript cell (``›`` user / ``•`` bullet).
+
+    Used as the upward bound on the header search: Codex draws the modal as ONE
+    cell, so a user line or an assistant bullet is a hard boundary that the box
+    cannot span. This replaces a fixed line count, which could not express
+    "same box" and therefore failed open on a modal taller than the window.
+    """
+    return bool(
+        re.match(USER_PREFIX_PATTERN, line, re.IGNORECASE)
+        or re.match(ASSISTANT_PREFIX_PATTERN, line, re.IGNORECASE)
+    )
 
 
 def _has_approval_modal_in_bottom(clean_output: str) -> bool:
     """Return True when Codex's boxed command-approval modal is active at the bottom.
 
-    Bottom-anchored and doubly corroborated for the same reason as trust-v2 and
-    the update dialog: the copy can appear in scrollback from an already-answered
-    turn, or inside the model's own prose ("I hit Command Approval Required with
-    [a] Accept / [d] Decline"). Five independent guards separate the live modal
-    from those look-alikes:
+    NOTE: this detects the LEGACY "Command Approval Required" / "[a] Accept"
+    modal, which codex-cli 0.147.0 does not render — see
+    APPROVAL_MODAL_HEADER_PATTERN's comment and
+    :func:`_has_approval_prompt_in_bottom` for the copy that is live today.
 
-    1. **Region.** Only the bottom ``STARTUP_PROMPT_BOTTOM_LINES`` are searched.
-       As the pane scrolls the header leaves the region before the choice keys
-       do, so guard 2 fails first and an answered modal cannot stay latched.
-       This assumes the modal is at most that tall — true whenever the box is
-       the bottom of the pane, which is how Codex renders it.
-    2. **Corroboration.** Both the header AND a choice key must be present, in
-       that vertical order — the modal always renders header-above-keys.
-    3. **Line structure.** Each half must own its line: after reduction, the
-       header line is *exactly* the header text and the choice line *starts*
-       with a choice key. Prose embeds the phrases mid-sentence, so it fails
-       this even when it names both halves.
-    4. **Left-margin position.** Each half must sit at the box's left margin
-       rather than under a prose indent — see :func:`_modal_line_content`. This
-       is what separates a live modal from a quoted transcript, which satisfies
-       guards 1-3.
-    5. **No spinner below the choice line.** An ANSWERED modal whose work has
-       resumed but not yet scrolled the box out of the region still satisfies
-       guards 1-4, and reporting WAITING there withholds work from a pane that
-       is actively running. A live modal blocks execution, so nothing can be
-       spinning *below* it; a resumed one renders "• Working (Ns • esc to
-       interrupt)" there. Guard 1 eventually clears this case on its own, so
-       this closes a transient window rather than a permanent misread.
+    Anchored BOTTOM-UP on the last choice line, because the thing being tested
+    is an invariant about the bottom of the pane, not about a region of it: a
+    live modal blocks the TUI, so it must BE the bottom, with only frame rows
+    and footer chrome after it. Four guards:
 
-       Scoped to lines strictly BELOW the choice line, not the whole region:
-       with ``--no-alt-screen`` a spinner from earlier in the same turn can
-       survive in scrollback ABOVE the box, and a region-wide test would then
-       suppress a genuinely live modal.
+    1. **Anchor.** The LAST line that reduces to a choice key. Taking the last
+       rather than the first is what lets an already-answered modal sitting in
+       scrollback above a live one be ignored instead of vetoing it.
+    2. **Nothing but chrome below the anchor.** See :func:`_is_chrome_only`.
+       This subsumes the older spinner test (a spinner is not chrome) and also
+       rejects a modal transcript the model quoted mid-reply, since the reply
+       continues below the quote. It replaces "footer must NOT appear below",
+       which would have false-negatived every real modal: with
+       ``--no-alt-screen`` the footer renders at the bottom regardless.
+    3. **Corroborating header above the anchor,** found by walking up and
+       stopping at the first :func:`_is_transcript_marker` — the box is one
+       transcript cell, so the header must be inside it. No fixed window, so an
+       arbitrarily tall modal still resolves; previously a >15-line modal lost
+       its header and failed open to COMPLETED.
+    4. **Line structure and left-margin position.** Each half must own its line
+       (header an exact match, choice line a prefix match) and sit at the box's
+       margin rather than under a prose indent — see :func:`_modal_line_content`.
 
-    Deliberately does NOT key on whether the idle composer/footer appears below
-    the box, even though a live modal blocks input: get_status's own TUI-progress
-    comment records that with ``--no-alt-screen`` the footer is rendered at the
-    bottom *even while processing*, so "footer below" is likely true of real
-    modals too and would false-negative every one of them. The spinner in guard 5
-    is a narrower signal — it means work is actually executing, which a live
-    modal precludes.
+    Known residual: a framed modal quote that ENDS a reply, with only the empty
+    composer and footer after it, satisfies all four guards and reads as live.
+    Distinguishing it needs semantics this detector does not have; it costs a
+    spurious WAITING_USER_ANSWER (work withheld) rather than a COMPLETED (work
+    pasted into a blocked pane), which is the safe direction to be wrong in.
     """
-    bottom_lines = clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:]
+    lines = clean_output.splitlines()
 
-    header_idx = None
-    for index, line in enumerate(bottom_lines):
+    choice_idx = None
+    for index in range(len(lines) - 1, -1, -1):
+        content = _modal_line_content(lines[index])
+        if content is not None and re.match(APPROVAL_MODAL_CHOICE_PATTERN, content, re.IGNORECASE):
+            choice_idx = index
+            break
+    if choice_idx is None:
+        return False
+
+    if not all(_is_chrome_only(line) for line in lines[choice_idx + 1 :]):
+        return False
+
+    for index in range(choice_idx - 1, -1, -1):
+        line = lines[index]
         content = _modal_line_content(line)
         if content is not None and re.fullmatch(
             APPROVAL_MODAL_HEADER_PATTERN, content, re.IGNORECASE
         ):
-            header_idx = index
-            break
-    if header_idx is None:
-        return False
-
-    # Choice keys render on a later line than the header, never above it.
-    for offset, line in enumerate(bottom_lines[header_idx + 1 :]):
-        content = _modal_line_content(line)
-        if content is not None and re.match(APPROVAL_MODAL_CHOICE_PATTERN, content, re.IGNORECASE):
-            choice_idx = header_idx + 1 + offset
-            return not _has_active_spinner(bottom_lines[choice_idx + 1 :])
+            return True
+        if _is_transcript_marker(line):
+            return False
     return False
+
+
+def _has_approval_prompt_in_bottom(clean_output: str) -> bool:
+    """Return True when Codex's runtime approval prompt is active at the bottom.
+
+    This is the prompt codex-cli 0.147.0 actually renders (verified against a
+    live capture; see APPROVAL_PROMPT_PATTERN). Corroborates the question with
+    its footer inside the bottom region, exactly like the trust-v2, login, and
+    update dialogs — the prompt is a numbered menu of the same shape, so the
+    same guard against the copy surviving in scrollback applies.
+
+    BLANK LINES ARE DROPPED before the region is taken. The prompt is ~10 rows
+    of question, command preview, and options separated by blank filler, and
+    ``tmux capture-pane`` pads the pane to its full height with empty rows, so a
+    raw 15-line tail can land entirely inside the padding and see neither half.
+    Compacting first is what :meth:`CodexProvider.get_status_from_screen`
+    already does to the pyte viewport, so this makes the buffer path agree with
+    the screen path rather than inventing a second rule.
+    """
+    rows = [line for line in clean_output.splitlines() if line.strip()]
+    bottom = "\n".join(rows[-STARTUP_PROMPT_BOTTOM_LINES:])
+    return (
+        re.search(APPROVAL_PROMPT_PATTERN, bottom) is not None
+        and re.search(APPROVAL_PROMPT_FOOTER, bottom) is not None
+    )
 
 
 def _has_startup_idle_composer(clean_output: str) -> bool:
@@ -1052,6 +1153,22 @@ class CodexProvider(BaseProvider):
         # merely quotes the copy is excluded structurally instead — see
         # _has_approval_modal_in_bottom.
         if _has_approval_modal_in_bottom(clean_output):
+            return TerminalStatus.WAITING_USER_ANSWER
+
+        # Runtime approval prompt as codex-cli 0.147.0 actually renders it -- a
+        # numbered menu, not the boxed modal above. This is the check that fires on
+        # a current-Codex approval; without it a live prompt classified as IDLE
+        # (verified against the live capture in
+        # test/providers/fixtures/codex_approval_modal_raw.txt), because the
+        # prompt's own "› 1. Yes, proceed (y)" cursor line is both the last
+        # USER_PREFIX_PATTERN match and an idle-prompt match, so the classification
+        # below saw a user message with no reply after it. IDLE is as dangerous as
+        # COMPLETED here: both tell the conductor the pane is free.
+        #
+        # Placed after the legacy modal check and before the idle classification,
+        # for the same reason: the composer and status bar keep rendering while the
+        # prompt is up, so the idle-prompt check cannot see the block.
+        if _has_approval_prompt_in_bottom(clean_output):
             return TerminalStatus.WAITING_USER_ANSWER
 
         # Check bottom of captured output for idle prompt.

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -126,9 +126,29 @@ UPDATE_DIALOG_MENU_PATTERN = r"Skip until next version"
 UPDATE_DIALOG_FOOTER = TRUST_PROMPT_FOOTER
 STARTUP_PROMPT_BOTTOM_LINES = 15
 STARTUP_ACTIVITY_PATTERN = r"^\s*•[^\S\n]+\S"
+# Codex's boxed command-approval modal, e.g.
+#   ╭─ Command Approval Required ─╮
+#   │ [a] Accept  [d] Decline     │
+#   ╰─────────────────────────────╯
+# Split into header and choice-key halves because the two paths that consume
+# them need different strictness. The startup path (_has_startup_idle_composer)
+# uses the permissive OR below as a NEGATIVE gate — any one token vetoes
+# "ready", and a false veto merely keeps polling, so over-matching is free.
+# get_status() uses them as a POSITIVE classifier where over-matching would
+# strand a healthy pane in WAITING_USER_ANSWER, so it corroborates the two
+# halves separately (see _has_approval_modal_in_bottom). Box-drawing characters
+# are deliberately NOT required: the frame chrome has changed across Codex
+# releases while this copy has not.
+APPROVAL_MODAL_HEADER_PATTERN = r"Command Approval Required"
+APPROVAL_MODAL_CHOICE_PATTERN = r"(?:\[[aA]\]\s+Accept\b|\[[dD]\]\s+Decline\b)"
+# Box-drawing frame and padding stripped from a modal line before matching, so a
+# framed line ("│ [a] Accept  [d] Decline     │") reduces to its text content.
+# Stripped as a character SET from both ends, hence no ordering assumption about
+# corner/edge glyphs.
+MODAL_FRAME_CHARS = "─│╭╮╰╯├┤ \t"
 STARTUP_BLOCKING_INPUT_PATTERN = (
-    r"(?:Command Approval Required|\[[aA]\]\s+Accept\b|"
-    r"\[[dD]\]\s+Decline\b|Press enter to continue)"
+    rf"(?:{APPROVAL_MODAL_HEADER_PATTERN}|{APPROVAL_MODAL_CHOICE_PATTERN}|"
+    rf"{TRUST_PROMPT_FOOTER})"
 )
 STARTUP_IDLE_PLACEHOLDER_PATTERN = (
     rf"^\s*{IDLE_PROMPT_PATTERN}[^\S\n]+(?:"
@@ -275,6 +295,46 @@ def _has_update_dialog_in_bottom(clean_output: str) -> bool:
         re.search(UPDATE_DIALOG_PATTERN, bottom) is not None
         and re.search(UPDATE_DIALOG_MENU_PATTERN, bottom) is not None
         and re.search(UPDATE_DIALOG_FOOTER, bottom) is not None
+    )
+
+
+def _has_approval_modal_in_bottom(clean_output: str) -> bool:
+    """Return True when Codex's boxed command-approval modal is active at the bottom.
+
+    Bottom-anchored and doubly corroborated for the same reason as trust-v2 and
+    the update dialog: the copy can appear in scrollback from an already-answered
+    turn, or inside the model's own prose ("I hit Command Approval Required with
+    [a] Accept / [d] Decline"). Three independent guards separate the live modal
+    from those look-alikes:
+
+    1. **Region.** Only the bottom ``STARTUP_PROMPT_BOTTOM_LINES`` are searched.
+       As the pane scrolls the header leaves the region before the choice keys
+       do, so guard 2 fails first and an answered modal cannot stay latched.
+    2. **Corroboration.** Both the header AND a choice key must be present, in
+       that vertical order — the modal always renders header-above-keys.
+    3. **Line structure.** Each half must own its line: with box-drawing chrome
+       and whitespace stripped, the header line is *exactly* the header text and
+       the choice line *starts* with a choice key. Prose embeds the phrases
+       mid-sentence, so it fails this even when it names both halves.
+
+    Deliberately does not require box-drawing characters: the frame chrome has
+    changed across Codex releases while this copy has not.
+    """
+    bottom_lines = clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:]
+
+    header_idx = None
+    for index, line in enumerate(bottom_lines):
+        bare = line.strip(MODAL_FRAME_CHARS)
+        if re.fullmatch(APPROVAL_MODAL_HEADER_PATTERN, bare, re.IGNORECASE):
+            header_idx = index
+            break
+    if header_idx is None:
+        return False
+
+    # Choice keys render on a later line than the header, never above it.
+    return any(
+        re.match(APPROVAL_MODAL_CHOICE_PATTERN, line.strip(MODAL_FRAME_CHARS), re.IGNORECASE)
+        for line in bottom_lines[header_idx + 1 :]
     )
 
 
@@ -891,6 +951,28 @@ class CodexProvider(BaseProvider):
         if re.search(LOGIN_MENU_PATTERN, bottom_region) and re.search(
             LOGIN_MENU_FOOTER, bottom_region
         ):
+            return TerminalStatus.WAITING_USER_ANSWER
+
+        # Boxed command-approval modal ("Command Approval Required" / "[a] Accept"
+        # / "[d] Decline"). Reuses the copy that STARTUP_BLOCKING_INPUT_PATTERN
+        # already vetoes readiness on at startup — the same modal can appear at
+        # RUNTIME under any approval-prompting codexProfile, and only the startup
+        # path used to notice it.
+        #
+        # Bottom-anchored like trust-v2 and the update dialog, and placed BEFORE
+        # the idle/COMPLETED classification for the same reason: the TUI composer
+        # and status bar keep rendering while the modal is up, so the idle-prompt
+        # check below would otherwise report COMPLETED (or PROCESSING when the
+        # composer has scrolled off) for a pane that is hard-blocked on a
+        # keystroke. A COMPLETED there is the dangerous case — it tells the
+        # conductor the agent is free and invites more work into a dead pane.
+        #
+        # NOT gated on `not assistant_after_last_user` (unlike WAITING_PROMPT_PATTERN
+        # below): the modal is raised mid-turn, after the model has already emitted
+        # bullets, so that gate would suppress every real occurrence. Prose that
+        # merely quotes the copy is excluded structurally instead — see
+        # _has_approval_modal_in_bottom.
+        if _has_approval_modal_in_bottom(clean_output):
             return TerminalStatus.WAITING_USER_ANSWER
 
         # Check bottom of captured output for idle prompt.

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -174,10 +174,16 @@ APPROVAL_PROMPT_PATTERN = (
     r"|grant these permissions)\?"
     r"|Do you want to approve network access to)"
 )
-# Rendered as `Press ` + `enter` + ` to confirm or ` + `esc` + ` to cancel`, with
-# the key names emitted as separately styled spans -- the whole sentence is not one
-# literal in the binary, so match the stable leading fragment only.
-APPROVAL_PROMPT_FOOTER = r"Press enter to confirm"
+# Rendered as `Press ` + `<accept-key>` + ` to confirm or ` + `<cancel-key>` +
+# ` to cancel`, with the key names emitted as separately styled spans -- the whole
+# sentence is not one literal in the binary. The accept key is CONFIGURABLE
+# (`tui.keymap.list.accept`, e.g. "space" -> "Press space to confirm ..."), so
+# match the stable structural wording independently of the key: "Press <key> to
+# confirm". `\S+` (not `.+`) keeps it to a single key token so this can't span
+# arbitrary prose, and it stays gated by the numbered-menu-at-bottom structure in
+# _has_approval_prompt_in_bottom, so a completed reply merely quoting the phrase is
+# still rejected.
+APPROVAL_PROMPT_FOOTER = r"Press \S+ to confirm\b"
 # One numbered menu option: "› 1. Yes, proceed (y)", "  2. No, ... (esc)". The
 # selection cursor is optional here because it sits on exactly one option at a
 # time and moves as the operator arrows around.

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -345,13 +345,18 @@ def _modal_line_content(line: str) -> Optional[str]:
     return content
 
 
+def _has_active_spinner(lines: list) -> bool:
+    """Return True when any of ``lines`` carries Codex's live progress spinner."""
+    return any(re.search(TUI_PROGRESS_PATTERN, line) for line in lines)
+
+
 def _has_approval_modal_in_bottom(clean_output: str) -> bool:
     """Return True when Codex's boxed command-approval modal is active at the bottom.
 
     Bottom-anchored and doubly corroborated for the same reason as trust-v2 and
     the update dialog: the copy can appear in scrollback from an already-answered
     turn, or inside the model's own prose ("I hit Command Approval Required with
-    [a] Accept / [d] Decline"). Four independent guards separate the live modal
+    [a] Accept / [d] Decline"). Five independent guards separate the live modal
     from those look-alikes:
 
     1. **Region.** Only the bottom ``STARTUP_PROMPT_BOTTOM_LINES`` are searched.
@@ -369,12 +374,26 @@ def _has_approval_modal_in_bottom(clean_output: str) -> bool:
        rather than under a prose indent — see :func:`_modal_line_content`. This
        is what separates a live modal from a quoted transcript, which satisfies
        guards 1-3.
+    5. **No spinner below the choice line.** An ANSWERED modal whose work has
+       resumed but not yet scrolled the box out of the region still satisfies
+       guards 1-4, and reporting WAITING there withholds work from a pane that
+       is actively running. A live modal blocks execution, so nothing can be
+       spinning *below* it; a resumed one renders "• Working (Ns • esc to
+       interrupt)" there. Guard 1 eventually clears this case on its own, so
+       this closes a transient window rather than a permanent misread.
+
+       Scoped to lines strictly BELOW the choice line, not the whole region:
+       with ``--no-alt-screen`` a spinner from earlier in the same turn can
+       survive in scrollback ABOVE the box, and a region-wide test would then
+       suppress a genuinely live modal.
 
     Deliberately does NOT key on whether the idle composer/footer appears below
     the box, even though a live modal blocks input: get_status's own TUI-progress
     comment records that with ``--no-alt-screen`` the footer is rendered at the
     bottom *even while processing*, so "footer below" is likely true of real
-    modals too and would false-negative every one of them.
+    modals too and would false-negative every one of them. The spinner in guard 5
+    is a narrower signal — it means work is actually executing, which a live
+    modal precludes.
     """
     bottom_lines = clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:]
 
@@ -390,10 +409,11 @@ def _has_approval_modal_in_bottom(clean_output: str) -> bool:
         return False
 
     # Choice keys render on a later line than the header, never above it.
-    for line in bottom_lines[header_idx + 1 :]:
+    for offset, line in enumerate(bottom_lines[header_idx + 1 :]):
         content = _modal_line_content(line)
         if content is not None and re.match(APPROVAL_MODAL_CHOICE_PATTERN, content, re.IGNORECASE):
-            return True
+            choice_idx = header_idx + 1 + offset
+            return not _has_active_spinner(bottom_lines[choice_idx + 1 :])
     return False
 
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -210,6 +210,17 @@ APPROVAL_MENU_OPTION_PATTERN = r"^[^\S\n]*(?:›[^\S\n]+)?\d+\.[^\S\n]+\S"
 # indented under its bullet, so a menu the model merely PASTED into its own reply
 # carries its cursor at column >= 2 and fails this while a live one passes.
 APPROVAL_MENU_CURSOR_PATTERN = r"^›[^\S\n]+\d+\.[^\S\n]+\S"
+# A wrapped option's continuation row. ListSelectionView renders wrapped rows by
+# default (SelectionRowDisplay::Wrapped, list_selection_view.rs at
+# rust-v0.147.0), and word_wrap_line indents every continuation to the option
+# TEXT column -- the width of the "{prefix} {n}. " gutter, so 5 columns for a
+# single-digit menu and one more per extra digit (build_rows sets wrap_indent to
+# the prefix width; wrap_standard_row feeds it to subsequent_indent). The
+# question, command preview, and footer rows all sit at 2 columns of indent, so
+# >= 5 columns directly under an option row is the menu's own wrapping, never
+# new content. Only honoured while inside an option (see the below-anchor scan)
+# -- indented prose elsewhere still disqualifies the block.
+APPROVAL_MENU_CONTINUATION_PATTERN = r"^[^\S\n]{5,}\S"
 # Minimum numbered options required above the footer. Two is the floor for a
 # genuine approval (accept and decline); requiring specific option COPY instead
 # would reintroduce exactly the enumeration fragility described above.
@@ -572,16 +583,22 @@ def _has_approval_prompt_in_bottom(clean_output: str) -> bool:
        model merely PASTED into a reply — carries its cursor at column >= 2 and
        fails this.
     2. **Nothing below the anchor but the rest of the menu block**: the
-       remaining (non-cursor) option rows, at most one footer hint in any of
-       its rendered forms, and chrome (:func:`_is_chrome_only`, shared with the
-       boxed-modal detector). A live prompt blocks the TUI, so its menu must BE
-       the bottom of the pane. This is the guard that rejects an ordinary
-       COMPLETED reply which quotes the menu while a live composer and more
-       prose sit underneath — the sticky WAITING_USER_ANSWER that case used to
-       latch would wedge a ready worker.
-    3. **Menu size.** At least APPROVAL_MENU_MIN_OPTIONS option rows counted
-       contiguously around the anchor (a genuine approval always offers accept
-       and decline). Contiguity matters: counting across the question or the
+       remaining (non-cursor) option rows — each an option-start row plus any
+       wrapped continuation rows at the option text column
+       (APPROVAL_MENU_CONTINUATION_PATTERN; the renderer wraps long options by
+       default, so a narrow pane splits one option across lines) — at most one
+       footer hint in any of its rendered forms, and chrome
+       (:func:`_is_chrome_only`, shared with the boxed-modal detector).
+       Continuations are honoured only while inside an option; indented prose
+       after the footer or after blank filler still disqualifies. A live
+       prompt blocks the TUI, so its menu must BE the bottom of the pane. This
+       is the guard that rejects an ordinary COMPLETED reply which quotes the
+       menu while a live composer and more prose sit underneath — the sticky
+       WAITING_USER_ANSWER that case used to latch would wedge a ready worker.
+    3. **Menu size.** At least APPROVAL_MENU_MIN_OPTIONS option-START rows
+       counted contiguously around the anchor, stepping over wrapped
+       continuation rows (a genuine approval always offers accept and
+       decline). Contiguity matters: counting across the question or the
        command preview would let a numbered list INSIDE a quoted command
        inflate the tally.
 
@@ -622,20 +639,31 @@ def _has_approval_prompt_in_bottom(clean_output: str) -> bool:
 
     options = 1  # the anchor row
     footer_seen = False
+    in_option = True  # the anchor row itself may wrap onto the next line
     for line in lines[anchor + 1 :]:
         if not footer_seen and re.match(APPROVAL_MENU_OPTION_PATTERN, line):
             options += 1
+            in_option = True
+            continue
+        if in_option and re.match(APPROVAL_MENU_CONTINUATION_PATTERN, line):
             continue
         if not footer_seen and re.search(APPROVAL_PROMPT_FOOTER, line):
             footer_seen = True
+            in_option = False
             continue
         if _is_chrome_only(line):
+            in_option = False
             continue
         return False
 
     for index in range(anchor - 1, -1, -1):
-        if re.match(APPROVAL_MENU_OPTION_PATTERN, lines[index]):
+        line = lines[index]
+        if re.match(APPROVAL_MENU_OPTION_PATTERN, line):
             options += 1
+            continue
+        if re.match(APPROVAL_MENU_CONTINUATION_PATTERN, line):
+            # Walking up, a continuation belongs to the option row above it;
+            # step over it and let that row (or anything else) decide.
             continue
         break
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -174,16 +174,20 @@ APPROVAL_PROMPT_PATTERN = (
     r"|grant these permissions)\?"
     r"|Do you want to approve network access to)"
 )
-# Rendered as `Press ` + `<accept-key>` + ` to confirm or ` + `<cancel-key>` +
+# Rendered as `Press ` + `<accept-label>` + ` to confirm or ` + `<cancel-key>` +
 # ` to cancel`, with the key names emitted as separately styled spans -- the whole
 # sentence is not one literal in the binary. The accept key is CONFIGURABLE
-# (`tui.keymap.list.accept`, e.g. "space" -> "Press space to confirm ..."), so
-# match the stable structural wording independently of the key: "Press <key> to
-# confirm". `\S+` (not `.+`) keeps it to a single key token so this can't span
-# arbitrary prose, and it stays gated by the numbered-menu-at-bottom structure in
-# _has_approval_prompt_in_bottom, so a completed reply merely quoting the phrase is
-# still rejected.
-APPROVAL_PROMPT_FOOTER = r"Press \S+ to confirm\b"
+# (`tui.keymap.list.accept`) and its label is NOT a single token: a two-stroke
+# chord such as "ctrl-x ctrl-s" renders via ShortcutHint::display_label() as
+# `ctrl + x ctrl + s` (strokes joined by a space, modifiers by " + ";
+# codex-rs/tui/src/key_hint.rs at rust-v0.147.0). Worst legal label is a chord
+# whose strokes each carry ctrl+shift+alt: 7 tokens per stroke, 14 in total, so
+# the label is matched as 1-15 whitespace-separated tokens. The bound keeps a
+# same-line prose sentence from bridging an unrelated "Press" to a distant
+# "to confirm"; the numbered-menu-at-bottom structure in
+# _has_approval_prompt_in_bottom stays the guard that rejects a completed reply
+# merely quoting the phrase.
+APPROVAL_PROMPT_FOOTER = r"Press \S+(?:[^\S\n]+\S+){0,14} to confirm\b"
 # One numbered menu option: "› 1. Yes, proceed (y)", "  2. No, ... (esc)". The
 # selection cursor is optional here because it sits on exactly one option at a
 # time and moves as the operator arrows around.

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -144,8 +144,23 @@ APPROVAL_MODAL_CHOICE_PATTERN = r"(?:\[[aA]\]\s+Accept\b|\[[dD]\]\s+Decline\b)"
 # Box-drawing frame and padding stripped from a modal line before matching, so a
 # framed line ("│ [a] Accept  [d] Decline     │") reduces to its text content.
 # Stripped as a character SET from both ends, hence no ordering assumption about
-# corner/edge glyphs.
-MODAL_FRAME_CHARS = "─│╭╮╰╯├┤ \t"
+# corner/edge glyphs. Light, heavy, and double variants are all covered because
+# only light glyphs have been observed and the frame style is not contractual.
+#
+# ASCII frame characters (+ - |) are deliberately EXCLUDED. They are markdown
+# table syntax, so including them would let a table the model wrote in its own
+# reply ("| Command Approval Required |" / "| [a] Accept | [d] Decline |")
+# reduce to the exact modal shape. No Codex release has been observed using
+# ASCII frames, so that trade buys a hypothetical false negative at the cost of
+# a plausible false positive.
+#
+# Note this set also strips leading whitespace, so an INDENTED plain-text quote
+# reduces to the modal shape too. That look-alike is excluded positionally
+# instead — see _has_approval_modal_in_bottom.
+MODAL_FRAME_CHARS = "─│╭╮╰╯├┤━┃┏┓┗┛┣┫═║╔╗╚╝╠╣ \t"
+# The same set minus padding, used to tell "this line began with box chrome"
+# from "this line began with a prose indent".
+MODAL_FRAME_GLYPHS = frozenset(MODAL_FRAME_CHARS) - frozenset(" \t")
 STARTUP_BLOCKING_INPUT_PATTERN = (
     rf"(?:{APPROVAL_MODAL_HEADER_PATTERN}|{APPROVAL_MODAL_CHOICE_PATTERN}|"
     rf"{TRUST_PROMPT_FOOTER})"
@@ -298,44 +313,88 @@ def _has_update_dialog_in_bottom(clean_output: str) -> bool:
     )
 
 
+def _modal_line_content(line: str) -> Optional[str]:
+    """Reduce one line to its modal text, or None if the line reads as prose.
+
+    Strips frame glyphs and padding so ``"│ [a] Accept  [d] Decline   │"``
+    reduces to ``"[a] Accept  [d] Decline"``. Returns None when the leading run
+    removed was whitespace ONLY while being non-empty — i.e. the line is
+    indented plain text.
+
+    That indent test is the discriminator against the model quoting a modal
+    transcript back in its own reply:
+
+        • The terminal output showed:
+            Command Approval Required
+            [a] Accept  [d] Decline
+          so it was waiting on approval.
+
+    Those quoted lines reproduce the modal's per-line structure exactly, so
+    line structure alone cannot separate them. Position can: Codex draws the
+    modal box flush at the left margin, whereas quoted or continuation prose is
+    indented under its bullet. So a leading run of frame glyphs is accepted, a
+    leading run of spaces/tabs is not, and column 0 is accepted either way
+    (an unframed modal would still start there).
+    """
+    content = line.strip(MODAL_FRAME_CHARS)
+    if not content:
+        return None
+    lead = line[: len(line) - len(line.lstrip(MODAL_FRAME_CHARS))]
+    if lead and not (MODAL_FRAME_GLYPHS & set(lead)):
+        return None
+    return content
+
+
 def _has_approval_modal_in_bottom(clean_output: str) -> bool:
     """Return True when Codex's boxed command-approval modal is active at the bottom.
 
     Bottom-anchored and doubly corroborated for the same reason as trust-v2 and
     the update dialog: the copy can appear in scrollback from an already-answered
     turn, or inside the model's own prose ("I hit Command Approval Required with
-    [a] Accept / [d] Decline"). Three independent guards separate the live modal
+    [a] Accept / [d] Decline"). Four independent guards separate the live modal
     from those look-alikes:
 
     1. **Region.** Only the bottom ``STARTUP_PROMPT_BOTTOM_LINES`` are searched.
        As the pane scrolls the header leaves the region before the choice keys
        do, so guard 2 fails first and an answered modal cannot stay latched.
+       This assumes the modal is at most that tall — true whenever the box is
+       the bottom of the pane, which is how Codex renders it.
     2. **Corroboration.** Both the header AND a choice key must be present, in
        that vertical order — the modal always renders header-above-keys.
-    3. **Line structure.** Each half must own its line: with box-drawing chrome
-       and whitespace stripped, the header line is *exactly* the header text and
-       the choice line *starts* with a choice key. Prose embeds the phrases
-       mid-sentence, so it fails this even when it names both halves.
+    3. **Line structure.** Each half must own its line: after reduction, the
+       header line is *exactly* the header text and the choice line *starts*
+       with a choice key. Prose embeds the phrases mid-sentence, so it fails
+       this even when it names both halves.
+    4. **Left-margin position.** Each half must sit at the box's left margin
+       rather than under a prose indent — see :func:`_modal_line_content`. This
+       is what separates a live modal from a quoted transcript, which satisfies
+       guards 1-3.
 
-    Deliberately does not require box-drawing characters: the frame chrome has
-    changed across Codex releases while this copy has not.
+    Deliberately does NOT key on whether the idle composer/footer appears below
+    the box, even though a live modal blocks input: get_status's own TUI-progress
+    comment records that with ``--no-alt-screen`` the footer is rendered at the
+    bottom *even while processing*, so "footer below" is likely true of real
+    modals too and would false-negative every one of them.
     """
     bottom_lines = clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:]
 
     header_idx = None
     for index, line in enumerate(bottom_lines):
-        bare = line.strip(MODAL_FRAME_CHARS)
-        if re.fullmatch(APPROVAL_MODAL_HEADER_PATTERN, bare, re.IGNORECASE):
+        content = _modal_line_content(line)
+        if content is not None and re.fullmatch(
+            APPROVAL_MODAL_HEADER_PATTERN, content, re.IGNORECASE
+        ):
             header_idx = index
             break
     if header_idx is None:
         return False
 
     # Choice keys render on a later line than the header, never above it.
-    return any(
-        re.match(APPROVAL_MODAL_CHOICE_PATTERN, line.strip(MODAL_FRAME_CHARS), re.IGNORECASE)
-        for line in bottom_lines[header_idx + 1 :]
-    )
+    for line in bottom_lines[header_idx + 1 :]:
+        content = _modal_line_content(line)
+        if content is not None and re.match(APPROVAL_MODAL_CHOICE_PATTERN, content, re.IGNORECASE):
+            return True
+    return False
 
 
 def _has_startup_idle_composer(clean_output: str) -> bool:

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -174,20 +174,32 @@ APPROVAL_PROMPT_PATTERN = (
     r"|grant these permissions)\?"
     r"|Do you want to approve network access to)"
 )
-# Rendered as `Press ` + `<accept-label>` + ` to confirm or ` + `<cancel-key>` +
-# ` to cancel`, with the key names emitted as separately styled spans -- the whole
-# sentence is not one literal in the binary. The accept key is CONFIGURABLE
-# (`tui.keymap.list.accept`) and its label is NOT a single token: a two-stroke
+# The footer under a blocking list menu is OPTIONAL CORROBORATION, not an
+# anchor: both list actions are unbindable (`tui.keymap.list.accept = []` --
+# an empty list explicitly unbinds; config/src/tui_keymap.rs at rust-v0.147.0),
+# and accept_cancel_hint_line (tui/src/bottom_pane/popup_consts.rs) renders one
+# of FOUR shapes accordingly:
+#   both bound     -> "Press <a> to confirm or <c> to cancel"
+#   accept unbound -> "Press <c> to cancel"
+#   cancel unbound -> "Press <a> to confirm"
+#   both unbound   -> no footer line at all
+# The approval overlay may append " or <k> to open thread"
+# (approval_overlay.rs), which is also the WHOLE line when both list actions
+# are unbound, and the generic popups (model picker) say "to go back" where
+# the approval says "to cancel". So this pattern's job is only to recognise a
+# footer line as part of the menu block wherever one is rendered.
+#
+# The key labels are emitted as separately styled spans -- the sentence is not
+# one literal in the binary -- and a label is NOT a single token: a two-stroke
 # chord such as "ctrl-x ctrl-s" renders via ShortcutHint::display_label() as
 # `ctrl + x ctrl + s` (strokes joined by a space, modifiers by " + ";
-# codex-rs/tui/src/key_hint.rs at rust-v0.147.0). Worst legal label is a chord
-# whose strokes each carry ctrl+shift+alt: 7 tokens per stroke, 14 in total, so
-# the label is matched as 1-15 whitespace-separated tokens. The bound keeps a
-# same-line prose sentence from bridging an unrelated "Press" to a distant
-# "to confirm"; the numbered-menu-at-bottom structure in
-# _has_approval_prompt_in_bottom stays the guard that rejects a completed reply
-# merely quoting the phrase.
-APPROVAL_PROMPT_FOOTER = r"Press \S+(?:[^\S\n]+\S+){0,14} to confirm\b"
+# key_hint.rs). Worst legal label is a chord whose strokes each carry
+# ctrl+shift+alt: 7 tokens per stroke, 14 in total, so a label is matched as
+# 1-15 whitespace-separated tokens. The bound keeps a same-line prose sentence
+# from bridging an unrelated "Press" to a distant "to confirm".
+APPROVAL_PROMPT_FOOTER = (
+    r"Press \S+(?:[^\S\n]+\S+){0,14} to (?:confirm|cancel|go back|open thread)\b"
+)
 # One numbered menu option: "› 1. Yes, proceed (y)", "  2. No, ... (esc)". The
 # selection cursor is optional here because it sits on exactly one option at a
 # time and moves as the operator arrows around.
@@ -537,88 +549,97 @@ def _has_approval_modal_in_bottom(clean_output: str) -> bool:
     return False
 
 
-def _has_approval_menu_above(lines: list[str], footer_idx: int) -> bool:
-    """Return True when a numbered selection menu sits above ``lines[footer_idx]``.
-
-    Walks UP from the footer collecting option lines, stopping at the first
-    :func:`_is_transcript_marker` — the prompt is one transcript cell, so the
-    menu must live inside it. Option lines are classified BEFORE the marker test
-    because the cursor line ("› 1. Yes, proceed (y)") itself matches
-    USER_PREFIX_PATTERN and would otherwise end the walk immediately.
-
-    Blank rows and the question/command-preview rows between the menu and the
-    title are stepped over rather than terminating the walk, which is what makes
-    the height of the command preview irrelevant.
-
-    Requires APPROVAL_MENU_MIN_OPTIONS options AND the selection cursor flush at
-    column 0 (see APPROVAL_MENU_CURSOR_PATTERN).
-    """
-    options = 0
-    cursor_at_margin = False
-    for index in range(footer_idx - 1, -1, -1):
-        line = lines[index]
-        if re.match(APPROVAL_MENU_OPTION_PATTERN, line):
-            options += 1
-            if re.match(APPROVAL_MENU_CURSOR_PATTERN, line):
-                cursor_at_margin = True
-            continue
-        if not line.strip():
-            continue
-        if _is_transcript_marker(line):
-            break
-    return options >= APPROVAL_MENU_MIN_OPTIONS and cursor_at_margin
-
-
 def _has_approval_prompt_in_bottom(clean_output: str) -> bool:
     """Return True when Codex's runtime approval prompt is active at the bottom.
 
     This is the prompt codex-cli 0.147.0 actually renders (verified against three
     live captures). Detection is STRUCTURAL and bottom-up — the numbered menu
-    plus its confirm footer, not the question title — for the two reasons set out
-    at APPROVAL_PROMPT_PATTERN: the title list cannot be completed, and a fixed
-    row budget fails open on a long command preview.
+    itself, not the question title and not the footer — because none of the
+    alternatives can be relied on: the title list cannot be completed, a fixed
+    row budget fails open on a long command preview (see
+    APPROVAL_PROMPT_PATTERN), and the footer is absent entirely when the list
+    actions are unbound (`tui.keymap.list.accept = []` renders the same blocking
+    menu with only "Press esc to cancel", or with no footer line at all — see
+    APPROVAL_PROMPT_FOOTER).
 
     Three guards, in the order they are cheapest to refute:
 
-    1. **Footer anchor.** The LAST line matching APPROVAL_PROMPT_FOOTER. Taking
-       the last, not the first, lets an already-answered prompt in scrollback be
-       ignored rather than shadow a live one below it.
-    2. **Nothing but chrome below the anchor** (:func:`_is_chrome_only`, shared
-       with the boxed-modal detector). A live prompt blocks the TUI, so it must
-       BE the bottom of the pane. This is the guard that rejects an ordinary
-       COMPLETED reply which happens to quote both the question and the footer
-       while a live composer and more prose sit underneath — the sticky
-       WAITING_USER_ANSWER that case used to latch would wedge a ready worker.
-    3. **A numbered menu directly above the anchor**
-       (:func:`_has_approval_menu_above`), bounded by transcript markers rather
-       than a line count, so an arbitrarily tall preview still resolves.
+    1. **Menu-cursor anchor.** The LAST line whose selection cursor sits flush
+       at column 0 (APPROVAL_MENU_CURSOR_PATTERN). Taking the last, not the
+       first, lets an already-answered prompt in scrollback be ignored rather
+       than shadow a live one below it. Column 0 is where Codex draws every
+       transcript gutter marker, so quoted or continuation prose — a menu the
+       model merely PASTED into a reply — carries its cursor at column >= 2 and
+       fails this.
+    2. **Nothing below the anchor but the rest of the menu block**: the
+       remaining (non-cursor) option rows, at most one footer hint in any of
+       its rendered forms, and chrome (:func:`_is_chrome_only`, shared with the
+       boxed-modal detector). A live prompt blocks the TUI, so its menu must BE
+       the bottom of the pane. This is the guard that rejects an ordinary
+       COMPLETED reply which quotes the menu while a live composer and more
+       prose sit underneath — the sticky WAITING_USER_ANSWER that case used to
+       latch would wedge a ready worker.
+    3. **Menu size.** At least APPROVAL_MENU_MIN_OPTIONS option rows counted
+       contiguously around the anchor (a genuine approval always offers accept
+       and decline). Contiguity matters: counting across the question or the
+       command preview would let a numbered list INSIDE a quoted command
+       inflate the tally.
 
-    Deliberately NOT required: any particular question title, and any particular
-    option copy. The consequence is that this also fires on Codex's other
-    blocking numbered menus that share the confirm footer (the model picker, for
-    one). That is correct rather than tolerated — those panes are equally blocked
+    Deliberately NOT required: any particular question title, any particular
+    option copy, and the footer. The footer, when present in any of its four
+    rendered shapes, is accepted as part of the block; its absence proves
+    nothing because unbinding the accept action removes it while the menu still
+    blocks. Firing on Codex's other blocking numbered menus (the model picker,
+    for one) is correct rather than tolerated — those panes are equally blocked
     on a keystroke, and WAITING_USER_ANSWER is the right answer for them too.
 
-    Residual risk, disclosed: guard 3's column-0 cursor test is what separates a
-    live menu from one pasted into a reply, so a future renderer that indents the
-    cursor would fail open to IDLE. The three live captures in
-    test/providers/fixtures/ (codex_approval_{modal,edits,long_preview}_raw.txt)
-    pin the current rendering against that.
+    Residual risks, disclosed:
+
+    - The column-0 cursor test is what separates a live menu from one pasted
+      into a reply, so a future renderer that indents the cursor would fail
+      open to IDLE. The live captures in test/providers/fixtures/
+      (codex_approval_{modal,edits,long_preview}_raw.txt) pin the current
+      rendering against that.
+    - A USER message that is itself a numbered list ("1. foo\\n2. bar") renders
+      with the same column-0 gutter marker ("› 1. foo" over "  2. bar"), so if
+      it is the last transcript cell with only the idle composer below — codex
+      interrupted before replying, say — it now reads WAITING rather than IDLE.
+      That errs toward withholding work, never toward pasting into a blocked
+      pane, and clears as soon as codex renders any activity below the cell.
+      The footer-anchored version rejected this shape, but only by failing open
+      to IDLE on every unbound-keymap approval, which is the dangerous
+      direction to be wrong in.
     """
     lines = clean_output.splitlines()
 
-    footer_idx = None
+    anchor = None
     for index in range(len(lines) - 1, -1, -1):
-        if re.search(APPROVAL_PROMPT_FOOTER, lines[index]):
-            footer_idx = index
+        if re.match(APPROVAL_MENU_CURSOR_PATTERN, lines[index]):
+            anchor = index
             break
-    if footer_idx is None:
+    if anchor is None:
         return False
 
-    if not all(_is_chrome_only(line) for line in lines[footer_idx + 1 :]):
+    options = 1  # the anchor row
+    footer_seen = False
+    for line in lines[anchor + 1 :]:
+        if not footer_seen and re.match(APPROVAL_MENU_OPTION_PATTERN, line):
+            options += 1
+            continue
+        if not footer_seen and re.search(APPROVAL_PROMPT_FOOTER, line):
+            footer_seen = True
+            continue
+        if _is_chrome_only(line):
+            continue
         return False
 
-    return _has_approval_menu_above(lines, footer_idx)
+    for index in range(anchor - 1, -1, -1):
+        if re.match(APPROVAL_MENU_OPTION_PATTERN, lines[index]):
+            options += 1
+            continue
+        break
+
+    return options >= APPROVAL_MENU_MIN_OPTIONS
 
 
 def _has_startup_idle_composer(clean_output: str) -> bool:

--- a/test/providers/fixtures/codex_approval_edits_raw.txt
+++ b/test/providers/fixtures/codex_approval_edits_raw.txt
@@ -1,0 +1,40 @@
+╭──────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.147.0)                           │
+│                                                      │
+│ model:     openai.gpt-5.6-sol low   /model to change │
+│ directory: /private/tmp/codex-work-567               │
+╰──────────────────────────────────────────────────────╯
+
+  Tip: New Build faster with the Desktop app. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true
+
+
+› Run this shell command now, do not explain first: mkdir -p /private/tmp/codex-work-567/subdir
+
+
+✗ You canceled the request to run mkdir -p /private/tmp/codex-work-567/subdir
+
+• Ran mkdir -p /private/tmp/codex-work-567/subdir
+  └ (no output)
+
+■ Conversation interrupted - tell the model what to do differently. Something went wrong? Hit `/feedback` to report the
+issue.
+
+
+› Now edit note.txt and change hello to goodbye. Do it now, no explanation.
+
+
+• Edited note.txt (+1 -1)
+    1 -hello
+    1 +goodbye
+
+
+  Would you like to make the following edits?
+
+
+› 1. Yes, proceed (y)
+  2. Yes, and don't ask again for these files (a)
+  3. No, and tell Codex what to do differently (esc)
+
+  Press enter to confirm or esc to cancel
+
+

--- a/test/providers/fixtures/codex_approval_long_preview_raw.txt
+++ b/test/providers/fixtures/codex_approval_long_preview_raw.txt
@@ -1,0 +1,50 @@
+╭───────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.147.0)                            │
+│                                                       │
+│ model:     openai.gpt-5.6-sol high   /model to change │
+│ directory: /private/tmp/codex-cap-567                 │
+╰───────────────────────────────────────────────────────╯
+
+  Tip: New Build faster with the Desktop app. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true
+
+
+› Create the file migrate.sh in the current directory containing a bash script with a shebang, set -euo pipefail, and a psql heredoc holding five SQL statements. Use ONE single bash -lc command with
+  a heredoc to write it. Do it now, no explanation first.
+
+
+• Running bash -lc 'cat > migrate.sh <<'"'"'SCRIPT'"'"'
+  │ #!/usr/bin/env bash
+  │ set -euo pipefail
+  │ … +9 lines
+
+
+  Would you like to run the following command?
+
+  Environment: local
+
+  $ bash -lc 'cat > migrate.sh <<'"'"'SCRIPT'"'"'
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  psql <<'"'"'SQL'"'"'
+  BEGIN;
+  CREATE TABLE IF NOT EXISTS schema_migrations (version bigint PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now());
+  INSERT INTO schema_migrations (version) VALUES (1) ON CONFLICT (version) DO NOTHING;
+  ANALYZE schema_migrations;
+  COMMIT;
+  SQL
+  SCRIPT'
+
+› 1. Yes, proceed (y)
+  2. No, and tell Codex what to do differently (esc)
+
+  Press enter to confirm or esc to cancel
+
+
+
+
+
+
+
+
+

--- a/test/providers/fixtures/codex_approval_modal.txt
+++ b/test/providers/fixtures/codex_approval_modal.txt
@@ -1,0 +1,11 @@
+› run the deploy script
+• I'll run the deploy script now.
+
+• Called shell.exec({"command":"./scripts/deploy.sh"})
+
+╭─ Command Approval Required ──────────────────╮
+│                                              │
+│ ./scripts/deploy.sh                          │
+│                                              │
+│ [a] Accept  [d] Decline                      │
+╰──────────────────────────────────────────────╯

--- a/test/providers/fixtures/codex_approval_modal_heavy_box.txt
+++ b/test/providers/fixtures/codex_approval_modal_heavy_box.txt
@@ -1,0 +1,9 @@
+› run the deploy script
+• I'll run the deploy script now.
+
+┏━ Command Approval Required ━━━━━━━━━━━━━━━━━━┓
+┃                                              ┃
+┃ ./scripts/deploy.sh                          ┃
+┃                                              ┃
+┃ [a] Accept   [d] Decline                     ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

--- a/test/providers/fixtures/codex_approval_modal_quoted_in_reply.txt
+++ b/test/providers/fixtures/codex_approval_modal_quoted_in_reply.txt
@@ -1,0 +1,11 @@
+› why did the earlier run stall?
+• The terminal output showed:
+
+    Command Approval Required
+    [a] Accept  [d] Decline
+
+  so the pane was blocked waiting on approval. I have since set
+  approval_policy = "never" in the profile, so it will not recur.
+
+›
+  openai.gpt-5.6-sol high · ~/wt

--- a/test/providers/fixtures/codex_approval_modal_raw.txt
+++ b/test/providers/fixtures/codex_approval_modal_raw.txt
@@ -1,0 +1,40 @@
+╭──────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.147.0)                           │
+│                                                      │
+│ model:     openai.gpt-5.6-sol low   /model to change │
+│ directory: /private/tmp/codex-work-567               │
+╰──────────────────────────────────────────────────────╯
+
+  Tip: New Build faster with the Desktop app. Run 'codex app' or visit https://chatgpt.com/codex?app-landing-page=true
+
+
+› Run this shell command now, do not explain first: mkdir -p /private/tmp/codex-work-567/subdir
+
+
+• Running mkdir -p /private/tmp/codex-work-567/subdir
+
+
+  Would you like to run the following command?
+
+  Environment: local
+
+  $ mkdir -p /private/tmp/codex-work-567/subdir
+
+› 1. Yes, proceed (y)
+  2. Yes, and don't ask again for commands that start with `mkdir -p /private/tmp/codex-work-567/subdir` (p)
+  3. No, and tell Codex what to do differently (esc)
+
+  Press enter to confirm or esc to cancel
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/providers/fixtures/codex_approval_modal_scrollback.txt
+++ b/test/providers/fixtures/codex_approval_modal_scrollback.txt
@@ -1,0 +1,22 @@
+› run the deploy script
+• I'll run the deploy script now.
+
+╭─ Command Approval Required ──────────────────╮
+│                                              │
+│ ./scripts/deploy.sh                          │
+│                                              │
+│ [a] Accept  [d] Decline                      │
+╰──────────────────────────────────────────────╯
+
+• Accepted — running ./scripts/deploy.sh
+• Uploading build artifacts.
+• Waiting for the health check.
+• Health check passed.
+• Draining the old revision.
+• Old revision drained.
+• Invalidating the CDN cache.
+• Cache invalidated.
+• Deploy finished successfully in 84s.
+
+›
+  ? for shortcuts                     88% context left

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -3103,11 +3103,21 @@ class TestCodexProviderApprovalPromptLive:
     The boxed "Command Approval Required" / "[a] Accept" modal that
     TestCodexProviderApprovalModal covers is not emitted by 0.147.0 at all --
     ``strings`` over the vendored native binary finds zero occurrences of that
-    copy. The live prompt is a numbered menu (see the fixture below), so without
-    APPROVAL_PROMPT_PATTERN a pane hard-blocked on a real approval classified as
-    IDLE: the prompt's own "› 1. Yes, proceed (y)" cursor line is simultaneously
-    the last USER_PREFIX_PATTERN match and an idle-prompt match, so get_status
-    saw a user message with no reply after it.
+    copy. The live prompt is a numbered menu (see the fixtures below), so without
+    an approval check a pane hard-blocked on a real approval classified as IDLE:
+    the prompt's own "› 1. Yes, proceed (y)" cursor line is simultaneously the
+    last USER_PREFIX_PATTERN match and an idle-prompt match, so get_status saw a
+    user message with no reply after it.
+
+    Detection is STRUCTURAL -- the numbered menu plus its confirm footer, anchored
+    bottom-up -- not a list of question titles inside a fixed-height window. The
+    tests below pin the three ways the title-in-a-window approach was wrong:
+    a long command preview pushed the title out of the window and failed OPEN to
+    IDLE (test_live_capture_long_command_preview_is_waiting, against a real
+    capture); the title list was incomplete
+    (test_network_approval_prompt_is_waiting); and a reply that merely QUOTED the
+    copy latched a sticky WAITING_USER_ANSWER onto a ready worker
+    (test_quoted_prompt_in_completed_reply_is_not_waiting).
     """
 
     def test_get_status_live_capture_is_waiting(self):
@@ -3159,12 +3169,12 @@ class TestCodexProviderApprovalPromptLive:
         )
 
     def test_capture_pane_trailing_padding_does_not_hide_the_prompt(self):
-        """Blank padding rows must not push the question out of the bottom region.
+        """Blank padding rows below the prompt must not defeat detection.
 
-        ``tmux capture-pane`` pads to the full pane height, and the prompt is
-        ~10 rows tall, so a raw 15-line tail can land entirely inside the
-        padding. This is the concrete reason _has_approval_prompt_in_bottom
-        compacts blank lines before taking the region.
+        ``tmux capture-pane`` pads to the full pane height, so a live prompt is
+        followed by an arbitrary number of empty rows. Those rows are why the
+        "nothing but chrome below the footer" guard has to treat blank lines as
+        chrome (:func:`_is_chrome_only` does, via ``_is_frame_padding``).
         """
         prompt = (
             "  Would you like to run the following command?\n"
@@ -3247,6 +3257,259 @@ class TestCodexProviderApprovalPromptLive:
 
         assert provider.get_status(output) == TerminalStatus.COMPLETED
 
+    def test_live_capture_long_command_preview_is_waiting(self):
+        """A long command preview must not push the prompt out of detection.
+
+        Fixture is an unedited ``tmux capture-pane -p`` of codex-cli 0.147.0
+        parked on an exec approval whose command is a 12-line heredoc, produced
+        the same way as the two captures above (``codex -a untrusted -s read-only
+        --no-alt-screen``) by asking it to write a script with a single
+        ``bash -lc`` heredoc. The renderer does NOT truncate the preview.
+
+        This is the P1 fail-open case, and it is real rather than constructed:
+        in this capture the question lands on non-blank row 16 counted from the
+        bottom, one row outside the 15-row window the title-based detector used,
+        so that detector found no title and returned IDLE for a pane hard-blocked
+        on a keystroke. IDLE is the dangerous direction -- it invites the
+        conductor to send more work into a dead pane.
+        """
+        output = load_fixture("codex_approval_long_preview_raw.txt")
+
+        # The premise of the regression: the question really is outside a 15-row
+        # window of non-blank rows, so this fixture cannot pass by accident.
+        rows = [line for line in output.splitlines() if line.strip()]
+        assert not any("Would you like to" in line for line in rows[-15:])
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(output.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_network_approval_prompt_is_waiting(self):
+        """The network-access approval is a fourth title on the same menu.
+
+        SYNTHETIC, not a capture: this prompt only fires with
+        ``features.network_proxy=true`` AND reachable DNS, and the sandbox the
+        other fixtures were captured in has no network. The copy is not invented
+        though -- the title and every option string below appear verbatim in the
+        0.147.0 native binary's string table alongside the three titles the old
+        detector enumerated, which is the point: the title list was a list of the
+        variants someone had happened to see, and could not be completed.
+
+        Note this menu carries no ``(y)``/``(esc)`` key hints, so it also
+        demonstrates that detection does not depend on those.
+        """
+        output = (
+            "› fetch the changelog from example.com\n"
+            "\n"
+            "• Fetching https://example.com/CHANGELOG.md\n"
+            "\n"
+            '  Do you want to approve network access to "example.com"?\n'
+            "\n"
+            "› 1. Yes, just this once\n"
+            "  2. Yes, and allow this host for this conversation\n"
+            "  3. Yes, and allow this host in the future\n"
+            "  4. No, and block this host in the future\n"
+            "\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(output.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_detector_does_not_require_a_known_title(self):
+        """An unrecognized title over the same menu must still classify as WAITING.
+
+        The whole point of anchoring on structure: a title nobody has catalogued
+        yet (0.147.0 also ships "Approve app tool call?", and future releases will
+        ship more) still blocks the pane, so it must still be detected.
+        """
+        output = (
+            "› do the thing\n"
+            "• Working on it.\n"
+            "  Some approval question nobody has catalogued yet?\n"
+            "\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_quoted_prompt_in_completed_reply_is_not_waiting(self):
+        """A reply that QUOTES the prompt must not latch WAITING_USER_ANSWER.
+
+        This is the P2 quoted-latch case, and the failure it caused is worse than
+        a one-off misread: WAITING_USER_ANSWER is sticky, and CodexProvider sets
+        ``blocks_orchestrated_input_while_waiting_user_answer``, so a finished
+        worker whose summary happened to quote both the question and the footer
+        would be held out of rotation with orchestrated delivery blocked.
+
+        Rejected by the "nothing but chrome below the footer" guard: the reply
+        continues below the quote and ends at a live composer.
+        """
+        output = (
+            "› summarize what PR #567 changes\n"
+            "\n"
+            "• PR #567 teaches the Codex provider to recognize the runtime approval\n"
+            "  prompt. Codex 0.147.0 renders it as a numbered menu:\n"
+            "\n"
+            "    Would you like to run the following command?\n"
+            "    Environment: local\n"
+            "    $ mkdir -p /tmp/subdir\n"
+            "  › 1. Yes, proceed (y)\n"
+            "    2. Yes, and don't ask again (p)\n"
+            "    3. No, and tell Codex what to do differently (esc)\n"
+            "    Press enter to confirm or esc to cancel\n"
+            "\n"
+            "  Before the fix get_status returned IDLE for that screen.\n"
+            "\n"
+            "›\n"
+            "  openai.gpt-5.6-sol high · ~/wt\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.COMPLETED
+        assert provider.get_status_from_screen(output.splitlines()) == TerminalStatus.COMPLETED
+
+    def test_quoted_prompt_ending_a_reply_is_not_waiting(self):
+        """The harder quoted variant: the quote is the LAST thing in the reply.
+
+        With only the empty composer and status bar below it, the chrome guard
+        cannot help -- this is exactly the residual the boxed-modal detector
+        documents as a known false positive
+        (test_framed_quote_ending_a_reply_is_a_known_false_positive). The numbered
+        menu closes it on position instead: Codex draws the live prompt's
+        selection cursor flush at column 0, while a quote indented under its
+        bullet carries the cursor at column >= 2.
+        """
+        output = (
+            "› what did the approval prompt look like?\n"
+            "\n"
+            "• It renders like this:\n"
+            "\n"
+            "    Would you like to run the following command?\n"
+            "    $ mkdir -p /tmp/subdir\n"
+            "  › 1. Yes, proceed (y)\n"
+            "    2. No, and tell Codex what to do differently (esc)\n"
+            "    Press enter to confirm or esc to cancel\n"
+            "\n"
+            "›\n"
+            "  openai.gpt-5.6-sol high · ~/wt\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.COMPLETED
+
+    def test_answered_prompt_with_work_resumed_is_not_waiting(self):
+        """Once answered, the prompt must stop latching even though it stays in the buffer.
+
+        The rendered screen drops the prompt entirely on answer -- there is no
+        footer left to anchor on -- but the pipe-pane buffer get_status() also
+        reads is append-only and keeps the frame. The resumption copy below is
+        verbatim from a live 0.147.0 pane observed immediately after pressing
+        enter on the curl approval.
+        """
+        output = (
+            "› Fetch https://example.com/ with curl right now.\n"
+            "\n"
+            "• Running curl https://example.com/\n"
+            "\n"
+            "  Would you like to run the following command?\n"
+            "\n"
+            "  $ curl https://example.com/\n"
+            "\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "\n"
+            "  Press enter to confirm or esc to cancel\n"
+            "\n"
+            "✔ You approved codex to run curl https://example.com/ this time\n"
+            "\n"
+            "• Ran curl https://example.com/\n"
+            "  └ (output elided)\n"
+            "\n"
+            "• Fetched the page.\n"
+            "\n"
+            "›\n"
+            "  openai.gpt-5.6-sol high · ~/wt\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.COMPLETED
+
+    def test_menu_without_the_selection_cursor_is_not_waiting(self):
+        """Options and a footer with no cursor anywhere are not a live menu.
+
+        Codex always draws the cursor on one option, so its absence means this is
+        a rendering of a menu rather than a menu.
+        """
+        assert not _has_approval_prompt_in_bottom(
+            "› do the thing\n"
+            "• Working on it.\n"
+            "  Would you like to run the following command?\n"
+            "  1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+
+    def test_single_option_is_not_a_menu(self):
+        """One option is not an approval -- an approval can always be declined."""
+        assert not _has_approval_prompt_in_bottom(
+            "› do the thing\n"
+            "• Working on it.\n"
+            "› 1. Acknowledged\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+
+    def test_trust_dialog_is_not_matched_by_the_approval_footer(self):
+        """The startup trust dialog is a numbered menu too, but a different footer.
+
+        Copy taken from a live 0.147.0 startup screen. It ends "Press enter to
+        continue", not "...to confirm", so the approval detector must not claim
+        it -- TRUST_PROMPT_PATTERN_V2 owns it, and get_status still reports
+        WAITING_USER_ANSWER through that path.
+        """
+        output = (
+            "  Welcome to Codex, OpenAI's command-line coding agent\n"
+            "\n"
+            "> You are in /private/tmp/codex-cap-567\n"
+            "\n"
+            "  Do you trust the contents of this directory? Working with untrusted\n"
+            "  contents comes with higher risk of prompt injection.\n"
+            "\n"
+            "› 1. Yes, continue\n"
+            "  2. No, quit\n"
+            "\n"
+            "  Press enter to continue\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+
     def test_startup_path_vetoes_readiness_on_the_live_prompt(self):
         """The startup readiness veto must know the copy Codex actually emits.
 
@@ -3260,6 +3523,21 @@ class TestCodexProviderApprovalPromptLive:
             "  Would you like to run the following command?\n"
             "› 1. Yes, proceed (y)\n"
             "  Press enter to confirm or esc to cancel\n"
+        )
+
+    def test_startup_path_vetoes_readiness_on_the_network_prompt(self):
+        """The startup veto must cover the network title too.
+
+        The footer alone already vetoes here, but the title is folded into
+        APPROVAL_PROMPT_PATTERN as well: that pattern's only remaining job is this
+        permissive negative gate, where an extra match merely keeps the startup
+        poll running and so costs nothing.
+        """
+        assert not _has_startup_idle_composer(
+            "› Write tests for @filename\n"
+            "  gpt-5.6-sol medium · Context 100% left\n"
+            '  Do you want to approve network access to "example.com"?\n'
+            "› 1. Yes, just this once\n"
         )
 
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -15,6 +15,7 @@ from cli_agent_orchestrator.providers.codex import (
     ProviderError,
     _find_response_marker,
     _has_approval_modal_in_bottom,
+    _has_approval_prompt_in_bottom,
     _has_startup_idle_composer,
     _toml_override,
     _toml_scalar,
@@ -2968,6 +2969,297 @@ class TestCodexProviderApprovalModal:
             "  gpt-5.6-sol medium · Context 100% left\n"
             "╭─ Command Approval Required ─╮\n"
             "│ [a] Accept  [d] Decline     │\n"
+        )
+
+    def test_modal_taller_than_bottom_region_is_still_waiting(self):
+        """A modal taller than STARTUP_PROMPT_BOTTOM_LINES must not fail open.
+
+        The first implementation searched only the bottom 15 lines for BOTH
+        halves, so a box with a long command preview pushed its header out of
+        the window, dropped the corroboration guard, and returned COMPLETED —
+        the exact "pane is free" misreport this class exists to prevent.
+        Anchoring bottom-up on the choice line and walking up to the enclosing
+        transcript cell removes the height ceiling.
+        """
+        preview = "".join(f"│ arg-{n:02d}={'x' * 30}   │\n" for n in range(20))
+        output = (
+            "› run the deploy script\n"
+            "• I'll run the deploy script now.\n"
+            "╭─ Command Approval Required ─╮\n" + preview + "│ [a] Accept  [d] Decline     │\n"
+            "╰─────────────────────────────╯\n"
+        )
+
+        assert _has_approval_modal_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_answered_modal_above_live_modal_does_not_veto_the_live_one(self):
+        """An answered modal above a live one must not suppress the live one.
+
+        Top-down anchoring found the FIRST header and paired it with the FIRST
+        choice line below it, then judged liveness from THAT box. The spinner
+        left in scrollback by the first command's execution sits below the first
+        choice line, so the answered box vetoed the whole detector and the live
+        box below was never considered — get_status fell through to PROCESSING.
+        Anchoring on the LAST choice line makes the live modal the subject.
+
+        The surviving spinner is the same --no-alt-screen artefact that
+        test_get_status_live_modal_with_stale_spinner_above_is_waiting relies on.
+        """
+        output = (
+            "› run both deploy scripts\n"
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept  [d] Decline     │\n"
+            "╰─────────────────────────────╯\n"
+            "• Accepted — running ./scripts/deploy-a.sh.\n"
+            "• Working (12s • esc to interrupt)\n"
+            "• deploy-a.sh finished. deploy-b.sh needs approval.\n"
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept  [d] Decline     │\n"
+            "╰─────────────────────────────╯\n"
+        )
+
+        assert _has_approval_modal_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_framed_quote_mid_reply_is_not_waiting(self):
+        """A framed modal quote the reply CONTINUES past must not latch WAITING.
+
+        Harder than the indented plain-text quote: the model reproduces the box
+        glyphs too, so the left-margin guard passes (the leading run contains
+        frame chrome, not just spaces) and the old detector latched
+        WAITING_USER_ANSWER for as long as the reply stayed on screen — work
+        withheld from an idle pane indefinitely.
+
+        The discriminator is positional: a live modal IS the bottom of the pane,
+        so only frame rows and footer chrome may follow it. Here the reply's own
+        closing sentence follows, which no live modal can have below it.
+        """
+        output = (
+            "› why did the earlier run stall?\n"
+            "• The terminal showed:\n"
+            "    ╭─ Command Approval Required ─╮\n"
+            "    │ [a] Accept  [d] Decline     │\n"
+            "    ╰─────────────────────────────╯\n"
+            "  so the pane was blocked on approval.\n"
+            "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+        assert not _has_approval_modal_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.COMPLETED
+
+    def test_typed_draft_below_modal_is_not_waiting(self):
+        """Text typed into the composer below the box means the box is not the bottom.
+
+        Control for _is_chrome_only's composer case: the EMPTY composer is
+        chrome, a composer holding a draft is content.
+        """
+        assert not _has_approval_modal_in_bottom(
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept  [d] Decline     │\n"
+            "╰─────────────────────────────╯\n"
+            "› and now do the other thing\n"
+        )
+
+    def test_framed_quote_ending_a_reply_is_a_known_false_positive(self):
+        """Documents the one accepted misread: a framed quote that ENDS the reply.
+
+        With only the empty composer and status bar after it, the quote is
+        positionally indistinguishable from a live modal — separating them needs
+        semantics this detector does not have. Asserted rather than left
+        undocumented so the behaviour is a recorded trade, not a surprise.
+
+        Costs a spurious WAITING_USER_ANSWER (work withheld from an idle pane)
+        rather than a COMPLETED (work pasted into a hard-blocked pane), which is
+        the safe direction for this detector to be wrong in.
+        """
+        output = (
+            "› why did the earlier run stall?\n"
+            "• The terminal showed:\n"
+            "    ╭─ Command Approval Required ─╮\n"
+            "    │ [a] Accept  [d] Decline     │\n"
+            "    ╰─────────────────────────────╯\n"
+            "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+
+
+class TestCodexProviderApprovalPromptLive:
+    """Tests for the approval prompt codex-cli 0.147.0 ACTUALLY renders.
+
+    The boxed "Command Approval Required" / "[a] Accept" modal that
+    TestCodexProviderApprovalModal covers is not emitted by 0.147.0 at all --
+    ``strings`` over the vendored native binary finds zero occurrences of that
+    copy. The live prompt is a numbered menu (see the fixture below), so without
+    APPROVAL_PROMPT_PATTERN a pane hard-blocked on a real approval classified as
+    IDLE: the prompt's own "› 1. Yes, proceed (y)" cursor line is simultaneously
+    the last USER_PREFIX_PATTERN match and an idle-prompt match, so get_status
+    saw a user message with no reply after it.
+    """
+
+    def test_get_status_live_capture_is_waiting(self):
+        """Regression against a real captured approval prompt.
+
+        Fixture is an unedited ``tmux capture-pane -p`` of codex-cli 0.147.0
+        parked on an exec approval, produced by launching
+        ``codex -a untrusted -s read-only --no-alt-screen`` and asking it to run
+        ``mkdir -p``. Before APPROVAL_PROMPT_PATTERN this returned IDLE.
+        """
+        output = load_fixture("codex_approval_modal_raw.txt")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_from_screen_live_capture_is_waiting(self):
+        """The pyte-composited screen path must agree with the buffer path.
+
+        supports_screen_detection is True for this provider, so the screen path
+        is what StatusMonitor actually calls in production.
+        """
+        output = load_fixture("codex_approval_modal_raw.txt")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert (
+            provider.get_status_from_screen(output.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_get_status_live_capture_edits_approval_is_waiting(self):
+        """Regression against a real captured apply_patch approval.
+
+        Second unedited capture from the same live session, parked on
+        "Would you like to make the following edits?" after being asked to edit a
+        file under ``-s read-only``. Corroborates that the variants share one
+        prompt shape and footer rather than being three unrelated screens.
+        Returns IDLE without APPROVAL_PROMPT_PATTERN, same as the exec capture.
+        """
+        output = load_fixture("codex_approval_edits_raw.txt")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(output.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_capture_pane_trailing_padding_does_not_hide_the_prompt(self):
+        """Blank padding rows must not push the question out of the bottom region.
+
+        ``tmux capture-pane`` pads to the full pane height, and the prompt is
+        ~10 rows tall, so a raw 15-line tail can land entirely inside the
+        padding. This is the concrete reason _has_approval_prompt_in_bottom
+        compacts blank lines before taking the region.
+        """
+        prompt = (
+            "  Would you like to run the following command?\n"
+            "\n"
+            "  Environment: local\n"
+            "\n"
+            "  $ mkdir -p /tmp/subdir\n"
+            "\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+
+        assert _has_approval_prompt_in_bottom(prompt + "\n" * 20)
+
+    @pytest.mark.parametrize(
+        "question",
+        [
+            "Would you like to run the following command?",
+            "Would you like to make the following edits?",
+            "Would you like to grant these permissions?",
+        ],
+    )
+    def test_all_three_approval_variants_are_waiting(self, question):
+        """exec, apply_patch, and permission-escalation approvals all block the TUI.
+
+        All three strings are present in the 0.147.0 binary and all three park
+        the pane on the same numbered menu.
+        """
+        output = (
+            "› do the thing\n"
+            "• Working on it.\n"
+            f"  {question}\n"
+            "\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_question_without_footer_is_not_waiting(self):
+        """Corroboration guard: the question alone does not classify as WAITING."""
+        assert not _has_approval_prompt_in_bottom(
+            "› why did it stall?\n"
+            "• Codex asked 'Would you like to run the following command?' and waited.\n"
+            "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+    def test_footer_without_question_is_not_waiting(self):
+        """Corroboration guard: the footer alone does not classify as WAITING.
+
+        "Press enter to confirm" also appears under non-approval prompts, so on
+        its own it is not evidence of an approval.
+        """
+        assert not _has_approval_prompt_in_bottom(
+            "  Name this session\n  Press enter to confirm or esc to cancel\n"
+        )
+
+    def test_answered_prompt_scrolled_out_is_not_waiting(self):
+        """Once the prompt scrolls out of the region it must stop latching."""
+        output = (
+            "  Would you like to run the following command?\n"
+            "  $ mkdir -p /tmp/subdir\n"
+            "› 1. Yes, proceed (y)\n"
+            "  Press enter to confirm or esc to cancel\n"
+            + "".join(f"• step {n} done.\n" for n in range(16))
+            + "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.COMPLETED
+
+    def test_startup_path_vetoes_readiness_on_the_live_prompt(self):
+        """The startup readiness veto must know the copy Codex actually emits.
+
+        STARTUP_BLOCKING_INPUT_PATTERN only carried the legacy modal's copy, so
+        a pane parked on a real approval during initialize() could be read as an
+        idle composer and declared ready.
+        """
+        assert not _has_startup_idle_composer(
+            "› Write tests for @filename\n"
+            "  gpt-5.6-sol medium · Context 100% left\n"
+            "  Would you like to run the following command?\n"
+            "› 1. Yes, proceed (y)\n"
+            "  Press enter to confirm or esc to cancel\n"
         )
 
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -3276,6 +3276,123 @@ class TestCodexProviderApprovalPromptLive:
         assert not re.search(APPROVAL_PROMPT_FOOTER, prose)
 
     @pytest.mark.parametrize(
+        ("keymap_case", "footer_replacement"),
+        [
+            # tui.keymap.list.accept = [] — an empty list explicitly unbinds
+            # (config/src/tui_keymap.rs at rust-v0.147.0), and
+            # accept_cancel_hint_line's (None, Some(cancel)) arm renders the
+            # cancel hint alone (popup_consts.rs).
+            ("accept_unbound_cancel_only", "  Press esc to cancel"),
+            # Both list actions unbound: the (None, None) arm renders an empty
+            # line — the blocking menu has NO footer at all.
+            ("both_unbound_no_footer", ""),
+            # Both unbound on a request with a thread label: the overlay
+            # appends its own hint, so the whole footer is the thread hint
+            # (approval_overlay.rs approval_footer_hint).
+            ("both_unbound_thread_hint", "  Press t to open thread"),
+        ],
+    )
+    def test_unbound_accept_keymap_is_waiting_via_both_status_paths(
+        self, keymap_case, footer_replacement
+    ):
+        """An approval menu with the accept action UNBOUND must still classify
+        WAITING through both public entry points.
+
+        Codex 0.147.0 renders the same blocking numbered menu either with a
+        cancel-only footer or with no footer line at all, so the footer cannot
+        be the anchor — the menu is (haofeif round 5). At ``e6f0a57`` these
+        shapes returned IDLE from both paths while the overlay stayed active,
+        re-enabling delivery into a blocked pane.
+
+        Built from the real capture with only the footer line swapped, so the
+        menu/preview/question rows stay pinned to the live rendering.
+        """
+        raw = load_fixture("codex_approval_modal_raw.txt")
+        footer_line = next(line for line in raw.splitlines() if "to confirm" in line)
+        output = raw.replace(footer_line, footer_replacement)
+        assert output != raw
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert _has_approval_prompt_in_bottom(output)
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(output.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_quoted_menu_without_footer_is_still_rejected(self):
+        """Making the footer optional must not admit a menu the model QUOTED.
+
+        The discriminator is the column-0 cursor: quoted or continuation prose
+        is indented under its bullet, so a pasted menu carries its cursor at
+        column >= 2 and finds no anchor even now that no footer is required.
+        """
+        output = (
+            "› what did the approval look like?\n"
+            "• It showed this menu:\n"
+            "  › 1. Yes, proceed (y)\n"
+            "    2. No, and tell Codex what to do differently (esc)\n"
+            "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert not _has_approval_prompt_in_bottom(output)
+        assert provider.get_status(output) != TerminalStatus.WAITING_USER_ANSWER
+
+    def test_menu_with_reply_below_is_rejected_even_without_footer(self):
+        """A scrolled-out menu followed by reply content must stay rejected:
+        the menu-block scan below the anchor refuses anything that is not an
+        option row, a footer hint, or chrome."""
+        output = (
+            "› 1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "• proceeding with the command.\n"
+            "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+    def test_single_numbered_line_at_bottom_is_not_a_menu(self):
+        """A lone column-0 numbered line over the idle composer is NOT a menu.
+
+        APPROVAL_MENU_MIN_OPTIONS is the floor: a genuine approval always
+        offers at least accept and decline, so a single-item shape — most
+        commonly a user message that happens to start with "1." — must not
+        anchor. This is also what keeps the disclosed numbered-list residual
+        (below) confined to MULTI-line user lists.
+        """
+        output = (
+            "› 1. run the tests\n" "› \n" "  ? for shortcuts                     88% context left\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+    def test_user_numbered_list_at_bottom_is_the_disclosed_residual(self):
+        """DOCUMENTED RESIDUAL, asserted so a change is a conscious decision.
+
+        A user message that is itself a numbered list renders with the same
+        column-0 gutter marker as a live menu cursor, so parked at the bottom
+        of an otherwise idle pane (codex interrupted before replying) it now
+        reads WAITING rather than IDLE. That errs toward withholding work —
+        never toward pasting into a blocked pane — and clears as soon as codex
+        renders any activity below the cell (the case above). The
+        footer-anchored detector rejected this shape only by failing open to
+        IDLE on every unbound-keymap approval, the dangerous direction.
+        """
+        output = (
+            "› 1. run the tests\n"
+            "  2. fix whatever fails\n"
+            "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+        assert _has_approval_prompt_in_bottom(output)
+
+    @pytest.mark.parametrize(
         "question",
         [
             "Would you like to run the following command?",

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -14,6 +14,7 @@ from cli_agent_orchestrator.providers.codex import (
     CodexProvider,
     ProviderError,
     _find_response_marker,
+    _has_approval_modal_in_bottom,
     _has_startup_idle_composer,
     _toml_override,
     _toml_scalar,
@@ -2695,6 +2696,131 @@ class TestCodexProviderUpdateDialog:
 
         assert "check_for_update_on_startup=true" in command
         assert command.endswith("-c check_for_update_on_startup=false")
+
+
+class TestCodexProviderApprovalModal:
+    """Tests for Codex's boxed command-approval modal appearing at RUNTIME.
+
+    The modal's copy was previously only consulted on the startup path
+    (STARTUP_BLOCKING_INPUT_PATTERN in _has_startup_idle_composer), so a pane
+    blocked on it mid-session was classified COMPLETED/PROCESSING and the
+    conductor would keep sending work into a pane hard-blocked on a keystroke.
+    """
+
+    def test_get_status_approval_modal_waiting(self):
+        """Active approval modal classifies as WAITING_USER_ANSWER."""
+        output = load_fixture("codex_approval_modal.txt")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_approval_modal_below_tui_footer_is_not_completed(self):
+        """Composer chrome above the modal must not win over the modal.
+
+        This is the dangerous shape: the TUI keeps rendering the idle composer
+        and status bar while the modal is up, so the idle-prompt check reported
+        COMPLETED — telling the conductor the agent was free.
+        """
+        output = (
+            "› run the deploy script\n"
+            "• I'll run the deploy script now.\n"
+            "› \n"
+            "  ? for shortcuts                     92% context left\n"
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept  [d] Decline     │\n"
+            "╰─────────────────────────────╯\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_approval_modal_unframed(self):
+        """Modal without box-drawing chrome still classifies as WAITING.
+
+        The frame glyphs have changed across Codex releases while the copy has
+        not, so detection must not depend on them.
+        """
+        output = "› run the deploy script\nCommand Approval Required\n[a] Accept  [d] Decline\n"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_approval_modal_in_scrollback_is_completed(self):
+        """An already-answered modal scrolled out of the bottom region must not latch."""
+        output = load_fixture("codex_approval_modal_scrollback.txt")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.COMPLETED
+
+    def test_get_status_approval_modal_quoted_in_assistant_reply_is_completed(self):
+        """The model describing the modal in prose must not be read as the modal.
+
+        Cannot be excluded by the assistant_after_last_user gate — a real modal
+        also appears after assistant bullets — so it is excluded structurally:
+        prose embeds the copy mid-sentence instead of owning its own line.
+        """
+        output = (
+            "› why did the last run stall?\n"
+            "• The pane was blocked on Codex's Command Approval Required modal, "
+            "which offers [a] Accept and [d] Decline and cannot be answered by CAO.\n"
+            '• Switch the profile to approval_policy = "never" to avoid it.\n'
+            "› \n"
+            "  ? for shortcuts                     91% context left\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.COMPLETED
+
+    def test_get_status_choice_keys_without_header_is_completed(self):
+        """Choice keys alone are not a modal — both halves must corroborate."""
+        output = (
+            "› list the approval keys\n"
+            "• [a] Accept and [d] Decline are the approval keys.\n"
+            "› \n"
+            "  ? for shortcuts                     91% context left\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.COMPLETED
+
+    def test_get_status_header_without_choice_keys_is_not_waiting(self):
+        """Header alone is not a modal — the choice line must be present too."""
+        output = "› run the deploy script\n╭─ Command Approval Required ─╮\n"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status != TerminalStatus.WAITING_USER_ANSWER
+
+    def test_has_approval_modal_requires_header_above_choices(self):
+        """Choice keys ABOVE the header are a partial/scrolled frame, not a live modal."""
+        assert not _has_approval_modal_in_bottom(
+            "│ [a] Accept  [d] Decline     │\n╭─ Command Approval Required ─╮\n"
+        )
+        assert _has_approval_modal_in_bottom(
+            "╭─ Command Approval Required ─╮\n│ [a] Accept  [d] Decline     │\n"
+        )
+
+    def test_startup_blocking_input_pattern_still_vetoes_readiness(self):
+        """Splitting the startup pattern must not weaken the startup-path veto."""
+        assert not _has_startup_idle_composer(
+            "› Write tests for @filename\n"
+            "  gpt-5.6-sol medium · Context 100% left\n"
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept  [d] Decline     │\n"
+        )
 
 
 class TestCodexProviderUpdateDialogLive:

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2902,6 +2902,65 @@ class TestCodexProviderApprovalModal:
             "    Command Approval Required\n│ [a] Accept  [d] Decline │\n"
         )
 
+    def test_get_status_answered_modal_with_work_resumed_is_not_waiting(self):
+        """An answered modal still in-window, with work running below it, is not WAITING.
+
+        The box has not scrolled out yet, so guards 1-4 all pass; only the
+        spinner below the choice line reveals that the modal was answered and
+        execution resumed. Reporting WAITING here withholds work from a pane
+        that is actively running.
+        """
+        output = (
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept   [d] Decline    │\n"
+            "╰─────────────────────────────╯\n"
+            "• Accepted. Running deploy...\n"
+            "• Working (3s • esc to interrupt)\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status != TerminalStatus.WAITING_USER_ANSWER
+        assert status == TerminalStatus.PROCESSING
+
+    def test_get_status_live_modal_without_spinner_is_still_waiting(self):
+        """Control for the spinner guard: no spinner below the box means WAITING."""
+        output = (
+            "› run the deploy script\n"
+            "• I'll run the deploy script now.\n"
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept   [d] Decline    │\n"
+            "╰─────────────────────────────╯\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_live_modal_with_stale_spinner_above_is_waiting(self):
+        """A spinner in scrollback ABOVE the box must not suppress a live modal.
+
+        Why the spinner guard is scoped to lines strictly below the choice line
+        rather than the whole bottom region: with --no-alt-screen a spinner from
+        earlier in the same turn can survive above the box, and a region-wide
+        test would then miss a genuinely blocked pane.
+        """
+        output = (
+            "› run the deploy script\n"
+            "• Working (5s • esc to interrupt)\n"
+            "• I need approval to run this.\n"
+            "╭─ Command Approval Required ─╮\n"
+            "│ [a] Accept   [d] Decline    │\n"
+            "╰─────────────────────────────╯\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
     def test_startup_blocking_input_pattern_still_vetoes_readiness(self):
         """Splitting the startup pattern must not weaken the startup-path veto."""
         assert not _has_startup_idle_composer(

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -3191,6 +3191,24 @@ class TestCodexProviderApprovalPromptLive:
 
         assert _has_approval_prompt_in_bottom(prompt + "\n" * 20)
 
+    @pytest.mark.parametrize("accept_key", ["enter", "space", "tab", "y"])
+    def test_configurable_confirm_key_still_detected(self, accept_key):
+        """The accept key is configurable (``tui.keymap.list.accept``), so the
+        footer can read ``Press space to confirm ...`` etc. Detection must key on
+        the structural wording, not the literal "enter" — otherwise a custom
+        keymap re-creates the original unsafe IDLE classification (haofeif P2)."""
+        prompt = (
+            "  Would you like to run the following command?\n"
+            "\n"
+            "  $ rm -rf build\n"
+            "\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "\n"
+            f"  Press {accept_key} to confirm or esc to cancel\n"
+        )
+        assert _has_approval_prompt_in_bottom(prompt + "\n" * 10)
+
     @pytest.mark.parametrize(
         "question",
         [

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -11,6 +11,7 @@ import pytest
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.codex import (
+    APPROVAL_PROMPT_FOOTER,
     CodexProvider,
     ProviderError,
     _find_response_marker,
@@ -3191,12 +3192,35 @@ class TestCodexProviderApprovalPromptLive:
 
         assert _has_approval_prompt_in_bottom(prompt + "\n" * 20)
 
-    @pytest.mark.parametrize("accept_key", ["enter", "space", "tab", "y"])
+    @pytest.mark.parametrize(
+        "accept_key",
+        [
+            "enter",
+            "space",
+            "tab",
+            "y",
+            # Modified single keys: modifiers join with " + "
+            # (key_hint.rs CTRL_PREFIX et al.), so one binding is already
+            # multi-token on screen.
+            "ctrl + s",
+            "shift + tab",
+            # Two-stroke chords: RuntimeChordKeymap accepts e.g.
+            # tui.keymap.list.accept="ctrl-x ctrl-s" and
+            # ShortcutHint::display_label() joins the strokes with a single
+            # space (haofeif round 4). A single-token match classified this
+            # pane IDLE — the unsafe direction.
+            "ctrl + x ctrl + s",
+            # Worst legal shape: every modifier on both strokes, 14 tokens.
+            "ctrl + shift + alt + x ctrl + shift + alt + s",
+        ],
+    )
     def test_configurable_confirm_key_still_detected(self, accept_key):
         """The accept key is configurable (``tui.keymap.list.accept``), so the
         footer can read ``Press space to confirm ...`` etc. Detection must key on
         the structural wording, not the literal "enter" — otherwise a custom
-        keymap re-creates the original unsafe IDLE classification (haofeif P2)."""
+        keymap re-creates the original unsafe IDLE classification (haofeif P2).
+        The label is not even one token: chords render as e.g.
+        ``ctrl + x ctrl + s`` (haofeif round 4)."""
         prompt = (
             "  Would you like to run the following command?\n"
             "\n"
@@ -3208,6 +3232,48 @@ class TestCodexProviderApprovalPromptLive:
             f"  Press {accept_key} to confirm or esc to cancel\n"
         )
         assert _has_approval_prompt_in_bottom(prompt + "\n" * 10)
+
+    def test_chord_confirm_key_is_waiting_via_both_status_paths(self):
+        """A two-stroke accept chord must classify WAITING through both public
+        entry points, not just the private helper.
+
+        At ``a926f89`` the footer ``Press ctrl + x ctrl + s to confirm ...``
+        (the exact rendering of ``tui.keymap.list.accept="ctrl-x ctrl-s"`` at
+        0.147.0) made both :meth:`get_status` and :meth:`get_status_from_screen`
+        return IDLE for a hard-blocked pane, so queued input was pasted into
+        the approval menu (haofeif round 4).
+        """
+        output = (
+            "› do the thing\n"
+            "• Working on it.\n"
+            "  Would you like to run the following command?\n"
+            "\n"
+            "  $ mkdir -p /tmp/subdir\n"
+            "\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. No, and tell Codex what to do differently (esc)\n"
+            "\n"
+            "  Press ctrl + x ctrl + s to confirm or esc to cancel\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(output.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_footer_match_is_bounded_against_prose(self):
+        """The multi-token key label is BOUNDED (15 tokens, the worst legal
+        chord). A prose sentence that happens to contain "Press" and, much
+        later on the same line, "to confirm" must not bridge the two — the
+        bound is the regex-level backstop under the structural gates."""
+        prose = (
+            "  Press the escape key if you would instead like the assistant "
+            "to stop what it is doing right now and wait for you to confirm\n"
+        )
+        assert not re.search(APPROVAL_PROMPT_FOOTER, prose)
 
     @pytest.mark.parametrize(
         "question",

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2813,6 +2813,95 @@ class TestCodexProviderApprovalModal:
             "╭─ Command Approval Required ─╮\n│ [a] Accept  [d] Decline     │\n"
         )
 
+    def test_get_status_modal_quoted_as_indented_transcript_is_completed(self):
+        """The model quoting a modal TRANSCRIPT back must not be read as the modal.
+
+        Harder than prose: the quoted block reproduces the modal's per-line
+        structure exactly (header alone on its line, choice keys starting their
+        line), so it satisfies the corroboration and line-structure guards. Only
+        the left-margin guard separates it — the quote is indented under its
+        bullet, the real box is drawn at the margin.
+        """
+        output = load_fixture("codex_approval_modal_quoted_in_reply.txt")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.COMPLETED
+
+    def test_get_status_modal_quoted_as_markdown_table_is_completed(self):
+        """A modal transcribed into a markdown table must not be read as the modal.
+
+        Motivates excluding ASCII ``+-|`` from MODAL_FRAME_CHARS: were they
+        stripped as frame chrome, these rows would reduce to the modal shape
+        while sitting at the left margin, defeating every guard.
+        """
+        output = (
+            "› document the approval modal\n"
+            "• I documented it as:\n"
+            "| Command Approval Required |\n"
+            "| [a] Accept | [d] Decline |\n"
+            "› \n"
+            "  ? for shortcuts                     90% context left\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.COMPLETED
+
+    def test_get_status_approval_modal_heavy_box(self):
+        """A modal framed in heavy box-drawing glyphs still classifies as WAITING.
+
+        Defensive: only light glyphs have been observed in the wild, but the
+        frame style is not contractual and missing a real modal is the costly
+        direction.
+        """
+        output = load_fixture("codex_approval_modal_heavy_box.txt")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_get_status_approval_modal_double_box(self):
+        """Double-line frame glyphs are stripped as chrome too."""
+        output = (
+            "› run the deploy script\n"
+            "╔═ Command Approval Required ═╗\n"
+            "║ [a] Accept  [d] Decline    ║\n"
+            "╚════════════════════════════╝\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        status = provider.get_status(output)
+
+        assert status == TerminalStatus.WAITING_USER_ANSWER
+
+    def test_has_approval_modal_accepts_framed_box_with_whitespace_gutter(self):
+        """A framed box indented as a whole is still a modal.
+
+        The left-margin guard rejects a leading run of whitespace ONLY; a run
+        containing frame glyphs is chrome regardless of surrounding padding, so
+        indenting the box does not break detection.
+        """
+        assert _has_approval_modal_in_bottom(
+            "    ╭─ Command Approval Required ─╮\n    │ [a] Accept  [d] Decline    │\n"
+        )
+
+    def test_has_approval_modal_accepts_unframed_modal_at_left_margin(self):
+        """An unframed modal at column 0 is accepted — no indent, so no prose signal."""
+        assert _has_approval_modal_in_bottom("Command Approval Required\n[a] Accept  [d] Decline\n")
+
+    def test_has_approval_modal_requires_both_halves_at_left_margin(self):
+        """One half framed and the other indented is a quote, not a box."""
+        assert not _has_approval_modal_in_bottom(
+            "╭─ Command Approval Required ─╮\n    [a] Accept  [d] Decline\n"
+        )
+        assert not _has_approval_modal_in_bottom(
+            "    Command Approval Required\n│ [a] Accept  [d] Decline │\n"
+        )
+
     def test_startup_blocking_input_pattern_still_vetoes_readiness(self):
         """Splitting the startup pattern must not weaken the startup-path veto."""
         assert not _has_startup_idle_composer(

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -3371,6 +3371,96 @@ class TestCodexProviderApprovalPromptLive:
 
         assert not _has_approval_prompt_in_bottom(output)
 
+    # The real capture's 108-column option and the tagged renderer's width-100
+    # wrapping of it: ListSelectionView wraps rows by default
+    # (SelectionRowDisplay::Wrapped) and word_wrap_line indents each
+    # continuation to the option text column — 5 columns for a single-digit
+    # menu (haofeif round 6).
+    _UNWRAPPED_OPTION = (
+        "  2. Yes, and don't ask again for commands that start with "
+        "`mkdir -p /private/tmp/codex-work-567/subdir` (p)"
+    )
+    _WRAPPED_OPTION = (
+        "  2. Yes, and don't ask again for commands that start with `mkdir -p\n"
+        "     /private/tmp/codex-work-567/subdir` (p)"
+    )
+
+    def test_wrapped_option_rows_are_waiting_via_both_status_paths(self):
+        """A menu whose long option WRAPPED at a narrow pane width must still
+        classify WAITING through both public entry points.
+
+        CAO's panes shrink when a narrower terminal attaches and the screen
+        path is the production path, so at ``9418e65`` the width-100 rendering
+        of this PR's own capture returned IDLE from ``get_status_from_screen``
+        while the menu was live (haofeif round 6).
+        """
+        raw = load_fixture("codex_approval_modal_raw.txt")
+        output = raw.replace(self._UNWRAPPED_OPTION, self._WRAPPED_OPTION)
+        assert output != raw, "fixture no longer contains the 108-column option"
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert _has_approval_prompt_in_bottom(output)
+        assert provider.get_status(output) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(output.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    def test_wrapped_anchor_row_is_still_the_anchor(self):
+        """The CURSOR row itself can be the one that wraps — the continuation
+        sits between the anchor and the next option and must not break the
+        below-anchor scan."""
+        raw = load_fixture("codex_approval_modal_raw.txt")
+        output = raw.replace(self._UNWRAPPED_OPTION, self._WRAPPED_OPTION)
+        # move the cursor from option 1 onto the wrapped option 2
+        output = output.replace("› 1. Yes, proceed (y)", "  1. Yes, proceed (y)")
+        output = output.replace("  2. Yes, and don't ask", "› 2. Yes, and don't ask")
+        assert "› 2." in output and "› 1." not in output
+
+        assert _has_approval_prompt_in_bottom(output)
+
+    @pytest.mark.parametrize(
+        "tail",
+        [
+            # after the footer: no option is open, so option-column indent is
+            # foreign content again
+            "  Press enter to confirm or esc to cancel\n     stray indented prose",
+            # after blank filler: same — wrapping never crosses a blank row
+            "  3. No, and tell Codex what to do differently (esc)\n\n     stray indented prose",
+        ],
+    )
+    def test_indented_prose_outside_an_option_still_disqualifies(self, tail):
+        """Continuation rows are honoured only while INSIDE an option: indented
+        prose after the footer or after a blank row still proves the menu is
+        not the bottom of the pane."""
+        raw = load_fixture("codex_approval_modal_raw.txt")
+        needle = tail.splitlines()[0]
+        output = raw.replace(needle, tail)
+        assert output != raw
+
+        assert not _has_approval_prompt_in_bottom(output)
+
+    def test_two_column_indent_below_an_option_is_not_wrapping(self):
+        """The continuation floor is the option TEXT column (5), not the
+        2-column indent of the question/footer/ordinary prose.
+
+        The renderer wraps to the width of the "{prefix} {n}. " gutter, so a
+        2-column-indented line directly under an option is foreign content and
+        must disqualify the block. This is the boundary that keeps the
+        numbered-list residual (below) from swallowing a user list that
+        continues with ordinary indented prose.
+        """
+        output = (
+            "› 1. run the tests\n"
+            "  2. fix whatever fails\n"
+            "  then rerun them until green\n"
+            "› \n"
+            "  ? for shortcuts                     88% context left\n"
+        )
+
+        assert not _has_approval_prompt_in_bottom(output)
+
     def test_user_numbered_list_at_bottom_is_the_disclosed_residual(self):
         """DOCUMENTED RESIDUAL, asserted so a change is a conscious decision.
 


### PR DESCRIPTION
## Problem

When Codex shows a runtime command-approval prompt, `CodexProvider.get_status` misclassifies the pane as **IDLE**. Because `inbox_service.deliver_pending` gates on `IDLE`/`COMPLETED`, the orchestrator then pastes queued work into a pane that is hard-blocked on a keystroke, and the task is lost.

## What the live capture changed

The original revision (and its review) targeted a boxed modal titled **"Command Approval Required"** with `[a] Accept` / `[d] Decline` keys. A live capture from **codex-cli 0.147.0** shows that string does not exist:

- `strings` over the vendored native binary (`@openai/codex-darwin-arm64/.../bin/codex`, 220 MB) finds **zero** occurrences of "Command Approval Required", "] Accept", or "] Decline". (`/opt/homebrew/bin/codex` is only a 7 KB Node shim — running `strings` on it is misleading.)
- The real prompt is an unframed **numbered menu**:

  ```
    Would you like to run the following command?

    $ mkdir -p /private/tmp/…/subdir

  › 1. Yes, proceed (y)
    2. Yes, and don't ask again for commands that start with `…` (p)
    3. No, and tell Codex what to do differently (esc)

    Press enter to confirm or esc to cancel
  ```

Two consequences:

1. **The misclassification mechanism is IDLE, not COMPLETED.** The prompt's own `› 1. Yes, proceed (y)` line is simultaneously the last user-prefix match *and* an idle-prompt match, so `get_status` sees "a user message with no reply after it" → IDLE. A fix keyed on the COMPLETED path never fires.
2. **The submitted box-detector left the bug unfixed.** `_has_approval_modal_in_bottom` returns `False` on both real captures (verified on the rebased head before any change). On current `main` both captures return IDLE on the buffer *and* screen paths.

## The fix

- New `_has_approval_prompt_in_bottom`: `APPROVAL_PROMPT_PATTERN` covering the three prompts present in the 0.147.0 string table (run command / make edits / grant permissions), corroborated by `APPROVAL_PROMPT_FOOTER` ("Press enter to confirm") in the bottom region — the same question+footer, bottom-anchored shape already used for the trust-v2, login, and update dialogs. Blank rows are compacted before the region is taken (the prompt is ~10 rows and `capture-pane` pads to full pane height), which also makes the buffer path agree with the screen path.
- Added the copy to `STARTUP_BLOCKING_INPUT_PATTERN` so `initialize()` cannot treat a pane parked on a real approval as ready.
- The boxed-modal detector from @call-me-ram's review is **also** applied (bottom-up anchor on the last choice line, `_is_chrome_only` tail guard, walk-up to the enclosing transcript cell instead of a fixed window) and the legacy box patterns are **kept** — that copy is still load-bearing in `STARTUP_BLOCKING_INPUT_PATTERN` and may be emitted by older builds; both legacy patterns are commented to record that 0.147.0 does not emit them.
- Two real fixtures captured (`codex_approval_modal_raw.txt` for the exec prompt, `codex_approval_edits_raw.txt` for the edit prompt), each with a regression test asserting `get_status(...) == WAITING_USER_ANSWER`.

`blocks_orchestrated_input_while_waiting_user_answer` (a reviewer ask) already landed on `CodexProvider` via #497, so no change was needed here.

## Verification

- Real capture: **IDLE on `main` → WAITING_USER_ANSWER on this branch**, both buffer and screen paths.
- Behaviour table (19 asserted behaviours + reviewer defects + both real captures + the residual): 18/25 correct before → **24/25** after. The single residual is a framed quote that *ends* a reply with only a composer after it; it is asserted, documented, and errs toward WAITING (work withheld), never toward pasting into a blocked pane.
- `test_codex_provider_unit.py` + `test_status_monitor.py`: **259 passed, 3 skipped** (+16 new tests, no existing test changed).
- Full suite: no regressions vs `main` (the pre-existing ag-ui/otel missing-dep failures only).
- `black`/`isort` clean; `mypy` error-set identical to `main`. Rebased onto current `main`.



## Round 4 (chord keymaps)

@haofeif's round-4 finding was real and is fixed: at 0.147.0 `tui.keymap.list.accept` also accepts a **two-stroke chord** (`RuntimeChordKeymap`), and `ShortcutHint::display_label()` renders `"ctrl-x ctrl-s"` as `ctrl + x ctrl + s` — strokes joined by a space, modifiers by `" + "` (`codex-rs/tui/src/key_hint.rs`, verified at the `rust-v0.147.0` tag). The footer regex's single-token `\S+` could not match that, so both public status paths returned IDLE for a hard-blocked pane (reproduced first-hand at `a926f89` before changing anything).

The label is now matched as **1–15 whitespace-separated tokens** — 15 bounds the worst legal shape (both strokes carrying `ctrl+shift+alt` = 14 tokens) while still refusing to bridge same-line prose. The structural gates in `_has_approval_prompt_in_bottom` are unchanged and remain the primary guard against a reply that merely quotes the footer.

**Verification:** chord labels added to the configurable-key parametrization (including the 14-token worst case), a chord run through **both** `get_status()` and `get_status_from_screen()` (both now WAITING_USER_ANSWER), and a negative prose-bound case. All three regex mutants are killed by the new tests (single-token revert: 5 failures; unbounded quantifier: 1; under-sized bound: 3). Full suite re-diffed against current `main` (`b5781f3`): failure set identical, zero new. `black`/`isort` clean; `mypy` parity on the touched file. Rebased onto `b5781f3`.



## Round 5 (unbound keymaps — footer optional, menu is the anchor)

@haofeif's round-5 finding was also real, verified upstream at `rust-v0.147.0`: an empty key list explicitly unbinds a list action (`config/src/tui_keymap.rs`), and `accept_cancel_hint_line` (`popup_consts.rs`) then renders the same blocking menu with a cancel-only footer, or **no footer line at all** when both actions are unbound; the overlay can also append/substitute an "open thread" hint (`approval_overlay.rs`). Reproduced on the real capture: swapping in the exact cancel-only rendering made both public status paths return IDLE.

The detector now anchors on the **bottom-most column-0 selection cursor** instead of the footer: below the anchor only the menu's remaining option rows, at most one footer hint (any of its four rendered shapes, `to confirm` / `to cancel` / `to go back` / `to open thread`), and chrome are allowed; options are counted contiguously around the anchor with the existing floor of 2. The footer is optional corroboration — its absence proves nothing.

**Disclosed residual (asserted in a test, per this PR's convention):** a user message that is itself a multi-line numbered list renders with the same column-0 gutter marker, so parked over an idle composer (codex interrupted before replying) it now reads WAITING rather than IDLE. That errs toward withholding work — never toward pasting into a blocked pane — and clears as soon as codex renders any activity below the cell. Single-line numbered messages stay IDLE (the min-options floor).

**Verification:** accept-unbound / both-unbound / thread-hint regressions built from the real capture through **both** `get_status()` and `get_status_from_screen()`; quoted-menu and reply-below rejections re-asserted **without** a footer; four mutants killed (footer-required-again, indented-cursor anchor, permissive below-scan, dropped min-options floor). Full suite re-diffed against `main` (`b5781f3`): failure set identical, zero new. `black`/`isort`/`mypy` clean.



## Round 6 (wrapped option rows)

@haofeif's round-6 finding, verified at `rust-v0.147.0`: `ListSelectionView` wraps rows by default (`SelectionRowDisplay::Wrapped`), and `word_wrap_line` indents each continuation to the option text column — the width of the `"{prefix} {n}. "` gutter, 5 columns for a single-digit menu (`build_rows` → `wrap_indent` → `subsequent_indent`). Reproduced with the width-100 rendering of this PR's own 108-column capture line: the menu-block scan hit the continuation row and `get_status_from_screen()` — the production path — returned IDLE at `9418e65`.

The scan now accepts continuation rows (≥ 5 columns of indent) **in both directions around the cursor anchor**, but only while inside an option: indented prose after the footer or after blank filler still disqualifies, continuations never add to the option count, and the 5-column floor is pinned so ordinary 2-column content (question/footer/prose) is never mistaken for wrapping — which also keeps the numbered-list residual from growing.

**Verification:** width-100 wrapped capture through both public status paths, a wrapped **cursor** row, indented-prose-outside-an-option negatives (after-footer and after-blank), and a 2-column-indent boundary case. Four mutants killed (continuations never accepted, accepted anywhere, chrome keeps the option open, floor loosened to 2 — the last one initially **survived** and got its own pinning test before the push). Full suite re-diffed against `main` (`b5781f3`): failure set identical, zero new. `black`/`isort`/`mypy` clean.
