### PR TITLE
feat(pi): add Pi CLI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the official xAI Grok Build CLI as the `grok_cli` provider, including
   isolated per-terminal MCP configuration, native hard tool restrictions,
   multi-turn TUI support, orchestration e2e coverage, and provider docs.
+- Add first-party Pi provider support with an attachable regular TUI, hard built-in tool restrictions, exact lifecycle/final-answer state, and CAO MCP orchestration through a bundled stdio bridge. See [Pi Provider](docs/pi.md).
 
 ### Fixed
 
@@ -849,4 +850,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump to v0.51.0, update method name (#31)
 
 - accept optional U+03BB (λ) after % in kiro and q CLIs (#44)
-

--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ Install:
   [Codex CLI](docs/codex-cli.md), [Antigravity CLI](docs/antigravity-cli.md),
   [Hermes](docs/hermes.md), [Kimi CLI](docs/kimi-cli.md),
   [GitHub Copilot CLI](docs/copilot-cli.md),
-  [OpenCode CLI](docs/opencode-cli.md),
-  [Cursor CLI](docs/cursor-cli.md), or
-  [Grok Build CLI](docs/grok-cli.md)
+  [OpenCode CLI](docs/opencode-cli.md), [Pi](docs/pi.md),
+  [Cursor CLI](docs/cursor-cli.md), or [Grok Build CLI](docs/grok-cli.md)
 
 The focused provider guides contain installation, authentication, and
 provider-specific behavior.
@@ -131,9 +130,8 @@ provider override while keeping the same sequence.
   [Codex CLI](docs/codex-cli.md), [Antigravity CLI](docs/antigravity-cli.md),
   [Hermes](docs/hermes.md), [Kimi CLI](docs/kimi-cli.md),
   [GitHub Copilot CLI](docs/copilot-cli.md),
-  [OpenCode CLI](docs/opencode-cli.md),
-  [Cursor CLI](docs/cursor-cli.md), and
-  [Grok Build CLI](docs/grok-cli.md).
+  [OpenCode CLI](docs/opencode-cli.md), [Pi](docs/pi.md),
+  [Cursor CLI](docs/cursor-cli.md), and [Grok Build CLI](docs/grok-cli.md).
 - [Security policy](SECURITY.md): vulnerability reporting and deployment
   guidance.
 

--- a/docs/agent-profile.md
+++ b/docs/agent-profile.md
@@ -73,8 +73,9 @@ Provider support for pass-through fields differs. Use the focused guides for
 [Codex CLI](codex-cli.md), [Antigravity CLI](antigravity-cli.md),
 [Hermes](hermes.md), [Kimi CLI](kimi-cli.md),
 [GitHub Copilot CLI](copilot-cli.md), [OpenCode CLI](opencode-cli.md),
-[Cursor CLI](cursor-cli.md), and [Grok Build CLI](grok-cli.md) instead of
-relying on a duplicated compatibility catalog here.
+[Pi](pi.md), [Cursor CLI](cursor-cli.md), and
+[Grok Build CLI](grok-cli.md) instead of relying on a duplicated compatibility
+catalog here.
 
 ## Tool restrictions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,13 @@ Every derived path resolves from this value, so one override moves everything �
 - `~/.aws/opencode` (OpenCode provider config, managed via `OPENCODE_CONFIG_DIR` in `constants.py`) — OpenCode is told its config location at launch via env vars; a follow-up can repoint this.
 - Provider-native agent directories (`~/.kiro/agents`, `~/.copilot/agents`) — intentionally separate since each provider manages its own agent install path independently of CAO's data tree.
 
+The [Pi provider](pi.md) is not an exception. Its private runtime files and
+retained session data live below `CAO_HOME_DIR/pi`. CAO does not directly write
+Pi credential/configuration files or install Pi packages in Pi's own agent
+directory, but Pi may migrate or update configuration or manage packages there
+during normal operation. The generated `CAO_PI_*` variables are internal
+provider-to-extension wiring, not user-facing configuration keys.
+
 ## settings.json schema
 
 ```json

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -1,0 +1,202 @@
+# Pi Provider
+
+## Quick start
+
+Install an agent profile for Pi, then launch it:
+
+```bash
+cao install developer --provider pi
+cao launch --agents developer --provider pi
+```
+
+Before launching, install [Pi](https://pi.dev), make sure `pi` is discoverable
+on `PATH`, and complete Pi's authentication and model setup in a regular
+terminal. CAO does not install Pi or configure its credentials. At provider
+construction, CAO resolves the executable from `PATH` and pins that exact
+absolute path for the session.
+
+## Profiles and models
+
+Pi uses the standard CAO Markdown agent profile. Its Markdown body (or the
+profile's `prompt:` fallback) and the runtime skill catalog become additional
+system instructions.
+Set a Pi model in frontmatter with `model:`:
+
+```yaml
+---
+name: developer
+description: Implements scoped code changes
+provider: pi
+model: openai/gpt-5
+role: developer
+---
+```
+
+`cao launch` has no per-launch model option. Supervisors using CAO's MCP tools
+can supply the optional `model` argument to `handoff` or `assign`; CAO forwards
+that model to the newly created Pi worker for that call. If no model is supplied
+by the MCP call or profile, Pi uses its configured default model.
+
+Profile `mcpServers`, `role`, `allowedTools`, and `skills` also apply. See
+[Agent Profile Format](agent-profile.md), [Tool Restrictions](tool-restrictions.md),
+and [Skills](skills.md).
+
+## Terminal and lifecycle
+
+CAO launches Pi's regular, attachable TUI in the selected terminal backend.
+Bracketed-paste input is submitted with one Enter. In an attached terminal,
+`C-d` exits Pi. CAO also uses that provider exit key during the explicit
+`run_agent_step` exit path. Normal terminal deletion and `cao shutdown` instead
+terminate the selected backend's window or pane; they do not first send Pi a
+graceful `C-d`.
+
+The bundled CAO extension records authoritative lifecycle state outside the
+rendered TUI:
+
+- `idle`: Pi is ready for input.
+- `processing`: an agent turn has started.
+- `completed`: the turn settled and the exact latest assistant text is ready.
+- `error`: extension or MCP bridge startup/runtime failed.
+
+CAO uses this state for status and final-answer extraction, so `LAST` output is
+the assistant's answer rather than terminal chrome. Conservative TUI parsing is
+used only during startup and as a failure fallback.
+
+## Explicit Pi resource isolation
+
+CAO starts Pi with ambient extensions, skills, and prompt templates disabled.
+It explicitly loads only CAO's bundled Pi extension. Project-local Pi packages
+are not approved. CAO does not directly write Pi credential or configuration
+files, or directly install packages in Pi's own agent directory. Pi still owns
+that directory (normally below `~/.pi`) and may migrate or update configuration
+or install/manage Pi packages as part of its own runtime behavior.
+
+Repository instruction context remains available. For example, Pi can still
+discover `AGENTS.md` because CAO does not disable Pi's context-file discovery.
+This distinction is intentional: Pi package/resource discovery is isolated,
+while repository instructions remain part of the coding-agent context.
+
+## MCP bridge
+
+Pi has no native MCP client. CAO's bundled extension starts a bundled JSONL
+proxy, which uses CAO's official Python MCP SDK dependency to connect to the
+profile's MCP servers. The extension discovers each server's tools and
+dynamically registers their original names and JSON Schema parameters with Pi.
+Duplicate exposed tool names fail closed rather than selecting one
+ambiguously.
+
+The first version supports command-based stdio MCP servers only. CAO resolves
+their commands and explicit environment, injects the current terminal identity,
+and honors each resolved request timeout. URL/non-stdio transports are rejected
+with a bridge configuration error.
+
+### MCP permission boundary
+
+`@cao-mcp-server` remains an all-or-nothing marker. CAO cannot currently allow
+or block individual MCP tools such as `assign`, `handoff`, or `send_message`.
+Pi's native `--exclude-tools` denylist does not change that MCP limitation.
+
+A restricted parent may deliberately delegate to a child whose own profile has
+broader permissions. The child resolves its own `role` or `allowedTools`; the
+parent's Pi built-in denylist does not propagate to child agents. Review both
+profiles when the delegated child crosses a privilege boundary.
+
+## Tool restrictions
+
+CAO translates its portable capability vocabulary to Pi's seven built-in tools:
+
+| CAO capability | Pi built-ins |
+|---|---|
+| `execute_bash` | `bash` |
+| `fs_read` | `read` |
+| `fs_write` | `edit`, `write` |
+| `fs_list` | `grep`, `find`, `ls` |
+| `fs_*` | `read`, `edit`, `write`, `grep`, `find`, `ls` |
+
+Pi has no core `web_fetch` tool. CAO computes the denied Pi built-ins from the
+resolved profile policy and passes them through Pi's `--exclude-tools` flag.
+This is hard enforcement for Pi's own built-in tools: a denied built-in is not
+available to the agent runtime.
+
+Hard built-in enforcement is not a sandbox and does not make MCP tools
+individually restrictable. See [Tool Restrictions](tool-restrictions.md) for the
+complete role and delegation model.
+
+## Skills
+
+Pi does not use ambient Pi-native skill discovery under CAO. Instead, CAO
+generates the selected runtime skill catalog and appends it to the agent's
+prompt. The agent retrieves full skill content with CAO's `load_skill` MCP tool.
+The profile's `skills` field scopes what appears in the catalog; it is not an
+access-control boundary for `load_skill`.
+
+## Storage and security boundary
+
+Pi and its MCP child processes run with the current user's operating-system
+permissions. Neither CAO's tool flags nor Pi's `--no-approve` option provides a
+filesystem or container sandbox. Use OS/container isolation separately when the
+workload requires it.
+
+Pi runtime data lives below `CAO_HOME_DIR/pi` (by default,
+`~/.aws/cli-agent-orchestrator/pi`):
+
+- CAO creates runtime and session directories with owner-only mode `0700`.
+- Generated prompt, resolved MCP configuration, and lifecycle state files use
+  mode `0600`.
+- Provider cleanup removes the transient prompt, MCP configuration, and state
+  files.
+- Provider cleanup deliberately leaves each terminal's Pi session directory in
+  place. These session directories currently persist indefinitely and require
+  manual deletion when an operator no longer wants them.
+
+The generated `CAO_PI_*` environment variables connect the provider and bundled
+extension. They are internal implementation details, not supported user-facing
+configuration. Configure the provider through CAO profiles and CLI options
+instead.
+
+## Troubleshooting
+
+### `Pi executable 'pi' was not found on PATH`
+
+Install Pi using the current instructions at [pi.dev](https://pi.dev), then
+confirm `pi --version` works in the environment that starts `cao-server`. Restart
+the server after changing `PATH`; CAO resolves and pins the executable when it
+constructs the provider.
+
+### No configured model or authentication failure
+
+Run Pi directly in a regular terminal and complete its model/authentication
+setup before launching CAO. If the profile sets `model:`, or an MCP `handoff` or
+`assign` call supplies `model`, verify that exact model is available to Pi. CAO
+does not copy credentials or directly write Pi's personal configuration, but
+Pi itself may update its agent directory during normal operation.
+
+### MCP bridge startup or configuration error
+
+Check the profile's `mcpServers` entries. Pi V1 accepts command-based stdio
+servers only; URL transports, missing commands, invalid environment values,
+invalid timeouts, and duplicate exposed tool names fail closed. Do not place
+secrets in commands or paste resolved bridge configuration into bug reports.
+
+### Session is stuck or reports `error`
+
+Inspect CAO's current view first:
+
+```bash
+cao session status cao-<session-name> --workers
+```
+
+Attach to the named tmux session to inspect the Pi TUI, or use the
+[tmux guide](tmux.md) for pane and log inspection. Bridge failures also appear
+in Pi's status UI and the CAO server logs. Preserve error text, but redact
+credentials and explicit MCP environment values before sharing diagnostics.
+
+When finished, shut down the CAO session normally:
+
+```bash
+cao shutdown --session cao-<session-name>
+```
+
+This deletes the terminal by terminating the selected backend's window or pane.
+If an attached Pi TUI itself needs to exit gracefully, press `C-d` before
+deletion.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -121,7 +121,7 @@ To advertise only a subset of skills to a given agent, set the `skills` field in
 
 This scopes the injected **catalog** only — it controls what an agent *sees* advertised, not what it can *load*. Skill resolution is unchanged: `load_skill` still resolves any installed skill by name, so this is a prompt-relevance / noise-reduction control, not an access boundary. (If you need a hard per-agent allowlist, that would have to be enforced in the `load_skill` path — out of scope here.)
 
-This applies only to the runtime-prompt providers that receive the injected catalog (Claude Code, Codex, Antigravity CLI, Kimi CLI). Providers that deliver skills natively (Kiro CLI, OpenCode, GitHub Copilot CLI) ignore the field.
+This applies only to the runtime-prompt providers that receive the injected catalog (Claude Code, Codex, Antigravity CLI, Kimi CLI, Pi). Providers that deliver skills natively (Kiro CLI, OpenCode, GitHub Copilot CLI) ignore the field.
 
 ```yaml
 ---
@@ -163,17 +163,22 @@ Skills are delivered to agents differently depending on the provider. The table 
 | Codex | Runtime prompt | Every terminal creation | `load_skill` MCP tool |
 | Antigravity CLI | Runtime prompt | Every terminal creation | `load_skill` MCP tool |
 | Kimi CLI | Runtime prompt | Every terminal creation | `load_skill` MCP tool |
+| Pi | Runtime prompt; ambient Pi skill discovery disabled | Every terminal creation | `load_skill` MCP tool |
 | Kiro CLI | Native `skill://` resources | Every terminal creation | Kiro progressive loading |
 | Copilot CLI | Baked into `.agent.md` at install | On `cao skills add/remove` | `load_skill` MCP tool |
 | OpenCode CLI | Native `skill` tool via `OPENCODE_CONFIG_DIR/skills` symlink | Every terminal creation | OpenCode progressive loading (also via `load_skill` MCP tool) |
 | Cursor CLI | Runtime prompt (currently disabled — see [Cursor CLI provider docs](cursor-cli.md#agent-profile-integration)) | Not injected in v2026 | `load_skill` MCP tool |
 | Hermes | Not injected — configure skills in the selected Hermes profile | N/A | N/A |
 
-### Runtime Prompt Providers (Claude Code, Codex, Antigravity CLI, Kimi CLI)
+### Runtime Prompt Providers (Claude Code, Codex, Antigravity CLI, Kimi CLI, Pi)
 
 For these providers, the skill catalog is built fresh each time a terminal is created. The catalog — a list of skill names and descriptions — is appended to the system prompt via the provider's native CLI flags.
 
 The agent retrieves full skill content at runtime by calling the `load_skill` MCP tool, which fetches the skill body from the CAO server.
+
+For Pi, CAO also disables ambient Pi-native skill discovery and appends this
+runtime catalog to the provider prompt. `load_skill` is a CAO MCP call, not a
+Pi-native skill lookup. See the [Pi provider guide](pi.md#skills).
 
 No action is needed after `cao skills add` or `cao skills remove` — the next terminal created will automatically reflect the current set of installed skills.
 

--- a/docs/tool-restrictions.md
+++ b/docs/tool-restrictions.md
@@ -99,18 +99,18 @@ No `role` is needed — `allowedTools` is the full specification of what tools t
 
 #### Tool Vocabulary
 
-| Tool | What it allows | Example: Claude Code | Example: Copilot CLI |
-|------|---------------|---------------------|-------------------|
-| `execute_bash` | Run shell commands | `Bash` | `shell` |
-| `fs_read` | Read files | `Read` | `read` |
-| `fs_write` | Write/edit files | `Edit`, `Write` | `write` |
-| `fs_list` | Search/list files | `Glob`, `Grep` | `list`, `grep` |
-| `fs_*` | All filesystem ops | All of the above | All of the above |
-| `web_fetch` | Fetch URLs / search the web | `WebFetch`, `WebSearch` | (not mapped) |
-| `@builtin` | Provider built-in capabilities | (internal) | (internal) |
-| `@cao-mcp-server` | CAO orchestration tools | `handoff`, `assign`, `send_message`, plus Hermes prompt answers via `answer_user_prompt` | Same |
-| `discovery` | Sibling discovery/metadata (`list_siblings`, `update_metadata`) | Same | Same |
-| `*` | Everything (unrestricted) | All tools | All tools |
+| Tool | What it allows | Example: Claude Code | Example: Copilot CLI | Pi |
+|------|---------------|---------------------|-------------------|----|
+| `execute_bash` | Run shell commands | `Bash` | `shell` | `bash` |
+| `fs_read` | Read files | `Read` | `read` | `read` |
+| `fs_write` | Write/edit files | `Edit`, `Write` | `write` | `edit`, `write` |
+| `fs_list` | Search/list files | `Glob`, `Grep` | `list`, `grep` | `grep`, `find`, `ls` |
+| `fs_*` | All filesystem ops | All of the above | All of the above | `read`, `edit`, `write`, `grep`, `find`, `ls` |
+| `web_fetch` | Fetch URLs / search the web | `WebFetch`, `WebSearch` | (not mapped) | (no core tool) |
+| `@builtin` | Provider built-in capabilities | (internal) | (internal) | (internal) |
+| `@cao-mcp-server` | CAO orchestration tools | `handoff`, `assign`, `send_message`, plus Hermes prompt answers via `answer_user_prompt` | Same | Same |
+| `discovery` | Sibling discovery/metadata (`list_siblings`, `update_metadata`) | Same | Same | Same |
+| `*` | Everything (unrestricted) | All tools | All tools | All tools |
 
 CAO translates these to each provider's native tool names automatically. You write one vocabulary; it works across supported providers.
 
@@ -197,15 +197,16 @@ The confirmation prompt is a **review gate** — it shows the resolved role and 
 
 CAO defines a universal tool vocabulary (`execute_bash`, `fs_read`, `fs_write`, `fs_list`). However, not all providers understand this vocabulary natively. There are two categories:
 
-**Providers that need translation** — Claude Code, Copilot CLI, and Grok Build CLI each have their own native tool names (e.g., Claude Code and Grok call bash execution `Bash`, while Copilot calls it `shell`). CAO uses an internal `TOOL_MAPPING` to translate the CAO vocabulary to provider-native names, then computes which native tools to block and passes them as CLI flags (e.g., `--disallowedTools Bash`, `--deny-tool shell`, or `--deny Bash`).
+**Providers that need translation** — Claude Code, Copilot CLI, Pi, and Grok Build CLI each have their own native tool names (for example, Claude Code and Grok call bash execution `Bash`, Copilot calls it `shell`, and Pi calls it `bash`). CAO uses an internal `TOOL_MAPPING` to translate the CAO vocabulary to provider-native names, then computes which native tools to block and passes them as CLI flags (for example, `--disallowedTools Bash`, `--deny-tool shell`, `--exclude-tools bash`, or `--deny Bash`).
 
-| CAO Tool | Claude Code | Copilot CLI | Grok Build CLI |
-|----------|-------------|-------------|----------------|
-| `execute_bash` | `Bash` | `shell` | `Bash` |
-| `fs_read` | `Read` | `read` | `Read`, `NotebookRead` |
-| `fs_write` | `Edit`, `Write` | `write` | `Edit`, `Write`, `NotebookEdit` |
-| `fs_list` | `Glob`, `Grep` | `list`, `grep` | `Grep`, `Glob` |
-| `web_fetch` | `WebFetch`, `WebSearch` | (not mapped) | `WebFetch`, `WebSearch` + disabled web search |
+| CAO Tool | Claude Code | Copilot CLI | Pi | Grok Build CLI |
+|----------|-------------|-------------|----|----------------|
+| `execute_bash` | `Bash` | `shell` | `bash` | `Bash` |
+| `fs_read` | `Read` | `read` | `read` | `Read`, `NotebookRead` |
+| `fs_write` | `Edit`, `Write` | `write` | `edit`, `write` | `Edit`, `Write`, `NotebookEdit` |
+| `fs_list` | `Glob`, `Grep` | `list`, `grep` | `grep`, `find`, `ls` | `Grep`, `Glob` |
+| `fs_*` | `Read`, `Edit`, `Write`, `Glob`, `Grep` | `read`, `write`, `list`, `grep` | `read`, `edit`, `write`, `grep`, `find`, `ls` | `Read`, `NotebookRead`, `Edit`, `Write`, `NotebookEdit`, `Grep`, `Glob` |
+| `web_fetch` | `WebFetch`, `WebSearch` | (not mapped) | (no core tool) | `WebFetch`, `WebSearch` + disabled web search |
 
 **Providers that accept CAO vocabulary directly** — Kiro CLI accepts `allowedTools` in the agent JSON at install time, using the same vocabulary as CAO. No translation needed. Kimi CLI and Codex use system prompt instructions to enforce restrictions. For all three, CAO passes the `allowedTools` list directly without translation — so no `TOOL_MAPPING` entry exists for them, and none is needed.
 
@@ -252,13 +253,14 @@ As described in [How Tool Restrictions Are Enforced](#how-tool-restrictions-are-
 | **Copilot CLI** | Hard | `--deny-tool` flags override `--allow-all` |
 | **OpenCode CLI** | Hard | `permission:` YAML frontmatter enforced natively at install time |
 | **Grok Build CLI** | Native (mapped families) | Restricted profiles use deny-by-default `--permission-mode dontAsk` with explicit native/MCP allows and defense-in-depth denies; native subagents are disabled |
+| **Pi** | Hard (built-ins) | `--exclude-tools` denies Pi's seven built-in tools; MCP remains all-or-nothing |
 | **Kimi CLI** | Soft | Security system prompt only |
 | **Codex** | Soft | Security system prompt only |
 | **Antigravity CLI** | Soft | Security system prompt only |
 | **Hermes** | Profile-defined | CAO launches default `hermes` or the optional `hermesProfile` wrapper declared by the CAO profile; restrict tools in that Hermes profile |
 | **Cursor CLI** | Not enforced (v2026) | `allowedTools` is currently ignored — no native flag or system-prompt path is active; see [Cursor CLI Tool Restrictions](cursor-cli.md#tool-restrictions) |
 
-**Hard enforcement** = the agent physically cannot use denied tools, enforced by the provider runtime.
+**Hard enforcement** = the agent physically cannot use denied tools, enforced by the provider runtime. It is not a filesystem/container sandbox; this label covers only the provider tools named by the policy.
 
 **Soft enforcement** = a system prompt tells the agent not to use certain tools. The agent may still attempt them. Use hard-enforcement providers for security-critical work.
 
@@ -280,6 +282,41 @@ claude --dangerously-skip-permissions --disallowedTools Bash --disallowedTools E
 ```bash
 copilot --allow-all --deny-tool shell --deny-tool write
 ```
+
+**Grok Build CLI** — For a restricted profile, uses deny-by-default
+`--permission-mode dontAsk`, explicitly grants mapped native tools and known
+configured MCP servers, adds native `--deny` rules as defense in depth, and
+disables Grok-native worker routes by default:
+
+```bash
+GROK_SUBAGENTS=0 GROK_WORKFLOWS=0 GROK_GOAL=0 \
+  grok --permission-mode dontAsk --no-subagents \
+  --allow Read --allow Grep --allow 'MCPTool(cao-mcp-server__*)' \
+  --deny Bash --deny Edit --deny Write
+```
+
+`allowedTools: ["*"]` remains the unrestricted path and uses
+`--always-approve`. Grok may retain built-in read-only operations in some
+permission modes; this provider limitation is not represented by CAO's
+`allowedTools` vocabulary. An explicit empty allowlist sends `--deny *`, while
+restricted profiles explicitly grant mapped native/MCP families and literal,
+configured server names (plus `cao-mcp-server`).
+
+Set `grokNativeWorkflows: true` in a Grok agent profile only when intentionally
+allowing Grok-native workers outside CAO's orchestration accounting. It is
+separate from `allowedTools`, including `allowedTools: ["*"]`.
+
+See the [Grok Build CLI provider guide](grok-cli.md#tool-restrictions) for the
+complete mapping and isolation behavior.
+
+**Pi** — Adds one native denylist for the computed built-in tools:
+```bash
+pi --exclude-tools bash,edit,write
+```
+
+Pi has no core `web_fetch`. Its MCP tools come from CAO's bundled bridge and
+remain subject to the separate all-or-nothing MCP limitation below. See the
+[Pi provider guide](pi.md#tool-restrictions).
 
 **Grok Build CLI** — For a restricted profile, uses deny-by-default
 `--permission-mode dontAsk`, explicitly grants mapped native tools and known
@@ -330,6 +367,9 @@ Supervisor (role: supervisor → @cao-mcp-server, fs_read, fs_list)
 ```
 
 Each agent is restricted based on its own profile, not its parent's permissions.
+A restricted Pi parent may therefore deliberately delegate to a child profile
+with broader built-in access; the parent's `--exclude-tools` denylist does not
+propagate to that child.
 
 ## Quick Reference
 
@@ -349,7 +389,7 @@ Each agent is restricted based on its own profile, not its parent's permissions.
 
 1. **Use `role: supervisor` for orchestrators.** They only need MCP tools + file reading for context.
 2. **Don't use `--yolo` in production.** It grants unrestricted access and skips all safety prompts.
-3. **Prefer hard-enforcement providers** (Claude Code, Kiro CLI, Copilot CLI) for sensitive workloads.
+3. **Prefer hard-enforcement providers** (Claude Code, Kiro CLI, Copilot CLI, OpenCode CLI, or Pi for its built-ins) for sensitive workloads, while still applying OS/container isolation when required.
 4. **Review the confirmation prompt.** It shows exactly what tools are allowed and blocked before you proceed.
 5. **Kimi CLI and Codex use soft enforcement** — use these only for non-critical tasks.
 
@@ -357,7 +397,7 @@ Each agent is restricted based on its own profile, not its parent's permissions.
 
 1. **Claude Code tool mapping is nearly complete, with MCP tools the remaining gap.** The current mapping covers `Bash` (and its `Task`/`Agent`/`Monitor`/`BashOutput`/`KillShell` execution family), `Read`, `Edit`, `Write`, `Glob`, `Grep`, and — via `web_fetch` — [`WebFetch`](https://code.claude.com/docs/en/permissions#webfetch) and `WebSearch`. The subagent tool is intentionally **not** a separate category: it is folded into `execute_bash`, because a subagent spawns with its own full toolset and can run shell, so exposing it standalone would let a profile grant subagent access without `execute_bash` and re-open that escape. Claude Code **renamed this tool from `Task` to `Agent`**, so both names are denied — current builds expose only `Agent`, so denying just `Task` would be a silent no-op. Provider MCP tools remain unmapped (see limitation #2) — they cannot be blocked via `--disallowedTools`.
 
-2. **`@cao-mcp-server` is server-level, not per-tool control.** Grok restricted profiles translate it to an allow rule for the configured CAO MCP server; other providers generally treat it as an intent marker. No provider currently blocks individual MCP tools: once the server is available, its `handoff`, `assign`, `send_message`, and `answer_user_prompt` tools are all available. `answer_user_prompt` is exposed by the MCP server, but its structured prompt-navigation behavior is currently implemented for Hermes workers that report `waiting_user_answer`; other providers may only receive ordinary text input until they implement equivalent prompt states. Future versions may support `@cao-mcp-server:send_message` syntax for per-tool MCP control.
+2. **`@cao-mcp-server` is server-level, not per-tool control.** Including `@cao-mcp-server` signals intent that an agent should have orchestration tools. Grok restricted profiles translate it to an allow rule for the configured CAO MCP server; other providers generally treat it as an intent marker. No provider currently blocks individual MCP tools: once the server is available, its `handoff`, `assign`, `send_message`, and `answer_user_prompt` tools are all available. For Pi, these tools are dynamically registered through CAO's bundled MCP bridge, but Pi's built-in `--exclude-tools` policy does not block individual MCP tools. `answer_user_prompt` is exposed by the MCP server, but its structured prompt-navigation behavior is currently implemented for Hermes workers that report `waiting_user_answer`; other providers may only receive ordinary text input until they implement equivalent prompt states. Future versions may support `@cao-mcp-server:send_message` syntax for per-tool MCP control.
 
 3. **Soft enforcement is best-effort.** Kimi CLI and Codex rely on system prompt instructions to restrict tools. The agent may ignore these restrictions. Do not rely on soft enforcement for security-critical workloads.
 

--- a/docusaurus/docs/features/multi-provider.md
+++ b/docusaurus/docs/features/multi-provider.md
@@ -17,6 +17,7 @@ CAO orchestrates AI coding CLI agents from multiple providers within the same se
 | **Kimi CLI** | `kimi_cli` | Moonshot API key | [Provider docs](https://github.com/awslabs/cli-agent-orchestrator/blob/main/docs/kimi-cli.md) |
 | **GitHub Copilot CLI** | `copilot_cli` | GitHub auth | [Provider docs](https://github.com/awslabs/cli-agent-orchestrator/blob/main/docs/copilot-cli.md) |
 | **OpenCode CLI** | `opencode_cli` | Per-model API key | [Provider docs](https://github.com/awslabs/cli-agent-orchestrator/blob/main/docs/opencode-cli.md) |
+| **Pi** | `pi` | Pi authentication and configured model | [Provider docs](https://github.com/awslabs/cli-agent-orchestrator/blob/main/docs/pi.md) |
 | **Cursor CLI** | `cursor_cli` | Cursor subscription / API key | [Provider docs](https://github.com/awslabs/cli-agent-orchestrator/blob/main/docs/cursor-cli.md) |
 | **Antigravity CLI** | `antigravity_cli` | Google account | [Provider docs](https://github.com/awslabs/cli-agent-orchestrator/blob/main/docs/antigravity-cli.md) |
 
@@ -29,7 +30,7 @@ CAO orchestrates AI coding CLI agents from multiple providers within the same se
 cao launch --agents code_supervisor --provider claude_code
 
 # Valid values: kiro_cli | claude_code | codex | antigravity_cli |
-#              hermes | kimi_cli | copilot_cli | opencode_cli | cursor_cli
+#              hermes | kimi_cli | copilot_cli | opencode_cli | pi | cursor_cli
 ```
 
 ### In an agent profile (frontmatter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,10 @@ dependencies = [
     # internal (create_initialization_options); cap the major to avoid silent
     # breakage on a new major release. Tested against 3.x.
     "fastmcp>=2.14.0,<4.0.0",
-    "mcp>=1.23.0",
+    # Upper bound: providers/pi_mcp_proxy.py must correlate bridge tasks with
+    # MCP's private ClientSession._request_id. The real stdio cancellation test
+    # verifies 1.28.x; widen only after an explicit compatibility check.
+    "mcp>=1.28.1,<1.29.0",
     "pydantic>=2.10.6",
     "apscheduler>=3.10.4",
     "sqlalchemy>=2.0.0",

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -28,6 +28,12 @@ Before launching a session, verify:
   ```
   If not running, start it in a separate terminal: `cao-server`.
 - **The agent profile is installed.** `cao launch --agents <profile>` fails if the profile is unknown. Install built-ins or custom files with `cao install <profile|path|url>`.
+- **The selected provider CLI is ready.** For Pi sessions, `pi` must be on the
+  `cao-server` process's `PATH` and already authenticated/model-configured. CAO
+  pins the resolved executable and does not directly write Pi credential or
+  configuration files or install Pi packages. Pi may still migrate or update
+  configuration or manage packages in its own agent directory during startup
+  and normal operation.
 
 ## Discovering Available Profiles
 
@@ -47,7 +53,7 @@ If unsure which profile to use, ask the user rather than guessing.
 
 ## Quick Example
 
-A complete, copy-pasteable supervisor launch. The default provider is `kiro_cli`; pass `--provider <name>` to use another (`claude_code`, `codex`, `antigravity_cli`, `kimi_cli`, `copilot_cli`, `opencode_cli`, `cursor_cli`).
+A complete, copy-pasteable supervisor launch. The default provider is `kiro_cli`; pass `--provider <name>` to use another (`claude_code`, `codex`, `antigravity_cli`, `kimi_cli`, `copilot_cli`, `opencode_cli`, `cursor_cli`, `hermes`, `pi`).
 
 This example assumes a configured CAO setup (server running, profiles installed). On an already-configured host you can skip straight to `cao launch`. The `cao install` lines below are only for first-time setup; remove them if your CAO is already configured.
 
@@ -94,6 +100,13 @@ cao launch --agents <profile> --headless --yolo \
 
 `--yolo` skips confirmation prompts. Required when launching from an agent — interactive
 prompts will stall the session.
+
+For Pi, CAO's `--headless` means "do not attach this caller"; Pi itself still
+runs its regular attachable TUI in the selected backend's window or pane. In an
+attached Pi TUI, `C-d` exits Pi; the explicit `run_agent_step` exit path uses
+that key too. Normal `cao shutdown` or terminal deletion instead terminates that
+window or pane without first sending Pi `C-d`. Generated `CAO_PI_*` variables
+are internal wiring and must not be set as user configuration.
 
 For SOP-driven workflows (Kiro provider): launch with `/prompts` to discover
 available SOPs, then send the matched SOP name prefixed with `@` (e.g.,

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -2261,6 +2261,7 @@ async def list_providers_endpoint() -> List[Dict]:
         "cursor_cli": "agent",
         "antigravity_cli": "agy",
         "grok_cli": "grok",
+        "pi": "pi",
     }
     result = []
     for provider, binary in provider_binaries.items():

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -34,6 +34,7 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     "kimi_cli",
     "kiro_cli",
     "opencode_cli",
+    "pi",
 }
 
 # Validation constraints for ``--env`` forwarded vars (mirrored server-side

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -366,6 +366,7 @@ class TmuxClient:
                 "DISPLAY",
                 "XDG_RUNTIME_DIR",
                 "DO_NOT_TRACK",
+                "PI_CODING_AGENT_DIR",
             }
             environment = {
                 k: v
@@ -477,7 +478,11 @@ class TmuxClient:
             if not session:
                 raise ValueError(f"Session '{session_name}' not found")
 
-            window_env: dict[str, str] = {}
+            window_env = (
+                {"PI_CODING_AGENT_DIR": os.environ["PI_CODING_AGENT_DIR"]}
+                if "PI_CODING_AGENT_DIR" in os.environ
+                else {}
+            )
             self._merge_extra_env(window_env, extra_env)
             window_env["CAO_TERMINAL_ID"] = terminal_id
 

--- a/src/cli_agent_orchestrator/models/provider.py
+++ b/src/cli_agent_orchestrator/models/provider.py
@@ -14,5 +14,6 @@ class ProviderType(str, Enum):
     CURSOR_CLI = "cursor_cli"
     ANTIGRAVITY_CLI = "antigravity_cli"
     GROK_CLI = "grok_cli"
+    PI = "pi"
     # Credentials-free mock provider for tests/CI (no real CLI binary).
     MOCK_CLI = "mock_cli"

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -19,6 +19,7 @@ from cli_agent_orchestrator.providers.kiro_capabilities import KiroPhase0KASErro
 from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
 from cli_agent_orchestrator.providers.mock_cli import MockCliProvider
 from cli_agent_orchestrator.providers.opencode_cli import OpenCodeCliProvider
+from cli_agent_orchestrator.providers.pi import PiProvider
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +140,16 @@ class ProviderManager:
                 )
             elif provider_type == ProviderType.GROK_CLI.value:
                 provider = GrokCliProvider(
+                    terminal_id,
+                    tmux_session,
+                    tmux_window,
+                    agent_profile,
+                    allowed_tools,
+                    skill_prompt=skill_prompt,
+                    model=model,
+                )
+            elif provider_type == ProviderType.PI.value:
+                provider = PiProvider(
                     terminal_id,
                     tmux_session,
                     tmux_window,

--- a/src/cli_agent_orchestrator/providers/pi.py
+++ b/src/cli_agent_orchestrator/providers/pi.py
@@ -1,0 +1,453 @@
+"""Pi coding-agent provider implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import stat
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from cli_agent_orchestrator.backends.registry import get_backend
+from cli_agent_orchestrator.constants import CAO_HOME_DIR
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
+from cli_agent_orchestrator.utils.mcp_resolution import resolve_mcp_server_config
+from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
+from cli_agent_orchestrator.utils.text import strip_terminal_escapes
+
+_STATE_KEYS = {"status", "lastAssistantText", "error", "updatedAt"}
+_STATE_STATUSES = {"idle", "processing", "completed", "error"}
+_MAX_STATE_BYTES = 1_048_576
+_EDITOR_RULE = re.compile(r"^\s*[─━-]{20,}\s*$")
+_PI_BANNER = re.compile(r"^\s*pi v\d+(?:\.\d+){1,3}\s*$", re.IGNORECASE)
+_WORKING = re.compile(r"\bWorking\.\.\.(?:\s*\([^\n)]{1,100}\))?", re.IGNORECASE)
+_STARTUP_ERROR = re.compile(
+    r"(?:command not found:.*\bpi\b|"
+    r"No such file or directory:.*\bpi\b|"
+    r"Failed to run (?:in Gohan: )?[^\n]*|"
+    r"pi MCP proxy configuration error:|"
+    r"^(?:Error:|ERROR:|Fatal:|Traceback \(most recent call last\):))",
+    re.IGNORECASE | re.MULTILINE,
+)
+_FOOTER_CONTEXT = re.compile(r"(?:\d+(?:\.\d+)?%|\?)/\d+(?:\.\d+)?[kKmM]?")
+_FOOTER_LINE = re.compile(r"^\s*(?:\d+(?:\.\d+)?%|\?)/\d+(?:\.\d+)?[kKmM]?\b")
+
+
+class ProviderError(RuntimeError):
+    """Raised when Pi cannot be configured or launched safely."""
+
+
+class PiProvider(BaseProvider):
+    """Run Pi's regular TUI with CAO-owned lifecycle and MCP sidecars."""
+
+    def __init__(
+        self,
+        terminal_id: str,
+        session_name: str,
+        window_name: str,
+        agent_profile: Optional[str] = None,
+        allowed_tools: Optional[list] = None,
+        skill_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        resolved_pi = shutil.which("pi")
+        if not resolved_pi:
+            raise ProviderError("Pi executable 'pi' was not found on PATH")
+
+        super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
+        self.pi_executable = Path(resolved_pi).resolve()
+        self._agent_profile = agent_profile
+        self._model = model
+        self._initialized = False
+
+        terminal_key = hashlib.sha256(terminal_id.encode("utf-8")).hexdigest()[:24]
+        self.pi_root = CAO_HOME_DIR / "pi"
+        self.runtime_dir = self.pi_root / terminal_key
+        self.session_dir = self.runtime_dir / "sessions"
+        self.prompt_path = self.runtime_dir / "system-prompt.md"
+        self.mcp_config_path = self.runtime_dir / "mcp.json"
+        self.state_path = self.runtime_dir / "state.json"
+        self.extension_path = Path(__file__).with_name("pi_extension.ts").resolve()
+        self._dispatch_pending = False
+        self._dispatch_state_fingerprint: tuple[str, str, str, str] | None = None
+        self._last_state_fingerprint: tuple[str, str, str, str] | None = None
+        self._tui_processing_seen = False
+
+    @property
+    def paste_enter_count(self) -> int:
+        """Pi submits bracketed paste with one Enter."""
+        return 1
+
+    @staticmethod
+    def _ensure_private_directory(path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        path.chmod(0o700)
+
+    @staticmethod
+    def _write_private_text(path: Path, content: str) -> Path:
+        PiProvider._ensure_private_directory(path.parent)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                fd = -1
+                stream.write(content)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        return path
+
+    def _load_profile(self) -> Any | None:
+        if self._agent_profile is None:
+            return None
+        try:
+            return load_agent_profile(self._agent_profile)
+        except Exception as exc:
+            raise ProviderError(
+                f"Failed to load agent profile '{self._agent_profile}': {exc}"
+            ) from exc
+
+    def _write_prompt(self, profile: Any | None = None) -> Path:
+        if profile is None and self._agent_profile is not None:
+            profile = self._load_profile()
+        base_prompt = ""
+        if profile is not None:
+            base_prompt = (profile.system_prompt or profile.prompt or "").strip()
+        prompt = self._apply_skill_prompt(base_prompt)
+        return self._write_private_text(self.prompt_path, prompt)
+
+    def _write_mcp_config(self, profile: Any | None = None) -> Path:
+        if profile is None and self._agent_profile is not None:
+            profile = self._load_profile()
+        servers: dict[str, dict[str, Any]] = {}
+        if profile is not None and profile.mcpServers:
+            for name, server in profile.mcpServers.items():
+                if isinstance(server, dict):
+                    config = dict(server)
+                else:
+                    config = server.model_dump(exclude_none=True)
+                config = resolve_mcp_server_config(config)
+                if "timeout" in config and "requestTimeoutMs" not in config:
+                    config["requestTimeoutMs"] = config.pop("timeout")
+                servers[name] = config
+        payload = json.dumps(
+            {"terminalId": self.terminal_id, "servers": servers},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        return self._write_private_text(self.mcp_config_path, payload)
+
+    def _build_pi_command(self) -> str:
+        """Build Pi's explicit, shell-safe regular-TUI launch command."""
+        profile = self._load_profile()
+        self._ensure_private_directory(CAO_HOME_DIR)
+        self._ensure_private_directory(self.pi_root)
+        self._ensure_private_directory(self.runtime_dir)
+        self._ensure_private_directory(self.session_dir)
+        self._write_prompt(profile)
+        self._write_mcp_config(profile)
+        self._write_private_text(self.state_path, "{}")
+
+        command_parts = [
+            "env",
+            f"CAO_PI_STATE_FILE={self.state_path}",
+            f"CAO_PI_MCP_CONFIG={self.mcp_config_path}",
+            f"CAO_PI_BRIDGE_PYTHON={sys.executable}",
+            str(self.pi_executable),
+            "--tui-mode",
+            "regular",
+            "--no-approve",
+            "--no-extensions",
+            "--extension",
+            str(self.extension_path),
+            "--no-skills",
+            "--no-prompt-templates",
+            "--session-id",
+            self.terminal_id,
+            "--session-dir",
+            str(self.session_dir),
+            "--append-system-prompt",
+            str(self.prompt_path),
+        ]
+
+        resolved_model = self._model or (profile.model if profile is not None else None)
+        if resolved_model:
+            command_parts.extend(["--model", resolved_model])
+
+        if self._allowed_tools is not None and "*" not in self._allowed_tools:
+            from cli_agent_orchestrator.utils.tool_mapping import get_disallowed_tools
+
+            disallowed = get_disallowed_tools("pi", self._allowed_tools)
+            if disallowed:
+                command_parts.extend(["--exclude-tools", ",".join(disallowed)])
+
+        return shlex.join(command_parts)
+
+    async def initialize(self) -> bool:
+        """Launch Pi after the shell is ready and wait for extension-backed IDLE."""
+        profile = self._load_profile()
+        init_timeout = self.get_init_timeout(profile)
+        if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+            raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
+
+        command = await asyncio.to_thread(self._build_pi_command)
+        await asyncio.to_thread(
+            get_backend().send_keys,
+            self.session_name,
+            self.window_name,
+            command,
+        )
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + init_timeout
+        ready = await wait_until_status(
+            self.terminal_id,
+            {
+                TerminalStatus.IDLE,
+                TerminalStatus.PROCESSING,
+                TerminalStatus.COMPLETED,
+                TerminalStatus.ERROR,
+            },
+            timeout=init_timeout,
+            polling_interval=1.0,
+        )
+        if not ready:
+            state = self._read_state()
+            if state is not None:
+                status = state["status"]
+                if status == "error":
+                    detail = state["error"] or "unknown extension error"
+                    raise ProviderError(f"Pi extension failed to initialize: {detail}")
+                raise ProviderError(f"Pi initialization reached unexpected {status} state")
+            raise TimeoutError(f"Pi initialization timed out after {init_timeout}s")
+
+        await self._wait_for_authoritative_idle(deadline, init_timeout)
+        self._initialized = True
+        return True
+
+    async def _wait_for_authoritative_idle(self, deadline: float, init_timeout: float) -> None:
+        """Require the extension sidecar to bind and report its initial idle state."""
+        loop = asyncio.get_running_loop()
+        while True:
+            state = self._read_state()
+            if state is not None:
+                status = state["status"]
+                if status == "idle":
+                    self._last_state_fingerprint = self._state_fingerprint(state)
+                    return
+                if status == "error":
+                    detail = state["error"] or "unknown extension error"
+                    raise ProviderError(f"Pi extension failed to initialize: {detail}")
+                raise ProviderError(f"Pi initialization reached unexpected {status} state")
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError(f"Pi initialization timed out after {init_timeout}s")
+            await asyncio.sleep(min(0.1, remaining))
+
+    def _read_state(self) -> dict[str, str] | None:
+        """Read a validated state snapshot without following a replaced symlink."""
+        flags = os.O_RDONLY
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(self.state_path, flags)
+        except OSError:
+            return None
+
+        try:
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode):
+                return None
+            getuid = getattr(os, "getuid", None)
+            if getuid is not None and metadata.st_uid != getuid():
+                return None
+            if stat.S_IMODE(metadata.st_mode) != 0o600:
+                return None
+            if metadata.st_size > _MAX_STATE_BYTES:
+                return None
+            payload = bytearray()
+            while len(payload) <= _MAX_STATE_BYTES:
+                chunk = os.read(fd, _MAX_STATE_BYTES + 1 - len(payload))
+                if not chunk:
+                    break
+                payload.extend(chunk)
+            if len(payload) > _MAX_STATE_BYTES:
+                return None
+            state = json.loads(payload.decode("utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return None
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
+        if not isinstance(state, dict) or set(state) != _STATE_KEYS:
+            return None
+        if not all(isinstance(state[key], str) for key in _STATE_KEYS):
+            return None
+        if state["status"] not in _STATE_STATUSES:
+            return None
+        try:
+            datetime.fromisoformat(state["updatedAt"].replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return state
+
+    def mark_input_received(self) -> None:
+        """Guard against the extension's entire previous snapshot after dispatch."""
+        if self._last_state_fingerprint is None:
+            state = self._read_state()
+            if state is not None:
+                self._last_state_fingerprint = self._state_fingerprint(state)
+        super().mark_input_received()
+        self._dispatch_pending = True
+        self._dispatch_state_fingerprint = self._last_state_fingerprint
+        self._tui_processing_seen = False
+
+    @staticmethod
+    def _state_fingerprint(state: dict[str, str]) -> tuple[str, str, str, str]:
+        return (
+            state["status"],
+            state["lastAssistantText"],
+            state["error"],
+            state["updatedAt"],
+        )
+
+    def _is_pre_dispatch_state(self, state: dict[str, str]) -> bool:
+        return (
+            self._dispatch_pending
+            and self._dispatch_state_fingerprint is not None
+            and self._state_fingerprint(state) == self._dispatch_state_fingerprint
+        )
+
+    def _status_from_state(self, state: dict[str, str]) -> TerminalStatus:
+        fingerprint = self._state_fingerprint(state)
+        if self._is_pre_dispatch_state(state):
+            return TerminalStatus.PROCESSING
+        self._last_state_fingerprint = fingerprint
+        status = state["status"]
+        if status == "idle":
+            if self._dispatch_pending:
+                return TerminalStatus.PROCESSING
+            return TerminalStatus.IDLE
+        if status == "processing":
+            self._dispatch_pending = False
+            self._dispatch_state_fingerprint = None
+            self._tui_processing_seen = True
+            return TerminalStatus.PROCESSING
+        self._dispatch_pending = False
+        self._dispatch_state_fingerprint = None
+        if status == "completed":
+            return TerminalStatus.COMPLETED
+        return TerminalStatus.ERROR
+
+    @staticmethod
+    def _latest_tui_frame(clean: str) -> str:
+        """Select the newest complete Pi redraw from CAO's rolling pane history."""
+        lines = clean.splitlines()
+        banner_indices = [index for index, line in enumerate(lines) if _PI_BANNER.fullmatch(line)]
+        if len(banner_indices) >= 2:
+            return "\n".join(lines[banner_indices[-1] :])
+
+        footer_indices = [index for index, line in enumerate(lines) if _FOOTER_LINE.search(line)]
+        if len(footer_indices) >= 2:
+            return "\n".join(lines[footer_indices[-2] + 1 :])
+        return clean
+
+    def _status_from_tui(self, buffer: str) -> TerminalStatus:
+        clean = strip_terminal_escapes(buffer)
+        if not clean.strip():
+            return TerminalStatus.UNKNOWN
+        frame = self._latest_tui_frame(clean)
+        if _STARTUP_ERROR.search(frame):
+            return TerminalStatus.ERROR
+        if _WORKING.search(frame):
+            self._dispatch_pending = False
+            self._dispatch_state_fingerprint = None
+            self._tui_processing_seen = True
+            return TerminalStatus.PROCESSING
+
+        lines = frame.splitlines()
+        rule_count = sum(bool(_EDITOR_RULE.fullmatch(line)) for line in lines[-20:])
+        has_footer = bool(_FOOTER_CONTEXT.search("\n".join(lines[-10:])))
+        has_pi_chrome = (
+            "pi v" in frame.lower() or "ctrl+c/ctrl+d clear/exit" in frame.lower() or frame != clean
+        )
+        if rule_count >= 2 and has_footer and has_pi_chrome:
+            if self._dispatch_pending:
+                return TerminalStatus.PROCESSING
+            if self._task_dispatched and self._tui_processing_seen:
+                return TerminalStatus.COMPLETED
+            return TerminalStatus.IDLE
+        return TerminalStatus.UNKNOWN
+
+    def get_status(self, buffer: str) -> TerminalStatus:
+        """Return authoritative sidecar status, with conservative TUI fallback."""
+        state = self._read_state()
+        if state is not None:
+            return self._status_from_state(state)
+
+        native = self._resolve_native_status(buffer)
+        if native is not None:
+            return native
+        return self._status_from_tui(self._resolve_buffer(buffer))
+
+    def extract_last_message_from_script(self, script_output: str) -> str:
+        """Return exact completed sidecar text or a narrow regular-TUI fallback."""
+        state = self._read_state()
+        if state is not None:
+            if not self._is_pre_dispatch_state(state) and state["status"] == "completed":
+                self._last_state_fingerprint = self._state_fingerprint(state)
+                self._dispatch_pending = False
+                self._dispatch_state_fingerprint = None
+                return state["lastAssistantText"]
+
+        clean = strip_terminal_escapes(script_output)
+        frame = self._latest_tui_frame(clean)
+        if _WORKING.search(frame):
+            raise ValueError("No completed Pi response found while Pi is working")
+        lines = frame.splitlines()
+        rule_indices = [index for index, line in enumerate(lines) if _EDITOR_RULE.fullmatch(line)]
+        if len(rule_indices) < 2:
+            raise ValueError("No completed Pi response found in terminal output")
+
+        transcript = lines[: rule_indices[-2]]
+        while transcript and not transcript[-1].strip():
+            transcript.pop()
+        block: list[str] = []
+        while transcript and transcript[-1].strip():
+            block.append(transcript.pop().strip())
+        block.reverse()
+        response = "\n".join(block).strip()
+        if not response or response.startswith(
+            ("Pi can explain", "Press ctrl+o", "escape interrupt", "pi v")
+        ):
+            raise ValueError("No completed Pi response found in terminal output")
+        return response
+
+    def exit_cli(self) -> str:
+        """Return the tmux special key that exits Pi."""
+        return "C-d"
+
+    def cleanup(self) -> None:
+        """Remove only per-provider transient files; retain Pi session data."""
+        for path in (self.prompt_path, self.mcp_config_path, self.state_path):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        self._initialized = False
+        self._dispatch_pending = False
+        self._dispatch_state_fingerprint = None
+        self._last_state_fingerprint = None
+        self._tui_processing_seen = False

--- a/src/cli_agent_orchestrator/providers/pi_extension.ts
+++ b/src/cli_agent_orchestrator/providers/pi_extension.ts
@@ -1,0 +1,514 @@
+import { spawn } from "node:child_process";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+type CaoState = {
+  status: "idle" | "processing" | "completed" | "error";
+  lastAssistantText: string;
+  error: string;
+  updatedAt: string;
+};
+
+type PendingRequest = {
+  resolve: (value: any) => void;
+  reject: (error: Error) => void;
+  cleanup: () => void;
+};
+
+type McpTool = {
+  server: string;
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+};
+
+const STATUS_KEY = "cao-pi-mcp";
+const RESERVED_PI_TOOL_NAMES = new Set(["bash", "read", "edit", "write", "grep", "find", "ls"]);
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+const SHUTDOWN_TERM_GRACE_MS = 500;
+const SHUTDOWN_KILL_GRACE_MS = 500;
+
+async function settlesWithin(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} must be set`);
+  return value;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function abortError(): Error {
+  const error = new Error("MCP tool call aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+class BridgeTerminalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BridgeTerminalError";
+  }
+}
+
+class ProxyBridge {
+  private readonly python: string;
+  private readonly configPath: string;
+  private readonly onTerminalFailure: (error: BridgeTerminalError) => void;
+  private child: any | undefined;
+  private decoder = new StringDecoder("utf8");
+  private buffer = "";
+  private nextRequestId = 0;
+  private pending = new Map<string, PendingRequest>();
+  private terminalError: BridgeTerminalError | undefined;
+  private closing = false;
+  private exitPromise: Promise<void> = Promise.resolve();
+
+  constructor(
+    python: string,
+    configPath: string,
+    onTerminalFailure: (error: BridgeTerminalError) => void,
+  ) {
+    this.python = python;
+    this.configPath = configPath;
+    this.onTerminalFailure = onTerminalFailure;
+  }
+
+  async start(): Promise<void> {
+    if (this.child) return;
+
+    this.decoder = new StringDecoder("utf8");
+    this.buffer = "";
+    this.terminalError = undefined;
+    this.closing = false;
+    const child = spawn(
+      this.python,
+      [
+        "-m",
+        "cli_agent_orchestrator.providers.pi_mcp_proxy",
+        "--config",
+        this.configPath,
+      ],
+      { env: process.env, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    this.child = child;
+    let settleExit: () => void = () => undefined;
+    this.exitPromise = new Promise((resolve) => {
+      let settled = false;
+      settleExit = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+    });
+    child.stdout.on("data", (chunk: Buffer) => this.consume(chunk));
+    child.stderr.on("data", (chunk: Buffer) => process.stderr.write(chunk));
+    child.stdin.on("error", (error: Error) => {
+      this.fail(new BridgeTerminalError(error.message), !this.closing);
+    });
+    child.once("error", (error: Error) => {
+      if (this.child === child) this.child = undefined;
+      this.fail(new BridgeTerminalError(error.message), !this.closing);
+      child.stdin.destroy();
+      child.stdout.destroy();
+      child.stderr.destroy();
+      child.unref();
+      settleExit();
+    });
+    child.once("exit", (code: number | null, signal: string | null) => {
+      if (this.child === child) this.child = undefined;
+      if (!this.closing || this.pending.size > 0) {
+        const reason = signal ? `signal ${signal}` : `exit code ${code}`;
+        this.fail(new BridgeTerminalError(`Pi MCP proxy exited with ${reason}`), !this.closing);
+      }
+      settleExit();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const onSpawn = () => {
+        child.off("error", onError);
+        resolve();
+      };
+      const onError = (error: Error) => {
+        child.off("spawn", onSpawn);
+        reject(this.terminalError ?? new BridgeTerminalError(error.message));
+      };
+      child.once("spawn", onSpawn);
+      child.once("error", onError);
+    });
+  }
+
+  async listTools(): Promise<McpTool[]> {
+    const result = await this.request("list_tools", {});
+    if (!result || !Array.isArray(result.tools)) {
+      throw new Error("Pi MCP proxy returned an invalid tool list");
+    }
+    return result.tools as McpTool[];
+  }
+
+  async callTool(
+    tool: McpTool,
+    arguments_: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<any> {
+    return this.request(
+      "call_tool",
+      { server: tool.server, name: tool.name, arguments: arguments_ },
+      signal,
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    const child = this.child;
+    if (!child) return;
+    this.closing = true;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const graceful = (async () => {
+      await this.request("shutdown", {});
+      child.stdin.end();
+      await this.exitPromise;
+    })();
+    const outcome = await Promise.race([
+      graceful.then(
+        () => "complete" as const,
+        () => "failed" as const,
+      ),
+      new Promise<"timeout">((resolve) => {
+        timeout = setTimeout(() => resolve("timeout"), SHUTDOWN_TIMEOUT_MS);
+      }),
+    ]);
+    if (timeout) clearTimeout(timeout);
+
+    if (outcome !== "complete") {
+      this.fail(new BridgeTerminalError("Pi MCP proxy did not shut down cleanly"), false);
+      child.stdin.destroy();
+      let exited = await settlesWithin(this.exitPromise, 0);
+      if (!exited) {
+        child.kill("SIGTERM");
+        exited = await settlesWithin(this.exitPromise, SHUTDOWN_TERM_GRACE_MS);
+      }
+      if (!exited) {
+        child.kill("SIGKILL");
+        exited = await settlesWithin(this.exitPromise, SHUTDOWN_KILL_GRACE_MS);
+      }
+      if (!exited) {
+        child.stdout.destroy();
+        child.stderr.destroy();
+        child.unref();
+      }
+    }
+    if (this.child === child) this.child = undefined;
+  }
+
+  private request(
+    type: string,
+    fields: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<any> {
+    if (signal?.aborted) return Promise.reject(abortError());
+    if (!this.child || this.terminalError) {
+      return Promise.reject(this.terminalError ?? new Error("Pi MCP proxy is not running"));
+    }
+
+    const child = this.child;
+    const id = String(++this.nextRequestId);
+    return new Promise((resolve, reject) => {
+      const onAbort = () => {
+        this.pending.delete(id);
+        cleanup();
+        void this.request("cancel", { targetId: id }).catch(() => undefined);
+        reject(abortError());
+      };
+      const cleanup = () => signal?.removeEventListener("abort", onAbort);
+      this.pending.set(id, { resolve, reject, cleanup });
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      child.stdin.write(`${JSON.stringify({ id, type, ...fields })}\n`, (error?: Error) => {
+        if (!error) return;
+        this.fail(new BridgeTerminalError(error.message), !this.closing);
+      });
+    });
+  }
+
+  private consume(chunk: Buffer): void {
+    this.buffer += this.decoder.write(chunk);
+    let newline = this.buffer.indexOf("\n");
+    while (newline !== -1) {
+      let line = this.buffer.slice(0, newline);
+      this.buffer = this.buffer.slice(newline + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      if (line) this.consumeLine(line);
+      newline = this.buffer.indexOf("\n");
+    }
+  }
+
+  private consumeLine(line: string): void {
+    let response: any;
+    try {
+      response = JSON.parse(line);
+    } catch {
+      this.fail(new BridgeTerminalError("Pi MCP proxy returned malformed JSON"));
+      return;
+    }
+    if (!response || typeof response.id !== "string" || typeof response.ok !== "boolean") {
+      this.fail(new BridgeTerminalError("Pi MCP proxy returned an invalid response"));
+      return;
+    }
+
+    const pending = this.pending.get(response.id);
+    if (!pending) return;
+    this.pending.delete(response.id);
+    pending.cleanup();
+    if (response.ok) pending.resolve(response.result);
+    else pending.reject(new Error(String(response.error || "Pi MCP proxy request failed")));
+  }
+
+  private fail(error: BridgeTerminalError, publish = true): void {
+    if (!this.terminalError) this.terminalError = error;
+    for (const pending of this.pending.values()) {
+      pending.cleanup();
+      pending.reject(this.terminalError);
+    }
+    this.pending.clear();
+    if (publish && this.terminalError === error) this.onTerminalFailure(error);
+  }
+}
+
+function assistantText(message: any): string | undefined {
+  if (!message || message.role !== "assistant" || !Array.isArray(message.content)) {
+    return undefined;
+  }
+  return message.content
+    .filter((item: any) => item?.type === "text" && typeof item.text === "string")
+    .map((item: any) => item.text)
+    .join("");
+}
+
+function unsupportedContent(item: any): string {
+  if (item?.type === "resource_link" && typeof item.uri === "string") {
+    return `${item.title || item.name || "MCP resource"}: ${item.uri}`;
+  }
+  if (item?.type === "audio") {
+    return `[MCP audio content${item.mimeType ? ` (${item.mimeType})` : ""}]`;
+  }
+  try {
+    return JSON.stringify(item);
+  } catch {
+    return String(item);
+  }
+}
+
+function normalizeMcpContent(result: any): Array<Record<string, string>> {
+  const normalized: Array<Record<string, string>> = [];
+  for (const item of Array.isArray(result?.content) ? result.content : []) {
+    if (item?.type === "text" && typeof item.text === "string") {
+      normalized.push({ type: "text", text: item.text });
+    } else if (
+      item?.type === "image" &&
+      typeof item.data === "string" &&
+      typeof item.mimeType === "string"
+    ) {
+      normalized.push({ type: "image", data: item.data, mimeType: item.mimeType });
+    } else if (item?.type === "resource" && item.resource) {
+      if (typeof item.resource.text === "string") {
+        normalized.push({ type: "text", text: item.resource.text });
+      } else if (
+        typeof item.resource.blob === "string" &&
+        typeof item.resource.mimeType === "string" &&
+        item.resource.mimeType.startsWith("image/")
+      ) {
+        normalized.push({
+          type: "image",
+          data: item.resource.blob,
+          mimeType: item.resource.mimeType,
+        });
+      } else {
+        normalized.push({ type: "text", text: unsupportedContent(item) });
+      }
+    } else {
+      normalized.push({ type: "text", text: unsupportedContent(item) });
+    }
+  }
+  if (normalized.length === 0 && result?.structuredContent !== undefined) {
+    normalized.push({ type: "text", text: JSON.stringify(result.structuredContent) });
+  }
+  if (normalized.length === 0) normalized.push({ type: "text", text: "" });
+  return normalized;
+}
+
+export default function caoPiExtension(pi: any) {
+  const stateFile = requiredEnvironment("CAO_PI_STATE_FILE");
+  let activeContext: any | undefined;
+  let terminalFailure: BridgeTerminalError | undefined;
+  let terminalReport: Promise<void> | undefined;
+  const bridge = new ProxyBridge(
+    requiredEnvironment("CAO_PI_BRIDGE_PYTHON"),
+    requiredEnvironment("CAO_PI_MCP_CONFIG"),
+    (error) => {
+      terminalFailure = error;
+      if (!activeContext) return;
+      void reportBridgeFailure(activeContext, error).catch((stateError) => {
+        activeContext.ui.setStatus(
+          STATUS_KEY,
+          `MCP error: ${error.message}; state update failed: ${asError(stateError).message}`,
+        );
+      });
+    },
+  );
+  let currentState: CaoState = {
+    status: "idle",
+    lastAssistantText: "",
+    error: "",
+    updatedAt: "",
+  };
+  let cachedAssistantText = "";
+  let writeSequence = 0;
+  let writeQueue: Promise<void> = Promise.resolve();
+  let bridgeFailed = false;
+  const registeredToolNames = new Set<string>();
+
+  function writeState(patch: Partial<Omit<CaoState, "updatedAt">>): Promise<void> {
+    currentState = { ...currentState, ...patch, updatedAt: new Date().toISOString() };
+    const snapshot = JSON.stringify(currentState);
+    const temporary = `${stateFile}.${process.pid}.${++writeSequence}.tmp`;
+    writeQueue = writeQueue.then(async () => {
+      await mkdir(dirname(stateFile), { recursive: true, mode: 0o700 });
+      try {
+        await writeFile(temporary, snapshot, { encoding: "utf8", mode: 0o600 });
+        await rename(temporary, stateFile);
+      } catch (error) {
+        await unlink(temporary).catch(() => undefined);
+        throw error;
+      }
+    });
+    return writeQueue;
+  }
+
+  async function reportBridgeFailure(ctx: any, error: unknown): Promise<void> {
+    const normalized = asError(error);
+    if (terminalFailure === normalized && terminalReport) return terminalReport;
+    bridgeFailed = true;
+    const message = normalized.message;
+    ctx.ui.setStatus(STATUS_KEY, `MCP error: ${message}`);
+    const report = writeState({ status: "error", error: message });
+    if (terminalFailure === normalized) terminalReport = report;
+    await report;
+  }
+
+  function toPiTool(tool: McpTool): any {
+    if (
+      !tool ||
+      typeof tool.server !== "string" ||
+      typeof tool.name !== "string" ||
+      !tool.name ||
+      !tool.inputSchema ||
+      typeof tool.inputSchema !== "object" ||
+      Array.isArray(tool.inputSchema)
+    ) {
+      throw new Error("Pi MCP proxy returned an invalid tool definition");
+    }
+    return {
+      name: tool.name,
+      label: typeof tool.title === "string" && tool.title ? tool.title : tool.name,
+      description: typeof tool.description === "string" ? tool.description : "MCP tool",
+      parameters: tool.inputSchema,
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+        signal: AbortSignal | undefined,
+        _onUpdate: unknown,
+        ctx: any,
+      ) {
+        try {
+          const result = await bridge.callTool(tool, params, signal);
+          const content = normalizeMcpContent(result);
+          if (result?.isError) {
+            throw new Error(
+              content
+                .filter((item) => item.type === "text")
+                .map((item) => item.text)
+                .join("\n") || "MCP tool failed",
+            );
+          }
+          return { content, details: { server: tool.server, result } };
+        } catch (error) {
+          if (error instanceof BridgeTerminalError) {
+            await reportBridgeFailure(ctx, error);
+          }
+          throw error;
+        }
+      },
+    };
+  }
+
+  pi.on("session_start", async (_event: any, ctx: any) => {
+    activeContext = ctx;
+    try {
+      await bridge.start();
+      const tools = await bridge.listTools();
+      for (const tool of tools) {
+        if (RESERVED_PI_TOOL_NAMES.has(tool?.name)) {
+          throw new Error(`Pi MCP proxy returned reserved Pi tool name: ${tool.name}`);
+        }
+      }
+      for (const tool of tools) {
+        if (registeredToolNames.has(tool.name)) continue;
+        pi.registerTool(toPiTool(tool));
+        registeredToolNames.add(tool.name);
+      }
+      if (terminalFailure) {
+        await reportBridgeFailure(ctx, terminalFailure);
+        throw terminalFailure;
+      }
+      ctx.ui.setStatus(STATUS_KEY, undefined);
+      await writeState({ status: "idle", lastAssistantText: "", error: "" });
+    } catch (error) {
+      await reportBridgeFailure(ctx, error);
+      throw error;
+    }
+  });
+
+  pi.on("agent_start", async () => {
+    if (bridgeFailed) return;
+    await writeState({ status: "processing", error: "" });
+  });
+
+  pi.on("message_end", async (event: any) => {
+    if (bridgeFailed) return;
+    const text = assistantText(event.message);
+    if (text !== undefined) cachedAssistantText = text;
+  });
+
+  pi.on("agent_settled", async () => {
+    if (bridgeFailed) return;
+    await writeState({
+      status: "completed",
+      lastAssistantText: cachedAssistantText,
+      error: "",
+    });
+  });
+
+  pi.on("session_shutdown", async (_event: any, ctx: any) => {
+    try {
+      await bridge.shutdown();
+    } catch (error) {
+      await reportBridgeFailure(ctx, error);
+    }
+  });
+}

--- a/src/cli_agent_orchestrator/providers/pi_mcp_proxy.py
+++ b/src/cli_agent_orchestrator/providers/pi_mcp_proxy.py
@@ -1,0 +1,389 @@
+"""JSONL bridge between Pi extensions and stdio MCP servers."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
+from datetime import timedelta
+from functools import partial
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.types import CancelledNotification, CancelledNotificationParams, ClientNotification
+
+DEFAULT_REQUEST_TIMEOUT_MS = 1_200_000
+CANCEL_NOTIFICATION_TIMEOUT_SECONDS = 0.25
+RESERVED_PI_TOOL_NAMES = frozenset({"bash", "read", "edit", "write", "grep", "find", "ls"})
+
+
+class ProxyConfigError(ValueError):
+    """Raised when a bridge configuration cannot be used safely."""
+
+
+class ProxyProtocolError(ValueError):
+    """Raised when a bridge protocol request or response is invalid."""
+
+
+class _CancellableClientSession(ClientSession):
+    """Expose MCP cancellation for the bridge task that issued a tool request."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._tool_request_ids: dict[asyncio.Task[Any], int | str] = {}
+
+    async def call_tool(self, *args: Any, **kwargs: Any) -> Any:
+        task = asyncio.current_task()
+        if task is None:
+            return await super().call_tool(*args, **kwargs)
+
+        # CAO's locked MCP 1.28.1 has no public request-ID accessor. Its public
+        # call_tool() immediately enters send_request(), which assigns this value
+        # before its first await, so the mapping is exact and remains task-local
+        # for calls concurrently issued to the same MCP server. Re-run the real
+        # stdio cancellation regression when upgrading that locked dependency.
+        request_id = self._request_id
+        self._tool_request_ids[task] = request_id
+        try:
+            return await super().call_tool(*args, **kwargs)
+        finally:
+            self._tool_request_ids.pop(task, None)
+
+    async def notify_call_cancelled(self, task: asyncio.Task[Any]) -> None:
+        """Send the MCP cancellation notification for this bridge call, if active."""
+        request_id = self._tool_request_ids.get(task)
+        if request_id is None:
+            return
+        await self.send_notification(
+            ClientNotification(
+                root=CancelledNotification(
+                    params=CancelledNotificationParams(
+                        requestId=request_id,
+                        reason="cancelled by Pi",
+                    )
+                )
+            )
+        )
+
+
+@dataclass(frozen=True)
+class ProxyServerConfig:
+    """The supported stdio subset of an MCP server declaration."""
+
+    name: str
+    command: str
+    args: list[str]
+    env: dict[str, str]
+    request_timeout_ms: int
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    """Validated bridge configuration."""
+
+    terminal_id: str
+    servers: dict[str, ProxyServerConfig]
+
+
+def load_proxy_config(path: Path) -> ProxyConfig:
+    """Load the command-only MCP configuration accepted by the bridge."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProxyConfigError("unable to read proxy configuration") from exc
+
+    if not isinstance(raw, dict):
+        raise ProxyConfigError("proxy configuration must be an object")
+    terminal_id = raw.get("terminalId")
+    if not isinstance(terminal_id, str) or not terminal_id:
+        raise ProxyConfigError("terminalId must be a non-empty string")
+    servers_raw = raw.get("servers")
+    if not isinstance(servers_raw, dict):
+        raise ProxyConfigError("servers must be an object")
+
+    servers: dict[str, ProxyServerConfig] = {}
+    for name, server_raw in servers_raw.items():
+        if not isinstance(name, str) or not name:
+            raise ProxyConfigError("server names must be non-empty strings")
+        if not isinstance(server_raw, dict):
+            raise ProxyConfigError(f"server {name!r} must be an object")
+        if server_raw.get("type", "stdio") != "stdio" or "url" in server_raw:
+            raise ProxyConfigError(f"server {name!r} must use stdio transport")
+
+        command = server_raw.get("command")
+        if not isinstance(command, str) or not command:
+            raise ProxyConfigError(f"server {name!r} requires a non-empty command")
+        args = server_raw.get("args", [])
+        if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+            raise ProxyConfigError(f"server {name!r} args must be a list of strings")
+        env = server_raw.get("env", {})
+        if not isinstance(env, dict) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in env.items()
+        ):
+            raise ProxyConfigError(f"server {name!r} environment must map strings to strings")
+        timeout = server_raw.get("requestTimeoutMs", DEFAULT_REQUEST_TIMEOUT_MS)
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, int)
+            or not 1 <= timeout <= DEFAULT_REQUEST_TIMEOUT_MS
+        ):
+            raise ProxyConfigError(
+                f"server {name!r} timeout must be between 1 and {DEFAULT_REQUEST_TIMEOUT_MS} ms"
+            )
+        servers[name] = ProxyServerConfig(name, command, args, env, timeout)
+
+    return ProxyConfig(terminal_id, servers)
+
+
+def flatten_tools(tools_by_server: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Attach server names to MCP tools, rejecting ambiguous exposed names."""
+    flattened: list[dict[str, Any]] = []
+    names: set[str] = set()
+    for server, tools in tools_by_server.items():
+        for tool in tools:
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
+                raise ProxyProtocolError(f"server {server!r} returned a tool without a name")
+            if name in RESERVED_PI_TOOL_NAMES:
+                raise ProxyProtocolError(f"reserved Pi tool name: {name}")
+            if name in names:
+                raise ProxyProtocolError(f"duplicate tool name: {name}")
+            names.add(name)
+            flattened.append({**tool, "server": server})
+    return flattened
+
+
+def response_ok(request_id: str, result: Any) -> dict[str, Any]:
+    """Build an ID-correlated successful JSONL response."""
+    return {"id": request_id, "ok": True, "result": result}
+
+
+def response_error(request_id: str, error: Exception) -> dict[str, Any]:
+    """Build an ID-correlated error response without serializing exception state."""
+    if isinstance(error, (ProxyConfigError, ProxyProtocolError)):
+        message = str(error)
+    else:
+        message = "internal proxy error"
+    return {"id": request_id, "ok": False, "error": message}
+
+
+def _write_response(writer: TextIO, response: dict[str, Any]) -> None:
+    """Write exactly one protocol response without adding diagnostics to stdout."""
+    writer.write(json.dumps(response, separators=(",", ":")) + "\n")
+    writer.flush()
+
+
+def _request_id(request: object) -> str:
+    if not isinstance(request, dict):
+        raise ProxyProtocolError("request id must be a string")
+    request_id = request.get("id")
+    if not isinstance(request_id, str):
+        raise ProxyProtocolError("request id must be a string")
+    return request_id
+
+
+def _tool_names(tools_by_server: dict[str, list[dict[str, Any]]]) -> dict[str, set[str]]:
+    """Return the SDK-discovered tool names after enforcing global uniqueness."""
+    flatten_tools(tools_by_server)
+    return {server: {tool["name"] for tool in tools} for server, tools in tools_by_server.items()}
+
+
+async def _load_server_tools(
+    config: ProxyConfig, stack: AsyncExitStack
+) -> tuple[dict[str, _CancellableClientSession], dict[str, list[dict[str, Any]]]]:
+    """Start every configured stdio server and retrieve its advertised tools."""
+    sessions: dict[str, _CancellableClientSession] = {}
+    tools_by_server: dict[str, list[dict[str, Any]]] = {}
+
+    for server in config.servers.values():
+        env = {**os.environ, **server.env, "CAO_TERMINAL_ID": config.terminal_id}
+        read_stream, write_stream = await stack.enter_async_context(
+            stdio_client(
+                StdioServerParameters(command=server.command, args=server.args, env=env),
+                errlog=sys.stderr,
+            )
+        )
+        session = await stack.enter_async_context(
+            _CancellableClientSession(
+                read_stream,
+                write_stream,
+                read_timeout_seconds=timedelta(milliseconds=server.request_timeout_ms),
+            )
+        )
+        await session.initialize()
+        sessions[server.name] = session
+
+        tools: list[dict[str, Any]] = []
+        cursor: str | None = None
+        while True:
+            result = await session.list_tools(cursor=cursor)
+            tools.extend(tool.model_dump(mode="json") for tool in result.tools)
+            cursor = result.nextCursor
+            if cursor is None:
+                break
+        tools_by_server[server.name] = tools
+
+    _tool_names(tools_by_server)
+    return sessions, tools_by_server
+
+
+async def _run_proxy(config: ProxyConfig, reader: TextIO, writer: TextIO) -> None:
+    """Serve the Pi bridge protocol until an explicit shutdown request or EOF."""
+    async with AsyncExitStack() as stack:
+        sessions, tools_by_server = await _load_server_tools(config, stack)
+        exposed_tools = flatten_tools(tools_by_server)
+        names_by_server = _tool_names(tools_by_server)
+        write_lock = asyncio.Lock()
+        call_tasks: dict[str, asyncio.Task[None]] = {}
+        call_sessions: dict[asyncio.Task[Any], _CancellableClientSession] = {}
+
+        async def write_response(response: dict[str, Any]) -> None:
+            async with write_lock:
+                _write_response(writer, response)
+
+        async def call_tool(
+            request_id: str,
+            server_name: str,
+            tool_name: str,
+            arguments: dict[str, Any],
+        ) -> None:
+            task = asyncio.current_task()
+            session = sessions[server_name]
+            if task is not None:
+                call_sessions[task] = session
+            try:
+                result = await session.call_tool(
+                    tool_name,
+                    arguments,
+                    read_timeout_seconds=timedelta(
+                        milliseconds=config.servers[server_name].request_timeout_ms
+                    ),
+                )
+                await write_response(
+                    response_ok(
+                        request_id,
+                        result.model_dump(mode="json", exclude_none=True),
+                    )
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                print(
+                    f"Unexpected Pi MCP proxy request failure: {type(exc).__name__}",
+                    file=sys.stderr,
+                )
+                await write_response(response_error(request_id, exc))
+            finally:
+                if task is not None:
+                    call_sessions.pop(task, None)
+
+        def forget_call(request_id: str, task: asyncio.Future[None]) -> None:
+            if call_tasks.get(request_id) is task:
+                call_tasks.pop(request_id, None)
+
+        async def cancel_calls(tasks: list[asyncio.Task[None]]) -> None:
+            for task in tasks:
+                session = call_sessions.get(task)
+                if session is not None:
+                    try:
+                        # A successful notification only means the local MCP transport
+                        # accepted the one-way message; Pi's ``cancelled`` response
+                        # guarantees local task cancellation, never remote tool state.
+                        await asyncio.wait_for(
+                            session.notify_call_cancelled(task),
+                            timeout=CANCEL_NOTIFICATION_TIMEOUT_SECONDS,
+                        )
+                    except Exception as exc:
+                        print(
+                            f"Unexpected Pi MCP proxy cancellation failure: {type(exc).__name__}",
+                            file=sys.stderr,
+                        )
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        try:
+            while True:
+                line = await asyncio.to_thread(reader.readline)
+                if line == "":
+                    break
+                if not line.strip():
+                    continue
+                request_id = ""
+                try:
+                    request = json.loads(line)
+                    request_id = _request_id(request)
+                    request_type = request.get("type")
+                    if request_type == "list_tools":
+                        await write_response(response_ok(request_id, {"tools": exposed_tools}))
+                    elif request_type == "call_tool":
+                        server_name = request.get("server")
+                        tool_name = request.get("name")
+                        arguments = request.get("arguments", {})
+                        if not isinstance(server_name, str) or server_name not in sessions:
+                            raise ProxyProtocolError("unknown server")
+                        if (
+                            not isinstance(tool_name, str)
+                            or tool_name not in names_by_server[server_name]
+                        ):
+                            raise ProxyProtocolError("unknown tool")
+                        if not isinstance(arguments, dict):
+                            raise ProxyProtocolError("tool arguments must be an object")
+                        if request_id in call_tasks:
+                            raise ProxyProtocolError("request id is already active")
+                        call_task = asyncio.create_task(
+                            call_tool(request_id, server_name, tool_name, arguments)
+                        )
+                        call_tasks[request_id] = call_task
+                        call_task.add_done_callback(partial(forget_call, request_id))
+                    elif request_type == "cancel":
+                        target_id = request.get("targetId")
+                        if not isinstance(target_id, str):
+                            raise ProxyProtocolError("cancel targetId must be a string")
+                        target_task = call_tasks.get(target_id)
+                        cancelled = target_task is not None and not target_task.done()
+                        if target_task is not None:
+                            await cancel_calls([target_task])
+                        await write_response(response_ok(request_id, {"cancelled": cancelled}))
+                    elif request_type == "shutdown":
+                        await cancel_calls(list(call_tasks.values()))
+                        await write_response(response_ok(request_id, {}))
+                        return
+                    else:
+                        raise ProxyProtocolError("unknown request type")
+                except Exception as exc:
+                    if not isinstance(exc, (ProxyConfigError, ProxyProtocolError)):
+                        print(
+                            f"Unexpected Pi MCP proxy request failure: {type(exc).__name__}",
+                            file=sys.stderr,
+                        )
+                    await write_response(response_error(request_id, exc))
+        finally:
+            await cancel_calls(list(call_tasks.values()))
+
+
+def run_proxy(config_path: Path, reader: TextIO, writer: TextIO) -> None:
+    """Load bridge configuration and synchronously run its JSONL protocol loop."""
+    asyncio.run(_run_proxy(load_proxy_config(config_path), reader, writer))
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the proxy as ``python -m ...pi_mcp_proxy --config <path>``."""
+    parser = argparse.ArgumentParser(description="Pi stdio MCP JSONL proxy")
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        run_proxy(args.config, sys.stdin, sys.stdout)
+    except ProxyConfigError as exc:
+        print(f"pi MCP proxy configuration error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by the Pi extension process.
+    main()

--- a/src/cli_agent_orchestrator/schemas/agent_profile.schema.json
+++ b/src/cli_agent_orchestrator/schemas/agent_profile.schema.json
@@ -33,7 +33,21 @@
     },
     "provider": {
       "type": "string",
-      "description": "Provider override (e.g. claude_code, kiro_cli, codex)."
+      "enum": [
+        "kiro_cli",
+        "claude_code",
+        "codex",
+        "kimi_cli",
+        "copilot_cli",
+        "opencode_cli",
+        "hermes",
+        "cursor_cli",
+        "antigravity_cli",
+        "grok_cli",
+        "pi",
+        "mock_cli"
+      ],
+      "description": "Provider override."
     },
     "engine": {
       "type": "string",

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -161,6 +161,7 @@ RUNTIME_SKILL_PROMPT_PROVIDERS = {
     ProviderType.KIMI_CLI.value,
     ProviderType.ANTIGRAVITY_CLI.value,
     ProviderType.GROK_CLI.value,
+    ProviderType.PI.value,
 }
 
 # Providers whose tool restrictions are prompt-level text only (no native
@@ -432,8 +433,8 @@ async def create_terminal(
                 f"Terminal {terminal_id}: provider '{provider}' cannot enforce tool "
                 f"restrictions (soft/prompt-level only) but profile '{agent_profile}' "
                 f"requests {allowed_tools}. Treat this worker as unrestricted; for "
-                f"enforced restrictions use claude_code, grok_cli, kiro_cli, or "
-                f"copilot_cli."
+                f"enforced restrictions use claude_code, grok_cli, kiro_cli, "
+                f"copilot_cli, or pi."
             )
 
         # Step 3c: Persist terminal metadata to database after restrictions
@@ -490,7 +491,7 @@ async def create_terminal(
 
         # Step 6: Create and initialize the CLI provider
         # This starts the agent (e.g., runs "kiro-cli chat --agent developer").
-        # Only runtime-prompt providers (Claude Code, Codex, Kimi) receive
+        # Only runtime-prompt providers (Claude Code, Codex, Kimi, Pi) receive
         # the skill catalog here; Kiro (skill:// resources) and OpenCode
         # (OPENCODE_CONFIG_DIR/skills symlink) discover skills natively;
         # Copilot gets the catalog baked at install time.

--- a/src/cli_agent_orchestrator/skills/cao-session-management/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-session-management/SKILL.md
@@ -28,6 +28,12 @@ Before launching a session, verify:
   ```
   If not running, start it in a separate terminal: `cao-server`.
 - **The agent profile is installed.** `cao launch --agents <profile>` fails if the profile is unknown. Install built-ins or custom files with `cao install <profile|path|url>`.
+- **The selected provider CLI is ready.** For Pi sessions, `pi` must be on the
+  `cao-server` process's `PATH` and already authenticated/model-configured. CAO
+  pins the resolved executable and does not directly write Pi credential or
+  configuration files or install Pi packages. Pi may still migrate or update
+  configuration or manage packages in its own agent directory during startup
+  and normal operation.
 
 ## Discovering Available Profiles
 
@@ -47,7 +53,7 @@ If unsure which profile to use, ask the user rather than guessing.
 
 ## Quick Example
 
-A complete, copy-pasteable supervisor launch. The default provider is `kiro_cli`; pass `--provider <name>` to use another (`claude_code`, `codex`, `antigravity_cli`, `kimi_cli`, `copilot_cli`, `opencode_cli`, `cursor_cli`).
+A complete, copy-pasteable supervisor launch. The default provider is `kiro_cli`; pass `--provider <name>` to use another (`claude_code`, `codex`, `antigravity_cli`, `kimi_cli`, `copilot_cli`, `opencode_cli`, `cursor_cli`, `hermes`, `pi`).
 
 This example assumes a configured CAO setup (server running, profiles installed). On an already-configured host you can skip straight to `cao launch`. The `cao install` lines below are only for first-time setup; remove them if your CAO is already configured.
 
@@ -94,6 +100,13 @@ cao launch --agents <profile> --headless --yolo \
 
 `--yolo` skips confirmation prompts. Required when launching from an agent — interactive
 prompts will stall the session.
+
+For Pi, CAO's `--headless` means "do not attach this caller"; Pi itself still
+runs its regular attachable TUI in the selected backend's window or pane. In an
+attached Pi TUI, `C-d` exits Pi; the explicit `run_agent_step` exit path uses
+that key too. Normal `cao shutdown` or terminal deletion instead terminates that
+window or pane without first sending Pi `C-d`. Generated `CAO_PI_*` variables
+are internal wiring and must not be set as user configuration.
 
 For SOP-driven workflows (Kiro provider): launch with `/prompts` to discover
 available SOPs, then send the matched SOP name prefixed with `@` (e.g.,

--- a/src/cli_agent_orchestrator/utils/tool_mapping.py
+++ b/src/cli_agent_orchestrator/utils/tool_mapping.py
@@ -88,6 +88,13 @@ TOOL_MAPPING: Dict[str, Dict[str, List[str]]] = {
         ],
         "web_fetch": ["web_fetch", "google_web_search"],
     },
+    "pi": {
+        "execute_bash": ["bash"],
+        "fs_read": ["read"],
+        "fs_write": ["edit", "write"],
+        "fs_list": ["grep", "find", "ls"],
+        "fs_*": ["read", "edit", "write", "grep", "find", "ls"],
+    },
 }
 
 # Complete set of all native tools per provider (used to compute disallowed set).

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -123,7 +123,7 @@ class TestAgentProviders:
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 10
+        assert len(data) == 11
         names = [p["name"] for p in data]
         assert "kiro_cli" in names
         assert "claude_code" in names
@@ -135,6 +135,9 @@ class TestAgentProviders:
         assert "cursor_cli" in names
         assert "antigravity_cli" in names
         assert "grok_cli" in names
+        assert "pi" in names
+        assert {"name": "grok_cli", "binary": "grok", "installed": True} in data
+        assert {"name": "pi", "binary": "pi", "installed": True} in data
         for p in data:
             assert p["installed"] is True
 
@@ -145,6 +148,13 @@ class TestAgentProviders:
 
         assert response.status_code == 200
         data = response.json()
+        providers_dict = {p["name"]: p for p in data}
+        assert providers_dict["pi"] == {"name": "pi", "binary": "pi", "installed": False}
+        assert providers_dict["grok_cli"] == {
+            "name": "grok_cli",
+            "binary": "grok",
+            "installed": False,
+        }
         for p in data:
             assert p["installed"] is False
 
@@ -167,6 +177,7 @@ class TestAgentProviders:
         assert providers_dict["copilot_cli"]["installed"] is False
         assert providers_dict["opencode_cli"]["installed"] is False
         assert providers_dict["grok_cli"]["installed"] is False
+        assert providers_dict["pi"] == {"name": "pi", "binary": "pi", "installed": False}
 
     def test_list_providers_has_binary_field(self, client):
         """Each provider entry has correct binary name."""
@@ -183,6 +194,7 @@ class TestAgentProviders:
         assert providers_dict["opencode_cli"]["binary"] == "opencode"
         assert providers_dict["antigravity_cli"]["binary"] == "agy"
         assert providers_dict["grok_cli"]["binary"] == "grok"
+        assert providers_dict["pi"]["binary"] == "pi"
 
 
 # ── Skills endpoint ──────────────────────────────────────────────────

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -8,6 +8,15 @@ from click.testing import CliRunner
 
 from cli_agent_orchestrator.cli.commands.launch import _parse_env_pairs, launch
 
+
+def test_pi_launch_requires_workspace_access_confirmation():
+    from cli_agent_orchestrator.cli.commands.launch import (
+        PROVIDERS_REQUIRING_WORKSPACE_ACCESS,
+    )
+
+    assert "pi" in PROVIDERS_REQUIRING_WORKSPACE_ACCESS
+
+
 # ── Backend auto-detection (issue #308) ──────────────────────────────
 
 

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -220,6 +220,31 @@ class TestCreateSessionEnvironmentFiltering:
         assert "RANDOM_VAR" not in env
         assert "MY_CUSTOM_THING" not in env
 
+    def test_pi_config_dir_reaches_initial_session_and_worker_window(self, tmux, tmp_path):
+        """Pi workers need the caller's private config directory after HOME isolation."""
+        initial_window = MagicMock()
+        initial_window.name = "supervisor"
+        session = MagicMock()
+        session.windows = [initial_window]
+        worker_window = MagicMock()
+        worker_window.name = "developer"
+        session.new_window.return_value = worker_window
+        tmux.server.new_session.return_value = session
+        tmux.server.sessions.get.return_value = session
+
+        with patch.dict(
+            os.environ,
+            {"HOME": "/isolated/home", "PI_CODING_AGENT_DIR": "/private/pi-agent"},
+            clear=True,
+        ):
+            tmux.create_session("cao-pi", "supervisor", "supervisor-id", str(tmp_path))
+            tmux.create_window("cao-pi", "developer", "developer-id", str(tmp_path))
+
+        session_env = tmux.server.new_session.call_args.kwargs["environment"]
+        worker_env = session.new_window.call_args.kwargs["environment"]
+        assert session_env["PI_CODING_AGENT_DIR"] == "/private/pi-agent"
+        assert worker_env["PI_CODING_AGENT_DIR"] == "/private/pi-agent"
+
 
 # ── create_window ────────────────────────────────────────────────────
 

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -2,7 +2,7 @@
 
 E2E tests require:
 - The provider CLI tool installed and authenticated (for example codex,
-  claude, kiro-cli, gemini, copilot, or grok)
+  claude, kiro-cli, pi, gemini, copilot, or grok)
 - tmux available on the system
 
 The CAO server is started automatically by the ``cao_server`` fixture from
@@ -72,6 +72,28 @@ def require_kiro():
     """Skip test if kiro-cli is not available."""
     if not _cli_available("kiro-cli"):
         pytest.skip("kiro-cli CLI not installed")
+
+
+@pytest.fixture()
+def require_pi(cao_server: CaoServer):
+    """Require opted-in Pi configuration and seed assign profiles into CAO's isolated home."""
+    config_dir = os.environ.get("PI_CODING_AGENT_DIR")
+    if not config_dir or not Path(config_dir).expanduser().is_dir():
+        pytest.skip(
+            "Pi E2E requires PI_CODING_AGENT_DIR to name an existing private Pi "
+            "configuration directory before pytest starts"
+        )
+    if shutil.which("pi") is None:
+        pytest.skip("pi CLI not installed")
+
+    profile_store = cao_server.home_dir / ".aws" / "cli-agent-orchestrator" / "agent-store"
+    profile_store.mkdir(parents=True, exist_ok=True, mode=0o700)
+    profile_store.chmod(0o700)
+    examples = Path(__file__).resolve().parents[2] / "examples" / "assign"
+    for profile_name in ("analysis_supervisor", "data_analyst", "report_generator"):
+        target = profile_store / f"{profile_name}.md"
+        shutil.copy2(examples / f"{profile_name}.md", target)
+        target.chmod(0o600)
 
 
 @pytest.fixture()

--- a/test/e2e/test_allowed_tools.py
+++ b/test/e2e/test_allowed_tools.py
@@ -17,6 +17,8 @@ Provider coverage:
   Tests use the built-in code_supervisor profile (role=supervisor, no execute_bash).
 - Claude Code: Hard enforcement via --disallowedTools flags.
   Tests pass allowed_tools=@cao-mcp-server to trigger Bash blocking.
+- Pi: Hard enforcement via --exclude-tools for its seven built-in tools.
+- Grok Build CLI: Hard enforcement via deny-by-default native permissions.
 - Codex: Soft enforcement via security system prompt.
   Tests verify the prompt-based restriction is present (best-effort).
 - Kimi CLI: Soft enforcement via security system prompt.
@@ -24,7 +26,7 @@ Provider coverage:
 
 Requires:
 - Running CAO server
-- Authenticated CLI tools (claude, kiro-cli, kimi)
+- Authenticated CLI tools (claude, kiro-cli, pi, kimi, grok)
 - tmux
 - Agent profiles installed: code_supervisor, developer
 
@@ -32,6 +34,8 @@ Run:
     uv run pytest -m e2e test/e2e/test_allowed_tools.py -v -o "addopts="
     uv run pytest -m e2e test/e2e/test_allowed_tools.py -v -o "addopts=" -k kiro
     uv run pytest -m e2e test/e2e/test_allowed_tools.py -v -o "addopts=" -k claude
+    uv run pytest -m e2e test/e2e/test_allowed_tools.py -v -o "addopts=" -k Pi
+    uv run pytest -m e2e test/e2e/test_allowed_tools.py -v -o "addopts=" -k Grok
     uv run pytest -m e2e test/e2e/test_allowed_tools.py -v -o "addopts=" -k kimi
 """
 
@@ -299,7 +303,13 @@ def _grok_restricted_diagnostics(
         return f"<failed to collect Grok diagnostics: {type(exc).__name__}: {exc}>"
 
 
-def _run_restricted_tool_test(provider: str, agent_profile: str, allowed_tools: str):
+def _run_restricted_tool_test(
+    provider: str,
+    agent_profile: str,
+    allowed_tools: str,
+    *,
+    require_healthy_completion: bool = False,
+):
     """Test that a terminal with restricted allowedTools cannot execute bash.
 
     Creates a terminal with the given allowed_tools restriction, sends a task
@@ -343,7 +353,14 @@ def _run_restricted_tool_test(provider: str, agent_profile: str, allowed_tools: 
 
         completed = wait_for_status(terminal_id, "completed", timeout=COMPLETION_TIMEOUT)
 
-        if not completed:
+        if require_healthy_completion:
+            current_status = get_terminal_status(terminal_id)
+            assert completed, (
+                "Restricted tool probe did not reach COMPLETED; marker absence "
+                "cannot prove hard enforcement when the agent is unhealthy. "
+                f"Provider={provider}, current_status={current_status}"
+            )
+        elif not completed:
             # Agent timed out — it couldn't execute bash, which is the desired outcome.
             # Still verify the file wasn't created.
             pass
@@ -445,6 +462,47 @@ def _run_unrestricted_tool_test(provider: str, agent_profile: str):
     finally:
         if "marker_file" in locals():
             marker_file.unlink(missing_ok=True)
+        if terminal_id and actual_session:
+            cleanup_terminal(terminal_id, actual_session)
+
+
+def _run_restricted_write_test(provider: str):
+    """Verify a read-only reviewer cannot create a marker file."""
+    session_suffix = uuid.uuid4().hex[:6]
+    session_name = f"e2e-tools-rev-{provider[:5]}-{session_suffix}"
+    marker_file = Path(f"/tmp/cao_e2e_write_test_{uuid.uuid4().hex}.txt")
+    terminal_id = None
+    actual_session = None
+
+    try:
+        marker_file.unlink(missing_ok=True)
+        terminal_id, actual_session = _create_terminal_with_tools(
+            provider,
+            "reviewer",
+            "@builtin,fs_read,fs_list,@cao-mcp-server",
+            session_name,
+        )
+        assert terminal_id, "Terminal ID should not be empty"
+
+        s = _wait_for_ready(terminal_id)
+        assert s in ("idle", "completed")
+        time.sleep(2)
+
+        _send_task_and_get_output(
+            terminal_id,
+            "This is a direct built-in-tool probe, not a review or delegation "
+            "task. Do not use assign, handoff, send_message, or any other "
+            "MCP/orchestration tool, and do not delegate. Attempt to create "
+            f"{marker_file} with the exact content WRITE_TEST_MARKER using only "
+            "your own edit or write tool.",
+        )
+
+        assert not marker_file.exists(), (
+            "Reviewer wrote a file despite restricted allowedTools. "
+            f"Provider={provider}, marker={marker_file}"
+        )
+    finally:
+        marker_file.unlink(missing_ok=True)
         if terminal_id and actual_session:
             cleanup_terminal(terminal_id, actual_session)
 
@@ -624,40 +682,7 @@ class TestClaudeCodeAllowedTools:
 
     def test_reviewer_cannot_write(self, require_claude):
         """Reviewer with fs_read only should not be able to write files."""
-        session_suffix = uuid.uuid4().hex[:6]
-        session_name = f"e2e-tools-rev-claude-{session_suffix}"
-        terminal_id = None
-        actual_session = None
-
-        try:
-            terminal_id, actual_session = _create_terminal_with_tools(
-                "claude_code",
-                "reviewer",
-                "@builtin,fs_read,fs_list,@cao-mcp-server",
-                session_name,
-            )
-            assert terminal_id, "Terminal ID should not be empty"
-
-            s = _wait_for_ready(terminal_id)
-            assert s in ("idle", "completed")
-            time.sleep(2)
-
-            # Ask the agent to write a file — should be blocked
-            write_task = (
-                "Create a file called /tmp/cao_e2e_test_write.txt with the content "
-                "'WRITE_TEST_MARKER'. Write the file now."
-            )
-            output = _send_task_and_get_output(terminal_id, write_task)
-            output_lower = output.lower()
-
-            # Agent should not have written the file
-            assert "WRITE_TEST_MARKER" not in output or any(
-                kw in output_lower for kw in REFUSAL_KEYWORDS
-            ), f"Reviewer should not be able to write files. Output: {output[:500]}"
-
-        finally:
-            if terminal_id and actual_session:
-                cleanup_terminal(terminal_id, actual_session)
+        _run_restricted_write_test(provider="claude_code")
 
     def test_allowed_tools_stored_in_metadata(self, require_claude):
         """allowed_tools is persisted and returned by GET /terminals."""
@@ -665,6 +690,41 @@ class TestClaudeCodeAllowedTools:
             provider="claude_code",
             agent_profile="developer",
             allowed_tools="@builtin,fs_*,execute_bash,web_fetch,@cao-mcp-server",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pi provider — hard enforcement via --exclude-tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPiAllowedTools:
+    """E2E allowedTools tests for Pi's native built-in denylist."""
+
+    def test_restricted_supervisor_cannot_bash(self, require_pi):
+        """Supervisor with only @cao-mcp-server cannot execute bash."""
+        _run_restricted_tool_test(
+            provider="pi",
+            agent_profile="code_supervisor",
+            allowed_tools="@cao-mcp-server",
+            require_healthy_completion=True,
+        )
+
+    def test_reviewer_cannot_write(self, require_pi):
+        """Reviewer with fs_read and fs_list cannot write files."""
+        _run_restricted_write_test(provider="pi")
+
+    def test_unrestricted_developer_can_bash(self, require_pi):
+        """Developer with wildcard allowedTools can execute bash."""
+        _run_unrestricted_tool_test(provider="pi", agent_profile="developer")
+
+    def test_allowed_tools_stored_in_metadata(self, require_pi):
+        """allowed_tools is persisted and returned by GET /terminals."""
+        _run_allowed_tools_stored_test(
+            provider="pi",
+            agent_profile="developer",
+            allowed_tools="@builtin,fs_*,execute_bash,@cao-mcp-server",
         )
 
 

--- a/test/e2e/test_assign.py
+++ b/test/e2e/test_assign.py
@@ -33,6 +33,7 @@ Run:
     uv run pytest -m e2e test/e2e/test_assign.py -v -k codex
     uv run pytest -m e2e test/e2e/test_assign.py -v -k claude_code
     uv run pytest -m e2e test/e2e/test_assign.py -v -k kiro_cli
+    uv run pytest -m e2e test/e2e/test_assign.py -v -k Pi
     uv run pytest -m e2e test/e2e/test_assign.py -v -k copilot
 """
 
@@ -420,6 +421,38 @@ class TestKiroCliAssign:
     def test_assign_with_callback(self, require_kiro):
         """Kiro CLI full round-trip: worker completes → sends result → supervisor receives."""
         _run_assign_with_callback_test(provider="kiro_cli")
+
+
+# ---------------------------------------------------------------------------
+# Pi provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPiAssign:
+    """E2E assign tests for the Pi provider using examples/assign/ profiles."""
+
+    def test_assign_data_analyst(self, require_pi):
+        """Pi data_analyst receives a dataset and performs statistical analysis."""
+        _run_assign_test(
+            provider="pi",
+            agent_profile="data_analyst",
+            task_message=DATA_ANALYST_TASK,
+            content_keywords=DATA_ANALYST_KEYWORDS,
+        )
+
+    def test_assign_report_generator(self, require_pi):
+        """Pi report_generator creates a report template."""
+        _run_assign_test(
+            provider="pi",
+            agent_profile="report_generator",
+            task_message=REPORT_GENERATOR_TASK,
+            content_keywords=REPORT_GENERATOR_KEYWORDS,
+        )
+
+    def test_assign_with_callback(self, require_pi):
+        """Pi full round-trip: worker completes → sends result → supervisor receives."""
+        _run_assign_with_callback_test(provider="pi")
 
 
 # ---------------------------------------------------------------------------

--- a/test/e2e/test_handoff.py
+++ b/test/e2e/test_handoff.py
@@ -10,13 +10,14 @@ Tests the worker side of the handoff flow — validates that each provider can:
 NOTE: These tests do NOT test a supervisor agent calling the handoff() MCP tool.
 For real supervisor→worker delegation tests, see test_supervisor_orchestration.py.
 
-Requires: running CAO server, authenticated CLI tools (codex, claude, kiro-cli, copilot), tmux.
+Requires: running CAO server, authenticated CLI tools (codex, claude, kiro-cli, pi, copilot), tmux.
 
 Run:
     uv run pytest -m e2e test/e2e/test_handoff.py -v
     uv run pytest -m e2e test/e2e/test_handoff.py -v -k codex
     uv run pytest -m e2e test/e2e/test_handoff.py -v -k claude_code
     uv run pytest -m e2e test/e2e/test_handoff.py -v -k kiro_cli
+    uv run pytest -m e2e test/e2e/test_handoff.py -v -k Pi
     uv run pytest -m e2e test/e2e/test_handoff.py -v -k copilot
 """
 
@@ -38,7 +39,15 @@ import pytest
 COMPLETION_TIMEOUT = 180
 
 
-def _run_handoff_test(provider: str, agent_profile: str, task_message: str, content_keywords: list):
+def _run_handoff_test(
+    provider: str,
+    agent_profile: str,
+    task_message: str,
+    content_keywords: list,
+    *,
+    require_processing_transition: bool = False,
+    exact_output: str | None = None,
+):
     """Core handoff test logic shared across providers.
 
     Args:
@@ -78,6 +87,18 @@ def _run_handoff_test(provider: str, agent_profile: str, task_message: str, cont
 
         # Step 3: Send handoff message
         send_handoff_message(terminal_id, task_message, provider)
+        if require_processing_transition:
+            transition_deadline = time.time() + 30.0
+            observed_status = get_terminal_status(terminal_id)
+            while observed_status not in ("processing", "completed", "error"):
+                if time.time() >= transition_deadline:
+                    break
+                time.sleep(0.25)
+                observed_status = get_terminal_status(terminal_id)
+            assert observed_status == "processing", (
+                "Terminal did not expose PROCESSING before its terminal state "
+                f"advanced (provider={provider}, observed={observed_status})"
+            )
 
         # Step 4: Poll for COMPLETED with stabilization.
         assert wait_for_status(
@@ -107,12 +128,23 @@ def _run_handoff_test(provider: str, agent_profile: str, task_message: str, cont
         # Handoff prefix should not appear in extracted output
         assert "[CAO Handoff]" not in output, "Handoff prefix leaked into output"
 
-        # At least one content keyword should be present
-        output_lower = output.lower()
-        matched = [kw for kw in content_keywords if kw.lower() in output_lower]
-        assert (
-            matched
-        ), f"Expected at least one of {content_keywords} in output, got: {output[:200]}"
+        if exact_output is not None:
+            output_lower = output.lower()
+            assert (
+                output.strip() == exact_output
+            ), f"Expected exact sidecar output {exact_output!r}, got: {output[:200]!r}"
+            assert task_message not in output, "Submitted Pi instruction leaked into output"
+            assert "pi v" not in output_lower, "Pi banner leaked into output"
+            assert (
+                "ctrl+c/ctrl+d clear/exit" not in output_lower
+            ), "Pi help chrome leaked into output"
+        else:
+            # At least one content keyword should be present
+            output_lower = output.lower()
+            matched = [kw for kw in content_keywords if kw.lower() in output_lower]
+            assert (
+                matched
+            ), f"Expected at least one of {content_keywords} in output, got: {output[:200]}"
 
     finally:
         if terminal_id and actual_session:
@@ -275,6 +307,44 @@ class TestKiroCliHandoff:
                 "a and b and returns a minus b. Output only the function code."
             ),
             content_keywords=["subtract", "return", "def"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pi provider tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPiHandoff:
+    """E2E handoff tests for the Pi provider."""
+
+    def test_handoff_simple_function(self, require_pi):
+        """Pi lifecycle sidecar returns only the exact assistant response."""
+        exact_token = f"PI_E2E_EXACT_{uuid.uuid4().hex}"
+        instruction = (
+            f"Return exactly this token and nothing else: {exact_token}. "
+            "Do not use Markdown or add any explanation."
+        )
+        _run_handoff_test(
+            provider="pi",
+            agent_profile="developer",
+            task_message=instruction,
+            content_keywords=[],
+            require_processing_transition=True,
+            exact_output=exact_token,
+        )
+
+    def test_handoff_second_task(self, require_pi):
+        """Pi developer handles a second independent task."""
+        _run_handoff_test(
+            provider="pi",
+            agent_profile="developer",
+            task_message=(
+                "Create a Python function called 'divide' that takes two parameters "
+                "a and b and returns a divided by b. Output only the function code."
+            ),
+            content_keywords=["divide", "return", "def"],
         )
 
 

--- a/test/e2e/test_send_message.py
+++ b/test/e2e/test_send_message.py
@@ -12,13 +12,14 @@ NOTE: These tests send messages via the CAO API, not via an agent calling
 the send_message() MCP tool. For real agent-to-agent communication via
 MCP tools, see test_supervisor_orchestration.py.
 
-Requires: running CAO server, authenticated CLI tools (codex, claude, kiro-cli, copilot), tmux.
+Requires: running CAO server, authenticated CLI tools (codex, claude, kiro-cli, pi, copilot), tmux.
 
 Run:
     uv run pytest -m e2e test/e2e/test_send_message.py -v
     uv run pytest -m e2e test/e2e/test_send_message.py -v -k codex
     uv run pytest -m e2e test/e2e/test_send_message.py -v -k claude_code
     uv run pytest -m e2e test/e2e/test_send_message.py -v -k kiro_cli
+    uv run pytest -m e2e test/e2e/test_send_message.py -v -k Pi
     uv run pytest -m e2e test/e2e/test_send_message.py -v -k copilot
 """
 
@@ -240,6 +241,20 @@ class TestKiroCliSendMessage:
     def test_send_message_to_inbox(self, require_kiro):
         """Send a message to another Kiro CLI terminal's inbox and verify delivery."""
         _run_send_message_test(provider="kiro_cli", agent_profile="developer")
+
+
+# ---------------------------------------------------------------------------
+# Pi provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPiSendMessage:
+    """E2E send_message tests for the Pi provider."""
+
+    def test_send_message_to_inbox(self, require_pi):
+        """Send a message to another Pi terminal's inbox and verify delivery."""
+        _run_send_message_test(provider="pi", agent_profile="developer")
 
 
 # ---------------------------------------------------------------------------

--- a/test/e2e/test_supervisor_orchestration.py
+++ b/test/e2e/test_supervisor_orchestration.py
@@ -23,6 +23,7 @@ Requires:
 Run:
     uv run pytest -m e2e test/e2e/test_supervisor_orchestration.py -v -o "addopts="
     uv run pytest -m e2e test/e2e/test_supervisor_orchestration.py -v -o "addopts=" -k codex
+    uv run pytest -m e2e test/e2e/test_supervisor_orchestration.py -v -o "addopts=" -k Pi
     uv run pytest -m e2e test/e2e/test_supervisor_orchestration.py -v -o "addopts=" -k copilot
 """
 
@@ -776,6 +777,24 @@ class TestKiroCliSupervisorOrchestration:
     def test_supervisor_assign_and_handoff(self, require_kiro):
         """Supervisor uses assign + handoff to orchestrate multi-agent workflow."""
         _run_supervisor_assign_test(provider="kiro_cli")
+
+
+# ---------------------------------------------------------------------------
+# Pi provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestPiSupervisorOrchestration:
+    """E2E supervisor orchestration tests for the Pi provider."""
+
+    def test_supervisor_handoff(self, require_pi):
+        """Pi supervisor uses handoff MCP tool to delegate to report_generator."""
+        _run_supervisor_handoff_test(provider="pi")
+
+    def test_supervisor_assign_and_handoff(self, require_pi):
+        """Pi supervisor uses assign + handoff for multi-agent orchestration."""
+        _run_supervisor_assign_test(provider="pi")
 
 
 # ---------------------------------------------------------------------------

--- a/test/providers/fixtures/pi_completed.txt
+++ b/test/providers/fixtures/pi_completed.txt
@@ -1,0 +1,13 @@
+ pi v0.84.1
+ escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
+
+ Summarize the provider state.
+
+ The adapter is ready — café.
+ Exact fallback line two.
+
+────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────
+~/work/project (feat/pi-provider)
+0.2%/400k (auto)                                      (openai) gpt-5 • high

--- a/test/providers/fixtures/pi_idle.txt
+++ b/test/providers/fixtures/pi_idle.txt
@@ -1,0 +1,11 @@
+ pi v0.84.1
+ escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
+ Press ctrl+o to show full startup help and loaded resources.
+
+ Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.
+
+────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────
+~/work/project (feat/pi-provider)
+0.0%/400k (auto)                                      (openai) gpt-5 • high

--- a/test/providers/fixtures/pi_processing.txt
+++ b/test/providers/fixtures/pi_processing.txt
@@ -1,0 +1,12 @@
+ pi v0.84.1
+ escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
+
+ Summarize the provider state.
+
+ Working... (escape to interrupt)
+
+────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────
+~/work/project (feat/pi-provider)
+0.1%/400k (auto)                                      (openai) gpt-5 • high

--- a/test/providers/test_pi_extension.py
+++ b/test/providers/test_pi_extension.py
@@ -1,0 +1,918 @@
+"""Packaging and installed-Pi contract tests for the bundled extension."""
+
+import json
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+FAKE_PROXY_SOURCE = r'''"""Controllable JSONL child for Pi extension behavior tests."""
+import json
+import os
+import signal
+import sys
+import time
+
+
+def send(request_id, result):
+    sys.stdout.write(json.dumps({"id": request_id, "ok": True, "result": result}) + "\n")
+    sys.stdout.flush()
+
+
+def send_error(request_id, error):
+    sys.stdout.write(json.dumps({"id": request_id, "ok": False, "error": error}) + "\n")
+    sys.stdout.flush()
+
+
+def send_chunked(response):
+    payload = (json.dumps(response, ensure_ascii=False) + "\n").encode()
+    marker = "☃".encode()
+    split = payload.find(marker)
+    split = split + 1 if split >= 0 else max(1, len(payload) // 2)
+    sys.stdout.buffer.write(payload[:split])
+    sys.stdout.buffer.flush()
+    time.sleep(0.01)
+    sys.stdout.buffer.write(payload[split:])
+    sys.stdout.buffer.flush()
+
+
+scenario = os.environ["CAO_TEST_PROXY_SCENARIO"]
+with open(os.environ["CAO_TEST_PROXY_PID_FILE"], "w") as pid_file:
+    pid_file.write(str(os.getpid()))
+if scenario == "ignore_sigterm":
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+call_count = 0
+pending_calls = []
+for raw_line in sys.stdin:
+    request = json.loads(raw_line)
+    if request["type"] == "list_tools":
+        tools = []
+        if scenario == "builtin_collision":
+            tools = [
+                {
+                    "server": "fixture",
+                    "name": name,
+                    "description": f"{name} tool",
+                    "inputSchema": {"type": "object"},
+                }
+                for name in ["safe_mcp_tool", "bash", "read", "edit", "write", "grep", "find", "ls"]
+            ]
+        if scenario in {
+            "mcp_is_error",
+            "request_error",
+            "normalize",
+            "chunked_correlation",
+            "abort_late",
+            "abort_hang",
+            "exit_during_call",
+            "close_stdin",
+        }:
+            tools = [{
+                "server": "fixture",
+                "name": "echo",
+                "description": "Echo ☃ text" if scenario == "chunked_correlation" else "Echo text",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            }]
+        if scenario == "chunked_correlation":
+            send_chunked({"id": request["id"], "ok": True, "result": {"tools": tools}})
+        else:
+            send(request["id"], {"tools": tools})
+        if scenario == "exit_while_idle":
+            time.sleep(0.1)
+            raise SystemExit(7)
+        if scenario == "close_stdin":
+            os.close(0)
+            with open(os.environ["CAO_TEST_PROXY_READY_FILE"], "w") as ready_file:
+                ready_file.write("closed")
+            time.sleep(60)
+    elif request["type"] == "call_tool":
+        call_count += 1
+        if scenario == "chunked_correlation":
+            pending_calls.append(request)
+            if len(pending_calls) == 2:
+                for pending in reversed(pending_calls):
+                    send_chunked({
+                        "id": pending["id"],
+                        "ok": True,
+                        "result": {
+                            "content": [{"type": "text", "text": pending["arguments"]["text"]}],
+                            "isError": False,
+                        },
+                    })
+        elif scenario == "abort_late" and call_count == 1:
+            time.sleep(0.15)
+            send(request["id"], {
+                "content": [{"type": "text", "text": "late"}],
+                "isError": False,
+            })
+        elif scenario == "abort_hang" and call_count == 1:
+            pending_calls.append(request)
+        elif scenario == "abort_hang" and pending_calls:
+            continue
+        elif scenario == "exit_during_call":
+            raise SystemExit(9)
+        elif scenario == "mcp_is_error" and call_count == 1:
+            send(request["id"], {
+                "content": [{"type": "text", "text": "tool failed"}],
+                "isError": True,
+            })
+        elif scenario == "request_error" and call_count == 1:
+            send_error(request["id"], "request rejected")
+        elif scenario == "normalize":
+            send(request["id"], {
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {"type": "image", "data": "aW1n", "mimeType": "image/png"},
+                    {"type": "resource", "resource": {"text": "resource text"}},
+                    {
+                        "type": "resource",
+                        "resource": {"blob": "anBlZw==", "mimeType": "image/jpeg"},
+                    },
+                    {"type": "resource_link", "name": "Doc", "uri": "https://example.test"},
+                    {"type": "audio", "data": "YXVkaW8=", "mimeType": "audio/wav"},
+                    {"type": "custom", "value": 1},
+                ],
+                "isError": False,
+            })
+        else:
+            send(request["id"], {
+                "content": [{"type": "text", "text": "recovered"}],
+                "isError": False,
+            })
+    elif request["type"] == "cancel":
+        cancelled = bool(
+            pending_calls and request.get("targetId") == pending_calls[0]["id"]
+        )
+        if cancelled:
+            pending_calls.clear()
+        send(request["id"], {"cancelled": cancelled})
+    elif request["type"] == "shutdown":
+        if scenario == "exit_on_shutdown":
+            raise SystemExit(0)
+        if scenario in {"hang_on_shutdown", "ignore_sigterm"}:
+            time.sleep(60)
+        send(request["id"], {})
+        raise SystemExit(0)
+'''
+
+NODE_HARNESS = r"""
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const [extensionPath, action] = process.argv.slice(1);
+const extension = await import(pathToFileURL(extensionPath).href);
+
+async function waitForFile(path, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await readFile(path);
+      return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${path}`);
+}
+
+const handlers = new Map();
+const statuses = [];
+const tools = [];
+const piBuiltins = new Set(["bash", "read", "edit", "write", "grep", "find", "ls"]);
+const pi = {
+  on(name, handler) { handlers.set(name, handler); },
+  registerTool(tool) {
+    if (process.env.CAO_TEST_NATIVE_TOOL_POLICY === "denied" && piBuiltins.has(tool.name)) {
+      return;
+    }
+    tools.push(tool);
+  },
+};
+const ctx = {
+  ui: {
+    setStatus(key, text) { statuses.push({ key, text: text ?? null }); },
+  },
+};
+extension.default(pi);
+let startError;
+try {
+  await handlers.get("session_start")({}, ctx);
+} catch (error) {
+  if (action !== "spawn_failure" && action !== "builtin_collision") throw error;
+  startError = { name: error.name, message: error.message };
+}
+
+let output;
+if (action === "spawn_failure") {
+  const started = Date.now();
+  const settled = await Promise.race([
+    handlers.get("session_shutdown")({}, ctx).then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 1_500)),
+  ]);
+  output = {
+    startError,
+    settled,
+    elapsedMs: Date.now() - started,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "builtin_collision") {
+  output = {
+    startError,
+    registeredToolNames: tools.map((tool) => tool.name),
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+  await handlers.get("session_shutdown")({}, ctx);
+} else if (action === "shutdown_exit") {
+  const started = Date.now();
+  const settled = await Promise.race([
+    handlers.get("session_shutdown")({}, ctx).then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 1_000)),
+  ]);
+  output = {
+    settled,
+    elapsedMs: Date.now() - started,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "shutdown_hang") {
+  const started = Date.now();
+  const settled = await Promise.race([
+    handlers.get("session_shutdown")({}, ctx).then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 6_500)),
+  ]);
+  output = {
+    settled,
+    elapsedMs: Date.now() - started,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "shutdown_ignore_term") {
+  const started = Date.now();
+  const settled = await Promise.race([
+    handlers.get("session_shutdown")({}, ctx).then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 7_000)),
+  ]);
+  const proxyPid = Number(await readFile(process.env.CAO_TEST_PROXY_PID_FILE, "utf8"));
+  let proxyAlive = false;
+  try {
+    process.kill(proxyPid, 0);
+    proxyAlive = true;
+  } catch {}
+  output = {
+    settled,
+    elapsedMs: Date.now() - started,
+    proxyAlive,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "shutdown_closed_stdin") {
+  await waitForFile(process.env.CAO_TEST_PROXY_READY_FILE);
+  const started = Date.now();
+  const settled = await Promise.race([
+    handlers.get("session_shutdown")({}, ctx).then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 2_000)),
+  ]);
+  const proxyPid = Number(await readFile(process.env.CAO_TEST_PROXY_PID_FILE, "utf8"));
+  let proxyAlive = false;
+  try {
+    process.kill(proxyPid, 0);
+    proxyAlive = true;
+  } catch {}
+  output = {
+    settled,
+    elapsedMs: Date.now() - started,
+    proxyAlive,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "active_closed_stdin") {
+  await waitForFile(process.env.CAO_TEST_PROXY_READY_FILE);
+  await handlers.get("agent_start")({}, ctx);
+  let callError;
+  try {
+    await tools[0].execute("call-1", { text: "first" }, undefined, undefined, ctx);
+  } catch (error) {
+    callError = { name: error.name, message: error.message };
+  }
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  await handlers.get("agent_settled")({}, ctx);
+  const started = Date.now();
+  await handlers.get("session_shutdown")({}, ctx);
+  const proxyPid = Number(await readFile(process.env.CAO_TEST_PROXY_PID_FILE, "utf8"));
+  let proxyAlive = false;
+  try {
+    process.kill(proxyPid, 0);
+    proxyAlive = true;
+  } catch {}
+  output = {
+    callError,
+    shutdownElapsedMs: Date.now() - started,
+    proxyAlive,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "idle_exit") {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  output = {
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "terminal_sticky") {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const failureState = JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8"));
+  await handlers.get("agent_start")({}, ctx);
+  await handlers.get("message_end")({
+    message: { role: "assistant", content: [{ type: "text", text: "must not publish" }] },
+  }, ctx);
+  await handlers.get("agent_settled")({}, ctx);
+  output = {
+    failureState,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+} else if (action === "nonterminal_error") {
+  await handlers.get("agent_start")({}, ctx);
+  let firstError;
+  try {
+    await tools[0].execute("call-1", { text: "first" }, undefined, undefined, ctx);
+  } catch (error) {
+    firstError = { name: error.name, message: error.message };
+  }
+  const second = await tools[0].execute(
+    "call-2",
+    { text: "second" },
+    undefined,
+    undefined,
+    ctx,
+  );
+  await handlers.get("message_end")({
+    message: { role: "assistant", content: [{ type: "text", text: "after recovery" }] },
+  }, ctx);
+  await handlers.get("agent_settled")({}, ctx);
+  output = {
+    firstError,
+    second,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+  await handlers.get("session_shutdown")({}, ctx);
+} else if (action === "normalize") {
+  const result = await tools[0].execute(
+    "call-1",
+    { text: "input" },
+    undefined,
+    undefined,
+    ctx,
+  );
+  output = {
+    tool: {
+      name: tools[0].name,
+      description: tools[0].description,
+      parameters: tools[0].parameters,
+    },
+    result,
+  };
+  await handlers.get("session_shutdown")({}, ctx);
+} else if (action === "correlation") {
+  const [first, second] = await Promise.all([
+    tools[0].execute("call-1", { text: "first" }, undefined, undefined, ctx),
+    tools[0].execute("call-2", { text: "second" }, undefined, undefined, ctx),
+  ]);
+  output = {
+    description: tools[0].description,
+    first: first.content,
+    second: second.content,
+  };
+  await handlers.get("session_shutdown")({}, ctx);
+} else if (action === "abort_late") {
+  await handlers.get("agent_start")({}, ctx);
+  const controller = new AbortController();
+  const firstCall = tools[0].execute(
+    "call-1",
+    { text: "first" },
+    controller.signal,
+    undefined,
+    ctx,
+  );
+  setTimeout(() => controller.abort(), 20);
+  let firstError;
+  try {
+    await firstCall;
+  } catch (error) {
+    firstError = { name: error.name, message: error.message };
+  }
+  const second = await tools[0].execute(
+    "call-2",
+    { text: "second" },
+    undefined,
+    undefined,
+    ctx,
+  );
+  await handlers.get("message_end")({
+    message: { role: "assistant", content: [{ type: "text", text: "abort recovered" }] },
+  }, ctx);
+  await handlers.get("agent_settled")({}, ctx);
+  output = {
+    firstError,
+    second: second.content,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+  await handlers.get("session_shutdown")({}, ctx);
+} else if (action === "abort_hang") {
+  await handlers.get("agent_start")({}, ctx);
+  const controller = new AbortController();
+  const abortStarted = Date.now();
+  const firstCall = tools[0].execute(
+    "call-1",
+    { text: "hang" },
+    controller.signal,
+    undefined,
+    ctx,
+  );
+  setTimeout(() => controller.abort(), 20);
+  let firstError;
+  try {
+    await firstCall;
+  } catch (error) {
+    firstError = { name: error.name, message: error.message };
+  }
+  const abortElapsedMs = Date.now() - abortStarted;
+  const secondStarted = Date.now();
+  const secondCall = tools[0].execute(
+    "call-2",
+    { text: "second" },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const second = await Promise.race([
+    secondCall.then((result) => ({ settled: true, content: result.content })),
+    new Promise((resolve) => setTimeout(() => resolve({ settled: false }), 750)),
+  ]);
+  const secondElapsedMs = Date.now() - secondStarted;
+  const shutdownStarted = Date.now();
+  await handlers.get("session_shutdown")({}, ctx);
+  const shutdownElapsedMs = Date.now() - shutdownStarted;
+  const proxyPid = Number(await readFile(process.env.CAO_TEST_PROXY_PID_FILE, "utf8"));
+  let proxyAlive = false;
+  try {
+    process.kill(proxyPid, 0);
+    proxyAlive = true;
+  } catch {}
+  output = {
+    firstError,
+    abortElapsedMs,
+    second,
+    secondElapsedMs,
+    shutdownElapsedMs,
+    proxyAlive,
+    statuses,
+  };
+} else if (action === "lifecycle") {
+  const idle = JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8"));
+  await handlers.get("agent_start")({}, ctx);
+  const processing = JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8"));
+  await handlers.get("message_end")({
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "final " },
+        { type: "thinking", thinking: "hidden" },
+        { type: "text", text: "answer" },
+      ],
+    },
+  }, ctx);
+  await handlers.get("agent_settled")({}, ctx);
+  const completed = JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8"));
+  output = { idle, processing, completed };
+  await handlers.get("session_shutdown")({}, ctx);
+} else if (action === "terminal_call") {
+  await handlers.get("agent_start")({}, ctx);
+  let callError;
+  try {
+    await tools[0].execute("call-1", { text: "first" }, undefined, undefined, ctx);
+  } catch (error) {
+    callError = { name: error.name, message: error.message };
+  }
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  await handlers.get("agent_settled")({}, ctx);
+  output = {
+    callError,
+    state: JSON.parse(await readFile(process.env.CAO_PI_STATE_FILE, "utf8")),
+    statuses,
+  };
+}
+
+process.stdout.write(`${JSON.stringify(output)}\n`, () => process.exit(0));
+"""
+
+
+def pi_extension_path() -> Path:
+    return REPO_ROOT / "src/cli_agent_orchestrator/providers/pi_extension.ts"
+
+
+def build_wheel(tmp_path: Path) -> zipfile.ZipFile:
+    subprocess.run(
+        ["uv", "build", "--offline", "--wheel", "--out-dir", str(tmp_path)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheel_path = next(tmp_path.glob("cli_agent_orchestrator-*.whl"))
+    return zipfile.ZipFile(wheel_path)
+
+
+def run_node_harness(
+    tmp_path: Path,
+    *,
+    scenario: str,
+    action: str,
+    timeout: float = 10,
+    bridge_python: str | None = None,
+    native_tool_policy: str = "allowed",
+) -> dict:
+    node = shutil.which("node")
+    assert node is not None, "Node.js is required for Pi extension behavior tests"
+    fake_package = tmp_path / "fake-pythonpath/cli_agent_orchestrator/providers"
+    fake_package.mkdir(parents=True)
+    (fake_package.parent.parent / "__init__.py").write_text("")
+    (fake_package.parent / "__init__.py").write_text("")
+    (fake_package / "__init__.py").write_text("")
+    (fake_package / "pi_mcp_proxy.py").write_text(FAKE_PROXY_SOURCE)
+    config_file = tmp_path / "mcp.json"
+    config_file.write_text("{}")
+    state_file = tmp_path / "state/pi.json"
+    env = {
+        **os.environ,
+        "CAO_PI_STATE_FILE": str(state_file),
+        "CAO_PI_MCP_CONFIG": str(config_file),
+        "CAO_PI_BRIDGE_PYTHON": bridge_python or sys.executable,
+        "CAO_TEST_PROXY_SCENARIO": scenario,
+        "CAO_TEST_PROXY_PID_FILE": str(tmp_path / "proxy.pid"),
+        "CAO_TEST_PROXY_READY_FILE": str(tmp_path / "proxy.ready"),
+        "CAO_TEST_NATIVE_TOOL_POLICY": native_tool_policy,
+        "PYTHONPATH": str(tmp_path / "fake-pythonpath")
+        + os.pathsep
+        + os.environ.get("PYTHONPATH", ""),
+    }
+    try:
+        result = subprocess.run(
+            [
+                node,
+                "--no-warnings",
+                "--input-type=module",
+                "-e",
+                NODE_HARNESS,
+                str(pi_extension_path()),
+                action,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    finally:
+        pid_file = tmp_path / "proxy.pid"
+        if pid_file.exists():
+            try:
+                os.kill(int(pid_file.read_text()), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.splitlines()[-1])
+
+
+def test_bundled_extension_exists_and_has_required_events():
+    source = pi_extension_path().read_text()
+    assert 'pi.on("agent_start"' in source
+    assert 'pi.on("message_end"' in source
+    assert 'pi.on("agent_settled"' in source
+    assert "pi.registerTool" in source
+
+
+def test_wheel_contains_pi_extension(tmp_path):
+    with build_wheel(tmp_path) as wheel:
+        assert "cli_agent_orchestrator/providers/pi_extension.ts" in wheel.namelist()
+
+
+def test_shutdown_does_not_hang_when_proxy_exits_before_reply(tmp_path):
+    result = run_node_harness(tmp_path, scenario="exit_on_shutdown", action="shutdown_exit")
+
+    assert result["settled"] is True
+    assert result["elapsedMs"] < 1_000
+    assert result["state"]["status"] == "idle"
+    assert result["state"]["error"] == ""
+    assert result["statuses"] == [{"key": "cao-pi-mcp", "text": None}]
+
+
+def test_shutdown_bounds_nonreplying_proxy_and_kills_it(tmp_path):
+    result = run_node_harness(
+        tmp_path, scenario="hang_on_shutdown", action="shutdown_hang", timeout=8
+    )
+
+    assert result["settled"] is True
+    assert 4_500 <= result["elapsedMs"] < 6_000
+    assert result["state"]["status"] == "idle"
+    assert result["state"]["error"] == ""
+    assert result["statuses"] == [{"key": "cao-pi-mcp", "text": None}]
+
+
+def test_shutdown_escalates_when_proxy_ignores_sigterm(tmp_path):
+    result = run_node_harness(
+        tmp_path,
+        scenario="ignore_sigterm",
+        action="shutdown_ignore_term",
+        timeout=9,
+    )
+
+    assert result["settled"] is True
+    assert 5_000 <= result["elapsedMs"] < 7_000
+    assert result["proxyAlive"] is False
+    assert result["state"]["status"] == "idle"
+    assert result["state"]["error"] == ""
+    assert result["statuses"] == [{"key": "cao-pi-mcp", "text": None}]
+
+
+def test_shutdown_handles_proxy_closed_stdin_without_terminal_publication(tmp_path):
+    result = run_node_harness(
+        tmp_path,
+        scenario="close_stdin",
+        action="shutdown_closed_stdin",
+        timeout=4,
+    )
+
+    assert result["settled"] is True
+    assert result["elapsedMs"] < 2_000
+    assert result["proxyAlive"] is False
+    assert set(result["state"]) == {"status", "lastAssistantText", "error", "updatedAt"}
+    assert result["state"]["status"] == "idle"
+    assert result["state"]["error"] == ""
+    assert result["statuses"] == [{"key": "cao-pi-mcp", "text": None}]
+
+
+def test_active_call_closed_stdin_is_one_terminal_failure_and_tears_down(tmp_path):
+    result = run_node_harness(
+        tmp_path,
+        scenario="close_stdin",
+        action="active_closed_stdin",
+        timeout=4,
+    )
+
+    assert result["callError"]["name"] == "BridgeTerminalError"
+    assert "EPIPE" in result["callError"]["message"]
+    assert result["shutdownElapsedMs"] < 2_000
+    assert result["proxyAlive"] is False
+    assert set(result["state"]) == {"status", "lastAssistantText", "error", "updatedAt"}
+    assert result["state"]["status"] == "error"
+    assert "EPIPE" in result["state"]["error"]
+    assert len(result["statuses"]) == 2
+    assert result["statuses"][0] == {"key": "cao-pi-mcp", "text": None}
+    assert result["statuses"][1]["key"] == "cao-pi-mcp"
+    assert "EPIPE" in result["statuses"][1]["text"]
+
+
+def test_failed_spawn_leaves_shutdown_immediately_settled(tmp_path):
+    result = run_node_harness(
+        tmp_path,
+        scenario="normal",
+        action="spawn_failure",
+        timeout=3,
+        bridge_python=str(tmp_path / "missing-python"),
+    )
+
+    assert result["startError"]["name"] == "BridgeTerminalError"
+    assert result["settled"] is True
+    assert result["elapsedMs"] < 750
+    assert set(result["state"]) == {"status", "lastAssistantText", "error", "updatedAt"}
+    assert result["state"]["status"] == "error"
+    assert result["state"]["error"]
+    assert len(result["statuses"]) == 1
+    assert result["statuses"][0]["text"].startswith("MCP error: ")
+
+
+def test_unexpected_idle_proxy_exit_publishes_terminal_state_and_ui(tmp_path):
+    result = run_node_harness(tmp_path, scenario="exit_while_idle", action="idle_exit")
+
+    assert set(result["state"]) == {"status", "lastAssistantText", "error", "updatedAt"}
+    assert result["state"]["status"] == "error"
+    assert "exit code 7" in result["state"]["error"]
+    assert result["statuses"][-1]["key"] == "cao-pi-mcp"
+    assert "exit code 7" in result["statuses"][-1]["text"]
+
+
+def test_terminal_bridge_state_survives_later_lifecycle_events(tmp_path):
+    result = run_node_harness(tmp_path, scenario="exit_while_idle", action="terminal_sticky")
+
+    assert set(result["state"]) == {"status", "lastAssistantText", "error", "updatedAt"}
+    assert result["state"] == result["failureState"]
+    assert result["state"]["status"] == "error"
+    assert "exit code 7" in result["state"]["error"]
+    assert result["statuses"] == [
+        {"key": "cao-pi-mcp", "text": None},
+        {
+            "key": "cao-pi-mcp",
+            "text": "MCP error: Pi MCP proxy exited with exit code 7",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("scenario", "first_error"),
+    [("mcp_is_error", "tool failed"), ("request_error", "request rejected")],
+)
+def test_tool_level_errors_leave_bridge_and_lifecycle_usable(tmp_path, scenario, first_error):
+    result = run_node_harness(tmp_path, scenario=scenario, action="nonterminal_error")
+
+    assert result["firstError"]["message"] == first_error
+    assert result["second"]["content"] == [{"type": "text", "text": "recovered"}]
+    assert result["state"]["status"] == "completed"
+    assert result["state"]["lastAssistantText"] == "after recovery"
+    assert result["state"]["error"] == ""
+    assert result["statuses"] == [{"key": "cao-pi-mcp", "text": None}]
+
+
+@pytest.mark.parametrize("native_tool_policy", ["allowed", "denied"])
+def test_builtin_collision_fails_before_any_mcp_registration(tmp_path, native_tool_policy):
+    """MCP cannot shadow or be suppressed by Pi built-ins under either native policy."""
+    result = run_node_harness(
+        tmp_path,
+        scenario="builtin_collision",
+        action="builtin_collision",
+        native_tool_policy=native_tool_policy,
+    )
+
+    assert result["startError"] == {
+        "name": "Error",
+        "message": "Pi MCP proxy returned reserved Pi tool name: bash",
+    }
+    assert result["registeredToolNames"] == []
+    assert result["state"]["status"] == "error"
+
+
+def test_dynamic_tool_preserves_raw_schema_and_normalizes_actual_call_result(tmp_path):
+    result = run_node_harness(tmp_path, scenario="normalize", action="normalize")
+
+    assert result["tool"] == {
+        "name": "echo",
+        "description": "Echo text",
+        "parameters": {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+    }
+    assert result["result"]["content"] == [
+        {"type": "text", "text": "hello"},
+        {"type": "image", "data": "aW1n", "mimeType": "image/png"},
+        {"type": "text", "text": "resource text"},
+        {"type": "image", "data": "anBlZw==", "mimeType": "image/jpeg"},
+        {"type": "text", "text": "Doc: https://example.test"},
+        {"type": "text", "text": "[MCP audio content (audio/wav)]"},
+        {"type": "text", "text": '{"type":"custom","value":1}'},
+    ]
+
+
+def test_jsonl_chunks_preserve_utf8_and_correlate_reversed_replies(tmp_path):
+    result = run_node_harness(tmp_path, scenario="chunked_correlation", action="correlation")
+
+    assert result == {
+        "description": "Echo ☃ text",
+        "first": [{"type": "text", "text": "first"}],
+        "second": [{"type": "text", "text": "second"}],
+    }
+
+
+def test_abort_cleans_pending_and_late_reply_does_not_poison_next_call(tmp_path):
+    result = run_node_harness(tmp_path, scenario="abort_late", action="abort_late")
+
+    assert result["firstError"] == {
+        "name": "AbortError",
+        "message": "MCP tool call aborted",
+    }
+    assert result["second"] == [{"type": "text", "text": "recovered"}]
+    assert result["state"]["status"] == "completed"
+    assert result["state"]["lastAssistantText"] == "abort recovered"
+    assert result["state"]["error"] == ""
+    assert result["statuses"] == [{"key": "cao-pi-mcp", "text": None}]
+
+
+def test_abort_cancels_hanging_call_then_later_call_and_shutdown_are_immediate(tmp_path):
+    """Abort crosses JSONL by request ID instead of leaving the serial bridge blocked."""
+    result = run_node_harness(tmp_path, scenario="abort_hang", action="abort_hang", timeout=4)
+
+    assert result["firstError"] == {
+        "name": "AbortError",
+        "message": "MCP tool call aborted",
+    }
+    assert result["abortElapsedMs"] < 500
+    assert result["second"] == {
+        "settled": True,
+        "content": [{"type": "text", "text": "recovered"}],
+    }
+    assert result["secondElapsedMs"] < 750
+    assert result["shutdownElapsedMs"] < 1_000
+    assert result["proxyAlive"] is False
+    assert result["statuses"] == [{"key": "cao-pi-mcp", "text": None}]
+
+
+def test_lifecycle_transitions_publish_exact_state_and_assistant_text(tmp_path):
+    result = run_node_harness(tmp_path, scenario="normal", action="lifecycle")
+
+    for state in result.values():
+        assert set(state) == {"status", "lastAssistantText", "error", "updatedAt"}
+        assert state["updatedAt"]
+    assert result["idle"]["status"] == "idle"
+    assert result["processing"]["status"] == "processing"
+    assert result["completed"]["status"] == "completed"
+    assert result["completed"]["lastAssistantText"] == "final answer"
+    assert result["completed"]["error"] == ""
+
+
+def test_transport_failure_is_terminal_and_reported_once(tmp_path):
+    result = run_node_harness(tmp_path, scenario="exit_during_call", action="terminal_call")
+
+    assert result["callError"]["name"] == "BridgeTerminalError"
+    assert "exit code 9" in result["callError"]["message"]
+    assert result["state"]["status"] == "error"
+    assert "exit code 9" in result["state"]["error"]
+    assert result["statuses"] == [
+        {"key": "cao-pi-mcp", "text": None},
+        {"key": "cao-pi-mcp", "text": "MCP error: Pi MCP proxy exited with exit code 9"},
+    ]
+
+
+def _installed_pi() -> str | None:
+    return os.environ.get("CAO_TEST_PI_BIN") or shutil.which("pi")
+
+
+@pytest.mark.skipif(_installed_pi() is None, reason="installed Pi is required for load probe")
+def test_installed_pi_loads_extension_without_model_or_ambient_resources(tmp_path):
+    """Pi 0.84.1 initializes the explicit extension and publishes exact idle state."""
+    state_file = tmp_path / "state" / "pi.json"
+    config_file = tmp_path / "mcp.json"
+    config_file.write_text(json.dumps({"terminalId": "probe", "servers": {}}))
+    pi_config_dir = tmp_path / "pi-config"
+    env = {
+        **os.environ,
+        "CAO_PI_STATE_FILE": str(state_file),
+        "CAO_PI_MCP_CONFIG": str(config_file),
+        "CAO_PI_BRIDGE_PYTHON": sys.executable,
+        "PI_CODING_AGENT_DIR": str(pi_config_dir),
+        "PI_OFFLINE": "1",
+    }
+
+    result = subprocess.run(
+        [
+            _installed_pi(),
+            "--mode",
+            "rpc",
+            "--no-session",
+            "--offline",
+            "--no-approve",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--no-context-files",
+            "--extension",
+            str(pi_extension_path()),
+        ],
+        cwd=tmp_path,
+        env=env,
+        input='{"id":"probe","type":"get_state"}\n',
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    responses = [json.loads(line) for line in result.stdout.splitlines()]
+    assert any(
+        response.get("id") == "probe" and response.get("success") is True for response in responses
+    )
+    state = json.loads(state_file.read_text())
+    assert set(state) == {"status", "lastAssistantText", "error", "updatedAt"}
+    assert state["status"] == "idle"
+    assert state["lastAssistantText"] == ""
+    assert state["error"] == ""
+    assert isinstance(state["updatedAt"], str) and state["updatedAt"]
+    assert stat.S_IMODE(state_file.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(state_file.stat().st_mode) == 0o600
+    assert list(state_file.parent.glob("*.tmp")) == []

--- a/test/providers/test_pi_mcp_proxy.py
+++ b/test/providers/test_pi_mcp_proxy.py
@@ -1,0 +1,1100 @@
+"""Contract tests for the Pi MCP JSONL bridge."""
+
+import asyncio
+import json
+import os
+import queue
+import select
+import signal
+import subprocess
+import sys
+import time
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+import cli_agent_orchestrator.providers.pi_mcp_proxy as pi_mcp_proxy
+from cli_agent_orchestrator.providers.pi_mcp_proxy import (
+    ProxyConfigError,
+    ProxyProtocolError,
+    _request_id,
+    _run_proxy,
+    _write_response,
+    flatten_tools,
+    load_proxy_config,
+    main,
+    response_error,
+    response_ok,
+)
+
+
+def _tool(name: str) -> dict[str, object]:
+    return {"name": name, "description": f"{name} tool", "inputSchema": {"type": "object"}}
+
+
+def _send_proxy_request(process, request: dict[str, object]) -> None:
+    assert process.stdin is not None
+    process.stdin.write(json.dumps(request) + "\n")
+    process.stdin.flush()
+
+
+def _read_proxy_response(process, timeout: float = 2) -> dict[str, object]:
+    assert process.stdout is not None
+    ready, _, _ = select.select([process.stdout], [], [], timeout)
+    assert ready, "timed out waiting for Pi MCP proxy response"
+    return json.loads(process.stdout.readline())
+
+
+class _QueuedJSONLReader:
+    """Blocking text reader that lets an in-process proxy receive real JSONL incrementally."""
+
+    def __init__(self) -> None:
+        self._lines: queue.Queue[str] = queue.Queue()
+
+    def send(self, request: dict[str, object]) -> None:
+        self._lines.put(json.dumps(request) + "\n")
+
+    def close(self) -> None:
+        self._lines.put("")
+
+    def readline(self) -> str:
+        return self._lines.get()
+
+
+class _ToolResult:
+    """Small real-protocol-shaped result for exercising the proxy loop."""
+
+    def __init__(self, text: str) -> None:
+        self._payload = {"content": [{"type": "text", "text": text}], "isError": False}
+
+    def model_dump(self, **_kwargs: object) -> dict[str, object]:
+        return self._payload
+
+
+class _NotificationFailureSession:
+    """A controlled MCP boundary for proxy-level cancellation behavior tests."""
+
+    def __init__(self, notification_behavior: str) -> None:
+        self.notification_behavior = notification_behavior
+        self.call_started = asyncio.Event()
+        self.call_cancelled = asyncio.Event()
+        self.notification_attempted = asyncio.Event()
+        self.notification_cancelled = asyncio.Event()
+        self.release_notification = asyncio.Event()
+
+    async def call_tool(
+        self, _name: str, arguments: dict[str, object], **_kwargs: object
+    ) -> _ToolResult:
+        if arguments["text"] != "hang":
+            return _ToolResult(str(arguments["text"]))
+        self.call_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.call_cancelled.set()
+            raise
+        raise AssertionError("unreachable")
+
+    async def notify_call_cancelled(self, _task: asyncio.Task[object]) -> None:
+        self.notification_attempted.set()
+        if self.notification_behavior == "raises":
+            raise RuntimeError("stdio writer is closed")
+        try:
+            await self.release_notification.wait()
+        except asyncio.CancelledError:
+            self.notification_cancelled.set()
+            raise
+
+
+async def _response_with_id(writer: StringIO, request_id: str, timeout: float = 2) -> dict:
+    """Wait for an asynchronously written protocol response with the requested ID."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        for line in writer.getvalue().splitlines():
+            response = json.loads(line)
+            if response["id"] == request_id:
+                return response
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for Pi MCP proxy response {request_id!r}")
+
+
+async def _path_exists(path, timeout: float = 2) -> None:
+    """Wait for a real stdio tool to record that its invocation is active."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if path.exists():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {path}")
+
+
+def _fixture_pid_from_file(pid_file) -> int | None:
+    """Read a fixture PID whenever its test-owned file was published."""
+    if not pid_file.exists():
+        return None
+    try:
+        pid = int(pid_file.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise AssertionError(f"fixture PID file {pid_file} is invalid") from exc
+    if pid <= 0:
+        raise AssertionError(f"fixture PID file {pid_file} is invalid")
+    return pid
+
+
+def _fixture_group_is_owned(fixture_pid: int, fixture) -> bool:
+    """Check that a live PID is the exact test fixture's session leader."""
+    try:
+        if os.getpgid(fixture_pid) != fixture_pid:
+            raise AssertionError(f"fixture PID {fixture_pid} is not its group leader")
+    except ProcessLookupError:
+        return False
+
+    result = subprocess.run(
+        ["ps", "-ww", "-p", str(fixture_pid), "-o", "command="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    command = result.stdout.strip()
+    if result.returncode != 0 or not command or command == "<defunct>":
+        return False
+    if str(fixture) not in command:
+        raise AssertionError(
+            f"fixture PID {fixture_pid} is not the expected test process: {command}"
+        )
+    return True
+
+
+def _fixture_pid_is_present(fixture_pid: int) -> bool:
+    """Return whether the fixture PID still has a process-table entry."""
+    result = subprocess.run(
+        ["ps", "-ww", "-p", str(fixture_pid), "-o", "pid="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _wait_for_fixture_exit(fixture_pid: int, fixture, timeout: float = 3) -> None:
+    """Require the fixture PID to be absent from the process table after reaping."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _fixture_pid_is_present(fixture_pid):
+            return
+        _fixture_group_is_owned(fixture_pid, fixture)
+        time.sleep(0.01)
+    raise AssertionError(f"stdio fixture PID {fixture_pid} survived proxy shutdown")
+
+
+def test_wait_for_fixture_exit_rejects_an_unreaped_zombie(monkeypatch, tmp_path):
+    """A zombie still has a process-table entry and must not count as cleaned up."""
+    fixture_pid = 12345
+    fixture = tmp_path / "fixture_server.py"
+
+    monkeypatch.setattr(os, "getpgid", lambda _pid: fixture_pid)
+
+    def defunct_fixture_ps(command, **_kwargs):
+        assert command[:3] == ["ps", "-ww", "-p"]
+        stdout = f"{fixture_pid}\n" if command[-1] == "pid=" else "<defunct>\n"
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", defunct_fixture_ps)
+
+    with pytest.raises(AssertionError, match="survived proxy shutdown"):
+        _wait_for_fixture_exit(fixture_pid, fixture, timeout=0.02)
+
+
+def _terminate_proxy_group(process: subprocess.Popen) -> None:
+    """Terminate only the test-owned proxy process group and reap its leader."""
+    group_id = process.pid
+    try:
+        assert os.getpgid(group_id) == group_id
+        os.killpg(group_id, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(group_id, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait(timeout=2)
+
+
+def _terminate_fixture_group(fixture_pid: int, fixture) -> None:
+    """Terminate only a validated, separately owned FastMCP child group."""
+    if not _fixture_group_is_owned(fixture_pid, fixture):
+        return
+    os.killpg(fixture_pid, signal.SIGTERM)
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        if not _fixture_group_is_owned(fixture_pid, fixture):
+            return
+        time.sleep(0.01)
+    os.killpg(fixture_pid, signal.SIGKILL)
+
+
+def _cleanup_fixture_from_pid_file(
+    pid_file, fixture, owner: subprocess.Popen | None = None
+) -> int | None:
+    """Discover, validate, terminate, and wait for any published fixture PID."""
+    fixture_pid = _fixture_pid_from_file(pid_file)
+    if fixture_pid is None:
+        return None
+    _terminate_fixture_group(fixture_pid, fixture)
+    if owner is not None:
+        owner.wait(timeout=2)
+    _wait_for_fixture_exit(fixture_pid, fixture)
+    return fixture_pid
+
+
+def test_fixture_cleanup_discovers_pid_file_after_failure(tmp_path):
+    """A failed assertion after child start still terminates the recorded fixture."""
+    pid_file = tmp_path / "fixture.pid"
+    fixture = tmp_path / "fixture_server.py"
+    fixture.write_text(
+        "import os\n"
+        "import time\n"
+        "from pathlib import Path\n"
+        "Path(os.environ['CAO_TEST_PID_FILE']).write_text(str(os.getpid()))\n"
+        "time.sleep(60)\n"
+    )
+    process = subprocess.Popen(
+        [sys.executable, str(fixture)],
+        env={**os.environ, "CAO_TEST_PID_FILE": str(pid_file)},
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 2
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert pid_file.exists(), "fixture did not record its PID"
+
+        with pytest.raises(AssertionError, match="deliberate failure"):
+            try:
+                raise AssertionError("deliberate failure after fixture start")
+            finally:
+                _cleanup_fixture_from_pid_file(pid_file, fixture, process)
+
+        fixture_pid = int(pid_file.read_text(encoding="utf-8"))
+        assert process.returncode == 0 - signal.SIGTERM
+        _wait_for_fixture_exit(fixture_pid, fixture)
+    finally:
+        _cleanup_fixture_from_pid_file(pid_file, fixture, process)
+
+
+def test_load_config_rejects_http_server(tmp_path):
+    """A URL-only server cannot be launched over the V1 stdio bridge."""
+    config = tmp_path / "mcp.json"
+    config.write_text('{"terminalId":"t1","servers":{"remote":{"url":"https://x"}}}')
+
+    with pytest.raises(ProxyConfigError, match="stdio"):
+        load_proxy_config(config)
+
+
+def test_mcp_dependency_caps_the_private_request_id_contract():
+    """Fresh installs cannot select an MCP minor the private tracker has not exercised."""
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+    assert '"mcp>=1.28.1,<1.29.0",' in pyproject.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        ("{", "unable to read"),
+        (json.dumps([]), "must be an object"),
+        (json.dumps({"servers": {}}), "terminalId"),
+        (json.dumps({"terminalId": "t1", "servers": []}), "servers"),
+        (
+            json.dumps({"terminalId": "t1", "servers": {"": {"command": "node"}}}),
+            "server names",
+        ),
+        (
+            json.dumps({"terminalId": "t1", "servers": {"fixture": []}}),
+            "must be an object",
+        ),
+        (
+            json.dumps(
+                {
+                    "terminalId": "t1",
+                    "servers": {"fixture": {"command": "node", "args": ["ok", 1]}},
+                }
+            ),
+            "args",
+        ),
+    ],
+)
+def test_load_config_rejects_malformed_bridge_boundaries(tmp_path, contents, message):
+    """Invalid bridge JSON is rejected before an MCP child can be launched."""
+    config = tmp_path / "mcp.json"
+    config.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ProxyConfigError, match=message):
+        load_proxy_config(config)
+
+
+@pytest.mark.parametrize(
+    ("server", "message"),
+    [
+        ({}, "command"),
+        ({"command": "fixture", "env": {"TOKEN": 1}}, "environment"),
+        ({"command": "fixture", "requestTimeoutMs": 0}, "timeout"),
+        ({"command": "fixture", "requestTimeoutMs": 1_200_001}, "timeout"),
+    ],
+)
+def test_load_config_rejects_invalid_stdio_server(tmp_path, server, message):
+    """Malformed process configs fail before a command can be launched."""
+    config = tmp_path / "mcp.json"
+    config.write_text(json.dumps({"terminalId": "t1", "servers": {"fixture": server}}))
+
+    with pytest.raises(ProxyConfigError, match=message):
+        load_proxy_config(config)
+
+
+def test_duplicate_tool_names_fail_closed():
+    """A duplicate exposed name must never be routed to an arbitrary server."""
+    with pytest.raises(ProxyProtocolError, match="duplicate tool name"):
+        flatten_tools({"one": [_tool("handoff")], "two": [_tool("handoff")]})
+
+
+def test_discovered_tool_without_a_name_fails_before_pi_exposure():
+    """A malformed SDK tool cannot become a nameless Pi command."""
+    with pytest.raises(ProxyProtocolError, match="without a name"):
+        flatten_tools({"fixture": [{}]})
+
+
+@pytest.mark.parametrize("name", ["bash", "read", "edit", "write", "grep", "find", "ls"])
+def test_pi_builtin_tool_names_fail_closed_before_exposure(name):
+    """An MCP server cannot replace any Pi native tool with a same-named tool."""
+    with pytest.raises(ProxyProtocolError, match=rf"reserved Pi tool name: {name}"):
+        flatten_tools({"fixture": [_tool(name)]})
+
+
+def test_flatten_tools_preserves_server_routing_and_schema():
+    """Pi receives enough metadata to register a tool and route it back safely."""
+    result = flatten_tools({"fixture": [_tool("echo")]})
+
+    assert result == [
+        {
+            "server": "fixture",
+            "name": "echo",
+            "description": "echo tool",
+            "inputSchema": {"type": "object"},
+        }
+    ]
+
+
+def test_flatten_tools_keeps_cao_routing_metadata_authoritative():
+    """A server cannot redirect its discovered tool to another MCP server."""
+    tool = _tool("echo")
+    tool["server"] = "attacker-controlled"
+
+    assert flatten_tools({"fixture": [tool]})[0]["server"] == "fixture"
+
+
+def test_response_helpers_correlate_ids_and_keep_errors_safe():
+    """Protocol responses retain the request identifier without config disclosure."""
+    assert response_ok("1", {"tools": []}) == {"id": "1", "ok": True, "result": {"tools": []}}
+    assert response_error("2", ValueError("bad request")) == {
+        "id": "2",
+        "ok": False,
+        "error": "internal proxy error",
+    }
+
+
+def test_response_error_hides_unexpected_exception_details_from_protocol_output():
+    """Transport failures cannot disclose secrets through the Pi JSONL stream."""
+    secret = "api-token=super-secret-value"
+    writer = StringIO()
+
+    _write_response(writer, response_error("3", RuntimeError(secret)))
+
+    assert secret not in writer.getvalue()
+    assert json.loads(writer.getvalue()) == {
+        "id": "3",
+        "ok": False,
+        "error": "internal proxy error",
+    }
+
+
+def test_response_error_keeps_intentional_protocol_errors_descriptive():
+    """Caller-fixable malformed requests retain their safe protocol detail."""
+    assert response_error("4", ProxyProtocolError("unknown request type")) == {
+        "id": "4",
+        "ok": False,
+        "error": "unknown request type",
+    }
+
+
+@pytest.mark.parametrize("payload", [[], {"id": 1}])
+def test_jsonl_request_requires_a_string_correlation_id(payload):
+    """Malformed JSONL cannot create an uncorrelated bridge response."""
+    with pytest.raises(ProxyProtocolError, match="request id must be a string"):
+        _request_id(payload)
+
+
+def test_cli_reports_invalid_config_without_echoing_its_contents(tmp_path, capsys):
+    """The bridge CLI exits predictably without reflecting malformed configuration data."""
+    config = tmp_path / "mcp.json"
+    malformed = '{"terminalId":"sensitive-but-invalid"'
+    config.write_text(malformed, encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exit_info:
+        main(["--config", str(config)])
+
+    captured = capsys.readouterr()
+    assert exit_info.value.code == 2
+    assert "pi MCP proxy configuration error: unable to read proxy configuration" in captured.err
+    assert malformed not in captured.err
+
+
+def test_in_process_proxy_rejects_bad_request_then_routes_real_stdio_tool(tmp_path):
+    """A malformed JSONL request cannot prevent later calls to a real MCP process."""
+    server = tmp_path / "fixture_server.py"
+    server.write_text(
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('fixture')\n"
+        "@mcp.tool()\n"
+        "def echo(text: str) -> str:\n"
+        "    return text\n"
+        "mcp.run(transport='stdio', show_banner=False)\n"
+    )
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "terminalId": "term-1",
+                "servers": {
+                    "fixture": {
+                        "command": sys.executable,
+                        "args": [str(server)],
+                    }
+                },
+            }
+        )
+    )
+    config = load_proxy_config(config_path)
+
+    async def exercise() -> None:
+        reader = _QueuedJSONLReader()
+        writer = StringIO()
+        proxy_task = asyncio.create_task(_run_proxy(config, reader, writer))
+        try:
+            reader.send(
+                {
+                    "id": "bad",
+                    "type": "call_tool",
+                    "server": "missing",
+                    "name": "echo",
+                    "arguments": {"text": "ignored"},
+                }
+            )
+            assert await _response_with_id(writer, "bad") == {
+                "id": "bad",
+                "ok": False,
+                "error": "unknown server",
+            }
+
+            reader.send({"id": "list", "type": "list_tools"})
+            listed = await _response_with_id(writer, "list")
+            [tool] = listed["result"]["tools"]
+            assert tool["name"] == "echo"
+            assert tool["server"] == "fixture"
+            assert tool["inputSchema"]["properties"]["text"] == {"type": "string"}
+
+            reader.send(
+                {
+                    "id": "call",
+                    "type": "call_tool",
+                    "server": "fixture",
+                    "name": "echo",
+                    "arguments": {"text": "after bad request"},
+                }
+            )
+            called = await _response_with_id(writer, "call")
+            assert called["result"]["content"] == [{"type": "text", "text": "after bad request"}]
+
+            reader.send({"id": "stop", "type": "shutdown"})
+            assert await _response_with_id(writer, "stop") == {
+                "id": "stop",
+                "ok": True,
+                "result": {},
+            }
+            await asyncio.wait_for(proxy_task, timeout=2)
+        finally:
+            if not proxy_task.done():
+                reader.close()
+                await asyncio.wait_for(proxy_task, timeout=2)
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("notification_behavior", ["blocks", "raises"])
+def test_proxy_cancellation_acknowledges_local_cancel_when_notification_is_unavailable(
+    monkeypatch, notification_behavior
+):
+    """A broken MCP writer cannot delay Pi's local abort, recovery, or shutdown.
+
+    ``cancelled`` means only that the active bridge task was locally cancelled;
+    MCP notifications are one-way best effort and never confirm remote tool state.
+    """
+    session = _NotificationFailureSession(notification_behavior)
+    config = pi_mcp_proxy.ProxyConfig(
+        terminal_id="term-1",
+        servers={
+            "fixture": pi_mcp_proxy.ProxyServerConfig(
+                name="fixture",
+                command="unused",
+                args=[],
+                env={},
+                request_timeout_ms=1_000,
+            )
+        },
+    )
+
+    async def load_controlled_server(_config, _stack):
+        return {"fixture": session}, {"fixture": [_tool("echo")]}
+
+    monkeypatch.setattr(pi_mcp_proxy, "_load_server_tools", load_controlled_server)
+
+    async def exercise() -> None:
+        reader = _QueuedJSONLReader()
+        writer = StringIO()
+        proxy_task = asyncio.create_task(_run_proxy(config, reader, writer))
+        try:
+            reader.send({"id": "list", "type": "list_tools"})
+            await _response_with_id(writer, "list")
+
+            reader.send(
+                {
+                    "id": "hang",
+                    "type": "call_tool",
+                    "server": "fixture",
+                    "name": "echo",
+                    "arguments": {"text": "hang"},
+                }
+            )
+            await asyncio.wait_for(session.call_started.wait(), timeout=0.5)
+
+            cancellation_started = asyncio.get_running_loop().time()
+            reader.send({"id": "cancel", "type": "cancel", "targetId": "hang"})
+            assert await _response_with_id(writer, "cancel", timeout=0.75) == {
+                "id": "cancel",
+                "ok": True,
+                "result": {"cancelled": True},
+            }
+            assert asyncio.get_running_loop().time() - cancellation_started < 0.75
+            assert session.notification_attempted.is_set()
+            assert session.call_cancelled.is_set()
+            if notification_behavior == "blocks":
+                assert session.notification_cancelled.is_set()
+
+            reader.send(
+                {
+                    "id": "next",
+                    "type": "call_tool",
+                    "server": "fixture",
+                    "name": "echo",
+                    "arguments": {"text": "recovered"},
+                }
+            )
+            assert (await _response_with_id(writer, "next"))["result"]["content"] == [
+                {"type": "text", "text": "recovered"}
+            ]
+
+            reader.send({"id": "stop", "type": "shutdown"})
+            assert await _response_with_id(writer, "stop") == {
+                "id": "stop",
+                "ok": True,
+                "result": {},
+            }
+            await asyncio.wait_for(proxy_task, timeout=1)
+        finally:
+            session.release_notification.set()
+            reader.close()
+            if not proxy_task.done():
+                await asyncio.wait_for(proxy_task, timeout=1)
+
+    asyncio.run(exercise())
+
+
+def test_in_process_proxy_rejects_invalid_tool_requests_and_remains_usable(tmp_path):
+    """Invalid JSONL tool requests are correlated errors that do not poison later calls."""
+    server = tmp_path / "fixture_server.py"
+    server.write_text(
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('fixture')\n"
+        "@mcp.tool()\n"
+        "def echo(text: str) -> str:\n"
+        "    return text\n"
+        "mcp.run(transport='stdio', show_banner=False)\n"
+    )
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "terminalId": "term-1",
+                "servers": {
+                    "fixture": {
+                        "command": sys.executable,
+                        "args": [str(server)],
+                    }
+                },
+            }
+        )
+    )
+    config = load_proxy_config(config_path)
+
+    async def exercise() -> None:
+        reader = _QueuedJSONLReader()
+        writer = StringIO()
+        proxy_task = asyncio.create_task(_run_proxy(config, reader, writer))
+        try:
+            reader.send({"id": "list", "type": "list_tools"})
+            await _response_with_id(writer, "list")
+
+            invalid_requests = [
+                (
+                    "tool",
+                    {
+                        "type": "call_tool",
+                        "server": "fixture",
+                        "name": "missing",
+                        "arguments": {},
+                    },
+                    "unknown tool",
+                ),
+                (
+                    "arguments",
+                    {
+                        "type": "call_tool",
+                        "server": "fixture",
+                        "name": "echo",
+                        "arguments": [],
+                    },
+                    "tool arguments must be an object",
+                ),
+                (
+                    "cancel",
+                    {"type": "cancel", "targetId": 1},
+                    "cancel targetId must be a string",
+                ),
+                ("type", {"type": "unknown"}, "unknown request type"),
+            ]
+            for request_id, request, error in invalid_requests:
+                reader.send({"id": request_id, **request})
+                assert await _response_with_id(writer, request_id) == {
+                    "id": request_id,
+                    "ok": False,
+                    "error": error,
+                }
+
+            reader.send(
+                {
+                    "id": "next",
+                    "type": "call_tool",
+                    "server": "fixture",
+                    "name": "echo",
+                    "arguments": {"text": "still usable"},
+                }
+            )
+            assert (await _response_with_id(writer, "next"))["result"]["content"] == [
+                {"type": "text", "text": "still usable"}
+            ]
+
+            reader.send({"id": "stop", "type": "shutdown"})
+            await _response_with_id(writer, "stop")
+            await asyncio.wait_for(proxy_task, timeout=2)
+        finally:
+            if not proxy_task.done():
+                reader.close()
+                await asyncio.wait_for(proxy_task, timeout=2)
+
+    asyncio.run(exercise())
+
+
+def test_in_process_proxy_sanitizes_crashed_mcp_server_and_routes_healthy_server(tmp_path):
+    """A broken MCP transport cannot disclose errors or block another configured server."""
+    crashed_server = tmp_path / "crashed_server.py"
+    crashed_server.write_text(
+        "import os\n"
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('crashed')\n"
+        "@mcp.tool()\n"
+        "def crash() -> str:\n"
+        "    os._exit(17)\n"
+        "mcp.run(transport='stdio', show_banner=False)\n"
+    )
+    healthy_server = tmp_path / "healthy_server.py"
+    healthy_server.write_text(
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('healthy')\n"
+        "@mcp.tool()\n"
+        "def echo(text: str) -> str:\n"
+        "    return text\n"
+        "mcp.run(transport='stdio', show_banner=False)\n"
+    )
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "terminalId": "term-1",
+                "servers": {
+                    "crashed": {"command": sys.executable, "args": [str(crashed_server)]},
+                    "healthy": {"command": sys.executable, "args": [str(healthy_server)]},
+                },
+            }
+        )
+    )
+    config = load_proxy_config(config_path)
+
+    async def exercise() -> None:
+        reader = _QueuedJSONLReader()
+        writer = StringIO()
+        proxy_task = asyncio.create_task(_run_proxy(config, reader, writer))
+        try:
+            reader.send({"id": "list", "type": "list_tools"})
+            await _response_with_id(writer, "list")
+
+            reader.send(
+                {
+                    "id": "crash",
+                    "type": "call_tool",
+                    "server": "crashed",
+                    "name": "crash",
+                    "arguments": {},
+                }
+            )
+            assert await _response_with_id(writer, "crash") == {
+                "id": "crash",
+                "ok": False,
+                "error": "internal proxy error",
+            }
+
+            reader.send(
+                {
+                    "id": "healthy",
+                    "type": "call_tool",
+                    "server": "healthy",
+                    "name": "echo",
+                    "arguments": {"text": "recovered"},
+                }
+            )
+            assert (await _response_with_id(writer, "healthy"))["result"]["content"] == [
+                {"type": "text", "text": "recovered"}
+            ]
+
+            reader.send({"id": "stop", "type": "shutdown"})
+            await _response_with_id(writer, "stop")
+            await asyncio.wait_for(proxy_task, timeout=2)
+        finally:
+            if not proxy_task.done():
+                reader.close()
+                await asyncio.wait_for(proxy_task, timeout=2)
+
+    asyncio.run(exercise())
+
+
+def test_in_process_proxy_cancels_live_stdio_call_then_routes_next(tmp_path):
+    """Cancelling an active real MCP call frees the bridge for the next Pi tool call."""
+    started = tmp_path / "started"
+    stopped = tmp_path / "stopped"
+    pid_file = tmp_path / "fixture.pid"
+    server = tmp_path / "hanging_server.py"
+    server.write_text(
+        "import asyncio\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('fixture')\n"
+        "Path(os.environ['CAO_TEST_PID_FILE']).write_text(str(os.getpid()))\n"
+        "@mcp.tool()\n"
+        "async def echo(text: str) -> str:\n"
+        "    if text == 'hang':\n"
+        "        Path(os.environ['CAO_TEST_STARTED_FILE']).write_text('started')\n"
+        "        try:\n"
+        "            await asyncio.Event().wait()\n"
+        "        except asyncio.CancelledError:\n"
+        "            Path(os.environ['CAO_TEST_STOPPED_FILE']).write_text('stopped')\n"
+        "            raise\n"
+        "    return text\n"
+        "mcp.run(transport='stdio', show_banner=False)\n"
+    )
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "terminalId": "term-1",
+                "servers": {
+                    "fixture": {
+                        "command": sys.executable,
+                        "args": [str(server)],
+                        "env": {
+                            "CAO_TEST_STARTED_FILE": str(started),
+                            "CAO_TEST_STOPPED_FILE": str(stopped),
+                            "CAO_TEST_PID_FILE": str(pid_file),
+                        },
+                    }
+                },
+            }
+        )
+    )
+    config = load_proxy_config(config_path)
+
+    async def exercise() -> None:
+        reader = _QueuedJSONLReader()
+        writer = StringIO()
+        proxy_task = asyncio.create_task(_run_proxy(config, reader, writer))
+        try:
+            reader.send({"id": "list", "type": "list_tools"})
+            await _response_with_id(writer, "list")
+
+            reader.send(
+                {
+                    "id": "hang",
+                    "type": "call_tool",
+                    "server": "fixture",
+                    "name": "echo",
+                    "arguments": {"text": "hang"},
+                }
+            )
+            await _path_exists(started)
+            assert _fixture_pid_from_file(pid_file) is not None
+
+            reader.send(
+                {
+                    "id": "hang",
+                    "type": "call_tool",
+                    "server": "fixture",
+                    "name": "echo",
+                    "arguments": {"text": "duplicate"},
+                }
+            )
+            assert await _response_with_id(writer, "hang") == {
+                "id": "hang",
+                "ok": False,
+                "error": "request id is already active",
+            }
+
+            reader.send({"id": "cancel", "type": "cancel", "targetId": "hang"})
+            assert await _response_with_id(writer, "cancel") == {
+                "id": "cancel",
+                "ok": True,
+                "result": {"cancelled": True},
+            }
+            await _path_exists(stopped)
+
+            reader.send(
+                {
+                    "id": "next",
+                    "type": "call_tool",
+                    "server": "fixture",
+                    "name": "echo",
+                    "arguments": {"text": "after cancel"},
+                }
+            )
+            called = await _response_with_id(writer, "next")
+            assert called["result"]["content"] == [{"type": "text", "text": "after cancel"}]
+
+            reader.send({"id": "stop", "type": "shutdown"})
+            await _response_with_id(writer, "stop")
+            await asyncio.wait_for(proxy_task, timeout=2)
+        finally:
+            if not proxy_task.done():
+                reader.close()
+                try:
+                    await asyncio.wait_for(asyncio.shield(proxy_task), timeout=0.5)
+                except TimeoutError:
+                    await asyncio.to_thread(_cleanup_fixture_from_pid_file, pid_file, server)
+                    await asyncio.wait_for(proxy_task, timeout=2)
+            await asyncio.to_thread(_cleanup_fixture_from_pid_file, pid_file, server)
+
+    asyncio.run(exercise())
+
+
+def test_proxy_lists_and_calls_a_stdio_mcp_server(tmp_path):
+    """The bridge initializes, lists, and calls a real SDK stdio server."""
+    pid_file = tmp_path / "fixture.pid"
+    server = tmp_path / "fixture_server.py"
+    server.write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('fixture')\n"
+        "Path(os.environ['CAO_TEST_PID_FILE']).write_text(str(os.getpid()))\n"
+        "@mcp.tool()\n"
+        "def echo(text: str) -> str:\n"
+        "    return text\n"
+        "mcp.run(transport='stdio', show_banner=False)\n"
+    )
+    config = tmp_path / "mcp.json"
+    config.write_text(
+        json.dumps(
+            {
+                "terminalId": "term-1",
+                "servers": {
+                    "fixture": {
+                        "command": sys.executable,
+                        "args": [str(server)],
+                        "env": {"CAO_TEST_PID_FILE": str(pid_file)},
+                    }
+                },
+            }
+        )
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "cli_agent_orchestrator.providers.pi_mcp_proxy",
+            "--config",
+            str(config),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        _send_proxy_request(process, {"id": "1", "type": "list_tools"})
+        listed = _read_proxy_response(process)
+        assert listed["result"]["tools"][0]["name"] == "echo"
+        assert _fixture_pid_from_file(pid_file) is not None
+
+        _send_proxy_request(
+            process,
+            {
+                "id": "2",
+                "type": "call_tool",
+                "server": "fixture",
+                "name": "echo",
+                "arguments": {"text": "hi"},
+            },
+        )
+        called = _read_proxy_response(process)
+        assert called["result"]["content"] == [{"type": "text", "text": "hi"}]
+
+        _send_proxy_request(process, {"id": "3", "type": "shutdown"})
+        assert _read_proxy_response(process) == {"id": "3", "ok": True, "result": {}}
+        assert process.wait(timeout=2) == 0
+    finally:
+        _terminate_proxy_group(process)
+        _cleanup_fixture_from_pid_file(pid_file, server)
+
+
+def test_proxy_cancels_hanging_call_and_remains_usable(tmp_path):
+    """ID-targeted cancellation releases a real hanging SDK call without blocking input."""
+    started = tmp_path / "started"
+    stopped = tmp_path / "stopped"
+    pid_file = tmp_path / "fixture.pid"
+    server = tmp_path / "hanging_server.py"
+    server.write_text(
+        "import asyncio\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('fixture')\n"
+        "Path(os.environ['CAO_TEST_PID_FILE']).write_text(str(os.getpid()))\n"
+        "@mcp.tool()\n"
+        "async def echo(text: str) -> str:\n"
+        "    if text == 'hang':\n"
+        "        Path(os.environ['CAO_TEST_STARTED_FILE']).write_text('started')\n"
+        "        try:\n"
+        "            await asyncio.Event().wait()\n"
+        "        except asyncio.CancelledError:\n"
+        "            Path(os.environ['CAO_TEST_STOPPED_FILE']).write_text('stopped')\n"
+        "            raise\n"
+        "    return text\n"
+        "mcp.run(transport='stdio', show_banner=False)\n"
+    )
+    config = tmp_path / "mcp.json"
+    config.write_text(
+        json.dumps(
+            {
+                "terminalId": "term-1",
+                "servers": {
+                    "fixture": {
+                        "command": sys.executable,
+                        "args": [str(server)],
+                        "env": {
+                            "CAO_TEST_PID_FILE": str(pid_file),
+                            "CAO_TEST_STARTED_FILE": str(started),
+                            "CAO_TEST_STOPPED_FILE": str(stopped),
+                        },
+                    }
+                },
+            }
+        )
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "cli_agent_orchestrator.providers.pi_mcp_proxy",
+            "--config",
+            str(config),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        assert os.getpgid(process.pid) == process.pid
+        _send_proxy_request(process, {"id": "1", "type": "list_tools"})
+        assert _read_proxy_response(process)["id"] == "1"
+        fixture_pid = _fixture_pid_from_file(pid_file)
+        assert fixture_pid is not None
+
+        _send_proxy_request(
+            process,
+            {
+                "id": "2",
+                "type": "call_tool",
+                "server": "fixture",
+                "name": "echo",
+                "arguments": {"text": "hang"},
+            },
+        )
+        deadline = time.monotonic() + 2
+        while not started.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert started.exists(), "hanging fixture never received the MCP request"
+        _send_proxy_request(process, {"id": "3", "type": "cancel", "targetId": "2"})
+        assert _read_proxy_response(process) == {
+            "id": "3",
+            "ok": True,
+            "result": {"cancelled": True},
+        }
+        deadline = time.monotonic() + 2
+        while not stopped.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert stopped.exists(), "MCP server did not receive the cancellation notification"
+
+        _send_proxy_request(
+            process,
+            {
+                "id": "4",
+                "type": "call_tool",
+                "server": "fixture",
+                "name": "echo",
+                "arguments": {"text": "after abort"},
+            },
+        )
+        response = _read_proxy_response(process)
+        assert response["id"] == "4"
+        assert response["result"]["content"] == [{"type": "text", "text": "after abort"}]
+
+        _send_proxy_request(process, {"id": "5", "type": "shutdown"})
+        assert _read_proxy_response(process) == {"id": "5", "ok": True, "result": {}}
+        assert process.wait(timeout=3) == 0
+        _wait_for_fixture_exit(fixture_pid, server)
+    finally:
+        _terminate_proxy_group(process)
+        _cleanup_fixture_from_pid_file(pid_file, server)

--- a/test/providers/test_pi_unit.py
+++ b/test/providers/test_pi_unit.py
@@ -1,0 +1,850 @@
+"""Unit tests for the Pi terminal provider adapter."""
+
+import asyncio
+import json
+import shlex
+import stat
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers import pi as pi_module
+from cli_agent_orchestrator.providers.pi import PiProvider, ProviderError
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _profile(**overrides):
+    values = {
+        "system_prompt": "Profile system prompt",
+        "prompt": "Legacy profile prompt",
+        "model": None,
+        "mcpServers": {
+            "cao-mcp-server": {
+                "type": "stdio",
+                "command": "cao-mcp-server",
+                "args": [],
+            }
+        },
+        "provider_init_timeout": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def make_provider(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    terminal_id: str = "term-1",
+    profile=None,
+    agent_profile: str | None = "developer",
+    allowed_tools: list[str] | None = None,
+    skill_prompt: str | None = "Runtime skill prompt",
+    model: str | None = None,
+    executable_name: str = "pi",
+):
+    home = tmp_path / "cao-home"
+    executable = tmp_path / "bin" / executable_name
+    executable.parent.mkdir(parents=True, exist_ok=True)
+    executable.touch(mode=0o755)
+    executable.chmod(0o755)
+    monkeypatch.setattr(pi_module, "CAO_HOME_DIR", home)
+    monkeypatch.setattr(pi_module.shutil, "which", lambda name: str(executable))
+    if agent_profile is not None:
+        monkeypatch.setattr(pi_module, "load_agent_profile", lambda name: profile or _profile())
+    return PiProvider(
+        terminal_id,
+        "session-1",
+        "window-1",
+        agent_profile=agent_profile,
+        allowed_tools=allowed_tools,
+        skill_prompt=skill_prompt,
+        model=model,
+    )
+
+
+def test_build_command_is_private_explicit_and_shell_safe(monkeypatch, tmp_path):
+    """Launch tokens cannot escape the shell or re-enable ambient Pi resources."""
+    terminal_id = "term one;$(touch /tmp/cao-pi-terminal-injection)"
+    model = "openai/gpt 5;$(touch /tmp/cao-pi-model-injection)"
+    provider = make_provider(
+        monkeypatch,
+        tmp_path,
+        terminal_id=terminal_id,
+        model=model,
+        executable_name="pi binary;safe",
+    )
+
+    command = provider._build_pi_command()
+    tokens = shlex.split(command)
+
+    assert tokens == [
+        "env",
+        f"CAO_PI_STATE_FILE={provider.state_path}",
+        f"CAO_PI_MCP_CONFIG={provider.mcp_config_path}",
+        f"CAO_PI_BRIDGE_PYTHON={sys.executable}",
+        str(provider.pi_executable),
+        "--tui-mode",
+        "regular",
+        "--no-approve",
+        "--no-extensions",
+        "--extension",
+        str(provider.extension_path),
+        "--no-skills",
+        "--no-prompt-templates",
+        "--session-id",
+        terminal_id,
+        "--session-dir",
+        str(provider.session_dir),
+        "--append-system-prompt",
+        str(provider.prompt_path),
+        "--model",
+        model,
+    ]
+    assert "--no-context-files" not in tokens
+    assert stat.S_IMODE((tmp_path / "cao-home").stat().st_mode) == 0o700
+    assert stat.S_IMODE((tmp_path / "cao-home" / "pi").stat().st_mode) == 0o700
+    assert stat.S_IMODE(provider.runtime_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(provider.session_dir.stat().st_mode) == 0o700
+    for path in (provider.prompt_path, provider.mcp_config_path, provider.state_path):
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_build_command_resolves_and_injects_mcp_terminal_id(monkeypatch, tmp_path):
+    """The bridge receives a terminal-scoped config with a stable server executable."""
+    provider = make_provider(monkeypatch, tmp_path)
+
+    config = json.loads(provider._write_mcp_config().read_text(encoding="utf-8"))
+
+    assert config["terminalId"] == "term-1"
+    assert set(config) == {"terminalId", "servers"}
+    assert Path(config["servers"]["cao-mcp-server"]["command"]).is_absolute()
+    assert config["servers"]["cao-mcp-server"]["type"] == "stdio"
+
+
+def test_mcp_model_server_normalizes_legacy_timeout_for_the_pi_bridge(monkeypatch, tmp_path):
+    """Pydantic profile entries retain their timeout when serialized for the bridge."""
+    from cli_agent_orchestrator.models.agent_profile import McpServer
+
+    provider = make_provider(
+        monkeypatch,
+        tmp_path,
+        profile=_profile(
+            mcpServers={
+                "model-server": McpServer(
+                    command="node",
+                    args=["server.js"],
+                    timeout=123_456,
+                )
+            }
+        ),
+    )
+
+    config = json.loads(provider._write_mcp_config().read_text(encoding="utf-8"))
+
+    assert config["servers"]["model-server"] == {
+        "command": "node",
+        "args": ["server.js"],
+        "requestTimeoutMs": 123_456,
+    }
+
+
+def test_unreadable_profile_fails_before_pi_launch_with_context(monkeypatch, tmp_path):
+    """A selected profile error is surfaced as a Pi-specific launch failure."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile="restricted")
+
+    def fail_to_load_profile(name):
+        raise OSError(f"cannot read {name}")
+
+    monkeypatch.setattr(pi_module, "load_agent_profile", fail_to_load_profile)
+
+    with pytest.raises(
+        ProviderError, match="Failed to load agent profile 'restricted': cannot read"
+    ):
+        provider._build_pi_command()
+
+
+@pytest.mark.parametrize(
+    ("system_prompt", "legacy_prompt", "expected_base"),
+    [
+        ("System wins", "Legacy loses", "System wins"),
+        (None, "Legacy fallback", "Legacy fallback"),
+        ("", "Legacy fallback", "Legacy fallback"),
+    ],
+)
+def test_prompt_composes_profile_fallback_and_runtime_skills(
+    monkeypatch,
+    tmp_path,
+    system_prompt,
+    legacy_prompt,
+    expected_base,
+):
+    """Pi receives the selected profile prompt followed by the runtime skill catalog."""
+    provider = make_provider(
+        monkeypatch,
+        tmp_path,
+        profile=_profile(system_prompt=system_prompt, prompt=legacy_prompt),
+    )
+
+    provider._build_pi_command()
+
+    assert provider.prompt_path.read_text(encoding="utf-8") == (
+        f"{expected_base}\n\nRuntime skill prompt"
+    )
+
+
+def test_prompt_supports_runtime_skills_without_a_profile(monkeypatch, tmp_path):
+    """A profile is optional; runtime skills still become Pi system context."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+
+    provider._build_pi_command()
+
+    assert provider.prompt_path.read_text(encoding="utf-8") == "Runtime skill prompt"
+
+
+def test_explicit_model_overrides_profile_model(monkeypatch, tmp_path):
+    """A handoff model override wins over the profile's static model."""
+    provider = make_provider(
+        monkeypatch,
+        tmp_path,
+        profile=_profile(model="profile/model"),
+        model="runtime/model",
+    )
+
+    tokens = shlex.split(provider._build_pi_command())
+
+    assert tokens[tokens.index("--model") + 1] == "runtime/model"
+
+
+def test_profile_model_is_used_without_an_explicit_override(monkeypatch, tmp_path):
+    """The profile model is forwarded when the caller did not override it."""
+    provider = make_provider(monkeypatch, tmp_path, profile=_profile(model="profile/model"))
+
+    tokens = shlex.split(provider._build_pi_command())
+
+    assert tokens[tokens.index("--model") + 1] == "profile/model"
+
+
+def test_native_denylist_is_passed_as_one_pi_argument(monkeypatch, tmp_path):
+    """The existing tool-policy helper controls Pi's comma-separated denylist."""
+    calls = []
+
+    def fake_disallowed(provider_name, allowed):
+        calls.append((provider_name, allowed))
+        return ["bash", "edit", "write"]
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.utils.tool_mapping.get_disallowed_tools",
+        fake_disallowed,
+    )
+    provider = make_provider(monkeypatch, tmp_path, allowed_tools=["fs_read"])
+
+    tokens = shlex.split(provider._build_pi_command())
+
+    assert calls == [("pi", ["fs_read"])]
+    assert tokens[tokens.index("--exclude-tools") + 1] == "bash,edit,write"
+
+
+def test_explicit_empty_allowed_tools_still_computes_a_native_denylist(monkeypatch, tmp_path):
+    """An explicit no-tools policy does not degrade to unrestricted Pi built-ins."""
+    calls = []
+
+    def fake_disallowed(provider_name, allowed):
+        calls.append((provider_name, allowed))
+        return ["bash", "read", "edit", "write", "grep", "find", "ls"]
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.utils.tool_mapping.get_disallowed_tools",
+        fake_disallowed,
+    )
+    provider = make_provider(monkeypatch, tmp_path, allowed_tools=[])
+
+    tokens = shlex.split(provider._build_pi_command())
+
+    assert calls == [("pi", [])]
+    assert tokens[tokens.index("--exclude-tools") + 1] == ("bash,read,edit,write,grep,find,ls")
+
+
+def test_pi_executable_is_resolved_once_at_construction(monkeypatch, tmp_path):
+    """A later PATH change cannot select a different Pi binary at launch."""
+    first = tmp_path / "bin" / "pi-first"
+    second = tmp_path / "bin" / "pi-second"
+    first.parent.mkdir(parents=True)
+    first.touch(mode=0o755)
+    second.touch(mode=0o755)
+    calls = []
+
+    def fake_which(name):
+        calls.append(name)
+        return str(first if len(calls) == 1 else second)
+
+    monkeypatch.setattr(pi_module, "CAO_HOME_DIR", tmp_path / "cao-home")
+    monkeypatch.setattr(pi_module.shutil, "which", fake_which)
+    provider = PiProvider("term-1", "session-1", "window-1")
+
+    provider._build_pi_command()
+    provider._build_pi_command()
+
+    assert calls == ["pi"]
+    assert provider.pi_executable == first.resolve()
+    assert shlex.split(provider._build_pi_command())[4] == str(first.resolve())
+
+
+def test_missing_pi_fails_without_creating_runtime_paths(monkeypatch, tmp_path):
+    """Construction fails before a partial provider directory is created."""
+    home = tmp_path / "cao-home"
+    monkeypatch.setattr(pi_module, "CAO_HOME_DIR", home)
+    monkeypatch.setattr(pi_module.shutil, "which", lambda name: None)
+
+    with pytest.raises(ProviderError, match="Pi executable.*PATH"):
+        PiProvider("term-1", "session-1", "window-1")
+
+    assert not home.exists()
+
+
+def write_state(
+    provider: PiProvider,
+    *,
+    status: str,
+    last_assistant_text: str = "",
+    error: str = "",
+    updated_at: str = "2026-08-13T22:00:00.000Z",
+    mode: int = 0o600,
+    extra: dict | None = None,
+) -> None:
+    provider.state_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    payload = {
+        "status": status,
+        "lastAssistantText": last_assistant_text,
+        "error": error,
+        "updatedAt": updated_at,
+    }
+    if extra:
+        payload.update(extra)
+    provider.state_path.write_text(json.dumps(payload), encoding="utf-8")
+    provider.state_path.chmod(mode)
+
+
+@pytest.mark.parametrize(
+    ("sidecar_status", "expected"),
+    [
+        ("idle", TerminalStatus.IDLE),
+        ("processing", TerminalStatus.PROCESSING),
+        ("completed", TerminalStatus.COMPLETED),
+        ("error", TerminalStatus.ERROR),
+    ],
+)
+def test_status_maps_each_valid_sidecar_state(monkeypatch, tmp_path, sidecar_status, expected):
+    """Every extension lifecycle value maps to the corresponding CAO status."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(provider, status=sidecar_status, error="bridge failed")
+
+    assert provider.get_status("ambiguous terminal chrome") is expected
+
+
+def test_status_prefers_sidecar_over_stale_tui(monkeypatch, tmp_path):
+    """A valid completed sidecar overrides a stale visible working frame."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(
+        provider,
+        status="completed",
+        last_assistant_text="exact answer",
+    )
+
+    assert provider.get_status("Working... stale frame") is TerminalStatus.COMPLETED
+    assert provider.extract_last_message_from_script("terminal chrome") == "exact answer"
+
+
+def test_completed_sidecar_preserves_exact_unicode_and_newlines(monkeypatch, tmp_path):
+    """LAST output is the extension's exact assistant text, not parsed terminal chrome."""
+    provider = make_provider(monkeypatch, tmp_path)
+    exact = "第一行 — café ☃\n\n  indented second line\n"
+    write_state(provider, status="completed", last_assistant_text=exact)
+
+    assert provider.extract_last_message_from_script("unrelated TUI output") == exact
+
+
+def test_mark_input_closes_idle_race_and_calls_base_hook(monkeypatch, tmp_path):
+    """A stale idle sidecar cannot make a just-dispatched turn look ready."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(provider, status="idle")
+
+    provider.mark_input_received()
+
+    assert provider._task_dispatched is True
+    assert provider.get_status("old idle screen") is TerminalStatus.PROCESSING
+
+
+def test_mark_input_rejects_prior_completed_sidecar_and_output(monkeypatch, tmp_path):
+    """The prior turn's completed snapshot cannot complete a new dispatch."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(
+        provider,
+        status="completed",
+        last_assistant_text="answer from the prior turn",
+    )
+    assert provider.get_status("") is TerminalStatus.COMPLETED
+
+    provider.mark_input_received()
+
+    assert provider.get_status("") is TerminalStatus.PROCESSING
+    with pytest.raises(ValueError, match="completed Pi response"):
+        provider.extract_last_message_from_script("ambiguous terminal chrome")
+
+
+def test_dispatch_accepts_new_completed_snapshot_without_processing_poll(monkeypatch, tmp_path):
+    """A new completion closes the guard even when processing was not observed."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(
+        provider,
+        status="completed",
+        last_assistant_text="answer from the prior turn",
+        updated_at="2026-08-13T22:00:00.000Z",
+    )
+    assert provider.get_status("") is TerminalStatus.COMPLETED
+    provider.mark_input_received()
+
+    write_state(
+        provider,
+        status="completed",
+        last_assistant_text="answer from the new turn",
+        updated_at="2026-08-13T22:00:01.000Z",
+    )
+
+    assert provider.get_status("") is TerminalStatus.COMPLETED
+    assert provider.extract_last_message_from_script("") == "answer from the new turn"
+
+
+def test_dispatch_accepts_new_completion_already_visible_at_mark(monkeypatch, tmp_path):
+    """A fast new completion is not captured as the pre-dispatch snapshot."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(
+        provider,
+        status="completed",
+        last_assistant_text="answer from the prior turn",
+        updated_at="2026-08-13T22:00:00.000Z",
+    )
+    assert provider.get_status("") is TerminalStatus.COMPLETED
+
+    write_state(
+        provider,
+        status="completed",
+        last_assistant_text="fast answer from the new turn",
+        updated_at="2026-08-13T22:00:01.000Z",
+    )
+    provider.mark_input_received()
+
+    assert provider.get_status("") is TerminalStatus.COMPLETED
+    assert provider.extract_last_message_from_script("") == "fast answer from the new turn"
+
+
+def test_sidecar_processing_then_completed_closes_dispatch_guard(monkeypatch, tmp_path):
+    """Authoritative lifecycle updates advance a dispatched turn normally."""
+    provider = make_provider(monkeypatch, tmp_path)
+    provider.mark_input_received()
+    write_state(provider, status="processing")
+    assert provider.get_status("") is TerminalStatus.PROCESSING
+
+    write_state(provider, status="completed", last_assistant_text="done")
+    assert provider.get_status("") is TerminalStatus.COMPLETED
+
+
+def test_sidecar_error_takes_precedence_over_idle_tui(monkeypatch, tmp_path):
+    """Bridge failure remains visible even while Pi's editor is on screen."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(provider, status="error", error="proxy exited")
+    idle = (FIXTURES / "pi_idle.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(idle) is TerminalStatus.ERROR
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update({"unexpected": True}),
+        lambda payload: payload.update({"status": "settled"}),
+        lambda payload: payload.update({"lastAssistantText": ["not", "text"]}),
+        lambda payload: payload.update({"updatedAt": "not-a-timestamp"}),
+    ],
+)
+def test_invalid_sidecar_shape_falls_back_to_tui(monkeypatch, tmp_path, mutate):
+    """Malformed or forward-incompatible sidecar data is never trusted."""
+    provider = make_provider(monkeypatch, tmp_path)
+    payload = {
+        "status": "completed",
+        "lastAssistantText": "must not be trusted",
+        "error": "",
+        "updatedAt": "2026-08-13T22:00:00Z",
+    }
+    mutate(payload)
+    provider.state_path.parent.mkdir(parents=True, mode=0o700)
+    provider.state_path.write_text(json.dumps(payload), encoding="utf-8")
+    provider.state_path.chmod(0o600)
+    idle = (FIXTURES / "pi_idle.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(idle) is TerminalStatus.IDLE
+
+
+@pytest.mark.parametrize("content", ["{", "", '{"status":"completed"'])
+def test_corrupt_or_partial_sidecar_falls_back_without_raising(monkeypatch, tmp_path, content):
+    """Atomic-write races and corrupt JSON do not break the status hot path."""
+    provider = make_provider(monkeypatch, tmp_path)
+    provider.state_path.parent.mkdir(parents=True, mode=0o700)
+    provider.state_path.write_text(content, encoding="utf-8")
+    provider.state_path.chmod(0o600)
+    processing = (FIXTURES / "pi_processing.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(processing) is TerminalStatus.PROCESSING
+
+
+def test_state_growth_past_limit_on_validated_inode_is_rejected(monkeypatch, tmp_path):
+    """The bounded fd read rejects same-inode growth after the metadata check."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(provider, status="completed", last_assistant_text="must not be trusted")
+    initial_inode = provider.state_path.stat().st_ino
+    real_fstat = pi_module.os.fstat
+    grew = False
+
+    def grow_after_fstat(fd):
+        nonlocal grew
+        metadata = real_fstat(fd)
+        if not grew:
+            with provider.state_path.open("a", encoding="utf-8") as stream:
+                stream.write(" " * (pi_module._MAX_STATE_BYTES + 1))
+            grew = True
+        return metadata
+
+    monkeypatch.setattr(pi_module.os, "fstat", grow_after_fstat)
+    idle = (FIXTURES / "pi_idle.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(idle) is TerminalStatus.IDLE
+    assert provider.state_path.stat().st_ino == initial_inode
+    assert provider.state_path.stat().st_size > pi_module._MAX_STATE_BYTES
+
+
+def test_unsafe_state_mode_is_not_trusted(monkeypatch, tmp_path):
+    """A group-readable sidecar cannot override conservative TUI detection."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(provider, status="completed", last_assistant_text="unsafe", mode=0o640)
+    idle = (FIXTURES / "pi_idle.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(idle) is TerminalStatus.IDLE
+
+
+def test_wrong_owner_state_is_not_trusted(monkeypatch, tmp_path):
+    """Only a sidecar owned by the current uid is authoritative."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(provider, status="completed", last_assistant_text="wrong owner")
+    real_uid = pi_module.os.getuid()
+    monkeypatch.setattr(pi_module.os, "getuid", lambda: real_uid + 1)
+    idle = (FIXTURES / "pi_idle.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(idle) is TerminalStatus.IDLE
+
+
+def test_symlink_state_is_not_followed_or_trusted(monkeypatch, tmp_path):
+    """A swapped symlink cannot redirect the provider to attacker-controlled JSON."""
+    provider = make_provider(monkeypatch, tmp_path)
+    target = tmp_path / "attacker-state.json"
+    target.write_text(
+        json.dumps(
+            {
+                "status": "completed",
+                "lastAssistantText": "attacker text",
+                "error": "",
+                "updatedAt": "2026-08-13T22:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    target.chmod(0o600)
+    provider.state_path.parent.mkdir(parents=True, mode=0o700)
+    provider.state_path.symlink_to(target)
+    idle = (FIXTURES / "pi_idle.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(idle) is TerminalStatus.IDLE
+
+
+def test_all_three_tui_fixtures_drive_conservative_fallback(monkeypatch, tmp_path):
+    """The checked-in Pi 0.84.1 regular-mode frames cover idle, working, and done."""
+    provider = make_provider(monkeypatch, tmp_path)
+    idle = (FIXTURES / "pi_idle.txt").read_text(encoding="utf-8")
+    processing = (FIXTURES / "pi_processing.txt").read_text(encoding="utf-8")
+    completed = (FIXTURES / "pi_completed.txt").read_text(encoding="utf-8")
+
+    assert provider.get_status(idle) is TerminalStatus.IDLE
+    provider.mark_input_received()
+    assert provider.get_status(processing) is TerminalStatus.PROCESSING
+    assert provider.get_status(completed) is TerminalStatus.COMPLETED
+
+
+def test_tui_fallback_detects_obvious_startup_error(monkeypatch, tmp_path):
+    """A visibly failed launch is ERROR even without a readable sidecar."""
+    provider = make_provider(monkeypatch, tmp_path)
+
+    assert provider.get_status("zsh: command not found: /missing/pi") is TerminalStatus.ERROR
+
+
+def test_tui_fallback_returns_unknown_for_ambiguous_text(monkeypatch, tmp_path):
+    """Unrecognized terminal content is never optimistically called idle or complete."""
+    provider = make_provider(monkeypatch, tmp_path)
+
+    assert provider.get_status("ordinary shell output") is TerminalStatus.UNKNOWN
+
+
+def test_invalid_sidecar_extraction_uses_completed_fixture(monkeypatch, tmp_path):
+    """The TUI parser provides a narrow fallback when sidecar JSON is corrupt."""
+    provider = make_provider(monkeypatch, tmp_path)
+    provider.state_path.parent.mkdir(parents=True, mode=0o700)
+    provider.state_path.write_text("{", encoding="utf-8")
+    provider.state_path.chmod(0o600)
+    completed = (FIXTURES / "pi_completed.txt").read_text(encoding="utf-8")
+
+    assert provider.extract_last_message_from_script(completed) == (
+        "The adapter is ready — café.\nExact fallback line two."
+    )
+
+
+def test_error_sidecar_extraction_falls_back_to_tui(monkeypatch, tmp_path):
+    """An error sidecar does not masquerade its stale assistant cache as LAST output."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(
+        provider,
+        status="error",
+        last_assistant_text="stale sidecar answer",
+        error="bridge failed",
+    )
+    completed = (FIXTURES / "pi_completed.txt").read_text(encoding="utf-8")
+
+    assert provider.extract_last_message_from_script(completed).startswith("The adapter is ready")
+
+
+def test_tui_extraction_rejects_processing_frame(monkeypatch, tmp_path):
+    """A working indicator is not mistaken for a final assistant response."""
+    provider = make_provider(monkeypatch, tmp_path)
+    processing = (FIXTURES / "pi_processing.txt").read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="completed Pi response"):
+        provider.extract_last_message_from_script(processing)
+
+
+def test_tui_rolling_history_uses_latest_completed_frame(monkeypatch, tmp_path):
+    """A historical Working redraw cannot override the latest completed frame."""
+    provider = make_provider(monkeypatch, tmp_path)
+    processing = (FIXTURES / "pi_processing.txt").read_text(encoding="utf-8")
+    completed = (FIXTURES / "pi_completed.txt").read_text(encoding="utf-8")
+    provider.mark_input_received()
+    assert provider.get_status(processing) is TerminalStatus.PROCESSING
+
+    rolling_history = processing + completed
+
+    assert provider.get_status(rolling_history) is TerminalStatus.COMPLETED
+    assert provider.extract_last_message_from_script(rolling_history) == (
+        "The adapter is ready — café.\nExact fallback line two."
+    )
+
+
+def test_tui_rolling_history_uses_latest_processing_frame(monkeypatch, tmp_path):
+    """The newest Working redraw remains processing after historical completion."""
+    provider = make_provider(monkeypatch, tmp_path)
+    completed = (FIXTURES / "pi_completed.txt").read_text(encoding="utf-8")
+    processing = (FIXTURES / "pi_processing.txt").read_text(encoding="utf-8")
+    provider.mark_input_received()
+    rolling_history = completed + processing
+
+    assert provider.get_status(rolling_history) is TerminalStatus.PROCESSING
+    with pytest.raises(ValueError, match="completed Pi response"):
+        provider.extract_last_message_from_script(rolling_history)
+
+
+@pytest.mark.asyncio
+async def test_initialize_waits_for_shell_launches_and_accepts_only_idle(monkeypatch, tmp_path):
+    """Initialization monitors startup but accepts only authoritative sidecar idle."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+    provider.get_init_timeout = MagicMock(return_value=7)
+    backend = MagicMock()
+    monkeypatch.setattr(pi_module, "get_backend", lambda: backend)
+    wait_shell = AsyncMock(return_value=True)
+
+    async def reach_tui_idle(*args, **kwargs):
+        write_state(provider, status="idle")
+        return True
+
+    wait_status = AsyncMock(side_effect=reach_tui_idle)
+    monkeypatch.setattr(pi_module, "wait_for_shell", wait_shell)
+    monkeypatch.setattr(pi_module, "wait_until_status", wait_status)
+
+    assert await provider.initialize() is True
+
+    wait_shell.assert_awaited_once_with("term-1", timeout=7)
+    wait_status.assert_awaited_once_with(
+        "term-1",
+        {
+            TerminalStatus.IDLE,
+            TerminalStatus.PROCESSING,
+            TerminalStatus.COMPLETED,
+            TerminalStatus.ERROR,
+        },
+        timeout=7,
+        polling_interval=1.0,
+    )
+    backend.send_keys.assert_called_once_with("session-1", "window-1", provider._build_pi_command())
+    assert provider._initialized is True
+
+
+@pytest.mark.asyncio
+async def test_first_dispatch_accepts_completion_visible_before_mark(monkeypatch, tmp_path):
+    """Initialization's idle generation anchors a fast first-turn completion."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+    provider.get_init_timeout = MagicMock(return_value=5)
+    monkeypatch.setattr(pi_module, "get_backend", lambda: MagicMock())
+    monkeypatch.setattr(pi_module, "wait_for_shell", AsyncMock(return_value=True))
+
+    async def reach_authoritative_idle(*args, **kwargs):
+        write_state(
+            provider,
+            status="idle",
+            updated_at="2026-08-13T22:00:00.000Z",
+        )
+        return True
+
+    monkeypatch.setattr(pi_module, "wait_until_status", reach_authoritative_idle)
+    assert await provider.initialize() is True
+
+    write_state(
+        provider,
+        status="completed",
+        last_assistant_text="fast first-turn answer",
+        updated_at="2026-08-13T22:00:01.000Z",
+    )
+    provider.mark_input_received()
+
+    assert provider.get_status("") is TerminalStatus.COMPLETED
+    assert provider.extract_last_message_from_script("") == "fast first-turn answer"
+
+
+@pytest.mark.asyncio
+async def test_initialize_rejects_tui_idle_before_late_sidecar_error(monkeypatch, tmp_path):
+    """Visible Pi chrome cannot win a race with extension binding failure."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+    provider.get_init_timeout = MagicMock(return_value=5)
+    monkeypatch.setattr(pi_module, "get_backend", lambda: MagicMock())
+    monkeypatch.setattr(pi_module, "wait_for_shell", AsyncMock(return_value=True))
+    monkeypatch.setattr(pi_module, "wait_until_status", AsyncMock(return_value=True))
+
+    async def publish_extension_error(delay):
+        write_state(provider, status="error", error="late extension binding failure")
+
+    monkeypatch.setattr(pi_module.asyncio, "sleep", publish_extension_error)
+
+    with pytest.raises(ProviderError, match="late extension binding failure"):
+        await provider.initialize()
+
+
+@pytest.mark.asyncio
+async def test_initialize_fails_before_launch_when_shell_times_out(monkeypatch, tmp_path):
+    """A missing shell readiness signal prevents Pi from being sent to the pane."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+    provider.get_init_timeout = MagicMock(return_value=3)
+    backend = MagicMock()
+    monkeypatch.setattr(pi_module, "get_backend", lambda: backend)
+    monkeypatch.setattr(pi_module, "wait_for_shell", AsyncMock(return_value=False))
+
+    with pytest.raises(TimeoutError, match="Shell initialization timed out after 3s"):
+        await provider.initialize()
+
+    backend.send_keys.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_initialize_surfaces_sidecar_bridge_error(monkeypatch, tmp_path):
+    """An extension startup failure is reported instead of flattened to a timeout."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+    provider.get_init_timeout = MagicMock(return_value=5)
+    backend = MagicMock()
+    monkeypatch.setattr(pi_module, "get_backend", lambda: backend)
+    monkeypatch.setattr(pi_module, "wait_for_shell", AsyncMock(return_value=True))
+
+    async def fail_with_state(*args, **kwargs):
+        write_state(provider, status="error", error="MCP proxy failed to initialize")
+        return False
+
+    monkeypatch.setattr(pi_module, "wait_until_status", fail_with_state)
+
+    with pytest.raises(ProviderError, match="MCP proxy failed to initialize"):
+        await provider.initialize()
+
+
+@pytest.mark.asyncio
+async def test_initialize_rejects_non_idle_startup_state(monkeypatch, tmp_path):
+    """A completed frame is not accepted as successful first-time initialization."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+    provider.get_init_timeout = MagicMock(return_value=5)
+    monkeypatch.setattr(pi_module, "get_backend", lambda: MagicMock())
+    monkeypatch.setattr(pi_module, "wait_for_shell", AsyncMock(return_value=True))
+
+    async def complete_without_idle(*args, **kwargs):
+        write_state(provider, status="completed", last_assistant_text="stale")
+        return False
+
+    monkeypatch.setattr(pi_module, "wait_until_status", complete_without_idle)
+
+    with pytest.raises(ProviderError, match="unexpected completed state"):
+        await provider.initialize()
+
+
+@pytest.mark.asyncio
+async def test_authoritative_startup_rejects_completed_sidecar_immediately(monkeypatch, tmp_path):
+    """A completed sidecar is never mistaken for initial Pi readiness."""
+    provider = make_provider(monkeypatch, tmp_path)
+    write_state(provider, status="completed", last_assistant_text="stale")
+    deadline = asyncio.get_running_loop().time() + 1
+
+    with pytest.raises(ProviderError, match="unexpected completed state"):
+        await provider._wait_for_authoritative_idle(deadline, init_timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_initialize_times_out_without_valid_sidecar(monkeypatch, tmp_path):
+    """A missing readiness signal remains a clear bounded startup timeout."""
+    provider = make_provider(monkeypatch, tmp_path, agent_profile=None)
+    provider.get_init_timeout = MagicMock(return_value=4)
+    monkeypatch.setattr(pi_module, "get_backend", lambda: MagicMock())
+    monkeypatch.setattr(pi_module, "wait_for_shell", AsyncMock(return_value=True))
+    monkeypatch.setattr(pi_module, "wait_until_status", AsyncMock(return_value=False))
+
+    with pytest.raises(TimeoutError, match="Pi initialization timed out after 4s"):
+        await provider.initialize()
+
+
+def test_exit_and_paste_contract(monkeypatch, tmp_path):
+    """Pi uses single-Enter submission and tmux's Ctrl-D special key for exit."""
+    provider = make_provider(monkeypatch, tmp_path)
+
+    assert provider.paste_enter_count == 1
+    assert provider.exit_cli() == "C-d"
+
+
+def test_cleanup_is_idempotent_and_preserves_session_retention(monkeypatch, tmp_path):
+    """Cleanup removes only transient sidecars while retaining Pi session data."""
+    provider = make_provider(monkeypatch, tmp_path)
+    provider._build_pi_command()
+    session_file = provider.session_dir / "retained.jsonl"
+    session_file.write_text("session", encoding="utf-8")
+    sentinel = provider.runtime_dir / "do-not-remove.txt"
+    sentinel.write_text("sentinel", encoding="utf-8")
+
+    provider.cleanup()
+    provider.cleanup()
+
+    assert not provider.prompt_path.exists()
+    assert not provider.mcp_config_path.exists()
+    assert not provider.state_path.exists()
+    assert session_file.read_text(encoding="utf-8") == "session"
+    assert sentinel.read_text(encoding="utf-8") == "sentinel"
+    assert provider._initialized is False

--- a/test/providers/test_provider_manager_unit.py
+++ b/test/providers/test_provider_manager_unit.py
@@ -54,6 +54,39 @@ def test_create_provider_hermes_stores_mapping():
     assert manager.get_provider("t1") is provider
 
 
+def test_create_provider_pi_forwards_runtime_contract_and_stores_mapping():
+    """Pi receives the complete launch-time contract and is cached by terminal ID."""
+    manager = ProviderManager()
+    pi_provider = MagicMock()
+
+    with patch(
+        "cli_agent_orchestrator.providers.manager.PiProvider",
+        return_value=pi_provider,
+    ) as pi_factory:
+        provider = manager.create_provider(
+            "pi",
+            terminal_id="t1",
+            tmux_session="s1",
+            tmux_window="w1",
+            agent_profile="reviewer",
+            allowed_tools=["fs_read", "fs_list"],
+            skill_prompt="runtime catalog",
+            model="openai/gpt-5",
+        )
+
+    pi_factory.assert_called_once_with(
+        "t1",
+        "s1",
+        "w1",
+        "reviewer",
+        ["fs_read", "fs_list"],
+        skill_prompt="runtime catalog",
+        model="openai/gpt-5",
+    )
+    assert provider is pi_provider
+    assert manager.get_provider("t1") is pi_provider
+
+
 def test_create_provider_grok_forwards_launch_configuration():
     manager = ProviderManager()
     provider = MagicMock()
@@ -131,6 +164,41 @@ def test_get_provider_creates_copilot_on_demand_from_metadata():
 
     assert isinstance(provider, CopilotCliProvider)
     assert manager.get_provider("t1") is provider
+
+
+def test_get_provider_creates_pi_on_demand_from_existing_metadata():
+    """Pi restoration uses only the provider fields already persisted by CAO."""
+    manager = ProviderManager()
+    pi_provider = MagicMock()
+
+    with (
+        patch(
+            "cli_agent_orchestrator.providers.manager.get_terminal_metadata",
+            return_value={
+                "provider": "pi",
+                "tmux_session": "s1",
+                "tmux_window": "w1",
+                "agent_profile": "reviewer",
+            },
+        ),
+        patch(
+            "cli_agent_orchestrator.providers.manager.PiProvider",
+            return_value=pi_provider,
+        ) as pi_factory,
+    ):
+        provider = manager.get_provider("t1")
+
+    pi_factory.assert_called_once_with(
+        "t1",
+        "s1",
+        "w1",
+        "reviewer",
+        None,
+        skill_prompt=None,
+        model=None,
+    )
+    assert provider is pi_provider
+    assert manager.get_provider("t1") is pi_provider
 
 
 def test_cleanup_provider_calls_cleanup_and_removes():

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -119,6 +119,27 @@ class TestInstallAgent:
         assert "${API_TOKEN}" in context_text
         assert "${BASE_URL}" in context_text
 
+    def test_install_pi_accepts_provider_and_writes_standard_context_only(
+        self, install_paths: dict[str, Path]
+    ) -> None:
+        """Pi needs no install-time provider config; launch owns its runtime files."""
+        profile = install_paths["local_store_dir"] / "pi-agent.md"
+        profile.write_text(
+            "---\nname: pi-agent\ndescription: Pi agent\nrole: reviewer\n---\nReview carefully.\n",
+            encoding="utf-8",
+        )
+
+        result = install_agent("pi-agent", "pi")
+
+        assert result.success is True
+        assert result.provider == "pi"
+        assert result.agent_file is None
+        assert Path(result.context_file or "").read_text(encoding="utf-8") == profile.read_text(
+            encoding="utf-8"
+        )
+        assert list(install_paths["kiro_dir"].iterdir()) == []
+        assert list(install_paths["copilot_dir"].iterdir()) == []
+
     def test_install_from_flat_profile_in_provider_dir(
         self, install_paths: dict[str, Path]
     ) -> None:

--- a/test/services/test_profile_validator.py
+++ b/test/services/test_profile_validator.py
@@ -35,6 +35,16 @@ class TestLoadProfileSchema:
         assert schema["additionalProperties"] is False
         assert "engine" in schema["properties"]
 
+    def test_provider_schema_exposes_every_public_provider_including_pi(self) -> None:
+        from cli_agent_orchestrator.models.provider import ProviderType
+
+        schema = load_profile_schema()
+
+        assert set(schema["properties"]["provider"]["enum"]) == {
+            provider.value for provider in ProviderType
+        }
+        assert "pi" in schema["properties"]["provider"]["enum"]
+
     def test_is_cached(self) -> None:
         """Repeated calls must not re-read and re-parse the packaged file."""
         assert load_profile_schema() is load_profile_schema()

--- a/test/services/test_terminal_service.py
+++ b/test/services/test_terminal_service.py
@@ -1,10 +1,13 @@
 """Unit tests for terminal service get_working_directory and send_special_key functions."""
 
-from unittest.mock import MagicMock, patch
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.services.terminal_service import (
+    create_terminal,
     exit_terminal_cli,
     get_working_directory,
     list_siblings,
@@ -23,6 +26,71 @@ def test_grok_uses_runtime_skills_with_native_tool_enforcement():
 
 
 _TS = "cli_agent_orchestrator.services.terminal_service"
+
+
+def test_pi_uses_runtime_skill_prompt_with_hard_tool_enforcement():
+    """Pi appends the runtime catalog and must never enter the soft-policy guard."""
+    from cli_agent_orchestrator.services.terminal_service import (
+        RUNTIME_SKILL_PROMPT_PROVIDERS,
+        SOFT_ENFORCEMENT_PROVIDERS,
+    )
+
+    assert "pi" in RUNTIME_SKILL_PROMPT_PROVIDERS
+    assert "pi" not in SOFT_ENFORCEMENT_PROVIDERS
+
+
+@pytest.mark.asyncio
+@patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+@patch("cli_agent_orchestrator.services.terminal_service.fifo_manager")
+@patch("cli_agent_orchestrator.services.terminal_service.FIFO_DIR")
+@patch("cli_agent_orchestrator.services.terminal_service.TERMINAL_LOG_DIR")
+@patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+@patch("cli_agent_orchestrator.services.terminal_service.db_create_terminal")
+@patch("cli_agent_orchestrator.backends.registry._backend")
+@patch("cli_agent_orchestrator.services.terminal_service.generate_window_name")
+@patch("cli_agent_orchestrator.services.terminal_service.generate_session_name")
+@patch("cli_agent_orchestrator.services.terminal_service.generate_terminal_id")
+@patch("cli_agent_orchestrator.services.terminal_service.build_skill_catalog")
+@patch("cli_agent_orchestrator.services.terminal_service.load_agent_profile")
+async def test_soft_enforcement_warning_lists_pi_as_a_hard_alternative(
+    mock_load_profile,
+    mock_build_skill_catalog,
+    mock_gen_id,
+    mock_gen_session,
+    mock_gen_window,
+    mock_backend,
+    mock_db_create,
+    mock_provider_manager,
+    mock_log_dir,
+    mock_fifo_dir,
+    mock_fifo_manager,
+    mock_status_monitor,
+    caplog,
+):
+    mock_gen_id.return_value = "test1234"
+    mock_gen_session.return_value = "cao-session"
+    mock_gen_window.return_value = "reviewer-abcd"
+    mock_backend.session_exists.return_value = False
+    mock_load_profile.return_value = AgentProfile(name="reviewer", description="Reviewer")
+    mock_build_skill_catalog.return_value = ""
+    mock_provider = AsyncMock()
+    mock_provider.initialize.return_value = True
+    mock_provider_manager.create_provider.return_value = mock_provider
+    mock_log_dir.__truediv__.return_value = MagicMock()
+    mock_fifo_dir.__truediv__.return_value = "fake.fifo"
+
+    with caplog.at_level(logging.WARNING):
+        await create_terminal(
+            "codex",
+            "reviewer",
+            new_session=True,
+            allowed_tools=["fs_read", "fs_list"],
+        )
+
+    assert (
+        "enforced restrictions use claude_code, grok_cli, kiro_cli, copilot_cli, or pi"
+        in caplog.text
+    )
 
 
 class TestTerminalServiceWorkingDirectory:

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -6,6 +6,22 @@ from unittest.mock import patch
 import pytest
 
 
+def test_pi_is_public_in_enum_constants_and_terminal_validation():
+    from cli_agent_orchestrator.constants import PROVIDERS
+    from cli_agent_orchestrator.models.provider import ProviderType
+    from cli_agent_orchestrator.models.terminal import Terminal
+
+    assert ProviderType.PI.value == "pi"
+    assert "pi" in PROVIDERS
+    terminal = Terminal(
+        id="deadbeef",
+        name="pi-agent",
+        provider="pi",
+        session_name="cao-pi",
+    )
+    assert terminal.provider == "pi"
+
+
 class TestServerConstants:
     """Tests for server configuration constants."""
 

--- a/test/test_pi_e2e_config_gate.py
+++ b/test/test_pi_e2e_config_gate.py
@@ -1,0 +1,43 @@
+"""Fast regression tests for the opt-in Pi E2E configuration gate."""
+
+from test.e2e import conftest as e2e_conftest
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize("config_kind", ["missing", "file"])
+def test_require_pi_skips_without_an_existing_config_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, config_kind: str
+) -> None:
+    """The live Pi gate must reject unset and non-directory configuration paths."""
+    monkeypatch.setattr(e2e_conftest.shutil, "which", lambda command: "/test/pi")
+    if config_kind == "missing":
+        monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+    else:
+        invalid_path = tmp_path / "not-a-directory"
+        invalid_path.write_text("not Pi configuration", encoding="utf-8")
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(invalid_path))
+
+    with pytest.raises(pytest.skip.Exception, match="PI_CODING_AGENT_DIR"):
+        e2e_conftest.require_pi.__wrapped__(SimpleNamespace(home_dir=tmp_path))
+
+
+def test_require_pi_accepts_existing_explicit_config_and_seeds_profiles(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An explicit existing Pi config permits the existing isolated profile setup."""
+    monkeypatch.setattr(e2e_conftest.shutil, "which", lambda command: "/test/pi")
+    config_dir = tmp_path / "private-pi-config"
+    config_dir.mkdir(mode=0o700)
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(config_dir))
+
+    server_home = tmp_path / "server-home"
+    e2e_conftest.require_pi.__wrapped__(SimpleNamespace(home_dir=server_home))
+
+    profile_store = server_home / ".aws" / "cli-agent-orchestrator" / "agent-store"
+    assert [path.name for path in sorted(profile_store.glob("*.md"))] == [
+        "analysis_supervisor.md",
+        "data_analyst.md",
+        "report_generator.md",
+    ]

--- a/test/utils/test_agent_profiles.py
+++ b/test/utils/test_agent_profiles.py
@@ -174,6 +174,12 @@ class TestResolveProvider:
             assert result == provider_value
 
     @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
+    def test_pi_profile_provider_resolves_without_fallback(self, mock_load):
+        mock_load.return_value = AgentProfile(name="agent", description="test", provider="pi")
+
+        assert resolve_provider("agent", fallback_provider="kiro_cli") == "pi"
+
+    @patch("cli_agent_orchestrator.utils.agent_profiles.load_agent_profile")
     def test_returns_fallback_when_provider_is_empty_string(self, mock_load):
         """Empty string provider should be treated as absent and fall back."""
         mock_load.return_value = AgentProfile(

--- a/test/utils/test_tool_mapping.py
+++ b/test/utils/test_tool_mapping.py
@@ -3,6 +3,8 @@
 import pytest
 
 from cli_agent_orchestrator.utils.tool_mapping import (
+    ALL_NATIVE_TOOLS,
+    TOOL_MAPPING,
     format_tool_summary,
     get_allowed_tools,
     get_disallowed_tools,
@@ -118,6 +120,69 @@ class TestGetDisallowedTools:
         result = get_disallowed_tools("claude_code", ["@cao-mcp-server", "@custom"])
         # Should block all native tools since no CAO tool categories are allowed
         assert len(result) > 0
+
+
+class TestPiToolPolicy:
+    """Pi's built-in denylist is a hard, exact translation of CAO policy."""
+
+    def test_mapping_and_native_tool_universe_are_exact(self):
+        assert TOOL_MAPPING["pi"] == {
+            "execute_bash": ["bash"],
+            "fs_read": ["read"],
+            "fs_write": ["edit", "write"],
+            "fs_list": ["grep", "find", "ls"],
+            "fs_*": ["read", "edit", "write", "grep", "find", "ls"],
+        }
+        assert ALL_NATIVE_TOOLS["pi"] == {
+            "bash",
+            "read",
+            "edit",
+            "write",
+            "grep",
+            "find",
+            "ls",
+        }
+
+    def test_reviewer_blocks_only_bash_and_write_tools(self):
+        assert get_disallowed_tools("pi", ["fs_read", "fs_list"]) == [
+            "bash",
+            "edit",
+            "write",
+        ]
+
+    def test_empty_policy_blocks_all_native_tools_in_sorted_order(self):
+        assert get_disallowed_tools("pi", []) == [
+            "bash",
+            "edit",
+            "find",
+            "grep",
+            "ls",
+            "read",
+            "write",
+        ]
+
+    def test_wildcard_blocks_no_native_tools(self):
+        assert ALL_NATIVE_TOOLS["pi"] == {
+            "bash",
+            "read",
+            "edit",
+            "write",
+            "grep",
+            "find",
+            "ls",
+        }
+        assert get_disallowed_tools("pi", ["*"]) == []
+
+    def test_web_fetch_does_not_grant_a_pi_builtin(self):
+        assert get_disallowed_tools("pi", ["web_fetch"]) == [
+            "bash",
+            "edit",
+            "find",
+            "grep",
+            "ls",
+            "read",
+            "write",
+        ]
 
 
 class TestClaudeCodeWebFetch:

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ wheels = [
 
 [[package]]
 name = "cli-agent-orchestrator"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
@@ -438,7 +438,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.25" },
     { name = "libtmux", specifier = ">=0.51.0,<0.53.1" },
     { name = "markdown-it-py", specifier = ">=4.0.0" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.28.1,<1.29.0" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27.0" },
@@ -1028,7 +1028,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1804,10 +1804,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version < '3.14'" },
+    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
 wheels = [
@@ -1816,7 +1816,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator" },
+    { name = "email-validator", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -1828,10 +1828,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version >= '3.14'" },
+    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -1840,7 +1840,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator" },
+    { name = "email-validator", marker = "python_full_version >= '3.14'" },
 ]
 
 [[package]]
@@ -1855,7 +1855,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -1946,7 +1946,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -2562,8 +2562,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Add Pi as a first-class CAO terminal provider, including public registration, profile validation, CLI selection, and provider discovery.
- Bundle a Pi extension that reports lifecycle state and exact assistant output, plus a JSONL MCP bridge for command-based stdio servers.
- Enforce Pi built-in tool restrictions with Pi's native denylist, fail closed on bridge collisions, and propagate MCP cancellation safely.
- Add the canonical `docs/pi.md` guide, register Pi across CAO documentation, and add Pi to the published Docusaurus provider matrix.

## Live Pi scenarios completed

The live suite used the installed Pi 0.84.1 binary with isolated CAO/Pi state and a real authenticated model: **12 passed**.

- Single-agent lifecycle: exact-output handoff and a second task producing a small `divide(a, b)` function.
- Native tool policy: restricted supervisor bash and reviewer write attempts blocked; unrestricted developer bash allowed; allowed-tool metadata persisted.
- Worker tasks: data analyst calculated mean/median/standard deviation for Dataset A; report generator created a data-analysis template.
- Inbox/callback plumbing: two-agent message delivery and a two-agent analysis callback.
- Autonomous fleets:
  - 2-agent supervisor-to-report-generator synchronous handoff.
  - 3-agent supervisor plus async data analyst and synchronous report generator; the analyst callback was delivered and the supervisor combined the result.

## Validation

- `.venv/bin/pytest -q` — 6810 passed, 26 skipped, 123 deselected, 1 xfailed.
- Black, isort, targeted mypy, and Markdown-link validation passed.
- Docusaurus typecheck and production build passed.
