### PR TITLE
fix(api): block cross-origin state-changing HTTP requests (CSRF)

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -70,6 +70,7 @@ from cli_agent_orchestrator.constants import (
     WORKFLOW_ENV_VALUE_MAX_LEN,
     WS_ALLOWED_CLIENTS,
     add_local_cors_origins,
+    is_http_origin_allowed,
     is_ws_origin_allowed,
 )
 from cli_agent_orchestrator.ext_apps import mount_widget_static
@@ -1240,6 +1241,56 @@ app = FastAPI(
     version=SERVER_VERSION,
     lifespan=lifespan,
 )
+
+# Methods whose request could change server state. The Origin check only
+# guards these — GET/HEAD/OPTIONS stay open (reads leak nothing stateful, and
+# OPTIONS preflights must reach CORSMiddleware unchanged).
+_STATE_CHANGING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+class OriginCheckMiddleware:
+    """Reject state-changing HTTP requests with a disallowed ``Origin``.
+
+    CSRF / CWE-352 guard for the default-unauthenticated surface. Browsers
+    attach an ``Origin`` header on every cross-site state-changing request
+    (fetch, XHR, and form POST alike — the simple-request paths CORS can't
+    preflight-block), while non-browser clients (curl, ``requests``, MCP, the
+    ``cao`` CLI) send none, so a present-but-untrusted ``Origin`` is exactly
+    the browser-only signal this rejects. Reads and OPTIONS preflights always
+    pass through. Registered FIRST so it runs inside ``TrustedHostMiddleware``:
+    Host is validated against ``ALLOWED_HOSTS`` on the same scope before the
+    same-origin branch below can trust it (see ``is_http_origin_allowed``).
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] == "http" and scope["method"] in _STATE_CHANGING_METHODS:
+            headers = {
+                name.decode("latin-1").lower(): value.decode("latin-1")
+                for name, value in scope.get("headers", [])
+            }
+            origin = headers.get("origin")
+            if origin and not is_http_origin_allowed(origin, headers.get("host")):
+                logger.warning(
+                    "Rejected cross-origin %s request: disallowed Origin %r",
+                    scope["method"],
+                    origin,
+                )
+                response = JSONResponse(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    content={"detail": "Cross-origin request blocked"},
+                )
+                await response(scope, receive, send)
+                return
+        await self.app(scope, receive, send)
+
+
+# Security: CSRF / Cross-Origin Request Forgery (CWE-352). See the middleware
+# docstring; the guard must sit INSIDE TrustedHostMiddleware's Host validation
+# (add_middleware stacks last-added outermost), hence it is registered first.
+app.add_middleware(OriginCheckMiddleware)
 
 # Security: DNS Rebinding Protection
 # Validate Host header to prevent DNS rebinding attacks (CVE mitigation)

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -534,6 +534,50 @@ def is_ws_origin_allowed(origin: "str | None", host: "str | None" = None) -> boo
     return origin in CORS_ORIGINS or origin in WS_ALLOWED_ORIGINS
 
 
+def is_http_origin_allowed(origin: "str | None", host: "str | None" = None) -> bool:
+    """Whether a state-changing HTTP request ``Origin`` header is trusted.
+
+    CSRF / CWE-352 guard for the default-unauthenticated HTTP surface, mirroring
+    ``is_ws_origin_allowed`` on the read/mutation HTTP split:
+
+    * A missing / empty ``Origin`` is allowed. Browsers always attach one on a
+      cross-site state-changing request (``fetch``, XHR, and form posts alike),
+      so its absence means a non-browser client (curl, ``requests``, MCP, the
+      ``cao`` CLI) — one with no ambient credentials a foreign page could use.
+    * A literal ``*`` in ``CORS_ORIGINS`` (i.e. ``CAO_CORS_ORIGINS="*"``) allows
+      every origin — the operator-visible wildcard that ``CORSMiddleware``
+      already honors for the read surface, so a ``"*"``-configured deployment
+      behaves consistently for writes too.
+    * **Same-origin**: the ``Origin`` authority equals the request ``Host``.
+      This is the request the bundled Web UI makes when served by cao-server
+      itself, and it is exactly what a cross-site attacker CANNOT forge —
+      script-set ``Host`` is forbidden and the real ``Host`` is the CAO server
+      the request was made to, not the attacker's page. Matching on the live
+      ``Host`` lets the imported-app deployment and dynamic reverse-proxy /
+      Codespaces hostnames work without pre-registering every origin.
+
+      Like the WebSocket branch, this trusts ``Host`` and is only as safe as
+      ``Host`` itself: ``TrustedHostMiddleware`` validates ``Host`` against
+      ``ALLOWED_HOSTS`` on the same scope BEFORE the HTTP origin check runs,
+      which keeps the match DNS-rebinding-safe in the default loopback config.
+      ``CAO_ALLOWED_HOSTS="*"`` opts out of that protection, matching the WS
+      guard's documented tradeoff.
+    * Otherwise the ``Origin`` must be in ``CORS_ORIGINS``. Exact-string match
+      mirrors how the browser serializes ``Origin`` and how ``CORSMiddleware``
+      compares it, so anything the CORS layer already trusts for reads is
+      trusted for writes too.
+    """
+    if not origin:
+        return True
+    if "*" in CORS_ORIGINS:
+        return True
+    if host:
+        authority = _origin_authority(origin)
+        if authority is not None and authority == host:
+            return True
+    return origin in CORS_ORIGINS
+
+
 # Trusted upstream IP allowlist for uvicorn's ``proxy_headers`` and
 # ``forwarded_allow_ips`` settings. When cao-server is bound to a
 # non-loopback address (Codespaces, devcontainer, reverse proxy), uvicorn

--- a/test/api/test_csrf_origin.py
+++ b/test/api/test_csrf_origin.py
@@ -1,0 +1,85 @@
+"""Tests for the CSRF / cross-origin request guard on the HTTP API (CWE-352).
+
+The API is default-unauthenticated on the loopback interface, so state-changing
+HTTP methods must reject any browser-supplied ``Origin`` that is not the same
+origin or an explicitly trusted one — otherwise any web page the operator
+visits can forge POSTs to ``127.0.0.1`` (session launch, terminal keystroke
+injection, profile install). Read methods stay open: they never mutate state.
+"""
+
+from unittest.mock import patch
+
+CROSS_SITE_ORIGIN = "http://evil.example"
+SAME_ORIGIN = "http://127.0.0.1:9889"
+DEV_SERVER_ORIGIN = "http://localhost:5173"
+
+
+class TestCrossSiteStateChangesBlocked:
+    """State-changing methods carrying a disallowed Origin return 403."""
+
+    def test_post_flow_blocked(self, client):
+        """A cross-site POST is rejected before it reaches the route."""
+        response = client.post("/flows", headers={"Origin": CROSS_SITE_ORIGIN})
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Cross-origin request blocked"}
+
+    def test_delete_flow_blocked(self, client):
+        """A cross-site DELETE is rejected too."""
+        response = client.delete("/flows/test-flow", headers={"Origin": CROSS_SITE_ORIGIN})
+
+        assert response.status_code == 403
+
+    def test_cross_site_blocked_even_with_same_host(self, client):
+        """DNS rebinding can forge the Host but never the Origin.
+
+        An attacker page that has rebound ``evil.example`` to 127.0.0.1 still
+        can't set the ``Origin`` the browser sends, so the POST is rejected.
+        """
+        response = client.post(
+            "/flows",
+            headers={"Host": "127.0.0.1:9889", "Origin": CROSS_SITE_ORIGIN},
+        )
+
+        assert response.status_code == 403
+
+
+class TestAllowedStateChanges:
+    """Legitimate callers keep full write access."""
+
+    def test_same_origin_allowed(self, client):
+        """A same-origin browser POST passes the guard (422 is body validation)."""
+        response = client.post(
+            "/flows",
+            headers={"Host": "127.0.0.1:9889", "Origin": SAME_ORIGIN},
+        )
+
+        assert response.status_code != 403
+
+    def test_cors_listed_origin_allowed(self, client):
+        """A page served from a configured dev-server origin is trusted."""
+        response = client.post(
+            "/flows",
+            headers={"Host": "localhost", "Origin": DEV_SERVER_ORIGIN},
+        )
+
+        assert response.status_code != 403
+
+    def test_missing_origin_allowed(self, client):
+        """Non-browser clients (CLI, curl, MCP) send no Origin and pass."""
+        response = client.post("/flows")
+
+        assert response.status_code != 403
+
+
+class TestReadsStayOpen:
+    """GET requests are never blocked, whatever Origin they carry."""
+
+    def test_get_with_cross_site_origin(self, client):
+        """A cross-site read is still served."""
+        with patch("cli_agent_orchestrator.api.main.flow_service") as mock_svc:
+            mock_svc.list_flows.return_value = []
+            response = client.get("/flows", headers={"Origin": CROSS_SITE_ORIGIN})
+
+        assert response.status_code != 403
+        assert response.status_code == 200


### PR DESCRIPTION
## Security: HIGH — CSRF → RCE on the default loopback config

### Vulnerability
The FastAPI app has `TrustedHostMiddleware` + CORS but **no Origin/CSRF check on HTTP** (only the WebSocket handler checks Origin). Auth is default-off. CORS does not block browser "simple requests", and `TrustedHost` passes because Host is `127.0.0.1:port`. A malicious page visited by the operator can POST to the loopback API and launch an agent with `--dangerously-skip-permissions`, inject keystrokes into a live terminal, or install a profile.

### Fix
New pure-ASGI `OriginCheckMiddleware` (registered first, inside `TrustedHostMiddleware`):
- For `POST/PUT/PATCH/DELETE` with a **present** `Origin` header, accept only if `is_http_origin_allowed(origin, host)` — same-origin (DNS-rebinding-safe, mirrors the WS guard in `constants.py`) or in `CORS_ORIGINS` (honoring the `*` escape hatch).
- **Missing `Origin` is allowed** — non-browser clients (curl, `requests`, the `cao` CLI, MCP, workflows) have no ambient credentials and send none.
- Reads (`GET/HEAD/OPTIONS`) pass through. 403 `{"detail": "Cross-origin request blocked"}` otherwise.
- Default (auth-off) behavior unchanged; bundled Web UI and CLI unaffected.

### Tests
New `test/api/test_csrf_origin.py` (7 tests): cross-site POST/DELETE → 403 (incl. DNS-rebinding scenario), same-origin / CORS-listed / no-Origin → not 403, cross-site GET → served. Full required subset: 69 passed.