### PR TITLE
feat(api): add profile frontmatter validation and schema endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 # Testing
 .coverage
 coverage.json
+coverage.xml
 .pytest_cache/
 
 # MyPy

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,15 @@ See [AG-UI](agui.md) for enablement, event shapes, and privacy boundaries.
   a template's JSON-Schema without writing a profile.
 - `POST /agents/profiles/templates/preview` validates and renders a template to
   Markdown without writing a profile.
+- `POST /agents/profiles/validate` validates a finished profile's frontmatter
+  against the profile JSON-Schema plus CAO conventions, without writing
+  anything. This is the HTTP equivalent of `cao profile validate`, and is
+  distinct from `templates/validate`, which checks a template *config* against
+  that template's own schema. Findings are severity-tagged (`error` or
+  `warning`); only errors clear the `valid` flag, so warnings are advisory.
+- `GET /agents/profiles/schema` returns the agent profile JSON-Schema, so a
+  client can render create and edit forms from the server's definition instead
+  of duplicating the field list.
 - `POST /agents/profiles/install` installs a profile.
 - Template validation and preview require the selected template to include a
   `schema.json` file.

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -14,7 +14,7 @@ import termios
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Optional, Tuple, cast
+from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, cast
 
 from fastapi import (
     BackgroundTasks,
@@ -537,6 +537,39 @@ class PreviewTemplateResponse(BaseModel):
 
     template: str
     content: str
+
+
+class ProfileValidationRequest(BaseModel):
+    """Request body for the non-mutating profile validate route."""
+
+    content: str = Field(
+        max_length=262_144,
+        description="Full profile markdown, including YAML frontmatter",
+    )
+
+
+class ProfileValidationMessage(BaseModel):
+    """One validation finding.
+
+    ``path`` is the dotted frontmatter location for JSON-Schema errors and is
+    absent for convention checks that are not tied to a single key.
+    """
+
+    severity: Literal["error", "warning"]
+    message: str
+    path: Optional[str] = None
+
+
+class ProfileValidationResponse(BaseModel):
+    """Outcome of validating a profile's frontmatter.
+
+    ``valid`` is False only when at least one error-severity finding is
+    present. Warnings are advisory and do not invalidate a profile, so a
+    client should block a save on errors alone.
+    """
+
+    valid: bool
+    messages: List[ProfileValidationMessage] = Field(default_factory=list)
 
 
 class MemorySummary(BaseModel):
@@ -1701,6 +1734,51 @@ async def preview_profile_template_endpoint(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return PreviewTemplateResponse(template=request.template, content=content)
+
+
+@app.post("/agents/profiles/validate")
+async def validate_agent_profile_endpoint(
+    request: ProfileValidationRequest,
+) -> ProfileValidationResponse:
+    """Validate a profile's frontmatter against the profile schema. Writes nothing.
+
+    Distinct from ``/agents/profiles/templates/validate``, which checks a
+    *template config* against that template's own schema. This checks a
+    *finished profile* against ``agent_profile.schema.json`` plus CAO
+    conventions, and is the HTTP equivalent of ``cao profile validate``.
+
+    Deliberately NOT guarded by ``SCOPE_WRITE``, for the same reason as the
+    template validate route: this is a POST only because the profile content
+    travels in a JSON body rather than a query string, and it mutates no state.
+    """
+    from cli_agent_orchestrator.services.profile_validator import validate_profile_text
+
+    try:
+        findings = validate_profile_text(request.content)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return ProfileValidationResponse(
+        valid=not any(f.severity == "error" for f in findings),
+        messages=[
+            ProfileValidationMessage(severity=f.severity, message=f.message, path=f.path)
+            for f in findings
+        ],
+    )
+
+
+@app.get("/agents/profiles/schema")
+async def get_agent_profile_schema_endpoint() -> Dict:
+    """Return the agent profile JSON-Schema.
+
+    Lets a client render create and edit forms from the server's own schema
+    definition instead of duplicating the field list. Declared above
+    ``GET /agents/profiles/{name}`` because FastAPI matches in declaration
+    order, and the path parameter would otherwise capture "schema" as a name.
+    """
+    from cli_agent_orchestrator.services.profile_validator import load_profile_schema
+
+    return load_profile_schema()
 
 
 @app.get("/agents/profiles/{name}")

--- a/src/cli_agent_orchestrator/cli/commands/profile.py
+++ b/src/cli_agent_orchestrator/cli/commands/profile.py
@@ -10,34 +10,18 @@ from typing import Optional
 
 import click
 import frontmatter
-from jsonschema import Draft202012Validator
 
-from cli_agent_orchestrator.constants import LOCAL_AGENT_STORE_DIR, ROLE_TOOL_DEFAULTS
+from cli_agent_orchestrator.constants import LOCAL_AGENT_STORE_DIR
 from cli_agent_orchestrator.services.profile_store import (
     InvalidProfileNameError,
     ProfileNotFoundError,
     delete_profile,
     store_path,
 )
+from cli_agent_orchestrator.services.profile_validator import validate_frontmatter
 from cli_agent_orchestrator.utils.agent_profiles import (
     list_agent_profiles,
 )
-
-# Known deprecated frontmatter fields that should trigger warnings.
-_DEPRECATED_FIELDS = {"autoApproveTools"}
-
-# Derive valid tool vocabulary from constants (single source of truth).
-_VALID_TOOL_VOCAB: set[str] = set()
-for _tools in ROLE_TOOL_DEFAULTS.values():
-    _VALID_TOOL_VOCAB.update(_tools)
-
-
-def _load_schema() -> dict:
-    """Load the agent profile JSON-Schema from package resources."""
-    schema_path = (
-        Path(__file__).resolve().parent.parent.parent / "schemas" / "agent_profile.schema.json"
-    )
-    return json.loads(schema_path.read_text(encoding="utf-8"))
 
 
 def _resolve_profile_path(name_or_path: str) -> Optional[Path]:
@@ -92,49 +76,23 @@ def _read_profile_text(name_or_path: str) -> Optional[str]:
 
 
 def _validate_frontmatter(metadata: dict) -> list[str]:
-    """Validate frontmatter dict against schema and CAO conventions.
+    """Validate frontmatter and render the findings as display strings.
+
+    Thin adapter over :func:`profile_validator.validate_frontmatter`. The
+    service returns severity-tagged findings; this renders them in the
+    ``[error] path: message`` and ``[warn] message`` form that the CLI prints
+    and that ``validate_cmd``'s exit code keys off.
 
     Returns a list of error/warning messages (empty = valid).
     """
-    messages: list[str] = []
-
-    # 1. Check deprecated fields first (before schema rejects them via
-    #    additionalProperties:false, which gives a less helpful message).
-    for field in _DEPRECATED_FIELDS:
-        if field in metadata:
-            messages.append(
-                f"[warn] '{field}' is deprecated and rejected by CAO 2.2+. "
-                f"Use 'allowedTools' instead."
-            )
-
-    # 2. JSON-Schema structural validation
-    schema = _load_schema()
-    validator = Draft202012Validator(schema)
-    for error in sorted(validator.iter_errors(metadata), key=lambda e: list(e.path)):
-        path = ".".join(str(p) for p in error.absolute_path) or "(root)"
-        messages.append(f"[error] {path}: {error.message}")
-
-    # 3. allowedTools vocabulary check (advisory, not blocking)
-    allowed = metadata.get("allowedTools")
-    if allowed and isinstance(allowed, list):
-        for tool in allowed:
-            if tool not in _VALID_TOOL_VOCAB:
-                messages.append(
-                    f"[warn] allowedTools entry '{tool}' is not in CAO's recognized "
-                    f"vocabulary. It may be silently ignored by some providers."
-                )
-
-    # 4. Role check (advisory — custom roles are valid but worth flagging)
-    _BUILTIN_ROLES = set(ROLE_TOOL_DEFAULTS.keys())
-    role = metadata.get("role")
-    if role and role not in _BUILTIN_ROLES:
-        messages.append(
-            f"[warn] role '{role}' is not a built-in CAO role "
-            f"({', '.join(sorted(_BUILTIN_ROLES))}). "
-            f"Ensure it is defined in your settings.json custom roles."
-        )
-
-    return messages
+    rendered: list[str] = []
+    for finding in validate_frontmatter(metadata):
+        tag = "error" if finding.severity == "error" else "warn"
+        if finding.path is not None:
+            rendered.append(f"[{tag}] {finding.path}: {finding.message}")
+        else:
+            rendered.append(f"[{tag}] {finding.message}")
+    return rendered
 
 
 @click.group()

--- a/src/cli_agent_orchestrator/schemas/agent_profile.schema.json
+++ b/src/cli_agent_orchestrator/schemas/agent_profile.schema.json
@@ -96,6 +96,29 @@
       "type": "array",
       "items": {"type": "string"}
     },
+    "container": {
+      "type": "object",
+      "description": "CAO-native container settings. Consumed by the provider layer, not passed through to provider JSON.",
+      "properties": {
+        "path_maps": {
+          "type": "array",
+          "description": "Host-to-guest path translations for provider files used inside a container. CAO rewrites matching prefixes using the longest match; it does not create the container or its bind mounts.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {"type": "string", "minLength": 1},
+              "guest": {"type": "string", "minLength": 1}
+            },
+            "required": ["host", "guest"]
+          }
+        }
+      }
+    },
+    "provider_init_timeout": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Per-profile override, in seconds, for provider initialization. Replaces the server-wide provider_init_timeout as the hard outer cap for this profile."
+    },
     "prompt": {
       "type": "string"
     },

--- a/src/cli_agent_orchestrator/services/profile_validator.py
+++ b/src/cli_agent_orchestrator/services/profile_validator.py
@@ -1,0 +1,143 @@
+"""Profile frontmatter validation as a shared service.
+
+Validates a *finished agent profile's* frontmatter against
+``schemas/agent_profile.schema.json`` plus CAO conventions, so that
+``cao profile validate`` and the HTTP surface share one implementation.
+
+Distinct from :func:`agent_scaffold.validate_config`, which validates a
+*template config* (the answers fed to a Jinja2 template) against that
+template's own schema. This module validates a *profile* against the
+*profile* schema.
+
+Findings are returned severity-tagged rather than as pre-formatted strings, so
+that callers decide presentation: the CLI renders ``[error] …`` / ``[warn] …``
+lines, while the HTTP layer serialises them and lets a client block on errors
+without parsing text.
+
+Ref: https://github.com/awslabs/cli-agent-orchestrator/issues/510
+"""
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib.resources import files as _pkg_files
+from typing import Literal, Optional
+
+import frontmatter
+from jsonschema import Draft202012Validator
+
+from cli_agent_orchestrator.constants import ROLE_TOOL_DEFAULTS
+
+Severity = Literal["error", "warning"]
+
+# Known deprecated frontmatter fields that should trigger warnings.
+_DEPRECATED_FIELDS = {"autoApproveTools"}
+
+# Derive valid tool vocabulary from constants (single source of truth).
+_VALID_TOOL_VOCAB: set[str] = set()
+for _tools in ROLE_TOOL_DEFAULTS.values():
+    _VALID_TOOL_VOCAB.update(_tools)
+
+_BUILTIN_ROLES: set[str] = set(ROLE_TOOL_DEFAULTS.keys())
+
+
+@dataclass(frozen=True)
+class ValidationMessage:
+    """A single validation finding.
+
+    ``path`` is the dotted frontmatter location for JSON-Schema errors
+    (``"(root)"`` when the error is on the document itself), and ``None`` for
+    convention checks that are not tied to one key.
+    """
+
+    severity: Severity
+    message: str
+    path: Optional[str] = None
+
+
+@lru_cache(maxsize=1)
+def load_profile_schema() -> dict:
+    """Return the agent profile JSON-Schema.
+
+    Anchored through ``importlib.resources`` rather than a relative parent walk
+    so the lookup does not depend on this module's position in the package, and
+    resolves for both editable and wheel installs. Cached because the schema is
+    a packaged resource that cannot change at runtime and the HTTP validate
+    endpoint may be called repeatedly.
+
+    Callers must treat the returned dict as read-only; it is shared.
+    """
+    schema_path = _pkg_files("cli_agent_orchestrator") / "schemas" / "agent_profile.schema.json"
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def validate_frontmatter(metadata: dict) -> list[ValidationMessage]:
+    """Validate a frontmatter dict against the schema and CAO conventions.
+
+    Returns findings in a stable order: deprecated fields, then JSON-Schema
+    errors sorted by path, then ``allowedTools`` vocabulary warnings, then the
+    role check. An empty list means the profile is valid with no advisories.
+    """
+    messages: list[ValidationMessage] = []
+
+    # 1. Deprecated fields first, before ``additionalProperties: false``
+    #    rejects them with a less helpful message.
+    for field in sorted(_DEPRECATED_FIELDS):
+        if field in metadata:
+            messages.append(
+                ValidationMessage(
+                    "warning",
+                    f"'{field}' is deprecated and rejected by CAO 2.2+. "
+                    f"Use 'allowedTools' instead.",
+                )
+            )
+
+    # 2. JSON-Schema structural validation.
+    validator = Draft202012Validator(load_profile_schema())
+    for error in sorted(validator.iter_errors(metadata), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in error.absolute_path) or "(root)"
+        messages.append(ValidationMessage("error", error.message, path))
+
+    # 3. allowedTools vocabulary check (advisory, not blocking).
+    allowed = metadata.get("allowedTools")
+    if allowed and isinstance(allowed, list):
+        for tool in allowed:
+            if tool not in _VALID_TOOL_VOCAB:
+                messages.append(
+                    ValidationMessage(
+                        "warning",
+                        f"allowedTools entry '{tool}' is not in CAO's recognized "
+                        f"vocabulary. It may be silently ignored by some providers.",
+                    )
+                )
+
+    # 4. Role check (advisory — custom roles are valid but worth flagging).
+    role = metadata.get("role")
+    if role and role not in _BUILTIN_ROLES:
+        messages.append(
+            ValidationMessage(
+                "warning",
+                f"role '{role}' is not a built-in CAO role "
+                f"({', '.join(sorted(_BUILTIN_ROLES))}). "
+                f"Ensure it is defined in your settings.json custom roles.",
+            )
+        )
+
+    return messages
+
+
+def validate_profile_text(text: str) -> list[ValidationMessage]:
+    """Parse profile markdown and validate its frontmatter.
+
+    Convenience wrapper for callers holding a whole profile document rather
+    than a parsed metadata dict, so the frontmatter parse is not duplicated at
+    each call site.
+
+    Raises:
+        ValueError: ``text`` could not be parsed as frontmatter.
+    """
+    try:
+        post = frontmatter.loads(text)
+    except Exception as e:
+        raise ValueError(f"Error reading profile: {e}") from e
+    return validate_frontmatter(post.metadata)

--- a/test/api/test_api_profile_surface.py
+++ b/test/api/test_api_profile_surface.py
@@ -362,3 +362,115 @@ class TestPreviewProfileTemplateEndpoint:
 
         assert response.status_code == 422
         assert not mock_render.called
+
+
+_VALID_PROFILE = """---
+name: test-agent
+description: A test agent
+---
+
+You are a test agent.
+"""
+
+
+class TestValidateAgentProfileEndpoint:
+    """Tests for POST /agents/profiles/validate."""
+
+    def test_valid_profile_reports_valid_with_no_messages(self, client) -> None:
+        """A schema-clean profile with no advisories should come back empty."""
+        response = client.post("/agents/profiles/validate", json={"content": _VALID_PROFILE})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["valid"] is True
+        assert body["messages"] == []
+
+    def test_schema_violation_is_an_error_with_a_path(self, client) -> None:
+        """JSON-Schema failures must be error severity and carry the field path."""
+        content = "---\nname: test-agent\nengine: v3\n---\n\nBody.\n"
+        response = client.post("/agents/profiles/validate", json={"content": content})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["valid"] is False
+        errors = [m for m in body["messages"] if m["severity"] == "error"]
+        assert any(m["path"] == "engine" for m in errors)
+
+    def test_missing_required_name_is_an_error(self, client) -> None:
+        """``name`` is the only required field; omitting it must invalidate."""
+        content = "---\ndescription: no name here\n---\n\nBody.\n"
+        response = client.post("/agents/profiles/validate", json={"content": content})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["valid"] is False
+        assert any("name" in m["message"] for m in body["messages"])
+
+    def test_deprecated_field_yields_a_deprecation_warning(self, client) -> None:
+        """A deprecated key produces a warning and, separately, a schema error.
+
+        ``additionalProperties: false`` rejects the unknown key, so the profile
+        is not valid. The warning exists to explain *why* in useful terms rather
+        than leaving only the generic schema message.
+        """
+        content = "---\nname: test-agent\nautoApproveTools: true\n---\n\nBody.\n"
+        response = client.post("/agents/profiles/validate", json={"content": content})
+
+        assert response.status_code == 200
+        body = response.json()
+        warnings = [m for m in body["messages"] if m["severity"] == "warning"]
+        assert any("deprecated" in m["message"] for m in warnings)
+        assert body["valid"] is False
+
+    def test_non_builtin_role_warns_without_invalidating(self, client) -> None:
+        """Custom roles are legal but advisory-flagged, as in the CLI.
+
+        This is the property the UI relies on to decide whether to block a save:
+        a warning-only profile must still report ``valid: true``.
+        """
+        content = "---\nname: test-agent\nrole: not-a-real-role\n---\n\nBody.\n"
+        response = client.post("/agents/profiles/validate", json={"content": content})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["valid"] is True
+        warnings = [m for m in body["messages"] if m["severity"] == "warning"]
+        assert any("role" in m["message"] for m in warnings)
+
+    def test_oversized_content_is_rejected_by_the_model(self, client) -> None:
+        """The body is length-bounded so an unbounded parse cannot be forced."""
+        response = client.post(
+            "/agents/profiles/validate",
+            json={"content": "x" * 300_000},
+        )
+
+        assert response.status_code == 422
+
+
+class TestAgentProfileSchemaEndpoint:
+    """Tests for GET /agents/profiles/schema."""
+
+    def test_returns_the_profile_schema(self, client) -> None:
+        """The served document must be the profile schema itself."""
+        response = client.get("/agents/profiles/schema")
+
+        assert response.status_code == 200
+        schema = response.json()
+        assert schema["required"] == ["name"]
+        assert schema["additionalProperties"] is False
+        assert "engine" in schema["properties"]
+
+    def test_is_not_shadowed_by_the_name_route(self, client) -> None:
+        """Route ordering regression guard.
+
+        ``GET /agents/profiles/{name}`` is declared after this route. If the two
+        are ever reordered, FastAPI matches in declaration order and this path
+        would be captured as a profile literally named "schema", surfacing as a
+        404 from the profile lookup rather than the schema document.
+        """
+        with patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile") as mock_load:
+            response = client.get("/agents/profiles/schema")
+
+        assert response.status_code == 200
+        assert not mock_load.called
+        assert "properties" in response.json()

--- a/test/api/test_scope_coverage.py
+++ b/test/api/test_scope_coverage.py
@@ -27,10 +27,13 @@ _MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 # validates a spec file (read-only), mirroring a GET. ``/agents/profiles/templates/validate``
 # and ``/agents/profiles/templates/preview`` are POSTs for the same reason — their config
 # travels in a JSON body — and mutate nothing (schema check / template render).
+# ``/agents/profiles/validate`` is the same shape: the profile content travels in
+# a JSON body and is checked against the profile schema without being persisted.
 _EXEMPT = {
     ("POST", "/workflows/validate"),
     ("POST", "/agents/profiles/templates/validate"),
     ("POST", "/agents/profiles/templates/preview"),
+    ("POST", "/agents/profiles/validate"),
 }
 
 

--- a/test/services/test_profile_validator.py
+++ b/test/services/test_profile_validator.py
@@ -1,0 +1,280 @@
+"""Tests for profile frontmatter validation as a shared service.
+
+Covers the structured contract that both ``cao profile validate`` and
+``POST /agents/profiles/validate`` sit on top of. The CLI's rendered
+``[error]`` / ``[warn]`` string form is covered separately in
+``test/cli/test_profile_cmd.py``, which is deliberately left unchanged so it
+also serves as the no-behaviour-change guard for the extraction.
+
+Ref: https://github.com/awslabs/cli-agent-orchestrator/issues/510
+"""
+
+import pytest
+
+from cli_agent_orchestrator.models.agent_profile import AgentProfile
+from cli_agent_orchestrator.services.profile_validator import (
+    ValidationMessage,
+    load_profile_schema,
+    validate_frontmatter,
+    validate_profile_text,
+)
+
+
+class TestLoadProfileSchema:
+    """Tests for load_profile_schema."""
+
+    def test_returns_the_profile_schema(self) -> None:
+        """The packaged schema must resolve regardless of module position.
+
+        The loader is anchored via importlib.resources rather than a relative
+        parent walk, so this also guards against the module being moved.
+        """
+        schema = load_profile_schema()
+
+        assert schema["required"] == ["name"]
+        assert schema["additionalProperties"] is False
+        assert "engine" in schema["properties"]
+
+    def test_is_cached(self) -> None:
+        """Repeated calls must not re-read and re-parse the packaged file."""
+        assert load_profile_schema() is load_profile_schema()
+
+
+class TestValidateFrontmatter:
+    """Tests for validate_frontmatter."""
+
+    def test_valid_metadata_yields_no_findings(self) -> None:
+        assert validate_frontmatter({"name": "agent", "description": "d"}) == []
+
+    def test_missing_required_name_is_an_error(self) -> None:
+        findings = validate_frontmatter({"description": "no name"})
+
+        assert any(f.severity == "error" for f in findings)
+        assert any("name" in f.message for f in findings)
+
+    def test_schema_error_carries_the_field_path(self) -> None:
+        """Errors must be locatable, so the UI can point at the offending key."""
+        findings = validate_frontmatter({"name": "agent", "engine": "v3"})
+
+        errors = [f for f in findings if f.severity == "error"]
+        assert any(f.path == "engine" for f in errors)
+
+    def test_root_level_error_uses_the_root_sentinel(self) -> None:
+        """A document-level failure has no key, so path falls back to (root)."""
+        findings = validate_frontmatter({})
+
+        errors = [f for f in findings if f.severity == "error"]
+        assert errors
+        assert all(f.path is not None for f in errors)
+        assert any(f.path == "(root)" for f in errors)
+
+    def test_deprecated_field_yields_a_deprecation_warning(self) -> None:
+        """The deprecation notice itself is advisory and not tied to a key path.
+
+        Note this does not mean the profile is valid: ``additionalProperties:
+        false`` separately rejects the unknown key as an error. Filtering on the
+        field name alone would match both findings, so this narrows to the
+        deprecation notice.
+        """
+        findings = validate_frontmatter({"name": "agent", "autoApproveTools": True})
+
+        deprecated = [f for f in findings if "deprecated" in f.message]
+        assert deprecated
+        assert all(f.severity == "warning" for f in deprecated)
+        assert all(f.path is None for f in deprecated)
+
+    def test_deprecated_field_is_also_a_schema_error(self) -> None:
+        """Documents the double-report, which the ordering test then constrains.
+
+        ``additionalProperties: false`` is a document-level constraint, so the
+        error is reported at ``(root)`` and names the offending key in its
+        message rather than in its path. Keyed errors like a bad ``engine``
+        enum do carry the field path; the two shapes differ.
+        """
+        findings = validate_frontmatter({"name": "agent", "autoApproveTools": True})
+
+        errors = [f for f in findings if f.severity == "error"]
+        assert any(f.path == "(root)" and "autoApproveTools" in f.message for f in errors)
+
+    def test_deprecated_finding_precedes_the_schema_error(self) -> None:
+        """Ordering is load-bearing.
+
+        ``additionalProperties: false`` also rejects a deprecated key, but with a
+        less helpful message. The deprecation notice is emitted first so it is
+        the one a user reads.
+        """
+        findings = validate_frontmatter({"name": "agent", "autoApproveTools": True})
+
+        first_deprecated = next(i for i, f in enumerate(findings) if "deprecated" in f.message)
+        first_error = next(i for i, f in enumerate(findings) if f.severity == "error")
+        assert first_deprecated < first_error
+
+    def test_unrecognized_allowed_tool_warns(self) -> None:
+        findings = validate_frontmatter({"name": "agent", "allowedTools": ["shell:aws*"]})
+
+        warnings = [f for f in findings if f.severity == "warning"]
+        assert any("shell:aws*" in f.message for f in warnings)
+
+    def test_known_allowed_tool_does_not_warn(self) -> None:
+        """Guards against the vocabulary check firing on legitimate entries."""
+        findings = validate_frontmatter({"name": "agent", "allowedTools": ["fs_read"]})
+
+        assert not any("not in CAO's recognized" in f.message for f in findings)
+
+    def test_non_builtin_role_warns_but_stays_valid(self) -> None:
+        """Custom roles are legal; the warning exists only to catch typos."""
+        findings = validate_frontmatter({"name": "agent", "role": "not-a-real-role"})
+
+        assert not any(f.severity == "error" for f in findings)
+        assert any(f.severity == "warning" and "role" in f.message for f in findings)
+
+    def test_findings_are_validation_message_instances(self) -> None:
+        """The service must not leak the CLI's pre-formatted string shape."""
+        findings = validate_frontmatter({"name": "agent", "engine": "v3"})
+
+        assert all(isinstance(f, ValidationMessage) for f in findings)
+        assert all(not f.message.startswith("[") for f in findings)
+
+
+class TestValidateProfileText:
+    """Tests for validate_profile_text."""
+
+    def test_parses_frontmatter_and_delegates(self) -> None:
+        text = "---\nname: agent\ndescription: d\n---\n\nBody.\n"
+
+        assert validate_profile_text(text) == []
+
+    def test_surfaces_findings_from_the_parsed_frontmatter(self) -> None:
+        text = "---\nname: agent\nengine: v3\n---\n\nBody.\n"
+
+        findings = validate_profile_text(text)
+        assert any(f.severity == "error" and f.path == "engine" for f in findings)
+
+    def test_unparseable_frontmatter_raises_value_error(self) -> None:
+        """The HTTP layer maps this to 400, so the exception type is a contract.
+
+        A parse failure is distinct from a validation failure: there is nothing
+        to validate, so it cannot be reported as a finding.
+        """
+        text = "---\nname: [unclosed\n  bad: : yaml\n---\n\nBody.\n"
+
+        with pytest.raises(ValueError, match="Error reading profile"):
+            validate_profile_text(text)
+
+    def test_body_only_text_validates_as_empty_frontmatter(self) -> None:
+        """Markdown with no frontmatter block is empty metadata, not an error."""
+        findings = validate_profile_text("Just a body, no frontmatter.\n")
+
+        assert any(f.severity == "error" and "name" in f.message for f in findings)
+
+
+class TestCaoNativeFields:
+    """Tests for the CAO-native ``container`` and ``provider_init_timeout`` fields.
+
+    Both are documented in ``docs/agent-profile.md`` and read at runtime by
+    ``providers/base.py``, but were absent from the schema, so
+    ``additionalProperties: false`` rejected them as unknown keys. A profile
+    following the documented format therefore failed its own validator.
+    """
+
+    def test_documented_container_and_timeout_example_is_valid(self) -> None:
+        """The worked example from docs/agent-profile.md must validate cleanly.
+
+        This is the regression guard: the schema and the documented profile
+        format have to agree, or the validator rejects profiles CAO itself
+        tells users to write.
+        """
+        metadata = {
+            "name": "containerized-agent",
+            "container": {
+                "path_maps": [
+                    {
+                        "host": "/home/user/.aws/cli-agent-orchestrator/tmp",
+                        "guest": "/workspace/cao-tmp",
+                    }
+                ]
+            },
+            "provider_init_timeout": 180,
+        }
+
+        assert validate_frontmatter(metadata) == []
+
+    def test_path_map_requires_both_host_and_guest(self) -> None:
+        """A half-specified mapping cannot be applied, so it is an error."""
+        metadata = {"name": "agent", "container": {"path_maps": [{"host": "/a"}]}}
+
+        findings = validate_frontmatter(metadata)
+        assert any(f.severity == "error" and "guest" in f.message for f in findings)
+
+    def test_nested_error_path_is_dotted_and_indexed(self) -> None:
+        """Clients render errors against fields, so nested paths must be precise.
+
+        A bare ``container`` path would be useless for a form with one input per
+        mapping; the index identifies which row is wrong.
+        """
+        metadata = {
+            "name": "agent",
+            "container": {"path_maps": [{"host": "", "guest": "/g"}]},
+        }
+
+        findings = validate_frontmatter(metadata)
+        assert any(f.path == "container.path_maps.0.host" for f in findings)
+
+    def test_provider_init_timeout_must_be_an_integer(self) -> None:
+        """YAML quoting mistakes are the common failure here."""
+        findings = validate_frontmatter({"name": "agent", "provider_init_timeout": "180"})
+
+        assert any(f.severity == "error" and f.path == "provider_init_timeout" for f in findings)
+
+    def test_provider_init_timeout_rejects_non_positive(self) -> None:
+        """The value is used directly as a timeout, so 0 means instant failure.
+
+        ``providers/base.py`` returns this verbatim in place of the server
+        default rather than treating a falsy value as "unset" or "no limit".
+        """
+        findings = validate_frontmatter({"name": "agent", "provider_init_timeout": 0})
+
+        assert any(f.severity == "error" and f.path == "provider_init_timeout" for f in findings)
+
+    def test_unknown_top_level_key_is_still_rejected(self) -> None:
+        """Widening the schema must not weaken typo detection."""
+        findings = validate_frontmatter({"name": "agent", "provider_init_timeoutt": 180})
+
+        assert any(f.severity == "error" for f in findings)
+
+
+class TestSchemaModelParity:
+    """Guards the schema against the AgentProfile model drifting away from it.
+
+    ``GET /agents/profiles/schema`` invites clients to build create and edit
+    forms from the served schema. A field the model accepts but the schema
+    omits is therefore invisible to those clients *and* rejected by the
+    validator, which is how ``container`` and ``provider_init_timeout`` came to
+    be documented, functional, and unvalidatable at the same time.
+    """
+
+    # Model fields that are deliberately not frontmatter keys.
+    #
+    # ``system_prompt`` is assigned from the Markdown body rather than read
+    # from frontmatter (see ``parse_agent_profile_text``), so it must not
+    # appear in a schema that validates the frontmatter block.
+    _NOT_FRONTMATTER = {"system_prompt"}
+
+    def test_every_model_field_is_a_schema_property(self) -> None:
+        expected = set(AgentProfile.model_fields) - self._NOT_FRONTMATTER
+        missing = expected - set(load_profile_schema()["properties"])
+
+        assert not missing, (
+            f"AgentProfile accepts {sorted(missing)} but the schema omits them, so "
+            "additionalProperties:false will reject valid profiles and "
+            "schema-driven forms will not offer the fields."
+        )
+
+    def test_every_schema_property_is_a_model_field(self) -> None:
+        """The reverse direction: the schema must not advertise dead fields."""
+        extra = set(load_profile_schema()["properties"]) - set(AgentProfile.model_fields)
+
+        assert not extra, (
+            f"The schema declares {sorted(extra)} but AgentProfile has no such "
+            "field, so a client filling them in would have them silently dropped."
+        )


### PR DESCRIPTION
## What

Phase A of the profile management surface in #510: the validation half of the
HTTP API, plus the shared service behind it.

Two non-mutating routes:

```
POST /agents/profiles/validate    validate a profile document
GET  /agents/profiles/schema      serve the agent profile JSON-Schema
```

No write endpoints, no CLI verbs, no UI. Those are PR B and PR C.

## Why

`cao profile validate` checks a finished profile's frontmatter against
`agent_profile.schema.json` plus a few CAO conventions. There is no HTTP
equivalent, so a browser or TUI client cannot answer "is this profile valid"
without reimplementing the rules.

This is easy to confuse with something that already shipped, so to be explicit
about the two:

| Operation | Validates | Against | Exists? |
|---|---|---|---|
| `POST /agents/profiles/templates/validate` | a template **config** (Jinja2 answers) | that template's own schema | yes, #523 |
| `POST /agents/profiles/validate` | a finished **profile**'s frontmatter | the profile schema | this PR |

The validator itself already existed, as `_validate_frontmatter` at
`cli/commands/profile.py:94`, private to the CLI. PR B's `POST` and `PUT` need to
run the same rules server-side before persisting, and PR C needs them for inline
feedback. Three copies of the vocabulary and role checks is the outcome to avoid.

## What changed

**New `services/profile_validator.py`** (143 lines) owns the rules:

- `validate_frontmatter(metadata) -> list[ValidationMessage]` — the four existing
  checks, in the existing order
- `validate_profile_text(text) -> list[ValidationMessage]` — parses frontmatter,
  then delegates; raises `ValueError` on unparseable YAML
- `load_profile_schema() -> dict` — cached schema load

`ValidationMessage` is a frozen dataclass carrying `severity` (`"error"` or
`"warning"`), `message`, and `path`, where `path` is the dotted frontmatter
location for schema errors and `None` for conventions not tied to one key.

That structure is the point of the PR. The CLI's existing return type is a flat
`list[str]` with display tags baked in:

```python
messages.append(f"[warn] '{field}' is deprecated and rejected by CAO 2.2+. ...")
messages.append(f"[error] {path}: {error.message}")
```

and the CLI decides its exit code by string matching:

```python
if any(msg.startswith("[error]") for msg in messages):
```

That is a display format, not an API contract. Returning it over HTTP would make
a client call `startsWith("[error]")` to decide whether to block a save, which is
the same class of internal-shape leak that `TemplateSummary` was introduced to
close on #523.

**Two routes in `api/main.py`**, with three response models. `validate` maps
`ValueError` to 400, and sets `valid` to `false` only when at least one
error-severity finding is present, so a client blocks on errors alone without
counting severities itself.

**Schema loading moves to `importlib.resources`.** The old
`Path(__file__).resolve().parent.parent.parent / "schemas"` resolved correctly
from `cli/commands/` but overshoots from `services/`. The same anchoring is
already used for `WEB_DIST` in `api/main.py`. The loader is `lru_cache`d because
the endpoint can be hit on a debounced keystroke and the schema is a packaged
resource that cannot change at runtime.

**Also fixes a pre-existing schema gap**, described in its own section below,
because the new `/schema` route would otherwise publish it.

## On keeping `_validate_frontmatter` in the CLI

`_validate_frontmatter` does not move. It stays in `cli/commands/profile.py` as a
thin shim that calls the service and renders the same `[error] path: message` and
`[warn] message` strings.

That is deliberate. Twelve existing test functions depend on the rendered form,
either calling the function directly or asserting on the tags:

- `test/cli/test_profile_cmd.py` — 10 (`test_valid_profile`,
  `test_invalid_kiro_engine`, `test_missing_name`, `test_deprecated_field`,
  `test_invalid_role`, `test_unrecognized_tool`, and four more)
- `test/services/test_profile_search.py` — 2 (`test_capabilities_and_tags_valid`,
  `test_bad_tag_pattern_rejected`)

Keeping the shim means **both files are untouched by this PR**, so they act as
the no-behaviour-change guard for the extraction rather than being edited to
match it. `git status` on `test/cli/` and `test/services/test_profile_search.py`
is empty, and all of it still passes.

`validate_cmd` is also untouched: it still does its own `frontmatter.loads` and
raises its own `ClickException`, so the CLI's error path is provably unchanged.
`validate_profile_text` exists purely for the endpoint.

## Route ordering and scope

`GET /agents/profiles/schema` is declared **above** `GET /agents/profiles/{name}`
because FastAPI matches in declaration order and the path parameter would
otherwise capture `"schema"` as a profile name. There's a test that patches
`load_agent_profile` and asserts it is never called, so a future reordering fails
loudly instead of returning a confusing 404.

`POST /agents/profiles/validate` is added to `_EXEMPT` in
`test/api/test_scope_coverage.py`, for the same reason as
`/agents/profiles/templates/validate`: it is a POST only because the document
travels in a request body, and it persists nothing.

Only the POST needs the exemption. `_mutating_routes()` skips any route whose
methods do not intersect `{POST, PUT, PATCH, DELETE}`, so the GET is never
inspected.

## The schema fix

`agent_profile.schema.json` omitted two fields that `AgentProfile` accepts:

```
model fields: 26  |  schema properties: 23
in model, not in schema -> ['container', 'provider_init_timeout', 'system_prompt']
in schema, not in model -> []
```

`container` and `provider_init_timeout` are both documented in
`docs/agent-profile.md` (optional fields list, plus a worked YAML example) and
both are read at runtime by `providers/base.py`: `profile.provider_init_timeout`
for the per-profile init cap, `profile.container.path_maps` for host-to-guest
path translation.

Combined with `additionalProperties: false`, that means `cao profile validate`
rejected a profile written to CAO's own documented format. Same document, before
and after:

```
main (c7aff4b)  props=23  -> 1 ERROR
                (root): Additional properties are not allowed
                        ('container', 'provider_init_timeout' were unexpected)
this branch     props=25  -> VALID
```

`system_prompt` is correctly absent: `parse_agent_profile_text` assigns it from
the Markdown body, so it is not a frontmatter key.

**The addition is purely additive**, 23 insertions and 0 deletions. `required`,
`additionalProperties`, and all 23 pre-existing property definitions are
byte-identical. Before the change, *any* value of these two keys was rejected as
unknown; after, well-formed values are accepted and malformed ones are still
rejected. No previously-valid profile becomes invalid.

**A parity test now guards the class of bug, not just this instance.**
`TestSchemaModelParity` asserts in both directions that the schema's properties
and `AgentProfile`'s fields agree, with a documented exemption set containing
only `system_prompt`. This is the same shape as `_EXEMPT` in
`test_scope_coverage.py`, and it would have caught the original omission.

## Behaviour changes, disclosed

**1. `provider_init_timeout: 0` and a `container` with a malformed `path_maps`
now produce different error text.** Both were already rejected, as unknown keys.
They are still rejected, now with a message naming the actual problem and a path
a form can render against, for example
`container.path_maps.0.host: '' should be non-empty`. Verdict unchanged in every
case; only the diagnosis improved.

**2. `POST /agents/profiles/validate` bounds `content` at 256 KB** via a Pydantic
`max_length`. Generous for a profile, but the route has no scope guard, so an
unbounded YAML parse seemed worth avoiding. Happy to drop the cap if you'd
rather not encode a limit here.

**3. The deprecated-field loop is now `sorted()`.** A no-op today, since
`_DEPRECATED_FIELDS` has one element. It makes message order deterministic if
that set grows.

## Known gaps, disclosed

**The parity test checks field presence, not constraint agreement.** I added
`minimum: 1` on `provider_init_timeout` and `minLength: 1` on the path-map
strings; the model is `Optional[int]` and plain `str`, so the schema is stricter
than the model on those. That matches what this schema already does elsewhere
(`description.maxLength`, `capabilities.maxItems`, `tags.items.pattern`,
`codexProfile.minLength`), and `minimum: 1` is semantically right because
`providers/base.py` returns the value verbatim as a timeout, so `0` means instant
failure rather than "no limit". But the guard would not catch a future constraint
that contradicts the model.

**Three fields are still untyped objects.** `toolsSettings`, `codexConfig`, and
`hooks` are declared as bare `{"type": "object"}` with no properties, so a
schema-driven form cannot render them as fields. This is why PR C plans validated
JSON editors for the object-valued fields rather than generated widgets. Field
*presence* is now complete; field *shape* is not.

**Extra keys inside a `path_maps` entry are accepted.** `{host, guest, mode: ro}`
validates clean and `mode` does nothing. I matched `mcpServers`, the only
existing nested-object precedent in this schema, which is also permissive.
Tightening it would also be stricter than Pydantic, which ignores extras.

## Explicitly out of scope

- **Write endpoints.** `POST` / `PUT` / `DELETE /agents/profiles` are PR B, with
  real `SCOPE_WRITE` / `SCOPE_ADMIN` guards rather than an exemption.
- **An unresolved authoring read.** `GET /agents/profiles/{name}` returns a
  profile after `resolve_env_vars`, which is correct for running an agent and
  wrong for editing one. That needs its own source-fidelity response, and it
  belongs with the write endpoints that would consume it. PR B.
- **Markdown body round-trip.** The body is the system prompt. This PR validates
  frontmatter only, which is what the schema describes.
- **The remaining untyped object fields**, per the gaps section.
- **UI.** PR C.

## Testing

Full suite: **6,324 passed**, 39 skipped, 111 deselected, 1 xfailed.

My local environment also has 62 failures, all confined to
`test/api/test_agui_*`, `test/services/agui/`,
`test/telemetry/test_otel_init.py`, and `test/test_no_ffi_guard.py`. I measured
the same count and the same per-file distribution on `c7aff4b` with this
branch's changes absent, and none of those modules import profile code. Flagging
rather than omitting, since I can't confirm how they behave in CI.

Counts from `pytest --collect-only`, not inspection:

- `test/services/test_profile_validator.py` — **25 new**: schema resolution and
  caching, the four checks with their severities and paths, finding order,
  `additionalProperties` errors reported at root versus keyed errors reported at
  the key, the `ValueError` path, body-only text, the two CAO-native fields
  including the documented worked example, and the two parity assertions.
- `test/api/test_api_profile_surface.py` — 24 to **32**: the valid case, a keyed
  schema error, missing `name`, the deprecation warning, the warning-only case
  asserting `valid` stays `true`, the size cap, the schema payload, and a
  route-shadowing regression guard.
- `test/cli/test_profile_cmd.py` — 43, **unchanged**.

**33 net new tests.**

`black --check src/ test/` and `isort --check-only` clean across 536 files.
`mypy` reports the same errors as `main` on the touched files, no new ones.

End to end against a running `cao-server`, not only through the test client. I
generated 11 fixture profiles covering the whole surface, declared the outcome
each one should produce, and checked the CLI and both routes against that
declaration. All 23 checks matched:

```
case                             expected  actual
valid-minimal                    valid     valid
valid-cao-native-fields          valid     valid     <- rejected on main
warn-custom-role                 warning   warning
warn-unknown-allowed-tool        warning   warning
invalid-missing-name             invalid   invalid
invalid-engine-value             invalid   invalid
invalid-deprecated-field         invalid   invalid
invalid-timeout-type             invalid   invalid
invalid-timeout-zero             invalid   invalid
invalid-path-map-missing-guest   invalid   invalid
invalid-unknown-key              invalid   invalid

GET  /agents/profiles/schema     25 properties, both new fields present
POST /agents/profiles/validate   valid flag agreed with the CLI on all 11,
                                 and the two warning-only cases returned
                                 valid=true with warnings attached
```

The last line is the contract PR C depends on: a warning never clears `valid`.

## What comes next

- **PR B**: `POST` / `PUT` / `DELETE /agents/profiles` with real scope guards,
  an update-only persistence path so `PUT` cannot create a shadow of a built-in,
  a source-fidelity read for authoring, and server-side validation on every write
  using this service.
- **PR C**: the `Profiles` panel and nav tab, with inline validation through this
  endpoint and a from-scratch form driven by `/schema`.

Ref #510. Builds on #523 (read surface) and #543 (`profile_store`). The shared
validator is also what makes "invoke the same shared validator on the exact
submitted document before persistence" possible in PR B, per @haofeif's review
notes on #510; the schema reconciliation there is partly addressed here and
partly still open, as described under Known gaps.