### PR TITLE
fix(security): bump nanoid to 3.3.18 (CVE-2026-67213)

### DIFF
--- a/cao_mcp_apps/package-lock.json
+++ b/cao_mcp_apps/package-lock.json
@@ -1942,9 +1942,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/cao_mcp_apps/package.json
+++ b/cao_mcp_apps/package.json
@@ -56,5 +56,8 @@
     "vite": "^8.1.0",
     "vite-plugin-singlefile": "^2.1.0",
     "vitest": "^4.1.9"
+  },
+  "overrides": {
+    "nanoid": "^3.3.17"
   }
 }

--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -14061,9 +14061,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -52,6 +52,7 @@
   "overrides": {
     "brace-expansion": "^5.0.9",
     "fast-uri": "^3.1.5",
+    "nanoid": "^3.3.17",
     "postcss": "^8.5.23",
     "serialize-javascript": "^7.0.7",
     "uuid": "^11.1.1"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -34,5 +34,8 @@
     "typescript": "^5.0.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.0"
+  },
+  "overrides": {
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
> **This PR fixes a net-new, freshly-disclosed security vulnerability.**
> [CVE-2026-67213](https://nvd.nist.gov/vuln/detail/CVE-2026-67213) (HIGH) was **published 2026-07-29** — it is not a regression and not a long-standing known issue. Trivy's vulnerability DB began flagging it within the last day, which is why CI **Security Scan** started failing across `main` and every open PR at the same time.

## Problem

CVE-2026-67213 (HIGH) is a newly-published advisory: an infinite-loop / denial-of-service in `nanoid`'s `customAlphabet`/`customRandom` when called with `size = 0`, affecting `nanoid < 3.3.17` (fixed in 3.3.17 / 5.1.6). CI **Security Scan** (`trivy fs .`, `.github/workflows/ci.yml`) fails on `main` and every open PR — e.g. the post-merge `main` run for #574: https://github.com/awslabs/cli-agent-orchestrator/actions/runs/31296542115/job/93202432523

The affected version (`nanoid 3.3.16`) was already present transitively; **no code change introduced it** — this is a fresh CVE that the scanner only just started catching, not something a recent commit broke.

## Fix — pin at the root in `package.json`, not just the lockfile

A lockfile-only bump is **not durable**: regenerating `package-lock.json` would reintroduce the vulnerable version. Instead, pin nanoid to the fixed line via an npm **`overrides`** entry (`"nanoid": "^3.3.17"`) in `package.json` — matching the existing `overrides` style already used in `docusaurus/package.json` — for every project that resolves nanoid transitively:

| Project | How nanoid is pulled in | Trivy status |
|---|---|---|
| `docusaurus` | prod: `@docusaurus/core → postcss` | flagged |
| `cao_mcp_apps` | dev: `vite → postcss` | suppressed (dev-deps), same bad version |
| `web` | dev: `vite → postcss` | suppressed (dev-deps), same bad version |

All three lockfiles now resolve `nanoid 3.3.18`.

## Why this is durable

With the override in `package.json`, `package-lock.json` can no longer carry the vulnerable version:

- `npm install` regenerates the lockfile to a safe version — verified: a lockfile hand-edited back to `3.3.16` is rewritten to `3.3.18`.
- `npm ci` (used in CI) **rejects** any lockfile that violates the override: `Invalid: lock file's nanoid@3.3.16 does not satisfy nanoid@3.3.18` — a bad recommit fails CI instead of silently shipping.
- Trivy Security Scan would also catch a regression (defense in depth).

## Verification

- `trivy fs . --scanners vuln --ignore-unfixed` → **0 findings** (and **0 nanoid** even with `--include-dev-deps`).
- `npm run typecheck` + build pass for `docusaurus`, `web`, and `cao_mcp_apps`.

## Scope / impact

This is a security-only change (dependency pins in `package.json` + regenerated lockfiles); no product code changes. The exploit requires an attacker-controlled `size = 0` passed to `customAlphabet`/`customRandom`, which these projects don't do — but it is a **newly-disclosed HIGH CVE** and a **required CI gate now red on `main` and every open PR**, so it should land promptly to unblock the repo and keep the vulnerable version from returning.
