### PR TITLE
fix(ci): gate docs site deploy off by default on forks

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,17 @@ name: Docs site
 # signal, and additionally deploys to GitHub Pages when the change lands on
 # main. The deploy job is gated on the event type so pull requests never
 # publish.
+#
+# The deploy job is ALSO gated so it never runs on a fork by default: forks
+# don't have GitHub Pages enabled (and publish to the fork owner's own Pages
+# site, not upstream's), so `actions/deploy-pages` 404s there
+# (see run 31220638813 / job 93004402444 on a fork of this repo). Deploys run
+# when either:
+#   - this is the upstream repo (`awslabs/cli-agent-orchestrator`), or
+#   - the repository variable `DEPLOY_DOCS_PAGES` is set to `true` — an
+#     explicit opt-in for a fork maintainer who has enabled GitHub Pages in
+#     their own fork's Settings > Pages. See docusaurus/README.md for the
+#     opt-in steps.
 on:
   push:
     branches:
@@ -47,16 +58,22 @@ jobs:
       - name: Build website
         run: cd docusaurus && npm run build
 
-      # Only needed by the deploy job, which does not run on pull requests.
+      # Only needed by the deploy job, which does not run on pull requests or
+      # (by default) on forks. Keep this condition in sync with the `deploy`
+      # job's `if:` below.
       - name: Upload artifact
-        if: github.event_name == 'push'
+        if: |
+          github.event_name == 'push' &&
+          (github.repository == 'awslabs/cli-agent-orchestrator' || vars.DEPLOY_DOCS_PAGES == 'true')
         uses: actions/upload-pages-artifact@v4
         with:
           path: docusaurus/build
 
   deploy:
     needs: build
-    if: github.event_name == 'push'
+    if: |
+      github.event_name == 'push' &&
+      (github.repository == 'awslabs/cli-agent-orchestrator' || vars.DEPLOY_DOCS_PAGES == 'true')
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -271,6 +271,16 @@ Each provider has a dedicated workflow that runs only when its files change:
 
 Each includes unit tests (Python 3.10/3.11/3.12) and code quality checks (black, isort, mypy).
 
+### Docs Site Workflow (`gh-pages.yml`)
+
+Builds the Docusaurus site (`docusaurus/`) on every PR and push to `main` for a
+build signal, but only **deploys** to GitHub Pages on the upstream repo
+(`awslabs/cli-agent-orchestrator`) by default — forks don't have Pages enabled,
+so `actions/deploy-pages` would otherwise fail with a 404. Fork maintainers can
+opt in by enabling GitHub Pages in their fork and setting the `DEPLOY_DOCS_PAGES`
+repository variable to `true`; see [docusaurus/README.md](docusaurus/README.md#deploying-on-a-fork)
+for the full steps.
+
 ## Working with Providers
 
 ### Test Against a Real Provider CLI

--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -29,6 +29,29 @@ This generates static content into the `build` directory.
 3. Run `npm run build` to verify there are no broken links
 4. Submit a PR — the site auto-deploys when changes merge to `main`
 
+## Deploying on a fork
+
+The `Docs site` workflow (`.github/workflows/gh-pages.yml`) always builds the
+site on pull requests and pushes to `main` so you get a build signal, but by
+default it only **deploys** to GitHub Pages on the upstream repo
+(`awslabs/cli-agent-orchestrator`). On a fork, the `deploy` job is skipped —
+this avoids the workflow failing with `Error: Failed to create deployment
+... 404` (`actions/deploy-pages` errors because GitHub Pages isn't enabled on
+most forks).
+
+If you maintain a fork and want it to publish its own docs site, opt in
+explicitly:
+
+1. In your fork, go to **Settings → Pages** and set **Source** to **GitHub
+   Actions**.
+2. Go to **Settings → Secrets and variables → Actions → Variables** and add a
+   repository variable named `DEPLOY_DOCS_PAGES` with the value `true`.
+3. Push to `main` (or re-run the workflow). The `deploy` job will now run and
+   publish to `https://<your-username>.github.io/cli-agent-orchestrator/`.
+
+Without both of these steps, leave `DEPLOY_DOCS_PAGES` unset (or `false`) so
+the deploy job stays disabled and the workflow doesn't fail on your fork.
+
 ## Directory Structure
 
 ```


### PR DESCRIPTION
## Problem

The `Docs site` workflow's `deploy` job (`actions/deploy-pages@v5`) fails on forks with:

```
Error: Creating Pages deployment failed
Error: HttpError: Not Found
...
Error: Failed to create deployment (status: 404) ... Ensure GitHub Pages has been enabled
```

See a real failing run on a fork: https://github.com/plauzy/cli-agent-orchestrator/actions/runs/31220638813/job/93004402444

The `deploy` job previously ran on every `push` to `main`, including on forks that haven't enabled GitHub Pages (most forks). `actions/deploy-pages` then 404s trying to create a deployment.

## Fix

Gate the `deploy` job (and the `upload-pages-artifact` step that feeds it) so it only runs when:

- the repository is the upstream `awslabs/cli-agent-orchestrator`, **or**
- a fork maintainer explicitly opts in via the repository variable `DEPLOY_DOCS_PAGES=true`, after enabling GitHub Pages in their own fork's Settings > Pages.

This keeps the `build` job (typecheck + build) running everywhere for PR build signal, while making the deploy step default-off and safe on forks.

## Docs

- `docusaurus/README.md`: new "Deploying on a fork" section with the exact opt-in steps (enable Pages source = GitHub Actions, set the `DEPLOY_DOCS_PAGES` repo variable).
- `DEVELOPMENT.md`: cross-referenced the new behavior under the CI/CD workflow overview.

## Verification

- Parsed the modified `gh-pages.yml` with a YAML loader (`yaml.safe_load`) — valid YAML; confirmed the `build` job has no top-level `if` (still runs everywhere) and that the `deploy` job's `if` is identical to the `upload artifact` step's `if`.
- Confirmed the gate expression is `github.event_name == 'push' && (github.repository == 'awslabs/cli-agent-orchestrator' || vars.DEPLOY_DOCS_PAGES == 'true')`.
- Ran `uv run python scripts/validate_markdown_links.py` — exit 0, no broken links for the new `DEVELOPMENT.md` → `docusaurus/README.md#deploying-on-a-fork` cross-reference (anchor slug matches the `## Deploying on a fork` heading).

## Notes

Rebased onto the latest `main` at the time of authoring (single commit on top of current upstream `main`). Originally staged as plauzy/cli-agent-orchestrator#35 against the fork.
