### PR TITLE
fix(api): prevent YAML frontmatter injection in flow creation (RCE)

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any, AsyncIterator, Dict, List, Literal, Optional, Tuple, cast
 
+import yaml
 from fastapi import (
     BackgroundTasks,
     Body,
@@ -986,6 +987,22 @@ class CreateFlowRequest(BaseModel):
         """Prevent path traversal — flow name becomes a filename."""
         if "/" in v or "\\" in v or ".." in v:
             raise ValueError("Flow name must not contain '/', '\\', or '..'")
+        return v
+
+    @field_validator("schedule", "agent_profile", "provider")
+    @classmethod
+    def validate_no_control_characters(cls, v: str) -> str:
+        """Prevent YAML frontmatter injection — a newline could otherwise
+        smuggle extra keys (e.g. script) into the serialized file."""
+        if any(ord(ch) < 32 or ord(ch) == 127 for ch in v):
+            raise ValueError("must not contain control characters")
+        return v
+
+    @field_validator("agent_profile", "provider")
+    @classmethod
+    def validate_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must not be empty")
         return v
 
 
@@ -5780,16 +5797,18 @@ async def create_flow(
 
         file_path = flows_dir / f"{body.name}.flow.md"
 
-        # Build YAML frontmatter content
-        frontmatter_lines = [
-            "---",
-            f"name: {body.name}",
-            f'schedule: "{body.schedule}"',
-            f"agent_profile: {body.agent_profile}",
-            f"provider: {body.provider}",
-            "---",
-        ]
-        file_content = "\n".join(frontmatter_lines) + "\n" + body.prompt_template
+        # Serialize via yaml.safe_dump so a multi-line value becomes a quoted
+        # scalar rather than injecting a new frontmatter key.
+        frontmatter = yaml.safe_dump(
+            {
+                "name": body.name,
+                "schedule": body.schedule,
+                "agent_profile": body.agent_profile,
+                "provider": body.provider,
+            },
+            sort_keys=False,
+        )
+        file_content = "---\n" + frontmatter + "---\n" + body.prompt_template
 
         file_path.write_text(file_content)
 

--- a/test/api/test_flow_api.py
+++ b/test/api/test_flow_api.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
+import frontmatter
 import pytest
+import yaml
 
 from cli_agent_orchestrator.api.main import app
 from cli_agent_orchestrator.models.flow import Flow
@@ -244,6 +246,96 @@ class TestCreateFlow:
 
             assert response.status_code == 404
             assert "Invalid flow file" in response.json()["detail"]
+
+    def test_create_flow_rejects_schedule_with_newline(self, client, tmp_path, monkeypatch):
+        """A schedule embedding a newline and script key is rejected with 422 and
+        writes nothing, so no script key can be persisted."""
+        monkeypatch.setattr("cli_agent_orchestrator.api.main.CAO_HOME_DIR", tmp_path)
+        with patch("cli_agent_orchestrator.api.main.flow_service") as mock_svc:
+            response = client.post(
+                "/flows",
+                json={
+                    "name": "evil-flow",
+                    "schedule": '0 0 * * *"\nscript: /tmp/evil\n"',
+                    "agent_profile": "developer",
+                    "provider": "kiro_cli",
+                    "prompt_template": "Do work.",
+                },
+            )
+
+            assert response.status_code == 422
+            mock_svc.add_flow.assert_not_called()
+            flows_dir = tmp_path / "flows"
+            assert not flows_dir.exists() or not list(flows_dir.iterdir())
+
+    def test_create_flow_written_file_has_no_script_key(
+        self, client, sample_flow, tmp_path, monkeypatch
+    ):
+        """A valid POST writes a flow file whose frontmatter round-trips through
+        frontmatter.load with a single-line schedule and no script key."""
+        monkeypatch.setattr("cli_agent_orchestrator.api.main.CAO_HOME_DIR", tmp_path)
+        with patch("cli_agent_orchestrator.api.main.flow_service") as mock_svc:
+            mock_svc.add_flow.return_value = sample_flow
+
+            response = client.post(
+                "/flows",
+                json={
+                    "name": "test-flow",
+                    "schedule": "0 * * * *",
+                    "agent_profile": "developer",
+                    "provider": "kiro_cli",
+                    "prompt_template": "Do some work.",
+                },
+            )
+
+            assert response.status_code == 201
+            flow_file = tmp_path / "flows" / "test-flow.flow.md"
+            assert flow_file.exists()
+            post = frontmatter.loads(flow_file.read_text())
+            assert "script" not in post.metadata
+            assert post.metadata["schedule"] == "0 * * * *"
+            assert post.metadata["agent_profile"] == "developer"
+            assert post.metadata["provider"] == "kiro_cli"
+            assert "Do some work." in post.content
+
+    def test_create_flow_serialization_neutralizes_embedded_newline(self, tmp_path):
+        """Defense-in-depth: yaml.safe_dump renders a raw newline as a quoted
+        scalar, so a script key cannot be smuggled into the frontmatter even if
+        a hostile value reached the serializer."""
+        file_path = tmp_path / "evil.flow.md"
+        file_path.write_text(
+            "---\n"
+            + yaml.safe_dump(
+                {
+                    "name": "evil-flow",
+                    "schedule": '0 0 * * *"\nscript: /tmp/evil\n"',
+                    "agent_profile": "developer",
+                    "provider": "kiro_cli",
+                },
+                sort_keys=False,
+            )
+            + "---\n"
+            + "Do work."
+        )
+
+        post = frontmatter.loads(file_path.read_text())
+        assert "script" not in post.metadata
+        assert post.metadata["schedule"] == '0 0 * * *"\nscript: /tmp/evil\n"'
+        assert post.content.strip() == "Do work."
+
+    def test_create_flow_rejects_empty_agent_profile(self, client):
+        """POST /flows rejects an empty agent_profile with 422."""
+        response = client.post(
+            "/flows",
+            json={
+                "name": "empty-profile-flow",
+                "schedule": "0 * * * *",
+                "agent_profile": "",
+                "provider": "kiro_cli",
+                "prompt_template": "Do work.",
+            },
+        )
+        assert response.status_code == 422
 
 
 class TestDeleteFlow:

--- a/test/services/test_flow_service.py
+++ b/test/services/test_flow_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 from cli_agent_orchestrator.models.flow import Flow
@@ -209,6 +210,41 @@ Test prompt.
 
             assert result.name == "test-flow"
             mock_db_create.assert_called_once()
+
+    @patch("cli_agent_orchestrator.services.flow_service.db_create_flow")
+    def test_add_flow_accepts_api_safe_dump_frontmatter(self, mock_db_create, tmp_path):
+        """A flow file serialized with yaml.safe_dump (the API's new format)
+        registers cleanly with a single-line schedule and no script key."""
+        mock_db_create.return_value = Flow(
+            name="safe-flow",
+            file_path="/path/to/flow.md",
+            schedule="0 * * * *",
+            agent_profile="developer",
+            provider="kiro_cli",
+            next_run=datetime.now(),
+        )
+        file_path = tmp_path / "safe.flow.md"
+        file_path.write_text(
+            "---\n"
+            + yaml.safe_dump(
+                {
+                    "name": "safe-flow",
+                    "schedule": "0 * * * *",
+                    "agent_profile": "developer",
+                    "provider": "kiro_cli",
+                },
+                sort_keys=False,
+            )
+            + "---\n"
+            + "Prompt body."
+        )
+
+        flow = add_flow(str(file_path))
+
+        assert flow.name == "safe-flow"
+        assert flow.schedule == "0 * * * *"
+        assert flow.script == ""
+        mock_db_create.assert_called_once()
 
     def test_add_flow_missing_required_field(self):
         """Test that missing required field raises error."""


### PR DESCRIPTION
## Security: HIGH — YAML frontmatter injection → arbitrary script execution

### Vulnerability
`POST /flows` wrote `.flow.md` files by string-interpolating request fields into YAML frontmatter:

```python
f'schedule: "{body.schedule}"',
```

Only `name` was validated. A `schedule` of ``0 0 * * *"\nscript: /tmp/x\n"`` stayed a valid cron value **and** injected a `script:` key into the frontmatter. `flow_service.add_flow()` reads `metadata.get("script","")`, and `execute_flow()` runs it via `subprocess.run`. The `script` field is never meant to be settable through the API — this is remote code execution.

### Fix
1. **Serialize frontmatter with `yaml.safe_dump`** — a multi-line value now becomes a quoted scalar, so a newline can no longer inject a key.
2. **Reject control characters / empty values** on `schedule`, `agent_profile`, `provider` in `CreateFlowRequest` (Pydantic validators → 422).
3. Legitimate hand-authored flow files that use `script` (created via `cao schedule add`) are **unaffected**.

### Tests
+4 in `test/api/test_flow_api.py` (injection payload → 422 with nothing persisted; round-trip via `frontmatter.load` has no `script` key), +1 in `test/services/test_flow_service.py`. All 67 flow tests + 62 model tests pass.