### PR TITLE
feat(mcp): add app-surface-only mode

### DIFF
--- a/docs/mcp-apps.md
+++ b/docs/mcp-apps.md
@@ -40,6 +40,27 @@ uv run cao-server                  # FastAPI + /events on :9889
 uv run cao-mcp-server              # registers the MCP App tools/resources
 ```
 
+For a graph-only external host such as KiroCrew, the minimum environment is:
+
+```bash
+export CAO_MCP_APPS_ENABLED=true
+export CAO_MCP_APPS_ONLY=true
+uv run cao-server
+uv run cao-mcp-server
+```
+
+`CAO_MCP_APPS_ONLY` exposes only `render_dashboard`, `render_agent_view`,
+`cao_fetch_history`, `subscribe_events`, `render_graph_view`, and
+`submit_command`. It hides in-session tools such as `handoff`, `assign`, and
+`send_message`, which require a CAO-managed terminal. This behavior is explicit;
+it is never inferred from a missing `CAO_TERMINAL_ID`, so a misconfigured CAO
+session does not silently lose tools. The flag requires
+`CAO_MCP_APPS_ENABLED=true`.
+
+`CAO_AGUI_ENABLED` is not required for this integration. KiroCrew consumes the
+MCP Apps tools and `ui://cao/*` resources and has no AG-UI consumer, so enabling
+AG-UI would mount a surface that nothing reads.
+
 The surface is packaged as the built-in **`mcp_apps` plugin** (discovered via the
 `cao.plugins` entry-point group). On MCP server startup the plugin's
 `on_mcp_server` hook registers the tools, the `ui://cao/*` resources, the topology
@@ -148,12 +169,29 @@ pull-model equivalent.
   surface (including `submit_command` mutations) inherits CAO's unauthenticated,
   localhost-only trust model — keep it on a trusted loopback host and configure an
   IdP before exposing it more widely; the server logs a startup warning in this state.
+- **External app credentials stay server-side.** The MCP server process holds the
+  credential used for authenticated HTTP calls. It must never appear in a
+  `ui://` payload, tool arguments, or tool result text. A `ui://` resource is
+  server-supplied HTML rendered in a null-origin sandboxed iframe with no
+  storage, and the host gateway spools that payload to a file on disk; embedding
+  a token therefore exposes it in both the spool file and frame source. Tool
+  results are also persisted in the conversation transcript.
+- **Use the correct authentication transport.** `/agui/v1/stream` accepts
+  `?access_token=<JWT>` only because native `EventSource` cannot set request
+  headers. The graph route is ordinary HTTP and must receive the token in an
+  `Authorization` header; URL tokens are substantially more likely to enter
+  access logs and other telemetry.
+- **Fail visibly.** Insufficient graph scope must return a distinguishable error,
+  not a blank graph. For initial bring-up, the documented default is auth
+  disabled on localhost; configure an IdP and server-held credential before
+  exposing the service beyond trusted loopback.
 
 ## Configuration
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `CAO_MCP_APPS_ENABLED` | `false` | Master switch for the entire surface. |
+| `CAO_MCP_APPS_ONLY` | `false` | Expose only the six MCP Apps tools; requires `CAO_MCP_APPS_ENABLED=true`. |
 | `CAO_MCP_APPS_STATIC_DIR` | — | Override the built `apps_static/` location. |
 | `AUTH0_DOMAIN` / `CAO_AUTH_JWKS_URI` | — | Enable the auth layer (IdP). |
 | `CAO_AUTH_AUDIENCE`, `CAO_AUTH_ISSUER` | — | Token audience / issuer for validation + PRM. |

--- a/src/cli_agent_orchestrator/mcp_server/app_surface_only.py
+++ b/src/cli_agent_orchestrator/mcp_server/app_surface_only.py
@@ -1,0 +1,44 @@
+"""FastMCP middleware for exposing only the MCP Apps tool surface."""
+
+from typing import Sequence
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import Tool, ToolResult
+from mcp import types as mt
+
+APP_SURFACE_TOOL_NAMES = frozenset(
+    {
+        "render_dashboard",
+        "render_agent_view",
+        "cao_fetch_history",
+        "subscribe_events",
+        "render_graph_view",
+        "submit_command",
+    }
+)
+
+
+class AppSurfaceOnlyMiddleware(Middleware):
+    """Hide and reject tools that are not part of the MCP Apps surface."""
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        return [tool for tool in tools if tool.name in APP_SURFACE_TOOL_NAMES]
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        tool_name = context.message.name
+        if tool_name not in APP_SURFACE_TOOL_NAMES:
+            raise ToolError(
+                f"Tool '{tool_name}' is unavailable because the server is in "
+                "app-surface-only mode (CAO_MCP_APPS_ONLY=true)."
+            )
+        return await call_next(context)

--- a/src/cli_agent_orchestrator/plugins/builtin/mcp_apps.py
+++ b/src/cli_agent_orchestrator/plugins/builtin/mcp_apps.py
@@ -38,6 +38,12 @@ def _surface_enabled() -> bool:
     return bool(ConfigService.get("apps.enabled", default=False))
 
 
+def _app_surface_only() -> bool:
+    """Return whether non-app MCP tools should be hidden."""
+
+    return bool(ConfigService.get("apps.only", default=False))
+
+
 class McpAppsPlugin(CaoPlugin):
     """Registers the CAO MCP Apps surface on the FastMCP server at startup."""
 
@@ -74,3 +80,24 @@ class McpAppsPlugin(CaoPlugin):
         register_app_tools(mcp)
         register_widget(mcp)
         advertise_capability(mcp)
+
+        if _app_surface_only():
+            if not _surface_enabled():
+                logger.warning(
+                    "CAO_MCP_APPS_ONLY is set but CAO_MCP_APPS_ENABLED is false; "
+                    "not installing app-surface-only middleware because it would "
+                    "hide every MCP tool."
+                )
+                return
+
+            try:
+                from cli_agent_orchestrator.mcp_server.app_surface_only import (
+                    AppSurfaceOnlyMiddleware,
+                )
+
+                mcp.add_middleware(AppSurfaceOnlyMiddleware())
+            except Exception:
+                logger.exception(
+                    "Failed to install app-surface-only middleware; "
+                    "continuing with the full MCP tool surface"
+                )

--- a/src/cli_agent_orchestrator/services/config_service.py
+++ b/src/cli_agent_orchestrator/services/config_service.py
@@ -75,6 +75,7 @@ class TerminalConfig(BaseModel):
 
 class AppsConfig(BaseModel):
     enabled: bool = False
+    only: bool = False
     static_dir: Optional[str] = None
 
 
@@ -153,6 +154,7 @@ _OWNED_DEFAULTS: Dict[str, Any] = {
     "terminal.backend": "tmux",
     "terminal.herdr_session": "cao",
     "apps.enabled": False,
+    "apps.only": False,
     "apps.static_dir": None,
     "auth.jwks_uri": "",
     "auth.audience": "",
@@ -172,6 +174,7 @@ ENV_REGISTRY: Dict[str, Tuple[str, str, Any]] = {
     "CAO_TERMINAL_BACKEND": ("terminal.backend", "str", "tmux"),
     "CAO_HERDR_SESSION": ("terminal.herdr_session", "str", "cao"),
     "CAO_MCP_APPS_ENABLED": ("apps.enabled", "bool", False),
+    "CAO_MCP_APPS_ONLY": ("apps.only", "bool", False),
     "CAO_MCP_APPS_STATIC_DIR": ("apps.static_dir", "str", None),
     "CAO_AUTH_JWKS_URI": ("auth.jwks_uri", "str", ""),
     "CAO_AUTH_AUDIENCE": ("auth.audience", "str", ""),
@@ -530,6 +533,7 @@ class ConfigService:
             ),
             apps=AppsConfig(
                 enabled=_get_value("apps.enabled", default=False),
+                only=_get_value("apps.only", default=False),
                 static_dir=_get_value("apps.static_dir", default=None),
             ),
             network=NetworkConfig(

--- a/test/mcp_server/test_app_surface_only.py
+++ b/test/mcp_server/test_app_surface_only.py
@@ -1,0 +1,116 @@
+"""Tests for the app-surface-only FastMCP middleware."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+
+from cli_agent_orchestrator.ext_apps.apps import _RESOURCE_FILES
+from cli_agent_orchestrator.mcp_server.app_surface_only import (
+    APP_SURFACE_TOOL_NAMES,
+    AppSurfaceOnlyMiddleware,
+)
+from cli_agent_orchestrator.mcp_server.app_tools import register_app_tools
+
+
+def _server_with_tools(*, app_surface_only: bool, app_tools_are_stubs: bool = True) -> FastMCP:
+    mcp = FastMCP("app-surface-only-test")
+
+    names = {"handoff", "assign", "send_message", "unrelated_tool"}
+    if app_tools_are_stubs:
+        names |= APP_SURFACE_TOOL_NAMES
+
+    for name in names:
+
+        async def tool_stub() -> str:
+            return "tool result"
+
+        mcp.tool(name=name)(tool_stub)
+
+    if not app_tools_are_stubs:
+        register_app_tools(mcp)
+    if app_surface_only:
+        mcp.add_middleware(AppSurfaceOnlyMiddleware())
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_tools_list_contains_only_app_surface_tools_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    mcp = _server_with_tools(app_surface_only=True)
+
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    names = {tool.name for tool in tools}
+    assert names == APP_SURFACE_TOOL_NAMES
+    assert {"handoff", "assign", "send_message"}.isdisjoint(names)
+
+
+@pytest.mark.asyncio
+async def test_tools_list_is_unchanged_when_mode_is_off(monkeypatch) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    baseline = _server_with_tools(app_surface_only=False)
+    mode_off = _server_with_tools(app_surface_only=False)
+
+    async with Client(baseline) as client:
+        baseline_names = {tool.name for tool in await client.list_tools()}
+    async with Client(mode_off) as client:
+        mode_off_names = {tool.name for tool in await client.list_tools()}
+
+    assert mode_off_names == baseline_names
+    assert mode_off_names == APP_SURFACE_TOOL_NAMES | {
+        "handoff",
+        "assign",
+        "send_message",
+        "unrelated_tool",
+    }
+
+
+@pytest.mark.asyncio
+async def test_resources_and_graph_tool_register_in_both_modes(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    monkeypatch.setenv("CAO_MCP_APPS_STATIC_DIR", str(tmp_path))
+    for filename in _RESOURCE_FILES.values():
+        (tmp_path / filename).write_text("<html></html>", encoding="utf-8")
+
+    for app_surface_only in (False, True):
+        mcp = _server_with_tools(
+            app_surface_only=app_surface_only,
+            app_tools_are_stubs=False,
+        )
+        async with Client(mcp) as client:
+            tool_names = {tool.name for tool in await client.list_tools()}
+            resource_uris = {str(resource.uri) for resource in await client.list_resources()}
+
+        assert "render_graph_view" in tool_names
+        assert {
+            "ui://cao/dashboard",
+            "ui://cao/agent",
+            "ui://cao/event-stream",
+            "ui://cao/graph",
+        } <= resource_uris
+
+
+@pytest.mark.asyncio
+async def test_calling_hidden_tool_returns_mode_specific_error(monkeypatch) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    mcp = _server_with_tools(app_surface_only=True)
+
+    async with Client(mcp) as client:
+        with pytest.raises(ToolError, match="app-surface-only mode"):
+            await client.call_tool("handoff")
+
+
+@pytest.mark.asyncio
+async def test_app_surface_tool_names_match_registration(monkeypatch) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    mcp = FastMCP("app-surface-registration-test")
+
+    assert register_app_tools(mcp) is True
+
+    registered_names = {tool.name for tool in await mcp.local_provider.list_tools()}
+    assert registered_names == APP_SURFACE_TOOL_NAMES

--- a/test/plugins/builtin/test_mcp_apps.py
+++ b/test/plugins/builtin/test_mcp_apps.py
@@ -26,6 +26,7 @@ class _FakeMcp:
     def __init__(self) -> None:
         self.tools: List[str] = []
         self.resources: List[str] = []
+        self.middleware: List[Any] = []
         self._mcp_server = _FakeLowLevel()
 
     def tool(self, *args: Any, **kwargs: Any) -> Any:
@@ -41,6 +42,9 @@ class _FakeMcp:
             return fn
 
         return _deco
+
+    def add_middleware(self, middleware: Any) -> None:
+        self.middleware.append(middleware)
 
 
 def test_mcp_apps_is_a_cao_plugin() -> None:
@@ -103,3 +107,59 @@ def test_no_warning_when_surface_disabled(monkeypatch, caplog) -> None:
     with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.plugins.builtin.mcp_apps"):
         McpAppsPlugin().on_mcp_server(_FakeMcp())
     assert not any("no IdP" in r.getMessage() for r in caplog.records)
+
+
+def test_app_surface_only_installs_middleware_when_apps_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    monkeypatch.setenv("CAO_MCP_APPS_ONLY", "true")
+    fake = _FakeMcp()
+
+    McpAppsPlugin().on_mcp_server(fake)
+
+    assert len(fake.middleware) == 1
+    assert fake.middleware[0].__class__.__name__ == "AppSurfaceOnlyMiddleware"
+
+
+def test_apps_only_off_leaves_middleware_unmodified(monkeypatch) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    monkeypatch.delenv("CAO_MCP_APPS_ONLY", raising=False)
+    fake = _FakeMcp()
+
+    McpAppsPlugin().on_mcp_server(fake)
+
+    assert fake.middleware == []
+
+
+def test_app_surface_only_warns_and_does_not_install_when_apps_disabled(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.delenv("CAO_MCP_APPS_ENABLED", raising=False)
+    monkeypatch.setenv("CAO_MCP_APPS_ONLY", "true")
+    fake = _FakeMcp()
+
+    with caplog.at_level(logging.WARNING, logger="cli_agent_orchestrator.plugins.builtin.mcp_apps"):
+        McpAppsPlugin().on_mcp_server(fake)
+
+    assert fake.middleware == []
+    assert any(
+        "CAO_MCP_APPS_ONLY" in record.getMessage() and "hide every MCP tool" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_app_surface_only_middleware_failure_is_best_effort(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("CAO_MCP_APPS_ENABLED", "true")
+    monkeypatch.setenv("CAO_MCP_APPS_ONLY", "true")
+    fake = _FakeMcp()
+
+    def fail_to_install(middleware: Any) -> None:
+        raise RuntimeError("unsupported")
+
+    monkeypatch.setattr(fake, "add_middleware", fail_to_install)
+    with caplog.at_level(logging.ERROR, logger="cli_agent_orchestrator.plugins.builtin.mcp_apps"):
+        McpAppsPlugin().on_mcp_server(fake)
+
+    assert any(
+        "Failed to install app-surface-only middleware" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add `CAO_MCP_APPS_ONLY` / `apps.only` for external MCP Apps hosts
- filter `tools/list` to the six app-surface tools and reject direct calls to hidden tools with a mode-specific error
- preserve app tools, `render_graph_view`, and `ui://cao/*` resources while documenting graph-only setup and credential handling

## Design
This uses FastMCP 3.2 middleware at the built-in `mcp_apps` plugin boundary. It does not deregister decorated tools: `remove_tool()` is deprecated, mutates server state, and would make the default path depend on a drifting denylist. It also does not infer the mode from a missing `CAO_TERMINAL_ID`; an explicit flag avoids silently stripping tools from a misconfigured real CAO session.

The middleware is installed only when both `apps.enabled` and `apps.only` are true. With `apps.only` off, no middleware or tool objects are added or mutated. Tests compare the unfiltered tool list with the mode-off path, verify plugin middleware remains untouched, cover resources in both modes, and guard the six-name allowlist against `register_app_tools`.

## Verification
- `uv run --frozen pytest test/plugins/builtin/test_mcp_apps.py test/mcp_server/test_app_surface_only.py test/mcp_server/test_app_tools.py test/services/test_config_service.py` (68 passed)
- Black and isort checks on changed Python files
- strict mypy on changed source files

Closes #586