### PR TITLE
fix(security): bump js-yaml to 4.3.1 and make the Trivy gate legible (#568)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,6 +665,31 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
 
+      # FR-8: the SARIF step above writes findings to a FILE, so a failing scan
+      # logs an exit code and names nothing — diagnosing #568 took an out-of-band
+      # `gh api .../code-scanning/alerts` call to learn what had failed. This step
+      # re-runs the same scan in table format so the finding appears in the log.
+      #
+      # `if: failure()` — runs only when the gate above fails, so a green run pays
+      # nothing. `exit-code: '0'` — this step must not be the one that fails the
+      # job; the gate above already did, and a second failure would obscure which
+      # step is authoritative.
+      #
+      # No `severity:` input, matching the effective gate: trivy-action's
+      # entrypoint.sh unsets TRIVY_SEVERITY whenever format is sarif, so the step
+      # above scans at ALL severities. Passing CRITICAL,HIGH here would print a
+      # narrower set than the one that failed the build — and could print NOTHING
+      # while the job is red.
+      - name: Show Trivy findings in the log
+        if: failure()
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: '0'
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         # `always()` is load-bearing now that Trivy can fail: without it, a CRITICAL finding

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -256,7 +256,7 @@ Create a pull request on GitHub. CI will automatically run tests and code qualit
 Runs on all pushes to `main` and all PRs targeting `main`:
 - **Unit tests**: Python 3.10, 3.11, 3.12 matrix with coverage
 - **Code quality**: black, isort, mypy
-- **Security scan**: Trivy vulnerability scanner (CRITICAL/HIGH)
+- **Security scan**: Trivy filesystem scan — fails on a finding of **any** severity (see [SECURITY.md](SECURITY.md#running-security-scans-locally) for why the workflow's `CRITICAL,HIGH` input is ignored)
 - **Dependency review**: License and vulnerability checks on PRs
 
 ### Provider-Specific Workflows (path-triggered)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,12 +95,27 @@ brew install trivy  # macOS
 # or
 sudo apt-get install trivy  # Ubuntu/Debian
 
-# Scan the repository
-trivy fs --severity HIGH,CRITICAL .
-
-# Scan Python dependencies
-trivy fs --scanners vuln --severity HIGH,CRITICAL .
+# Scan the repository, at every severity and with Trivy's default scanner set —
+# this is what the CI gate actually does (see the note below).
+# `--frozen` matters: a plain `uv export` rewrites the tracked uv.lock.
+uv export --frozen --format requirements-txt > requirements.txt  # so Python deps are scanned
+trivy fs --ignore-unfixed --exit-code 1 .
+rm -f requirements.txt
 ```
+
+> **Do not add `--severity HIGH,CRITICAL` or `--scanners vuln`.** Both make the
+> local check *weaker than the gate*, so it passes while CI fails.
+>
+> The `security` job in `.github/workflows/ci.yml` does pass
+> `severity: 'CRITICAL,HIGH'` to `trivy-action`, but the action's `entrypoint.sh`
+> runs `unset TRIVY_SEVERITY` whenever `format` is `sarif` and
+> `limit-severities-for-sarif` is not `true`. CI uses `format: 'sarif'`, so that
+> input is discarded and the job logs `Building SARIF report with all severities`
+> — **the gate fails on a finding of any severity, including MEDIUM and LOW.**
+> Similarly, CI passes no `scanners` input, so Trivy runs its defaults: the job
+> log shows both `[vuln] Vulnerability scanning is enabled` and
+> `[secret] Secret scanning is enabled`. `--scanners vuln` would hide the
+> secret findings CI blocks on. (See issue #568.)
 
 Or use the bundled wrapper that mirrors CI (`trivy` + optional local CodeQL):
 

--- a/docs/issues/568-js-yaml-omap-dos/design.md
+++ b/docs/issues/568-js-yaml-omap-dos/design.md
@@ -1,0 +1,437 @@
+# Design: clear GHSA-5p4m-2wfm-xmqj (js-yaml) and make the Security Scan log its findings
+
+**Issue:** [#568](https://github.com/awslabs/cli-agent-orchestrator/issues/568)
+**Requirements:** [requirements.md](requirements.md)
+**Status:** Specified, not implemented.
+
+---
+
+## Contents
+
+1. [Overview](#overview)
+2. [Corrections to the issue's sketch](#corrections-to-the-issues-sketch)
+3. [Position in the system](#position-in-the-system)
+4. [File layout](#file-layout)
+5. [Interfaces](#interfaces)
+6. [Algorithms](#algorithms)
+7. [Error handling](#error-handling)
+8. [Decisions and trade-offs](#decisions-and-trade-offs)
+9. [Testing strategy](#testing-strategy)
+10. [Manual verification](#manual-verification)
+11. [Open questions](#open-questions)
+
+---
+
+## Overview
+
+Three lines of `docusaurus/package-lock.json` move `js-yaml` from `4.3.0` to
+`4.3.1`, clearing the repo's only open code-scanning alert and unblocking
+`Security Scan` on `main` and every open PR. Alongside it, two documentation
+surfaces that misdescribe the gate's severity condition are corrected, and the
+scan job gains a table-format step so the next failure names itself in the log
+instead of requiring an API call to identify.
+
+## Corrections to the issue's sketch
+
+### Changes what the code does
+
+**C-1 — `npm update js-yaml` works here, but the issue's reasoning for why is
+incomplete, and the reason matters.**
+
+The issue argues the fix is safe because "every declared constraint is `^4.1.0`,
+which already admits the patched `4.3.1`." True (P-13) but not sufficient: #551
+had the identical argument (`ajv` declared `fast-uri: ^3.0.1`, which admitted
+`3.1.5`) and `bun update` still left a **nested** vulnerable copy in place,
+forcing a `package.json` `overrides` entry in PR #552.
+
+*Evidence:* enumerating `Object.keys(lock.packages)` yields exactly one match,
+`node_modules/js-yaml` (P-12) — npm hoisted all five `^4.1.0` dependents onto a
+single node, so there is no nested copy for `npm update` to miss. Verified by
+running it: an 8-line diff, `package.json` untouched (P-11). I also built the
+`overrides`-based alternative and diffed it — **byte-identical lockfile** (DR-1).
+
+*Consequence:* the issue's command is correct as written; adopt it. But the
+acceptance criterion must be "exactly one `js-yaml` node, at 4.3.1" (Task 1's
+AC), not "the constraint permits it" — otherwise this spec would sanction the
+same check that passed for #551 and shipped a vulnerable tree.
+
+**C-2 — The Security Scan gate does not run at `CRITICAL,HIGH`, so the issue's
+verification command checks a weaker condition than the gate.**
+
+*Evidence:* `entrypoint.sh:76-83` at the pinned SHA `57a97c7e` (tag `v0.35.0`)
+runs `unset TRIVY_SEVERITY` when `format` is `sarif`. The live log of run
+31177773018 prints `Building SARIF report with all severities` then
+`Running Trivy with options: trivy fs .` — no `--severity` (P-8).
+
+*Consequence:* every acceptance check in `tasks.md` runs with severity unset. A
+MEDIUM or LOW finding fails this job, and the issue's repro command would not
+have shown it. Note that PR #552's commit message already recorded this exact
+behaviour for the postcss MEDIUM — so this is a rediscovery of a known trap that
+never made it into the repo's documentation, which is what C-3 fixes.
+
+**C-3 — The repo's own documentation instructs the wrong scan command.**
+
+`SECURITY.md:102` documents `trivy fs --scanners vuln --severity HIGH,CRITICAL .`
+and `scripts/security-scan.sh:31-35` — advertised as "matching CI" in its own
+echo string at line 24 — passes `--severity CRITICAL,HIGH`.
+
+*Evidence:* same as C-2. The wrapper's claim to mirror CI is false in the one
+dimension that decides pass/fail.
+
+*Consequence:* FR-6. This is a change the issue did not request; it is the
+mechanism that made the issue's own repro section wrong, so fixing the instance
+without fixing the source would leave the next contributor to rediscover it.
+
+**C-4 — `--scanners vuln` in the documented command silently narrows the gate a
+second time.**
+
+CI passes no `scanners` input, so Trivy runs its default set. The run-31177773018
+log shows both `[vuln] Vulnerability scanning is enabled` **and**
+`[secret] Secret scanning is enabled`. `SECURITY.md:102`'s `--scanners vuln`
+disables secret scanning, so a Trivy-detectable secret would fail CI and pass the
+documented local check.
+
+*Evidence:* job log, lines beginning `INFO [secret]`. My unrestricted scan
+confirmed zero secret findings today (P-9), so nothing is currently hidden.
+
+*Consequence:* folded into FR-6 — the corrected wrapper must not pass
+`--scanners`.
+
+**C-5 — Running the documented local scan dirties a tracked lockfile.**
+
+`scripts/security-scan.sh:30` runs `uv export --format requirements-txt`. With uv
+0.9.4 this **rewrites `uv.lock`**: 16 insertions / 16 deletions, including
+reverting the `cli-agent-orchestrator` version from `2.4.1` (matching
+`pyproject.toml:3`) back to `2.4.0`.
+
+*Evidence:* P-18 — reproduced twice; `git status` showed ` M uv.lock` each time.
+The script removes `requirements.txt` on the way out (line 36) but never restores
+`uv.lock`.
+
+*Consequence:* NFR-3, and a `git status` assertion in Task 3's acceptance
+criteria. A contributor running the repo's own security wrapper before committing
+a security patch is one `git add -A` away from shipping an unrelated version
+downgrade.
+
+*Resolution:* the wrapper's export now passes **`--frozen`**, which reads the
+lockfile without rewriting it — measured identical 1837-line output, tree clean.
+This turned out to be required rather than optional: T3's "tree clean after
+running the wrapper" criterion cannot be met while the export mutates a tracked
+file, and documenting `git checkout -- uv.lock` as the remedy leaves the trap
+armed for whoever forgets it. The identical call at **`ci.yml:752`** is left
+alone — harmless on an ephemeral checkout; see OQ-3.
+
+### Changes only documentation
+
+**C-6 — The issue's "every open PR inherits the red" is not currently true, and
+the reason is a timing artefact.**
+
+*Evidence:* `gh pr checks 567` and `gh pr checks 566` both show
+`Security Scan  pass`. Their runs were created 2026-08-06T23:59:58Z and
+2026-08-07T01:43:04Z — **before** the alert (2026-08-07T04:24:47Z) and before
+Trivy's DB picked the advisory up.
+
+*Consequence:* documentation only. The claim is right about the future and wrong
+about the present: those PRs carry a stale green and will turn red on their next
+run. Worth stating precisely because "every PR is red" invites someone to check
+one, see green, and conclude the issue is stale.
+
+**C-7 — The advisory has no CVE, and the upstream one it derives from is MEDIUM,
+not HIGH.**
+
+*Evidence:* `gh api advisories/GHSA-5p4m-2wfm-xmqj` → `cve_id: None`,
+`severity: high`, CVSS `3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` = 7.5, CWE-407.
+`gh api advisories/GHSA-724g-mxrg-4qvm` → CVE-2026-59870, **`severity: medium`**.
+
+*Consequence:* documentation only. The issue calls it "the same weakness as
+CVE-2026-59870", which is accurate about the code and misleading about the
+rating — the same defect is scored MEDIUM in 5.x and HIGH in 3.x/4.x. Do not
+write "CVE-2026-59870" as this alert's identifier in the commit message; the
+advisory has no CVE.
+
+**C-8 — Exposure is narrower than "any consumer parsing untrusted YAML": the
+`!!omap` tag must be present explicitly.**
+
+*Evidence:* `omap` sits in the `explicit:` list of `lib/schema/default.js`, not
+`implicit:` (P-4). Measured: 32 000 entries tagged `!!omap` = 655.9 ms;
+byte-for-byte the same entries untagged = 49.2 ms — no quadratic term. And
+`grep -rn '!!omap'` across the repo returns **zero** hits (P-20).
+
+*Consequence:* documentation only, but it sharpens the issue's claim. The
+issue's "a plain `yaml.load(input)` with no options is affected; no custom schema
+is needed" is right that the tag is *available* by default, and easy to read as
+"any YAML is affected", which is false. The tag is reachable through markdown
+frontmatter — a nested `items: !!omap` under a mapping key still costs 631 ms at
+n=32 000 (P-6) — so an untrusted-docs-contribution path would be real. It is not
+real today.
+
+### Checked and found correct
+
+- The vulnerable function, the mechanism, and the O(n²) claim: exact (P-1, P-5).
+- `4.3.1` (4.x) and `3.15.1` (3.x) as the fixed versions: exact, and the
+  advisory's ranges confirm them.
+- The five dependents and their `^4.1.0` constraints: all five verified
+  individually, and the list is complete.
+- "Docusaurus docs site, not the shipped package": confirmed — the other ten
+  lockfiles carry no `js-yaml`, and the unrestricted scan finds nothing in them.
+- "The only open code-scanning alert": exact — the API returns one.
+- "`Security Scan` is the only failing job": exact (P-16).
+- The `format: 'sarif'` phantom-failure diagnosis: exact (P-15).
+- The repro command does print the finding: verified.
+
+## Position in the system
+
+```
+                    ┌───────────────── in scope ──────────────────┐
+                    │                                             │
+  advisory DB       │  docusaurus/package-lock.json               │
+  (GitHub/Trivy)    │    node_modules/js-yaml  4.3.0 → 4.3.1      │   ← Task 1
+        │           │                                             │
+        │ publishes │        ▲ hoisted, single node (P-12)         │
+        ▼           │        │                                     │
+  ┌───────────┐     │  ┌─────┴──────────────────────────────┐      │
+  │  Trivy    │─────┼─▶│ 5 declared dependents, all ^4.1.0  │      │
+  │ fs scan   │     │  │  @11ty/gray-matter                 │      │
+  └─────┬─────┘     │  │  @docusaurus/plugin-content-docs   │      │
+        │           │  │  @docusaurus/utils                 │      │
+        │ SARIF     │  │  @docusaurus/utils-validation      │      │
+        ▼           │  │  cosmiconfig                       │      │
+  Security tab      │  └────────────────────────────────────┘      │
+  + alert #201      │                                             │
+        ▲           │  .github/workflows/ci.yml  (security job)   │   ← Task 2
+        │           │    + table step, log-visible findings       │
+        │           │                                             │
+        │           │  scripts/security-scan.sh + SECURITY.md     │   ← Task 3
+        └───────────┼──── severity condition corrected ───────────┘
+                    │                                             │
+                    └─────────────────────────────────────────────┘
+
+  ══════════════ trust boundary ══════════════
+  All five consumers run at STATIC-SITE-BUILD time, parsing repo-authored
+  markdown frontmatter and Docusaurus config. No request path; no untrusted
+  input (P-19). And no `!!omap` tag exists in the tree (P-20), so the
+  quadratic branch is not reached at all today.
+
+  NOT in scope: the shipped cli-agent-orchestrator package. uv.lock,
+  tui/Cargo.lock, web/, cao_mcp_apps/, examples/** carry no js-yaml.
+```
+
+## File layout
+
+| File | State | Why |
+|---|---|---|
+| `docusaurus/package-lock.json` | amended | FR-1. The three lines in P-11. The entire dependency fix. |
+| `.github/workflows/ci.yml` | amended | FR-8, FR-9. A second Trivy step in the existing `security` job. |
+| `scripts/security-scan.sh` | amended | FR-6, C-3, C-4. The wrapper claims to match CI and does not. |
+| `SECURITY.md` | amended | FR-6, C-3, C-4. Same defect in prose. |
+| `docs/issues/568-js-yaml-omap-dos/{requirements,design,tasks}.md` | NEW | This spec. Follows the `docs/issues/<n>-<slug>/` convention established by `docs/issues/345-okf-export-import/`. |
+
+**Not changed, and deliberately:** `docusaurus/package.json` (FR-2 — an
+`overrides` entry produces a byte-identical lockfile, so it would be pure
+liability; see DR-1). `DEVELOPMENT.md:259` says "Trivy vulnerability scanner
+(CRITICAL/HIGH)" — the same misdescription as C-3, but it is a one-line CI
+summary table, not an instruction someone runs; correcting it is folded into
+Task 3 as a one-word edit rather than left inconsistent with `SECURITY.md`.
+
+## Interfaces
+
+No code interfaces change. The behavioural contract that does change is the
+workflow step, given as the actual YAML to be added to the `security` job in
+`.github/workflows/ci.yml`, after the existing scanner step and before the SARIF
+upload:
+
+```yaml
+      # FR-8: the SARIF step above writes findings to a FILE, so a failing scan
+      # logs an exit code and names nothing — diagnosing #568 took an out-of-band
+      # `gh api .../code-scanning/alerts` call to learn what had failed. This step
+      # re-runs the same scan in table format so the finding appears in the log.
+      #
+      # `if: failure()` — runs only when the gate above fails, so a green run pays
+      # nothing. `exit-code: '0'` — this step must not be the one that fails the
+      # job; the gate above already did, and a second failure would obscure which
+      # step is authoritative.
+      #
+      # No `severity:` input, matching the effective gate: trivy-action's
+      # entrypoint.sh unsets TRIVY_SEVERITY whenever format is sarif, so the step
+      # above scans at ALL severities. Passing CRITICAL,HIGH here would print a
+      # narrower set than the one that failed the build — and could print NOTHING
+      # while the job is red.
+      - name: Show Trivy findings in the log
+        if: failure()
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: '0'
+```
+
+The action SHA must be the same pin as the existing step (`57a97c7e…`), so both
+steps observe identical resolution semantics and the repo keeps one Trivy version
+to reason about.
+
+## Algorithms
+
+The severity-resolution order inside `trivy-action`, which is the whole reason
+the added step omits `severity:` and every acceptance check unsets it:
+
+```
+# action.yaml:218 — the input is always exported, defaulted if absent
+TRIVY_SEVERITY := INPUT_SEVERITY or "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+
+# entrypoint.sh:76-83 — THEN, after the export, format is consulted
+if TRIVY_FORMAT == "sarif":
+    if INPUT_LIMIT_SEVERITIES_FOR_SARIF != "true":
+        unset TRIVY_SEVERITY          # ← the CI job's path; the input is DISCARDED
+        log "Building SARIF report with all severities"
+
+# entrypoint.sh:87-90
+run: trivy <scanType> <scanRef>       # no --severity flag ever appears in argv
+exit with returnCode                  # non-zero iff TRIVY_EXIT_CODE and findings
+```
+
+The order is load-bearing: the unset happens **after** the export, so a
+`severity:` input that is visibly present in the job's `with:` block (and echoed
+into the log — run 31177773018 prints `severity: CRITICAL,HIGH`) has no effect on
+the scan. Reading the workflow file, or even the job log's parameter echo, gives
+the wrong answer; only the ordering above gives the right one.
+
+Consequence for the fix, as pseudocode for the reproduction:
+
+```
+# WRONG — what the issue and SECURITY.md say. Narrower than the gate.
+trivy fs --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed docusaurus/
+
+# RIGHT — what the gate evaluates.
+TRIVY_IGNORE_UNFIXED=true TRIVY_PKG_TYPES=os,library trivy fs .
+#   severity: unset          → all severities, per the unset above
+#   scanners: unset          → vuln AND secret, per the job log
+#   scan-ref: "."            → whole repo, not docusaurus/ alone
+#   pkg-types: os,library    → action.yaml:217 default
+```
+
+## Error handling
+
+| Failure | Handling | Requirement |
+|---|---|---|
+| `npm update js-yaml` resolves a version other than 4.3.1+ | Stop. Assert the resolved version from the lockfile before proceeding; do not accept `npm`'s exit code as proof. | FR-1 |
+| `npm update` touches more than the three expected lines | Stop and read the diff. Extra churn means npm resolved beyond the target; a security patch must not carry unreviewed resolution changes. | FR-3 |
+| A nested `node_modules/**/js-yaml` appears | Stop and add a `package.json` `overrides` entry, as #551/PR #552 had to. Assert the node **count** is 1, not merely that the top-level one is patched. | FR-1, C-1 |
+| `npm ci` or `npm run build` fails on the patched lockfile | Stop; do not proceed to CI. Per P-17 the PR's docs-site gate would catch it, but locally is cheaper. | FR-5 |
+| Unrestricted scan still reports a finding after the bump | Do not narrow the severity to make it pass. A finding at any severity fails the real gate (P-8); report it and treat it as in scope for this issue. | FR-4 |
+| `uv.lock` is modified by a verification step | Prevented at the source: the wrapper's export passes `--frozen` (C-5). If a *different* command still dirties it, `git checkout -- uv.lock` and never stage it. | NFR-3, C-5 |
+| The added table step fails the job itself | `exit-code: '0'` prevents it. If it somehow errors, `if: failure()` means the job was already red — the gate's verdict is unchanged. | FR-8 |
+| Alert #201 does not auto-close after merge | Expected latency, not a failure: the alert closes on the next Trivy run against `main`. Confirm via the code-scanning API, not by assumption. | FR-4 |
+
+## Decisions and trade-offs
+
+| # | Decision | Alternative | Why |
+|---|---|---|---|
+| DR-1 | Lockfile-only bump via `npm update js-yaml`, no `package.json` change. | Add `"js-yaml": "^4.3.1"` to `docusaurus/package.json`'s existing `overrides` block, as #551/PR #552 did for `fast-uri`. **Fairly: this is the repo's most recent precedent for exactly this situation, it pins the floor durably so a future `npm install` cannot regress below 4.3.1, and the block already carries five such entries — consistency alone is a real argument.** | I built both and diffed the results: **byte-identical lockfiles** (8 changed lines each). The override buys nothing here because there is a single hoisted node (P-12), which is precisely what was *not* true for bun in #551 — there the override was load-bearing. An entry that changes no resolution is a permanent claim someone must later re-evaluate ("is this still needed?") for a package the docs site does not import. FR-2's cost of *not* having it is bounded: the docs build is a PR gate (P-17) and Trivy is a merge gate, so a regression below 4.3.1 is caught twice before it reaches `main`. |
+| DR-2 | Add a second, `if: failure()` Trivy step in table format. | Echo `trivy-results.sarif` (or `jq` it) in a failure step — cheaper, no second scan. | Reusing the SARIF means parsing SARIF in shell to get a readable line, and the raw file is thousands of lines of JSON, which is not "the log names what it failed on". A second Trivy run hits the warm cache (NFR-2) and costs one scan on **failing runs only**. Considered and rejected: adding `format: 'table'` to the *existing* step — that would destroy the SARIF upload the Security tab depends on, violating FR-9 and the load-bearing `if: always()` comment at `ci.yml:779`. |
+| DR-3 | Fix `scripts/security-scan.sh` + `SECURITY.md` in this issue, though #568 does not ask. | Leave them; file a follow-up. | The wrong command is *why* the issue's own repro section is wrong, and PR #552's commit message shows the trap was already hit once and never written down. Leaving it means a third rediscovery. Cost is a two-file, few-line docs change reviewed alongside a one-line lockfile bump — and it is what makes the acceptance criteria in `tasks.md` runnable by a contributor. |
+| DR-4 | Stay on the 4.x line (4.3.1). | Move `docusaurus` to `js-yaml@5.2.3` (`latest`). | Every dependent declares `^4.1.0` (P-13); 5.x satisfies none of them, so it would require an `overrides` force across five packages whose YAML behaviour would then be untested. 4.3.1's diff is 4 lines in one function with identical observable semantics (P-3, P-7). 5.x is a larger, unneeded blast radius for a build-time transitive. |
+| DR-5 | Do not set `limit-severities-for-sarif: true` to make the gate honour `CRITICAL,HIGH`. | Set it; the workflow would then mean what it says and match the docs. | It **narrows a security gate** — MEDIUM findings stop failing CI — which is a policy decision for the maintainers, not a security patch's business. It also shrinks the SARIF uploaded to the Security tab, losing MEDIUM/LOW history. Instead the docs are corrected to match the code (DR-3). Recorded as OQ-1 so the maintainers can take the other branch deliberately. |
+| DR-6 | Assert the `js-yaml` node **count**, not just the top-level version. | `grep '"js-yaml"' package-lock.json \| grep 4.3.1` — simpler. | A grep for the patched version passes while a *nested* vulnerable copy sits elsewhere in the file. That is the #551 failure mode verbatim. The count assertion is the only check that can fail for the right reason. |
+| DR-7 | Verify with `TRIVY_SEVERITY` unset and no `--scanners`. | Use the issue's documented command. | C-2, C-4. The documented command is strictly weaker than the gate on two independent axes. Trade-off: the unrestricted command is noisier and could surface pre-existing MEDIUMs unrelated to this issue — measured, it does not (P-9: exactly one finding, repo-wide, all severities). |
+
+## Testing strategy
+
+There is no application code here, so "tests" are executable assertions on
+artefacts. Per the team's same-commit rule, they ship with the change. Each is
+tagged with the requirement it proves.
+
+### `docusaurus/package-lock.json` — assertions run in Task 1
+
+| # | Case | Proves |
+|---|---|---|
+| 1 | Exactly **one** key in `lock.packages` matches `js-yaml`, and its `version` is `4.3.1`. | FR-1, C-1, DR-6 |
+| 2 | That entry's `resolved` ends `js-yaml-4.3.1.tgz` and `integrity` is `sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==`. | FR-1 |
+| 3 | `git diff --numstat docusaurus/package-lock.json` = `3  3` (three lines changed, no additions or deletions of entries). | FR-3 |
+| 4 | `git diff --name-only` lists **only** `docusaurus/package-lock.json`. | FR-2, FR-3 |
+| 5 | `lock.packages[""].dependencies` and `.devDependencies` are unchanged from `HEAD`. | FR-2 |
+| 6 | All five dependents still declare `^4.1.0` — i.e. no dependent's constraint was rewritten. | FR-2, NFR-1 |
+
+### `.github/workflows/ci.yml` — assertions run in Task 2
+
+| # | Case | Proves |
+|---|---|---|
+| 7 | The `security` job contains exactly two `aquasecurity/trivy-action` steps, both pinned to `57a97c7e…`. | FR-8 |
+| 8 | The new step has `if: failure()`, `format: 'table'`, `exit-code: '0'`, and **no** `severity:` key. | FR-8, C-2 |
+| 9 | The pre-existing step is unmodified — still `format: 'sarif'`, `exit-code: '1'`, `output: trivy-results.sarif`. | FR-9 |
+| 10 | The `upload-sarif` step retains `if: always()`. | FR-9 |
+| 11 | The file parses as YAML and the `security` job's step list is ordered scan → table → upload. | FR-8, FR-9 |
+
+### `scripts/security-scan.sh` + `SECURITY.md` — assertions run in Task 3
+
+| # | Case | Proves |
+|---|---|---|
+| 12 | `scripts/security-scan.sh` no longer passes `--severity` and no longer passes `--scanners`. | FR-6, C-3, C-4 |
+| 13 | Its echoed description no longer claims `CRITICAL,HIGH`, and states that the CI gate fires at all severities. | FR-6 |
+| 14 | `scripts/security-scan.sh trivy` still exits non-zero on a finding and zero on a clean tree (`--exit-code 1` retained). | FR-6 |
+| 15 | `git status --porcelain` is empty after `scripts/security-scan.sh trivy` — in particular `uv.lock` is not left modified. | NFR-3, C-5 |
+| 16 | `SECURITY.md`'s local-scan block and `DEVELOPMENT.md:259` no longer state a severity narrower than the gate. | FR-6 |
+| 17 | `bash -n scripts/security-scan.sh` passes. | FR-6 |
+
+### The three defects most likely to occur, and their coverage
+
+1. **A nested vulnerable `js-yaml` survives the bump** — the #551 failure mode,
+   and the one a version grep cannot see. Covered by case 1 (count, not
+   presence).
+2. **Verification passes at `CRITICAL,HIGH` while the real gate stays red** —
+   the trap PR #552 hit and never documented. Covered by cases 8 and 12 (the
+   severity filter is absent from both the new CI step and the wrapper) and by
+   Task 1's unrestricted scan.
+3. **`uv.lock` gets swept into the commit** by a contributor who ran the repo's
+   own security wrapper and then `git add -A`. Covered by case 15, and by
+   Task 3 making the wrapper leave a clean tree.
+
+### Commands that must pass
+
+```bash
+# Task 1
+cd docusaurus && npm ci && npm run typecheck && npm run build
+TRIVY_IGNORE_UNFIXED=true TRIVY_PKG_TYPES=os,library trivy fs .   # → 0 findings
+
+# Task 2
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))"
+
+# Task 3
+bash -n scripts/security-scan.sh && scripts/security-scan.sh trivy
+git status --porcelain      # → empty
+```
+
+## Manual verification
+
+Automation cannot confirm the alert closes, because that happens on GitHub's side
+after merge.
+
+1. Before the change, capture the baseline:
+   `gh api "repos/awslabs/cli-agent-orchestrator/code-scanning/alerts?state=open"`
+   → expect exactly alert #201.
+2. After the fix, run the gate's real condition locally:
+   `TRIVY_IGNORE_UNFIXED=true TRIVY_PKG_TYPES=os,library trivy fs .` → 0
+   findings. Do **not** substitute the issue's `--severity CRITICAL,HIGH`
+   command (C-2).
+3. Confirm the working tree is clean apart from the intended files —
+   specifically that `uv.lock` is untouched (C-5).
+4. On the PR, confirm `Security Scan` is green **and** that the `Docs site`
+   workflow ran (it is path-triggered on `docusaurus/**`, so this change fires
+   it) and passed.
+5. Deliberately red-run the log-visibility change: on a scratch branch,
+   temporarily revert the lockfile line, push, and confirm the failing
+   `Security Scan` job's log now prints a table naming `js-yaml`, `4.3.0`,
+   `HIGH`, `GHSA-5p4m-2wfm-xmqj`. This is the only way to prove FR-8 — a green
+   run never executes the `if: failure()` step. Discard the scratch branch.
+6. After merge to `main`, re-query the alerts endpoint and confirm #201 is
+   `closed`/`fixed`, and that the count of open alerts is 0.
+
+## Open questions
+
+| # | Question | Blocks | Leaning |
+|---|---|---|---|
+| OQ-1 | Should the gate be narrowed to `CRITICAL,HIGH` via `limit-severities-for-sarif: true`, so the workflow means what its `severity:` input says? | Nothing in this issue — the docs fix (DR-5) resolves the inconsistency in the safe direction. Blocks any future decision to treat MEDIUMs as non-blocking. | **No.** The gate is currently stricter than documented; making the documentation honest costs nothing, while narrowing the gate loses MEDIUM/LOW SARIF history and is a policy change. If the maintainers do want it, it should be its own PR with that rationale stated. |
+| OQ-2 | Why did Dependabot file no PR when security updates are enabled and unpaused, and why does it report **0** open alerts for a package Trivy calls HIGH (P-22)? | Nothing here (FR-7 lands the fix manually). Blocks relying on Dependabot for the *next* advisory of this shape. | Most likely the advisory is too new for Dependabot's alert pipeline, or `docusaurus/` is not in a Dependabot ecosystem config — there is **no `.github/dependabot.yml` in this repo** (verified: absent locally and 404 from the contents API), yet dependabot has previously opened PRs against `/docusaurus` (#549, #550), so the ecosystem is discovered some other way. Worth a follow-up issue; a scanner that silently covers less than believed is the more expensive problem than this bump. |
+| OQ-3 | Should `uv export` stop mutating `uv.lock` (C-5) — e.g. via `--frozen`, or restoring the file in the wrapper's trap? | Nothing. **Resolved during implementation for the local wrapper.** | **Done for `scripts/security-scan.sh`:** the export now passes `--frozen`. Measured: identical 1837-line output, and `git status` stays clean where a plain export left ` M uv.lock`. This was necessary, not optional — T3's acceptance criterion "tree clean after running the wrapper" could not otherwise be met, and documenting a manual `git checkout -- uv.lock` as the remedy left the trap armed for anyone who forgot it. **Still open for `ci.yml:752`**, which has the same call; harmless there (ephemeral checkout) so it stays out of this PR's scope. |
+| OQ-4 | Should the docs site pin `js-yaml` in `overrides` anyway, as a floor against future regression (the DR-1 alternative)? | Nothing. | **No**, per DR-1 — it changes no bytes today and adds a permanent entry to re-evaluate. Revisit if npm ever resolves this node non-deterministically, or if a second `js-yaml` node appears in the tree. |

--- a/docs/issues/568-js-yaml-omap-dos/requirements.md
+++ b/docs/issues/568-js-yaml-omap-dos/requirements.md
@@ -1,0 +1,250 @@
+# Requirements: clear GHSA-5p4m-2wfm-xmqj (js-yaml) from `docusaurus/package-lock.json`
+
+**Issue:** [#568](https://github.com/awslabs/cli-agent-orchestrator/issues/568)
+**Scope:** `security-patch` — lockfile-only dependency bump plus one CI-observability
+change.
+**Status:** Specified, not implemented.
+
+---
+
+## Context
+
+Trivy code-scanning alert **#201** flags `js-yaml@4.3.0` in
+`docusaurus/package-lock.json:11016` as vulnerable to **GHSA-5p4m-2wfm-xmqj**
+(HIGH, CVSS 7.5, CWE-407). It is the **only** open code-scanning alert on the
+repo and the `Security Scan` job is the only failing job on `main`.
+
+Nothing in the repository changed to cause this. The advisory was published
+2026-08-06T20:27:32Z against an unchanged pin; the alert was created
+2026-08-07T04:24:47Z. `main`'s CI went red on the first run after that.
+
+**The one hard constraint someone must internalise:** the `Security Scan` gate
+does **not** run at `CRITICAL,HIGH`. `trivy-action`'s `entrypoint.sh:76-83`
+executes `unset TRIVY_SEVERITY` whenever `format` is `sarif` and
+`limit-severities-for-sarif` is not `true` — which is the case in
+`.github/workflows/ci.yml:763-772`. The job therefore fails on a finding of
+**any** severity, including LOW and UNKNOWN. Verifying a fix with
+`--severity CRITICAL,HIGH` (as `SECURITY.md:102` and `scripts/security-scan.sh:31-35`
+both instruct) checks a **narrower** condition than the gate and can report a
+false all-clear. Every acceptance check in this spec runs at the gate's real,
+unrestricted severity.
+
+## Dependency status
+
+| Dependency | What it provides | Verified state |
+|---|---|---|
+| `js-yaml@4.3.1` | Patched `resolveYamlOmap` (O(n) key set) | **Published on npm.** `npm view js-yaml versions` lists `4.3.1`; `dist-tags.v4-legacy = 4.3.1`. Tarball downloaded and read. |
+| GHSA-5p4m-2wfm-xmqj | The advisory being cleared | **Open, reviewed.** `gh api advisories/GHSA-5p4m-2wfm-xmqj`: severity `high`, CVSS 7.5, no CVE assigned, ranges `>=4.0.0 <4.3.1` → `4.3.1` and `>=3.0.0 <3.15.1` → `3.15.1`. |
+| Code-scanning alert #201 | The CI-blocking signal | **Open.** Sole open alert; `gh api .../code-scanning/alerts?state=open` returns exactly 1. |
+| Dependabot | Would otherwise auto-fix | **Enabled but has NOT filed a PR.** `dependabot_security_updates: enabled`, `automated-security-fixes: {enabled: true, paused: false}`, yet `dependabot/alerts?state=open` returns **0** and no js-yaml PR exists. Manual fix required; see FR-7. |
+| `#551` / PR #552 | Prior art for this shape | **Merged** (`dd32f15`). Same shape, but its `bun update` step was **insufficient** and needed a `package.json` `overrides` entry — a difference this spec resolves for npm (see DR-1). |
+| Docs site build | Must survive the bump | **Green with 4.3.1.** `npm ci && npm run typecheck && npm run build` all pass locally on the patched lockfile. |
+
+## Provenance
+
+One row per claim this spec relies on.
+
+| # | Claim | Label | Evidence |
+|---|---|---|---|
+| P-1 | The vulnerable code is `resolveYamlOmap`'s `objectKeys.indexOf(pairKey)` inside the per-element loop, making resolution O(n²). | **OBSERVED** | Read `lib/type/omap.js:11-31` from the extracted `js-yaml-4.3.0.tgz`. |
+| P-2 | 4.3.1 fixes it by replacing the array with an object and `_hasOwnProperty.call` + `Object.defineProperty`. | **OBSERVED** | `diff -u p430/lib/type/omap.js p431/lib/type/omap.js` — a 4-line change. |
+| P-3 | 4.3.1 changes **nothing else**. | **OBSERVED** | `diff -rq` of the two tarballs: only `lib/type/omap.js`, the 6 `dist/` build artifacts, and `package.json`'s `version` field differ. No API, dependency, or engine change. |
+| P-4 | The quadratic path requires an **explicit `!!omap` tag**; untagged YAML is unaffected. | **OBSERVED** | `omap` is in the `explicit:` list of `lib/schema/default.js`, not `implicit:`. Measured: 32 000 tagged entries = 655.9 ms; the same 32 000 entries **untagged** = 49.2 ms (no quadratic term). |
+| P-5 | Growth is quadratic and material at realistic sizes. | **OBSERVED (measured)** | 4.3.0, `yaml.load` of an `!!omap`: n=4 000 → 17.7 ms; 8 000 → 50.9 ms; 16 000 → 172.1 ms; 32 000 → 655.9 ms (≈3.8× per doubling). Same inputs on 4.3.1: 8.6 / 16.6 / 26.5 / 74.0 ms. A 490 KB document costs 656 ms on one core. |
+| P-6 | A nested `!!omap` under a mapping key also triggers it — the tag need not be the document root. | **OBSERVED (measured)** | `title: x\nitems: !!omap\n  - …` × 32 000 → 631.0 ms on 4.3.0. This is the shape reachable through markdown frontmatter. |
+| P-7 | `!!omap` semantics are byte-identical across the bump, including for prototype-polluting key names. | **OBSERVED** | 6 cases (`valid`, `dup`, `__proto__`, `__proto__` dup, `hasOwnProperty`, `toString` dup) produce identical results on 4.3.0 and 4.3.1: same values, same throws. The `Object.defineProperty` form is what keeps `__proto__` from being swallowed. |
+| P-8 | The `Security Scan` gate runs at **all** severities, not `CRITICAL,HIGH`. | **OBSERVED** | `entrypoint.sh:76-83` at the pinned SHA `57a97c7e` (= tag `v0.35.0`) does `unset TRIVY_SEVERITY`. Confirmed in the live log of run 31177773018: `Building SARIF report with all severities` / `Running Trivy with options: trivy fs .`. |
+| P-9 | With severity unrestricted, `js-yaml` is the repo's **only** finding — of any severity. | **OBSERVED (measured)** | `TRIVY_IGNORE_UNFIXED=true TRIVY_PKG_TYPES=os,library trivy fs .` (severity unset, trivy 0.69.0, DB 2026-08-07) → `{'HIGH': 1}`, zero MEDIUM/LOW/UNKNOWN, zero secrets, zero misconfigurations. |
+| P-10 | Bumping only `js-yaml` makes the scan clean. | **OBSERVED (measured)** | Same unrestricted scan against the patched lockfile → **0 findings**. |
+| P-11 | `npm update js-yaml` produces a minimal, correct lockfile edit and does **not** add a direct dependency. | **OBSERVED (measured)** | Ran it (both with and without `--package-lock-only`). Diff = exactly 8 lines: `version`, `resolved`, `integrity` at `node_modules/js-yaml`. `package.json` byte-identical; `packages[""].dependencies` unchanged. |
+| P-12 | There is exactly **one** `js-yaml` node in the tree — no nested copies to miss. | **OBSERVED** | Enumerated `Object.keys(lock.packages)`: the only match is `node_modules/js-yaml`. This is why npm's flat hoist suffices where bun's did not for #551. |
+| P-13 | All five dependents declare `^4.1.0`, which already admits 4.3.1. | **OBSERVED** | Walked every `dependencies`/`devDependencies`/`peerDependencies` block in the lockfile: `@11ty/gray-matter`, `@docusaurus/plugin-content-docs`, `@docusaurus/utils`, `@docusaurus/utils-validation`, `cosmiconfig` — all `^4.1.0`, all under `dependencies`. |
+| P-14 | The docs site builds and typechecks on 4.3.1. | **OBSERVED (measured)** | `npm ci` → `npm run typecheck` (exit 0) → `npm run build` → `[SUCCESS] Generated static files`. Installed tree confirmed at `4.3.1`. |
+| P-15 | The failing job's log names no finding, so the failure reads as a phantom. | **OBSERVED** | Full log of the `Security Scan` job in run 31177773018: SARIF goes to `trivy-results.sarif`; the log ends after the scanner notices with no findings table. |
+| P-16 | `Security Scan` is the only failing job on `main`. | **OBSERVED** | Run 31177773018 (`e592b21`, current `main` and this branch's HEAD): 13 success, 1 failure (`Security Scan`), 1 skipped (`Dependency Review`). |
+| P-17 | The docs site build is gated on PRs, so a lockfile regression is caught pre-merge. | **OBSERVED** | `.github/workflows/gh-pages.yml:10-18` triggers on `pull_request` with `paths: docusaurus/**`; the `build` job runs `npm ci`, `typecheck`, `build`. Deploy is gated on `github.event_name == 'push'`. |
+| P-18 | `uv export` — run by both CI and the local wrapper — **mutates the tracked `uv.lock`**. | **OBSERVED (measured)** | Ran `uv export --format requirements-txt` twice with uv 0.9.4; each time `git status` showed ` M uv.lock` (16 insertions / 16 deletions: the `cli-agent-orchestrator` version reverting 2.4.1 → 2.4.0, plus marker churn). Restored both times. |
+| P-19 | The YAML `js-yaml` actually parses here is repo-authored frontmatter and config. | *source-read inference* | Read the call sites: `@11ty/gray-matter/lib/engines.js:15` (`parse: yaml.load.bind(yaml)`), reached from `@docusaurus/utils/lib/markdownUtils.js:18`; `cosmiconfig/dist/loaders.js:47-50`; `@docusaurus/utils/lib/dataFileUtils.js:18`; `@docusaurus/utils-validation/lib/{tagsFile,validationUtils}.js`; `@docusaurus/plugin-content-docs/lib/sidebars/index.js:19`. All are build-time. Inference: no untrusted input reaches them, because the site is built from this repo's own tree. |
+| P-20 | No file in the repo contains an `!!omap` tag today. | **OBSERVED** | `grep -rn '!!omap' .` excluding `node_modules` → zero hits. So the quadratic path is not currently exercised at all. |
+| P-21 | The advisory is a non-backport of CVE-2026-59870 / GHSA-724g-mxrg-4qvm. | **OBSERVED** | `gh api advisories/GHSA-724g-mxrg-4qvm`: CVE-2026-59870, **medium**, range `>=5.0.0 <=5.2.0` → patched `5.2.1`. Note the severity differs from this advisory's `high`. |
+| P-22 | Dependabot did not open a PR for this despite being enabled. | **OBSERVED** | Settings show enabled + unpaused; `dependabot/alerts?state=open` returns 0 while Trivy reports the finding. The two scanners disagree. |
+
+**The design is load-bearing on P-8, P-10, P-11, P-12 and P-14.** P-8 sets the
+acceptance bar (get it wrong and a passing local check still ships a red gate).
+P-10 says the one-package bump is sufficient. P-11 and P-12 together are why no
+`package.json` change is needed here even though #551 needed one. P-14 says the
+bump is safe for the only consumer that matters.
+
+## Functional requirements
+
+### FR-1 — Resolve `js-yaml` to a patched version
+
+The lockfile at `docusaurus/package-lock.json` SHALL resolve
+`node_modules/js-yaml` to `4.3.1` or later within the 4.x line, with matching
+`resolved` URL and `integrity` hash.
+
+*Rationale:* 4.3.1 is the first 4.x release carrying the O(n) `resolveYamlOmap`
+(P-2), and per P-3 it changes nothing else, so it is the smallest sufficient
+move. Staying in 4.x rather than jumping to 5.x keeps every `^4.1.0` constraint
+(P-13) satisfiable without touching a single dependent.
+
+### FR-2 — Do not add a direct dependency
+
+`docusaurus/package.json`'s `dependencies` and `devDependencies` SHALL be
+byte-identical before and after the change.
+
+*Rationale:* `js-yaml` is transitive-only (P-13). Promoting a build-time
+transitive to a declared dependency of the docs site would make the repo
+responsible for a package it does not import, and would survive long after the
+advisory stops mattering. #551 hit exactly this trap: `bun update` "adds a
+direct dependency" (PR #552's own commit message).
+
+### FR-3 — Change no file other than the lockfile in the fix commit
+
+The dependency-fix change SHALL touch exactly one file:
+`docusaurus/package-lock.json`, and within it only the three lines identified in
+P-11.
+
+*Rationale:* per P-11 and P-12 the minimal edit is also the complete one. Any
+additional lockfile churn indicates `npm` resolved something beyond the target
+and needs review before it ships inside a security patch.
+
+### FR-4 — Clear the gate at the gate's real severity
+
+After the change, `trivy fs .` run with `TRIVY_IGNORE_UNFIXED=true`,
+`TRIVY_PKG_TYPES=os,library` and **`TRIVY_SEVERITY` unset** SHALL report zero
+vulnerabilities.
+
+*Rationale:* this is the exact condition `Security Scan` evaluates (P-8), not
+the `CRITICAL,HIGH` condition the repo's own docs describe. P-9 establishes the
+baseline is already clean at every severity, so this requirement is currently
+satisfiable — but only because nothing else is outstanding. **This FR
+deliberately contradicts `SECURITY.md:102` and `scripts/security-scan.sh:31-35`;
+FR-6 reconciles them.**
+
+### FR-5 — Keep the docs site building
+
+`npm ci`, `npm run typecheck` and `npm run build` in `docusaurus/` SHALL all
+succeed on the patched lockfile.
+
+*Rationale:* the docs site is the only consumer of this lockfile, and per P-17
+its build is a PR gate — so a regression blocks the merge rather than reaching
+`main`. P-14 records that this already passes.
+
+### FR-6 — Make the documented local scan match the real gate
+
+`scripts/security-scan.sh` and `SECURITY.md`'s "Running Security Scans Locally"
+section SHALL describe an invocation whose pass/fail condition is no narrower
+than the CI gate's.
+
+*Rationale:* today both instruct `--severity CRITICAL,HIGH`, which per P-8 is
+strictly narrower than what CI enforces. A contributor who follows the
+documentation, sees green, and pushes can still turn `main` red on a MEDIUM
+finding. The documentation is wrong about the tool it documents; that is a
+defect independent of this advisory. **This is the one requirement here that the
+issue does not ask for.**
+
+### FR-7 — Land the fix manually rather than waiting for Dependabot
+
+The fix SHALL be committed by this change and SHALL NOT be deferred to an
+automated dependency PR.
+
+*Rationale:* Dependabot security updates are enabled and unpaused, yet per P-22
+it reports **0** open alerts for a package Trivy calls HIGH — GitHub's advisory
+database has the advisory (it answered `gh api advisories/…`) but Dependabot has
+not raised it against this lockfile. Waiting on a bot that has not fired leaves
+`main` red indefinitely.
+
+### FR-8 — Surface the finding in the job log
+
+The `Security Scan` job SHALL print the identity of any finding that fails it —
+at minimum package, installed version, severity, and advisory ID — to the job's
+own log.
+
+*Rationale:* per P-15, `format: 'sarif'` sends findings to a file, so the job
+that failed the build names nothing. The current log shows a scanner starting,
+some notices, and a non-zero exit. Diagnosing #568 required an out-of-band
+`gh api` call to the code-scanning endpoint to learn what the failure even was.
+Covers the issue's "worth considering separately" paragraph, which this spec
+promotes to in-scope: it is the reason this issue took a manual investigation to
+open. *Corresponds to AC-6.*
+
+### FR-9 — Preserve the SARIF upload
+
+The SARIF report SHALL continue to be produced and uploaded to the Security tab
+on both passing and failing runs.
+
+*Rationale:* the `if: always()` at `ci.yml:779` and its comment are load-bearing
+— without it, a finding fails the scan step and skips the upload, hiding the very
+finding that failed the build. FR-8 must not be implemented in a way that
+displaces the SARIF output; hence the design's second-step approach (DR-2).
+
+## Non-functional requirements
+
+### NFR-1 — No new network or build-time cost in the docs build
+
+The change SHALL NOT increase `docusaurus/`'s installed dependency count.
+
+*Rationale:* a version bump of an existing single node (P-12) with no dependency
+change (P-3) alters no edge in the graph.
+
+### NFR-2 — The added Trivy step SHALL NOT extend the job by more than one scan
+
+Any step added for FR-8 SHALL reuse the already-populated Trivy cache rather
+than re-downloading the vulnerability DB.
+
+*Rationale:* the DB download is 103.74 MiB and took 3.7 s of the job's 28 s in
+run 31177773018. `TRIVY_CACHE_DIR` is set by the action on every invocation
+(`action.yaml:248`), so a second step in the same job hits the warm cache.
+
+### NFR-3 — Leave `uv.lock` unmodified
+
+The working tree SHALL contain no modification to `uv.lock` after any
+verification step in this change.
+
+*Rationale:* P-18 — `uv export`, which both CI's scan job and
+`scripts/security-scan.sh` run, rewrites the tracked `uv.lock` as a side effect
+(it reverts the package version 2.4.1 → 2.4.0). Anyone reproducing this fix
+locally will find a dirty `uv.lock` that has nothing to do with the fix, and
+could easily commit it inside a security patch. Encountered and reverted twice
+during this spec's verification. Satisfied for the wrapper by passing `--frozen`
+to its `uv export` (C-5), which removes the side effect rather than documenting a
+cleanup step; `ci.yml:752` keeps the plain call, where an ephemeral checkout makes
+it harmless (OQ-3).
+
+## Acceptance criteria → requirements
+
+The issue states its fix as prose, not a numbered list. Its checks are
+enumerated here as AC-1…AC-6 and mapped.
+
+| AC | From the issue | Covered by |
+|---|---|---|
+| AC-1 | "Verify `docusaurus/package-lock.json` resolves `js-yaml@4.3.1`" | FR-1 |
+| AC-2 | "no `package.json` change is needed" | FR-2, FR-3 |
+| AC-3 | "confirm the docs site still builds (`npm run build`)" | FR-5 |
+| AC-4 | "commit the lockfile" | FR-3, FR-7 |
+| AC-5 | "confirm alert #201 auto-closes on the next Trivy scan" | FR-4 |
+| AC-6 | "Worth considering separately: adding `format: 'table'` … so the job log names what it failed on" | FR-8, FR-9 |
+
+AC-6 is the only one the issue defers. It is pulled in-scope: it is a
+five-line workflow change in the same file family, and per P-15 it is the reason
+this alert needed a manual investigation to identify at all.
+
+## Contradiction in the issue, resolved
+
+The issue's §"Reproducing locally" prescribes
+`trivy fs --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed docusaurus/`.
+That command does reproduce **this** finding (verified — it prints the js-yaml
+row). But per P-8 it does **not** reproduce the **gate**: CI discards the
+severity filter, and the issue's own §Summary asserts a conclusion about the
+gate ("the only failing job in CI"). Using the narrow command to confirm the fix
+would be checking a weaker condition than the one that must hold.
+
+| Option | Verdict |
+|---|---|
+| Verify at `CRITICAL,HIGH`, as the issue and `SECURITY.md` say | **Rejected.** Narrower than the gate (P-8). Passes while a MEDIUM finding keeps `main` red. This is precisely the trap PR #552's commit message documents hitting. |
+| Verify with severity unset, matching the gate | **Chosen** (FR-4). P-9 shows the unrestricted baseline is a single HIGH, so this is not a wider net in practice — it is the same net, correctly described. |
+| Change `ci.yml` to pass `limit-severities-for-sarif: true` so the gate honours `CRITICAL,HIGH` | **Rejected here.** It would make the gate match the docs, but it narrows an existing security gate — a policy change, not a patch. It also shrinks the SARIF uploaded to the Security tab. Out of scope; noted as OQ-1. |
+
+The reverse-facing half of the contradiction — that the repo's documentation
+misdescribes its own gate — is fixed by FR-6 rather than left in place.

--- a/docs/issues/568-js-yaml-omap-dos/tasks.md
+++ b/docs/issues/568-js-yaml-omap-dos/tasks.md
@@ -1,0 +1,215 @@
+# Tasks: clear GHSA-5p4m-2wfm-xmqj and make the Security Scan log its findings
+
+**Issue:** [#568](https://github.com/awslabs/cli-agent-orchestrator/issues/568)
+**Requirements:** [requirements.md](requirements.md) · **Design:** [design.md](design.md)
+
+---
+
+## Parallelisation plan
+
+Three tasks, no shared files, so all three run in one wave.
+
+| Wave | Task | Owns (exclusively) | Depends on |
+|---|---|---|---|
+| 1 | **T1** — bump `js-yaml` to 4.3.1 | `docusaurus/package-lock.json` | — |
+| 1 | **T2** — make the scan job log its findings | `.github/workflows/ci.yml` | — |
+| 1 | **T3** — correct the documented scan condition | `scripts/security-scan.sh`, `SECURITY.md`, `DEVELOPMENT.md` | — |
+
+No two tasks own a file. T1 is the fix; T2 and T3 are the observability and
+documentation corrections that keep the next occurrence from costing another
+manual investigation.
+
+**One cross-task hazard:** T1 and T3 both *run* Trivy for verification, and T3's
+verification runs the wrapper's `uv export`, which mutates the tracked `uv.lock`
+(C-5, P-18). T3 removes the hazard at its source by passing `--frozen`; until
+that edit lands, whoever runs the wrapper must `git checkout -- uv.lock`, and
+nobody should `git add -A` at any point. T1's verification does not invoke
+`uv export` and is unaffected.
+
+---
+
+## T1 — Bump `js-yaml` to 4.3.1 in the docs lockfile
+
+**Status:** [x] Complete — implemented and verified
+**Owns:** `docusaurus/package-lock.json`
+
+### Description
+
+Run `cd docusaurus && npm update js-yaml`. Expect an 8-line diff: `version`,
+`resolved`, `integrity` on the single `node_modules/js-yaml` entry. `package.json`
+must come out byte-identical.
+
+**Likely defects to watch for:**
+
+1. **Checking presence instead of count.** A grep for `4.3.1` passes while a
+   nested vulnerable copy survives elsewhere in the lockfile — the exact #551
+   failure, where `bun update` left `ajv`'s nested copy in place and needed a
+   `package.json` `overrides` entry (PR #552). npm hoists all five `^4.1.0`
+   dependents onto one node here, so `npm update` is sufficient — but assert the
+   **count is 1**, do not assume it.
+2. **Verifying at `CRITICAL,HIGH`.** The issue and `SECURITY.md` both say to.
+   `trivy-action` discards the severity filter under `format: sarif`
+   (`entrypoint.sh:76-83`), so the gate fires at *every* severity. Verify with
+   `TRIVY_SEVERITY` unset or the check is weaker than the gate.
+3. **Accepting `npm`'s exit code as proof.** `npm update` exits 0 while printing
+   `up to date` and changing nothing. Read the resolved version out of the file.
+4. **Committing extra lockfile churn.** More than three changed lines means npm
+   resolved beyond the target; stop and read the diff before shipping it inside a
+   security patch.
+
+Do **not** add a `js-yaml` entry to `docusaurus/package.json`'s `overrides`
+block. It produces a byte-identical lockfile (DR-1) and would be a permanent
+no-op entry.
+
+### Requirements addressed
+
+FR-1, FR-2, FR-3, FR-4, FR-5, FR-7, NFR-1
+
+### Acceptance criteria
+
+- [x] `node -e "const l=require('./docusaurus/package-lock.json'); const k=Object.keys(l.packages).filter(x=>/(^|\/)js-yaml$/.test(x)); console.log(k.length, k.map(x=>l.packages[x].version))"` prints exactly `1 [ '4.3.1' ]`.
+- [x] The `node_modules/js-yaml` entry's `resolved` ends with `js-yaml-4.3.1.tgz` and its `integrity` is `sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==`.
+- [x] `git diff --numstat docusaurus/package-lock.json` prints `3	3	docusaurus/package-lock.json`.
+- [x] `git diff --name-only` lists `docusaurus/package-lock.json` and nothing else.
+- [x] `git diff --quiet HEAD -- docusaurus/package.json` exits 0 (package.json untouched).
+- [x] All five dependents still declare `^4.1.0`: `node -e "const l=require('./docusaurus/package-lock.json'); const r=Object.entries(l.packages).filter(([,v])=>v.dependencies&&v.dependencies['js-yaml']).map(([k,v])=>[k,v.dependencies['js-yaml']]); console.log(r.length, new Set(r.map(x=>x[1])))"` prints `5 Set(1) { '^4.1.0' }`.
+- [x] `cd docusaurus && npm ci && npm run typecheck && npm run build` all succeed, ending in `[SUCCESS] Generated static files`.
+- [x] `node -e "console.log(require('./docusaurus/node_modules/js-yaml/package.json').version)"` prints `4.3.1`.
+- [x] `TRIVY_IGNORE_UNFIXED=true TRIVY_PKG_TYPES=os,library trivy fs . --format json --output /tmp/t.json --quiet` then a count of `Results[].Vulnerabilities` prints **0**, with `TRIVY_SEVERITY` unset in the environment.
+- [x] `git status --porcelain` shows no modification to `uv.lock`.
+
+**Command that must pass:**
+```bash
+cd docusaurus && npm ci && npm run typecheck && npm run build
+```
+
+---
+
+## T2 — Make the Security Scan job name what it failed on
+
+**Status:** [x] Complete — implemented and verified
+**Owns:** `.github/workflows/ci.yml`
+
+### Description
+
+Add the `if: failure()` table-format Trivy step given verbatim in
+[design.md § Interfaces](design.md#interfaces) to the `security` job, between the
+existing scanner step (`ci.yml:763-772`) and the SARIF upload (`ci.yml:774-781`).
+Keep the comment block — it records why each field is what it is.
+
+Today a failing `Security Scan` prints an exit code and no finding, because
+`format: 'sarif'` redirects output to a file. Identifying #568 required an
+out-of-band `gh api .../code-scanning/alerts` call.
+
+**Likely defects to watch for:**
+
+1. **Changing the existing step's `format` to `table` instead of adding a step.**
+   That destroys the SARIF upload the Security tab depends on, and the
+   `if: always()` comment at `ci.yml:776-778` explains why that upload is
+   load-bearing. FR-9 forbids it.
+2. **Passing `severity: 'CRITICAL,HIGH'` on the new step.** It would print a
+   *narrower* set than the one that failed the build — and could print **nothing**
+   while the job is red, which is worse than the current silence because it looks
+   authoritative. Omit `severity:` entirely.
+3. **Omitting `exit-code: '0'`.** Without it, the second step fails too and the
+   log no longer shows which step is the gate.
+4. **Using a different action SHA.** Both steps must pin `57a97c7e…` so the repo
+   has exactly one Trivy version to reason about.
+
+### Requirements addressed
+
+FR-8, FR-9, NFR-2
+
+### Acceptance criteria
+
+- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` exits 0.
+- [x] `grep -c 'aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1' .github/workflows/ci.yml` prints `2`.
+- [x] `grep -c 'aquasecurity/trivy-action' .github/workflows/ci.yml` also prints `2` — i.e. no unpinned or differently-pinned reference was introduced.
+- [x] The new step's block contains `if: failure()`, `format: 'table'`, and `exit-code: '0'`, and contains **no** `severity:` key.
+- [x] The pre-existing scanner step still has `format: 'sarif'`, `output: 'trivy-results.sarif'`, `severity: 'CRITICAL,HIGH'`, `ignore-unfixed: true` and `exit-code: '1'`, unchanged.
+- [x] The `upload-sarif` step still carries `if: always()`.
+- [x] Within the `security` job, step order is: scanner (sarif) → table → upload-sarif. Verified by reading the parsed `jobs.security.steps` name list.
+- [x] `git diff --name-only` for this task lists `.github/workflows/ci.yml` and nothing else.
+
+**Command that must pass:**
+```bash
+python3 -c "import yaml,sys; d=yaml.safe_load(open('.github/workflows/ci.yml')); \
+names=[s.get('name') for s in d['jobs']['security']['steps']]; print(names); \
+sys.exit(0 if len([s for s in d['jobs']['security']['steps'] if 'trivy-action' in str(s.get('uses',''))])==2 else 1)"
+```
+
+---
+
+## T3 — Correct the documented local-scan condition
+
+**Status:** [x] Complete — implemented and verified
+**Owns:** `scripts/security-scan.sh`, `SECURITY.md`, `DEVELOPMENT.md`
+
+### Description
+
+`scripts/security-scan.sh:24` echoes "matching CI" and then at lines 31-35 passes
+`--severity CRITICAL,HIGH` — which CI discards. `SECURITY.md:99-104` documents the
+same narrow command, and additionally `--scanners vuln`, which disables the secret
+scanning CI *does* run (both `[vuln]` and `[secret]` appear in the job log).
+`DEVELOPMENT.md:259` repeats "(CRITICAL/HIGH)".
+
+Change the wrapper to drop `--severity` and `--scanners` so its pass/fail
+condition is no narrower than the gate's, update its echoed description, and
+correct the two prose surfaces. Keep `--exit-code 1` and `--ignore-unfixed`.
+State explicitly, where a reader will see it, that the CI gate fires at **all**
+severities because `trivy-action` unsets `TRIVY_SEVERITY` under
+`format: sarif` — that is the fact whose absence caused this.
+
+**Likely defects to watch for:**
+
+1. **Dropping `--exit-code 1`** while editing the flag list, which would turn the
+   wrapper into a reporter that always succeeds — a check that cannot fail.
+2. **Leaving `uv.lock` dirty.** The script's `uv export` rewrites the tracked
+   `uv.lock` (reverting the version 2.4.1 → 2.4.0). It cleans up
+   `requirements.txt` afterwards but not `uv.lock`. Fix the cause, not the
+   symptom: add `--frozen` to the export so it reads the lockfile without
+   rewriting it. Do not settle for documenting a `git checkout -- uv.lock`
+   remedy, and do not `git add -A` at any point.
+3. **"Fixing" the mismatch by narrowing CI instead.** Setting
+   `limit-severities-for-sarif: true` would make the gate match the docs, but it
+   narrows an existing security gate and loses MEDIUM/LOW SARIF history. Rejected
+   as DR-5 / OQ-1; not this task.
+4. **Editing `SECURITY.md` and forgetting `DEVELOPMENT.md:259`**, leaving the two
+   inconsistent with each other.
+
+### Requirements addressed
+
+FR-6, NFR-3
+
+### Acceptance criteria
+
+- [x] `grep -n 'severity' scripts/security-scan.sh` returns no `--severity` flag on the `trivy fs` invocation.
+- [x] `grep -n 'scanners' scripts/security-scan.sh` returns nothing.
+- [x] `grep -n 'exit-code 1' scripts/security-scan.sh` still matches, and `--ignore-unfixed` is retained.
+- [x] The script's echoed banner no longer claims `CRITICAL,HIGH` and states the gate runs at all severities.
+- [x] `bash -n scripts/security-scan.sh` exits 0.
+- [x] `scripts/security-scan.sh trivy` exits 0 on the current (post-T1) tree, and its output shows the scan ran.
+- [x] `git status --porcelain` is **empty** immediately after `scripts/security-scan.sh trivy` — in particular `uv.lock` is not left modified. **Met by passing `--frozen` to the script's `uv export`**, not by a manual restore: a plain export rewrites the tracked lockfile (P-18), and `--frozen` reads it without rewriting. Measured: identical 1837-line `requirements.txt` either way. Do not "fix" this criterion with `git checkout -- uv.lock` — that leaves the hazard in place for the next contributor.
+- [x] `SECURITY.md`'s "Running Security Scans Locally" block no longer shows a `--severity` narrower than the gate, no longer shows `--scanners vuln`, and names the `trivy-action` severity-unset behaviour.
+- [x] `DEVELOPMENT.md:259` no longer states `(CRITICAL/HIGH)` as the scan's gate condition.
+- [x] `git diff --name-only` for this task lists only `scripts/security-scan.sh`, `SECURITY.md`, `DEVELOPMENT.md`.
+
+**Command that must pass:**
+```bash
+bash -n scripts/security-scan.sh && scripts/security-scan.sh trivy && \
+  test -z "$(git status --porcelain)"
+```
+
+---
+
+## Out of scope
+
+| Item | Owned by |
+|---|---|
+| Narrowing the gate to `CRITICAL,HIGH` via `limit-severities-for-sarif: true` | OQ-1 — needs a maintainer policy decision; it *reduces* what CI blocks on. |
+| Why Dependabot filed no PR and reports 0 open alerts for a HIGH Trivy finding; whether a `.github/dependabot.yml` should exist (there is none) | OQ-2 — a follow-up issue. A scanner covering less than believed outranks this bump in importance. |
+| Making `uv export` stop mutating `uv.lock` in **`ci.yml:752`** | OQ-3 — harmless on an ephemeral CI checkout, so it stays out of this PR. The **wrapper** side was fixed here with `--frozen`, because T3's clean-tree criterion required it. |
+| Pinning `js-yaml` in `docusaurus/package.json` `overrides` as a regression floor | OQ-4 / DR-1 — byte-identical lockfile today, so a no-op entry. |
+| Upgrading `docusaurus` to `js-yaml@5.x` | DR-4 — satisfies none of the five `^4.1.0` constraints. |
+| Any change to the shipped `cli-agent-orchestrator` package | Not affected: `js-yaml` appears in no other lockfile, and the unrestricted scan finds nothing elsewhere. |
+| Trivy 0.73.0 upgrade (the job log notices one is available) | Unrelated to this advisory; the pinned 0.69.3 detects it correctly. |

--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -11014,9 +11014,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -4,7 +4,7 @@
 # scanner failure so it's safe to wire into pre-push hooks or Makefile targets.
 #
 # Usage:
-#   scripts/security-scan.sh                 # run all available scanners
+#   scripts/security-scan.sh                 # run every available scanner
 #   scripts/security-scan.sh trivy           # just Trivy
 #   scripts/security-scan.sh codeql          # just CodeQL (python)
 #   scripts/security-scan.sh gitleaks        # just gitleaks (secret scan, #457)
@@ -21,15 +21,32 @@ cd "$ROOT_DIR"
 target="${1:-all}"
 exit_code=0
 
+# This scan passes NO severity filter, deliberately (#568). The CI `security`
+# job does pass `severity: 'CRITICAL,HIGH'`, but trivy-action's entrypoint.sh
+# runs `unset TRIVY_SEVERITY` whenever `format` is sarif and
+# `limit-severities-for-sarif` is not true — and CI uses `format: 'sarif'`.
+# So that input is DISCARDED and the gate fails on a finding of ANY severity
+# ("Building SARIF report with all severities" in the job log). A local check
+# narrowed to CRITICAL,HIGH passes while CI goes red, which is exactly how
+# #568 was missed. It likewise passes no scanner filter: CI supplies no such
+# input either, so Trivy runs its default scanner set — the job log shows both
+# [vuln] and [secret] scanning enabled. Narrowing either axis here would make
+# this wrapper weaker than the gate it claims to mirror; don't reintroduce it.
 run_trivy() {
-    echo "==> Trivy filesystem scan (CRITICAL,HIGH; unfixed ignored, matching CI)"
+    echo "==> Trivy filesystem scan (ALL severities; unfixed ignored, matching CI)"
+    echo "    Note: the CI gate fails on ANY severity — trivy-action unsets"
+    echo "    TRIVY_SEVERITY under format: sarif, so its CRITICAL,HIGH input is ignored."
     if ! command -v trivy >/dev/null 2>&1; then
         echo "  SKIP: trivy not on PATH (brew install aquasecurity/trivy/trivy)"
         return 0
     fi
-    uv export --format requirements-txt > requirements.txt
+    # `--frozen` is load-bearing: a plain `uv export` REWRITES the tracked
+    # uv.lock as a side effect (it reverts the cli-agent-orchestrator version to
+    # the last locked one), leaving a dirty tree that a contributor running this
+    # script before committing can easily sweep into an unrelated commit. With
+    # --frozen the export reads the lockfile and never rewrites it (#568).
+    uv export --frozen --format requirements-txt > requirements.txt
     trivy fs \
-        --severity CRITICAL,HIGH \
         --ignore-unfixed \
         --exit-code 1 \
         . || exit_code=1


### PR DESCRIPTION
Closes #568.

## What was red

Trivy code-scanning alert **#201** flagged `js-yaml@4.3.0` in `docusaurus/package-lock.json` as vulnerable to **GHSA-5p4m-2wfm-xmqj** (HIGH, CVSS 7.5, CWE-407 — quadratic CPU consumption in `!!omap` resolution). It was the only open alert on the repo, and `Security Scan` the only failing job on `main`. Nothing in the repo changed: the advisory was published against an unchanged pin.

## The fix

`npm update js-yaml` → 4.3.1. Three lines, one hoisted node, no `package.json` change.

Verified rather than assumed:
- **One** `js-yaml` node exists in the tree, so npm's flat hoist is sufficient. #551 needed a `package.json` `overrides` entry because bun left a nested copy — asserting the node **count is 1** is what rules that out here, not a version grep.
- 4.3.1 vs 4.3.0 differs *only* in `lib/type/omap.js` (4 lines), the `dist/` artifacts, and the version field. No API, dependency, or engine change.
- `!!omap` semantics are byte-identical across the bump on 6 cases, including `__proto__` and duplicate keys.
- Docs site: `npm ci && npm run typecheck && npm run build` all green on 4.3.1.

## The part worth reviewing

**The `Security Scan` gate does not run at `CRITICAL,HIGH`, despite the input saying so.** `trivy-action`'s `entrypoint.sh` runs `unset TRIVY_SEVERITY` whenever `format` is `sarif` and `limit-severities-for-sarif` is not `true` — which is our config. The input is echoed into the log and then discarded, so **the job fails on a finding of any severity, including MEDIUM and LOW.**

`SECURITY.md`, `scripts/security-scan.sh`, and `DEVELOPMENT.md` all told contributors to verify at `CRITICAL,HIGH` — a *narrower* condition than the gate. Follow the docs, see green, push, and `main` goes red on a MEDIUM. PR #552's commit message shows this trap was already hit once and never written down, so this PR fixes it at the source instead of only noting it.

Every check in this PR therefore runs with `TRIVY_SEVERITY` unset. Result: **0 findings across all 10 scan targets.**

Two smaller corrections that came out of the same reading:
- `--scanners vuln` (previously documented) disables the secret scanning CI *does* run — both `[vuln]` and `[secret]` appear in the job log. Removed.
- The wrapper's `uv export` rewrote the tracked `uv.lock` as a side effect (reverting the version 2.4.1 → 2.4.0), leaving a dirty tree a contributor could sweep into an unrelated commit. Now passes `--frozen`: identical 1837-line output, tree stays clean.

## Observability (the issue's deferred paragraph, pulled in-scope)

A failing `Security Scan` used to print an exit code and no finding, because `format: 'sarif'` sends output to a file. Identifying #568 needed an out-of-band `gh api .../code-scanning/alerts` call. Added an `if: failure()` step that re-runs Trivy with `format: 'table'` and `exit-code: '0'`, so a red job names what failed it.

Deliberately: **no `severity:` key** on the new step (it would print a narrower set than the one that failed the build — possibly nothing, while the job is red, which is worse than silence because it looks authoritative), and the existing sarif step plus its `if: always()` upload are untouched, so the Security tab keeps working. Both steps pin the same action SHA. The DB cache is warm, so this adds no download.

## Rejected

- **`overrides` entry for `js-yaml`** — built it and measured the lockfile byte-identical, so it would be a permanent no-op.
- **`limit-severities-for-sarif: true`** to make the gate honour `CRITICAL,HIGH` — it would make the gate match the docs, but by *narrowing an existing security gate* and shrinking SARIF history. That's a policy change, not a patch.
- **`js-yaml@5.x`** — satisfies none of the five `^4.1.0` constraints. (The 5.x advisory, CVE-2026-59870, is MEDIUM and was never backported, which is why 3.x/4.x got a separate HIGH one.)

## Spec

`docs/issues/568-js-yaml-omap-dos/` — requirements (9 FR / 3 NFR, 22-row provenance table labelling every claim OBSERVED / measured / inferred), design (8 numbered corrections, 7 decisions), tasks (3, all complete). Follows the `docs/issues/<n>-<slug>/` convention from #345.

## Verification

| Check | Result |
|---|---|
| `js-yaml` nodes in docs lockfile | `1` × `4.3.1`, `resolved` + `integrity` match |
| Lockfile diff | `3 3`; `package.json` byte-identical |
| Five dependents | all still `^4.1.0` |
| `trivy fs .`, severity **unset** | **0 findings**, 10 targets |
| Docs build | `[SUCCESS] Generated static files` |
| `ci.yml` | parses; exactly 2 trivy steps, same SHA; order sarif → table → upload |
| `scripts/security-scan.sh trivy` | exit 0, tree clean |

Note: exposure here was narrow — the quadratic path needs an **explicit** `!!omap` tag (it's in js-yaml's `explicit:` schema list, not `implicit:`), and the repo contains zero such tags. Measured 32k tagged entries = 656 ms vs the same untagged = 49 ms. The gate being red is the real cost.

Dependabot never filed a PR for this and reports 0 open alerts for it; not chased here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)