### PR TITLE
fix(mcp): restrict answer_user_prompt to the caller's own terminal

### DIFF
--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -378,6 +378,23 @@ def _send_direct_input(
 
 def _send_user_prompt_answer(terminal_id: str, answer: str) -> Dict[str, Any]:
     """Send an explicit answer to a terminal that is waiting on user input."""
+    # A worker may only answer its OWN terminal's approval prompt. The
+    # supervisor (CAO_TERMINAL_ID unset) is the role that legitimately answers
+    # other terminals' prompts, so only enforce ownership when the caller
+    # identifies as a worker. This keeps a prompt-injected or compromised
+    # worker from self-approving its own permission prompt or answering a
+    # sibling terminal's prompt.
+    caller_terminal_id = _current_terminal_id()
+    if caller_terminal_id and terminal_id != caller_terminal_id:
+        return {
+            "success": False,
+            "terminal_id": terminal_id,
+            "error": (
+                f"Worker terminal {caller_terminal_id} may only answer its own "
+                f"terminal's approval prompt, not terminal {terminal_id}'s. Only "
+                "the supervisor can answer another terminal's prompt."
+            ),
+        }
     if not answer.strip():
         return {
             "success": False,

--- a/test/mcp_server/test_answer_user_prompt.py
+++ b/test/mcp_server/test_answer_user_prompt.py
@@ -119,6 +119,71 @@ class TestAnswerUserPrompt:
         ]
         mock_sleep.assert_called_once_with(0.05)
 
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_worker_cannot_answer_another_terminals_prompt(self, mock_requests, monkeypatch):
+        from cli_agent_orchestrator.mcp_server.server import _send_user_prompt_answer
+
+        monkeypatch.setenv("CAO_TERMINAL_ID", "abcd1234")
+
+        result = _send_user_prompt_answer("deadbeef", "1")
+
+        assert result["success"] is False
+        assert "only answer its own terminal" in result["error"]
+        mock_requests.get.assert_not_called()
+        mock_requests.post.assert_not_called()
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_worker_can_answer_its_own_prompt(self, mock_requests, monkeypatch):
+        from cli_agent_orchestrator.mcp_server.server import _send_user_prompt_answer
+
+        monkeypatch.setenv("CAO_TERMINAL_ID", "abcd1234")
+
+        status_response = MagicMock()
+        status_response.json.return_value = {"status": "waiting_user_answer"}
+        status_response.raise_for_status.return_value = None
+        input_response = MagicMock()
+        input_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = status_response
+        mock_requests.post.return_value = input_response
+
+        result = _send_user_prompt_answer("abcd1234", "1")
+
+        assert result["success"] is True
+        mock_requests.post.assert_called_once_with(
+            f"{API_BASE_URL}/terminals/abcd1234/input",
+            params={
+                "message": "1",
+                "sender_id": "abcd1234",
+            },
+            timeout=_mcp_timeout(),
+        )
+
+    @patch("cli_agent_orchestrator.mcp_server.server.requests")
+    def test_supervisor_can_answer_any_terminals_prompt(self, mock_requests, monkeypatch):
+        from cli_agent_orchestrator.mcp_server.server import _send_user_prompt_answer
+
+        monkeypatch.delenv("CAO_TERMINAL_ID", raising=False)
+
+        status_response = MagicMock()
+        status_response.json.return_value = {"status": "waiting_user_answer"}
+        status_response.raise_for_status.return_value = None
+        input_response = MagicMock()
+        input_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = status_response
+        mock_requests.post.return_value = input_response
+
+        result = _send_user_prompt_answer("deadbeef", "1")
+
+        assert result["success"] is True
+        mock_requests.post.assert_called_once_with(
+            f"{API_BASE_URL}/terminals/deadbeef/input",
+            params={
+                "message": "1",
+                "sender_id": "supervisor",
+            },
+            timeout=_mcp_timeout(),
+        )
+
     @patch("cli_agent_orchestrator.mcp_server.server.time.sleep")
     @patch("cli_agent_orchestrator.mcp_server.server.requests")
     def test_hermes_clarify_custom_answer_uses_other_then_text(self, mock_requests, mock_sleep):


### PR DESCRIPTION
## Security: MEDIUM — approval-prompt spoofing

### Vulnerability
The `cao-mcp-server` `answer_user_prompt` tool takes an arbitrary `terminal_id` and submits an answer to **any** terminal in `WAITING_USER_ANSWER` state. No ownership check — a prompt-injected or compromised worker can self-approve its own permission prompt, or answer a sibling terminal's, defeating the human-in-the-loop approval gate.

### Fix
In `_send_user_prompt_answer`, resolve the caller via `CAO_TERMINAL_ID` (the same mechanism `assign`/`handoff`/`send_message` use):
- Worker (`CAO_TERMINAL_ID` set) targeting a **different** terminal → refused with `{"success": False, "error": ...}` and no HTTP call.
- Worker answering its **own** terminal → unchanged.
- Supervisor / external MCP client (`CAO_TERMINAL_ID` unset) → unchanged (the documented supervisor use case).

All existing success/error paths and the hermes special-case preserved.

### Tests
New `test/mcp_server/test_answer_user_prompt.py` (TDD, red→green): sibling refusal, own-terminal success, supervisor passthrough. `test/mcp_server` = 249 passed, `test/security` = 39 passed.