### PR TITLE
fix(agent-step): clean up terminal when output extraction fails

### DIFF
--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -485,9 +485,16 @@ async def run_agent_step(
     # provider's extract_last_message_from_script under the hood). This does a
     # blocking tmux capture-pane plus regex extraction over the scrollback —
     # potentially seconds for a large transcript — so run it off the loop.
-    last_message = await asyncio.to_thread(
-        terminal_service.get_output, terminal_id, OutputMode.LAST
-    )
+    # Clean up a terminal owned by this call if output extraction fails. Reused
+    # terminals remain owned by the caller.
+    try:
+        last_message = await asyncio.to_thread(
+            terminal_service.get_output, terminal_id, OutputMode.LAST
+        )
+    except BaseException:
+        if teardown and created_here:
+            await _best_effort_teardown(terminal_id, registry)
+        raise
 
     result = AgentStepResult(
         terminal_id=terminal_id,

--- a/test/services/test_agent_step.py
+++ b/test/services/test_agent_step.py
@@ -710,3 +710,54 @@ class TestInterruptibleCancel:
                 )
         m_delete.assert_not_called()
         m_exit.assert_not_called()
+
+
+class TestOutputExtractionTeardown:
+    def test_extraction_failure_tears_down_created_terminal(self):
+        create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer(
+            final_status=TerminalStatus.COMPLETED,
+        )
+        with (
+            create,
+            send,
+            delete as m_delete,
+            patch(
+                f"{_MODULE}.terminal_service.get_output",
+                side_effect=ValueError("No completion marker found after last user message"),
+            ) as m_out,
+            exit_cli as m_exit,
+            wait,
+            status,
+        ):
+            with pytest.raises(ValueError, match="No completion marker found"):
+                asyncio.run(run_agent_step("kiro_cli", "dev", "x"))
+        m_out.assert_called_once_with("abc12345", OutputMode.LAST)
+        # A terminal this call created is reclaimed exactly like the success path.
+        m_exit.assert_called_once_with("abc12345")
+        m_delete.assert_called_once_with("abc12345", registry=None)
+
+    def test_extraction_failure_does_not_tear_down_reused_terminal(self):
+        create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer(
+            final_status=TerminalStatus.COMPLETED,
+        )
+        with (
+            create,
+            send,
+            delete as m_delete,
+            patch(
+                f"{_MODULE}.terminal_service.get_output",
+                side_effect=ValueError("No completion marker found after last user message"),
+            ) as m_out,
+            exit_cli as m_exit,
+            wait,
+            status,
+            patch(
+                f"{_MODULE}.terminal_service.get_terminal_metadata",
+                return_value={"id": "reuse99", "provider": "kiro_cli", "engine": "v2"},
+            ),
+        ):
+            with pytest.raises(ValueError, match="No completion marker found"):
+                asyncio.run(run_agent_step("kiro_cli", "dev", "x", reuse_terminal_id="reuse99"))
+        m_out.assert_called_once_with("reuse99", OutputMode.LAST)
+        m_delete.assert_not_called()
+        m_exit.assert_not_called()


### PR DESCRIPTION
## What changed

`run_agent_step` now cleans up a terminal it created when output extraction fails. A reused terminal remains owned by its caller and is left alone.

## Why

`get_output()` can raise before the existing success-path teardown runs. Retrying then leaves another live tmux window and registry row behind each time.

## Tests

- `.venv/bin/python -m pytest test/services/test_agent_step.py -q --no-cov` (38 passed)
- `black --check` and `isort --check-only` on the changed files

Fixes #571
