### PR TITLE
fix(workflows+api): confine scan_dir to workflow root; gate+redact agent profile endpoints

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -3325,11 +3325,18 @@ async def validate_workflow_endpoint(body: WorkflowValidateRequest) -> Dict:
 
 @app.get("/workflows")
 async def list_workflows_endpoint(dir: Optional[str] = Query(default=None)) -> List[Dict]:
-    """List indexed workflows, rebuilt from the spec files on disk (FR-2.1)."""
+    """List indexed workflows, rebuilt from the spec files on disk (FR-2.1).
+
+    The ``dir`` query parameter is confined to the configured workflow root (or
+    a subdirectory of it) before any filesystem scan, so an out-of-root
+    directory (e.g. ``~/.ssh``) is a 400 rather than an unauthenticated
+    arbitrary-directory probe.
+    """
     from cli_agent_orchestrator.services import workflow_spec_service
 
     try:
-        rows = workflow_spec_service.list_workflows(scan_dir=dir)
+        scan_dir = workflow_spec_service._validate_scan_dir(dir)
+        rows = workflow_spec_service.list_workflows(scan_dir=scan_dir)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     return [row.model_dump() for row in rows]

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -2184,12 +2184,37 @@ async def get_agent_profile_schema_endpoint() -> Dict:
     return load_profile_schema()
 
 
+def _redact_profile_mcp_env(profile_data: Dict) -> Dict:
+    """Replace ``mcpServers[].env`` values in a serialized profile with ``"***"``.
+
+    ``load_agent_profile`` resolves ``${VAR}`` placeholders server-side, so
+    these values can hold live credentials (per-MCP-server API tokens). Keys
+    and structure are preserved so callers still see which servers a profile
+    configures, but their secrets never cross the wire.
+    """
+    mcp_servers = profile_data.get("mcpServers")
+    if isinstance(mcp_servers, dict):
+        for config in mcp_servers.values():
+            if isinstance(config, dict) and isinstance(config.get("env"), dict):
+                config["env"] = {key: "***" for key in config["env"]}
+    return profile_data
+
+
 @app.get("/agents/profiles/{name}")
-async def get_agent_profile_endpoint(name: str) -> Dict:
-    """Return the full parsed content of a named agent profile."""
+async def get_agent_profile_endpoint(
+    name: str,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Dict:
+    """Return the full parsed content of a named agent profile.
+
+    Scope-gated (READ/WRITE/ADMIN) and env-redacted: ``mcpServers[].env``
+    values are replaced with ``"***"`` before the response is serialized so an
+    authenticated caller sees which MCP servers a profile configures but never
+    their credentials.
+    """
     try:
         profile = load_agent_profile(name)
-        return profile.model_dump(exclude_none=True)
+        return _redact_profile_mcp_env(profile.model_dump(exclude_none=True))
     except FileNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ValueError as e:

--- a/src/cli_agent_orchestrator/services/workflow_spec_service.py
+++ b/src/cli_agent_orchestrator/services/workflow_spec_service.py
@@ -93,6 +93,31 @@ def _safe_dir(scan_dir: Optional[str]) -> str:
     return tmux_client._resolve_and_validate_working_directory(scan_dir)
 
 
+def _validate_scan_dir(scan_dir: Optional[str]) -> Optional[str]:
+    """Confine an explicit HTTP-supplied ``scan_dir`` to the workflow root.
+
+    ``None`` (the ``?dir=`` query param omitted) passes through unchanged so the
+    default ``WORKFLOW_SPEC_DIR`` applies. An explicit directory is realpath-
+    resolved and must be the configured root or a subdirectory of it; anything
+    else raises ``ValueError`` (-> HTTP 400 at the API boundary) so an
+    unauthenticated caller cannot use ``GET /workflows?dir=`` as an
+    arbitrary-directory scan (e.g. ``~/.ssh``) for workflow YAML, or probe file
+    layout via the ``source_path`` the listing echoes. Mirrors
+    ``_safe_spec_path``'s resolve-then-contain idiom; ``_safe_dir`` still
+    applies the blocked-directory policy to the accepted value.
+    """
+    if scan_dir is None:
+        return None
+    root = os.path.realpath(os.path.abspath(str(WORKFLOW_SPEC_DIR)))
+    candidate = os.path.realpath(os.path.abspath(os.path.expanduser(scan_dir)))
+    if candidate != root and not candidate.startswith(root + os.sep):
+        raise ValueError(
+            f"scan_dir '{scan_dir}' must be the configured workflow directory "
+            f"or a subdirectory of it"
+        )
+    return scan_dir
+
+
 def _safe_spec_path(path: Union[str, Path], base_dir: Optional[str] = None) -> str:
     """Canonicalize a spec FILE path and bind it to a CONFIGURED base directory.
 

--- a/test/api/test_api_profiles.py
+++ b/test/api/test_api_profiles.py
@@ -64,6 +64,63 @@ class TestGetAgentProfileEndpoint:
         assert response.status_code == 400
         assert "Invalid agent name" in response.json()["detail"]
 
+    def test_redacts_mcp_server_env_values(self, client) -> None:
+        """MCP server env values must never cross the wire as plaintext.
+
+        ``load_agent_profile`` resolves ``${VAR}`` placeholders server-side, so
+        ``mcpServers[].env`` can hold live credentials; the endpoint replaces
+        their values with ``"***"`` (keys and structure preserved) so an
+        authenticated caller still sees which servers a profile configures but
+        never their tokens.
+        """
+        profile = AgentProfile(
+            name="developer",
+            description="Developer agent",
+            system_prompt="Implement the task.",
+            mcpServers={
+                "cao": {"command": "cao-mcp-server", "env": {"API_TOKEN": "super-secret"}},
+                "db": {"command": "db-mcp", "env": {"HOST": "db.internal"}},
+            },
+        )
+
+        with patch(
+            "cli_agent_orchestrator.api.main.load_agent_profile",
+            return_value=profile,
+        ):
+            response = client.get("/agents/profiles/developer")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["mcpServers"]["cao"]["command"] == "cao-mcp-server"
+        assert body["mcpServers"]["cao"]["env"] == {"API_TOKEN": "***"}
+        assert body["mcpServers"]["db"]["env"] == {"HOST": "***"}
+        assert "super-secret" not in response.text
+
+    def test_requires_token_when_auth_enabled(self, client, monkeypatch) -> None:
+        """With auth enabled, the profile detail endpoint is gated: no token -> 401."""
+        monkeypatch.setenv("CAO_AUTH_JWKS_URI", "https://idp.example/jwks")
+        response = client.get("/agents/profiles/developer")
+        assert response.status_code == 401
+
+    def test_authorized_token_can_read_profile(self, client, monkeypatch) -> None:
+        """A token holding cao:read passes the gate (not 401/403)."""
+        from cli_agent_orchestrator.api import main
+        from cli_agent_orchestrator.security import auth
+
+        monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+        monkeypatch.setattr(auth, "extract_scopes_from_token", lambda tok: [auth.SCOPE_READ])
+        with patch(
+            "cli_agent_orchestrator.api.main.load_agent_profile",
+            return_value=AgentProfile(name="developer", description="Developer agent"),
+        ):
+            response = client.get(
+                "/agents/profiles/developer", headers={"Authorization": "Bearer test-token"}
+            )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "developer"
+        assert not main.app.dependency_overrides
+
 
 class TestInstallAgentProfileEndpoint:
     """Tests for POST /agents/profiles/install."""

--- a/test/api/test_workflow_endpoints.py
+++ b/test/api/test_workflow_endpoints.py
@@ -102,6 +102,24 @@ class TestListEndpoint:
         resp = client.get("/workflows", params={"dir": "/etc"})
         assert resp.status_code == 400
 
+    def test_out_of_root_dir_maps_to_400(self, client, isolated_db, spec_dir, tmp_path):
+        """A directory outside the configured workflow root is rejected, not
+        scanned: without this, ``?dir=/home/<user>/.ssh`` (or any other
+        arbitrary directory) is an unauthenticated filesystem probe."""
+        outside = tmp_path / "outside-root"
+        outside.mkdir(parents=True, exist_ok=True)
+        resp = client.get("/workflows", params={"dir": str(outside)})
+        assert resp.status_code == 400
+
+    def test_subdir_inside_root_still_works(self, client, isolated_db, spec_dir):
+        """A directory inside the configured workflow root stays scannable."""
+        sub = spec_dir / "subdir"
+        sub.mkdir(parents=True, exist_ok=True)
+        _write(sub, "nested")
+        resp = client.get("/workflows", params={"dir": str(sub)})
+        assert resp.status_code == 200
+        assert [r["name"] for r in resp.json()] == ["nested"]
+
 
 class TestGetEndpoint:
     def test_get_known(self, client, isolated_db, spec_dir):


### PR DESCRIPTION
Two related security fixes (two commits).

## Fix A — `GET /workflows?dir=` arbitrary-directory scan (LOW)
`scan_dir` was validated only against a short blocklist of exact system dirs, so `dir=/home/…/.ssh` was accepted and scanned for workflow YAML — an unauthenticated filesystem probe echoing `source_path`.
- `workflow_spec_service.py`: new `_validate_scan_dir()` — realpath-resolves the candidate and requires it to equal the configured `WORKFLOW_SPEC_DIR` or lie under it (mirrors the existing `_safe_spec_path` containment idiom). Out-of-root → `ValueError` → 400.
- `api/main.py`: `GET /workflows` calls the validator before listing. Default (no `dir`) behavior unchanged.

## Fix B — `GET /agents/profiles/{name}` leaks secrets (MEDIUM)
Profiles can embed `mcpServers[].env` (API tokens) and env-resolved `system_prompt`; the endpoint was ungated.
- Gated with `require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)` (no-op when auth is off).
- New `_redact_profile_mcp_env()`: `mcpServers[].env` values replaced with `"***"` (keys/schema preserved — least-breaking for the Web UI / ops-MCP consumers), documented in the route docstring. The list endpoint (discovery metadata only) is left open.

### Tests
+2 in `test/api/test_workflow_endpoints.py` (out-of-root → 400, in-root still works); +3 in `test/api/test_api_profiles.py` (redaction, 401-with-auth-on, `cao:read` admitted). Required subsets: 34 + 39 passed; broader sweep 968 passed (15 pre-existing AG-UI failures verified on base).