### PR TITLE
fix(tmux): launch the server with exit-empty off to survive mass teardown

### DIFF
--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -60,6 +60,31 @@ class TmuxClient:
     def __init__(self) -> None:
         self.server = libtmux.Server()
 
+    def _set_server_exit_empty_off(self) -> None:
+        """Keep the tmux server alive across a transient zero-session moment.
+
+        By default tmux terminates its whole server process the instant the last
+        session closes (``exit-empty on``). During a mass teardown — many sessions
+        ending near-simultaneously — that races CAO creating the next session
+        against the server vanishing: a momentary "no sessions" window tears the
+        entire server down, taking every other session's panes with it at once
+        (harness-control#845, the whole-server-death incident). ``exit-empty off``
+        keeps the server up through an empty moment.
+
+        This is the backend belt (HOME-independent, applies to whatever uid runs
+        cao-server); a HOME ``.tmux.conf`` set is the ops-side complement. Set on
+        every session-create rather than cached on the client: it is a cheap,
+        idempotent server option, and setting it each time means it survives even
+        if the tmux server is ever externally killed and recreated. ``server.cmd``
+        starts the server if it is not already running, so this also runs before
+        the very first session exists. Best-effort: a failure here must never block
+        a session launch.
+        """
+        try:
+            self.server.cmd("set-option", "-s", "exit-empty", "off")
+        except Exception:
+            logger.warning("failed to set tmux server option 'exit-empty off'", exc_info=True)
+
     # ── libtmux listing boundary ─────────────────────────────────────────
     #
     # Every read that makes libtmux shell out to `list-sessions` /
@@ -350,6 +375,11 @@ class TmuxClient:
     ) -> str:
         """Create detached tmux session with initial window and return window name."""
         try:
+            # Ensure the server won't die on a transient empty moment during a
+            # mass teardown (harness-control#845). Runs before new_session, and
+            # starts the server if it isn't up yet.
+            self._set_server_exit_empty_off()
+
             working_directory = self._resolve_and_validate_working_directory(working_directory)
 
             # Only pass essential env vars to avoid tmux "command too long"

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -62,6 +62,33 @@ class TestCreateSession:
         assert result == "my-window"
         tmux.server.new_session.assert_called_once()
 
+    def test_create_session_disables_exit_empty(self, tmux, tmp_path):
+        """harness-control#845: creating a session must set the server-wide
+        'exit-empty off' option (before new_session) so a transient empty moment
+        during a mass teardown can't take the whole tmux server down."""
+        mock_window = MagicMock()
+        mock_window.name = "my-window"
+        mock_session = MagicMock()
+        mock_session.windows = [mock_window]
+        tmux.server.new_session.return_value = mock_session
+
+        tmux.create_session("ses", "my-window", "tid1", str(tmp_path))
+
+        tmux.server.cmd.assert_any_call("set-option", "-s", "exit-empty", "off")
+
+    def test_exit_empty_failure_does_not_block_launch(self, tmux, tmp_path):
+        """Setting exit-empty is best-effort: a failure must NOT abort the launch."""
+        mock_window = MagicMock()
+        mock_window.name = "my-window"
+        mock_session = MagicMock()
+        mock_session.windows = [mock_window]
+        tmux.server.new_session.return_value = mock_session
+        tmux.server.cmd.side_effect = RuntimeError("tmux unavailable")
+
+        # Must still succeed despite the set-option failure.
+        result = tmux.create_session("ses", "my-window", "tid1", str(tmp_path))
+        assert result == "my-window"
+
     def test_create_session_window_name_none(self, tmux, tmp_path):
         mock_window = MagicMock()
         mock_window.name = None


### PR DESCRIPTION
By default tmux terminates its whole server process the instant the last session closes (`exit-empty on`). During a mass teardown — many sessions ending near-simultaneously — that races CAO creating the next session against the server vanishing: a momentary zero-session window tears the **entire** server down, taking every other session's panes with it at once (a whole-server-death incident observed in production).

**Fix:** `TmuxClient.create_session()` sets the server-wide `exit-empty off` option (`set-option -s exit-empty off`) before `new_session` (server.cmd starts the server if it is not already up), so the server survives a transient empty moment. Best-effort — a failure is logged and never blocks a launch — and set on every create_session so it survives an externally-killed-and-recreated server.

**Tests:** create_session issues `set-option -s exit-empty off`; a set-option failure does not abort the launch. Verified live against real tmux 3.4: after create_session, `show-options -s exit-empty` returns `off`.

Surfaced in production (harness-control#845).

🤖 Generated with [Claude Code](https://claude.com/claude-code)