### PR TITLE
fix(api): require bearer token on terminal WebSocket when auth enabled

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -99,6 +99,7 @@ from cli_agent_orchestrator.security.auth import (
     SCOPE_READ,
     SCOPE_WRITE,
     SCOPES_SUPPORTED,
+    _extract_bearer,
     extract_scopes_from_token,
     get_authorization_servers,
     get_current_scopes,
@@ -5534,12 +5535,29 @@ async def get_inbox_messages_endpoint(
 async def terminal_ws(websocket: WebSocket, terminal_id: str):
     """WebSocket endpoint for live terminal streaming via tmux attach.
 
-    Security: This endpoint provides full PTY access with no bearer/token
-    authentication. It is intended for localhost-only use and is gated by two
-    checks before accept: the peer IP must be in ``WS_ALLOWED_CLIENTS`` and,
-    for browser callers, the ``Origin`` header must be in the trusted set
-    (CWE-1385 cross-site WebSocket hijacking guard). Do NOT expose the server
-    to untrusted networks (e.g. --host 0.0.0.0) without adding authentication.
+    Security: This endpoint provides full PTY access (keystroke injection =
+    RCE) and is gated by three checks before accept:
+
+    * the peer IP must be in ``WS_ALLOWED_CLIENTS`` (loopback by default);
+    * for browser callers, the ``Origin`` header must be same-origin with the
+      request ``Host`` or in the trusted set (CWE-1385 cross-site WebSocket
+      hijacking guard);
+    * when the HTTP auth layer is enabled (``AUTH0_DOMAIN`` /
+      ``CAO_AUTH_JWKS_URI`` set — see :func:`is_auth_enabled`), the handshake
+      must carry a valid bearer token granting at least the ``cao:read``
+      scope.
+
+    Token scheme: browsers cannot set request headers on a WebSocket
+    handshake, so the token is accepted from either ``Authorization: Bearer
+    <token>`` (native clients) or a ``?token=<token>`` query parameter (the
+    bundled web viewer). The token is verified exactly like the HTTP layer —
+    RS256 signature, issuer, audience and expiry via the JWKS cache — and a
+    missing/invalid token or one lacking ``cao:read`` closes the handshake
+    with code 4401 before accept. This closes the bypass where widening
+    ``CAO_WS_ALLOWED_CLIENTS`` / ``CAO_WS_ALLOWED_ORIGINS`` for containers,
+    devcontainers or Codespaces exposed full PTY control with no credential.
+    Do NOT expose the server to untrusted networks (e.g. --host 0.0.0.0)
+    without authentication.
     """
     # Reject connections from clients outside the configured allowlist.
     # Defaults to loopback; operators running cao-server inside a container can
@@ -5582,6 +5600,42 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
         )
         await websocket.close(code=4403, reason="WebSocket Origin not allowed")
         return
+
+    # When the HTTP auth layer is enabled, the WS handshake must also prove
+    # identity: browsers cannot set request headers on a WebSocket handshake,
+    # so the token is accepted from the Authorization header or a ``?token=``
+    # query parameter. The token is verified with the same JWKS/issuer/
+    # audience/expiry logic as the HTTP layer and must grant at least
+    # ``SCOPE_READ``. Default-off (auth disabled): no token is required and
+    # behavior is byte-for-byte unchanged.
+    if is_auth_enabled():
+        token = _extract_bearer(websocket.headers.get("authorization"))
+        if not token:
+            token = websocket.query_params.get("token")
+        if not token:
+            logger.warning(
+                "Rejected WebSocket attach for terminal %r: auth enabled, missing bearer token",
+                terminal_id,
+            )
+            await websocket.close(code=4401, reason="Unauthorized")
+            return
+        try:
+            scopes = extract_scopes_from_token(token)
+        except Exception:
+            logger.warning(
+                "Rejected WebSocket attach for terminal %r: auth enabled, invalid bearer token",
+                terminal_id,
+            )
+            await websocket.close(code=4401, reason="Unauthorized")
+            return
+        if SCOPE_READ not in scopes:
+            logger.warning(
+                "Rejected WebSocket attach for terminal %r: token lacks %r scope",
+                terminal_id,
+                SCOPE_READ,
+            )
+            await websocket.close(code=4401, reason="Unauthorized")
+            return
 
     await websocket.accept()
 

--- a/test/api/test_ws_auth.py
+++ b/test/api/test_ws_auth.py
@@ -1,0 +1,252 @@
+"""Bearer-token authentication for the terminal WebSocket attach endpoint.
+
+Covers the security fix that closes the auth bypass on
+``/terminals/{terminal_id}/ws``: when the HTTP auth layer is enabled the
+handshake must carry a valid JWT (``Authorization: Bearer`` header or
+``?token=`` query parameter) granting at least ``cao:read``. Default-off —
+auth disabled — the attach must behave exactly as before (no token needed).
+
+The tests drive ``terminal_ws`` directly with a mock ``WebSocket`` (the same
+pattern the existing Origin/IP-guard tests in ``test_terminals.py`` use) so
+the exact ``close`` codes are observable. The admitted paths stop at the
+terminal-metadata lookup (mocked to return ``None``), so no real PTY is
+spawned.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.security import auth
+
+AUTH_DOMAIN = "test.local"
+AUTH_AUDIENCE = "cao://test"
+
+
+class _FakeSigningKey:
+    def __init__(self, key) -> None:
+        self.key = key
+
+
+class _FakeClient:
+    def __init__(self, public_key) -> None:
+        self._public_key = public_key
+
+    def get_signing_key_from_jwt(self, token):  # noqa: ANN001
+        return _FakeSigningKey(self._public_key)
+
+
+def _enable_auth(monkeypatch, jwt_factory):
+    """Enable the auth layer and route the JWKS cache to ``jwt_factory``.
+
+    Mirrors ``test/security/test_auth.py``: env-var enable + a fake JWKS
+    client so no network is involved. ``jwt_factory.mint(...)`` tokens are
+    issued against the same keypair, so they validate.
+    """
+    from cryptography.hazmat.primitives import serialization
+
+    monkeypatch.setenv("AUTH0_DOMAIN", AUTH_DOMAIN)
+    monkeypatch.setenv("AUTH0_AUDIENCE", AUTH_AUDIENCE)
+    public_key = serialization.load_pem_private_key(
+        jwt_factory.private_pem, password=None
+    ).public_key()
+    monkeypatch.setattr(auth.get_jwks_cache(), "get_client", lambda uri: _FakeClient(public_key))
+
+
+def _make_ws(**overrides):
+    """Build a mock WebSocket that passes the loopback IP + Origin gates."""
+    ws = MagicMock()
+    ws.client = MagicMock(host="127.0.0.1")
+    ws.headers = {}
+    ws.query_params = {}
+    ws.accept = AsyncMock()
+    ws.close = AsyncMock()
+    for key, value in overrides.items():
+        setattr(ws, key, value)
+    return ws
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_env(monkeypatch):
+    for var in (
+        "AUTH0_DOMAIN",
+        "CAO_AUTH_JWKS_URI",
+        "AUTH0_AUDIENCE",
+        "CAO_AUTH_AUDIENCE",
+        "CAO_AUTH_ISSUER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    auth.get_jwks_cache().clear()
+    yield
+    auth.get_jwks_cache().clear()
+
+
+@contextmanager
+def _admitted_patches():
+    with (
+        patch("cli_agent_orchestrator.api.main.WS_ALLOWED_CLIENTS", ["127.0.0.1"]),
+        patch("cli_agent_orchestrator.api.main.get_terminal_metadata", return_value=None),
+    ):
+        yield
+
+
+# --- default-off (no auth configured) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_disabled_no_token_attaches():
+    """Default-off: a token-less attach proceeds past the gate and reaches the
+    terminal lookup (closes 4004 terminal-not-found, never 4401)."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    ws = _make_ws()
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_awaited_once()
+    ws.close.assert_awaited_once()
+    assert ws.close.call_args.kwargs.get("code") == 4004
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_disabled_ignores_present_token(jwt_factory):
+    """Default-off: even a provided token does not gate the attach."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint_viewer()}"})
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_awaited_once()
+    assert ws.close.call_args.kwargs.get("code") == 4004
+
+
+# --- auth enabled: no / invalid token --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_enabled_missing_token_rejected(monkeypatch, jwt_factory):
+    """Auth on + no token → handshake closed 4401 before accept."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws()
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_not_called()
+    ws.close.assert_awaited_once()
+    kwargs = ws.close.call_args.kwargs
+    assert kwargs.get("code") == 4401
+    assert kwargs.get("reason") == "Unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_enabled_invalid_token_rejected(monkeypatch, jwt_factory):
+    """Auth on + a garbage bearer token → closed 4401."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws(headers={"authorization": "Bearer not-a-jwt"})
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_not_called()
+    assert ws.close.call_args.kwargs.get("code") == 4401
+
+
+# --- auth enabled: valid token ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_enabled_valid_bearer_header_attaches(monkeypatch, jwt_factory):
+    """Auth on + valid ``Authorization: Bearer`` token → proceeds past the gate
+    (closes 4004 terminal-not-found, never 4401)."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint_viewer()}"})
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_awaited_once()
+    ws.close.assert_awaited_once()
+    assert ws.close.call_args.kwargs.get("code") == 4004
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_enabled_valid_token_query_param_attaches(monkeypatch, jwt_factory):
+    """Auth on + valid ``?token=`` query param (browser clients cannot set
+    headers on a WebSocket handshake) → proceeds past the gate."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws(query_params={"token": jwt_factory.mint_viewer()})
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_awaited_once()
+    assert ws.close.call_args.kwargs.get("code") == 4004
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_enabled_write_only_token_rejected(monkeypatch, jwt_factory):
+    """Auth on + a valid token WITHOUT ``cao:read`` → closed 4401 (attach
+    requires at least the read scope)."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint(scopes='cao:write')}"})
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_not_called()
+    assert ws.close.call_args.kwargs.get("code") == 4401
+
+
+# --- existing IP + Origin checks still run (and precede auth) ---------------
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_ip_check_still_precedes_auth(monkeypatch, jwt_factory):
+    """A valid token does NOT bypass the loopback IP allowlist: an
+    out-of-allowlist peer is still closed 4003 before any auth evaluation."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint_viewer()}"})
+    ws.client = MagicMock(host="10.0.0.9")
+    with patch("cli_agent_orchestrator.api.main.WS_ALLOWED_CLIENTS", ["127.0.0.1"]):
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_not_called()
+    assert ws.close.call_args.kwargs.get("code") == 4003
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_origin_check_still_precedes_auth(monkeypatch, jwt_factory):
+    """A valid token does NOT bypass the Origin guard: a cross-site Origin is
+    still closed 4403 before any auth evaluation."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws(
+        headers={
+            "origin": "http://evil.example.com",
+            "host": "localhost:9889",
+            "authorization": f"Bearer {jwt_factory.mint_viewer()}",
+        }
+    )
+    with (
+        patch(
+            "cli_agent_orchestrator.api.main.WS_ALLOWED_CLIENTS",
+            ["127.0.0.1", "::1", "localhost"],
+        ),
+        patch("cli_agent_orchestrator.constants.CORS_ORIGINS", []),
+        patch("cli_agent_orchestrator.constants.WS_ALLOWED_ORIGINS", []),
+    ):
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_not_called()
+    assert ws.close.call_args.kwargs.get("code") == 4403


### PR DESCRIPTION
## Security: MEDIUM — WebSocket PTY attach bypasses the auth layer

### Vulnerability
`/terminals/{terminal_id}/ws` gives full PTY control (keystroke injection = RCE + full output read-back). It is gated only by the loopback IP allowlist and the Origin check — **no bearer token**, even when the HTTP auth layer is enabled. Once an operator widens allowed clients/origins (containers, devcontainers, Codespaces), any reachable client gets PTY control with no token.

### Fix
When `is_auth_enabled()`, after the existing IP (4003) and Origin (4403) checks and before `accept()`:
- Extract a token from `Authorization: Bearer <token>` (native clients) or `?token=<token>` query param (browser WebSockets can't set headers).
- Verify with the same JWKS/RS256/issuer/audience path as the HTTP layer (`_extract_bearer` + `extract_scopes_from_token`); require at least `cao:read`.
- Invalid/missing → close `4401` "Unauthorized".

**Default-off unchanged**: when auth is disabled the WS behaves exactly as before (no token needed), so the localhost workflow and bundled Web UI keep working.

### Tests
New `test/api/test_ws_auth.py` (9 tests, TDD): default-off attach with/without token; auth-on rejects missing/invalid/write-only-scope tokens with 4401; accepts valid `Bearer` and `?token=` (proceeds past auth to terminal lookup); IP/Origin guards still fire first. `test/api/test_ws_auth.py` + `test/security/test_auth.py` + `test/api/test_terminals.py` = 133 passed.