### PR TITLE
feat(workflow): parallel/pipeline DAG execution via needs edges (N7)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -12,10 +12,11 @@ There are two authoring tiers:
   and parameterized inputs. The [`cao-workflow` skill](../skills/cao-workflow/SKILL.md)
   teaches it. (The old declarative `workflow-author` YAML skill is **retired**.)
 - **YAML tier** (simpler, more limited) — a declarative spec for a fixed sequence. It is
-  easier to author and lint, but its `parallel` / `pipeline` / `loop` modes are
-  **reserved and not yet executable** in the current build (they validate as
-  `pass_reserved`, they do not run). Reach for it only for a plain sequential spec; for
-  anything with real control flow, write a script.
+  easier to author and lint. `parallel` and `pipeline` modes are executable: declare
+  `needs:` on a step and the engine schedules it only after those steps settle, running
+  ready steps concurrently (one agent terminal each). `loop` mode remains reserved. The
+  script tier still offers the most control (branching, per-iteration Python over agent
+  output); reach for the YAML tier for a straightforward fixed or parallel DAG.
 
 When in doubt, write a script.
 
@@ -229,6 +230,47 @@ Why these rules:
 
 See [`docs/examples/fanout_example.py`](examples/fanout_example.py) for the pattern
 end-to-end.
+
+## YAML parallel DAGs (`mode: parallel` / `mode: pipeline`)
+
+The YAML tier can also fan out: set `mode: parallel` and declare `needs:` edges. The
+engine runs every step whose `needs` have all settled **concurrently** (each step gets
+its own agent terminal), then the next wave, and so on:
+
+```yaml
+name: review_parallel
+mode: parallel
+steps:
+  - id: plan
+    provider: claude_code
+    agent: developer
+    prompt: Write a one-line implementation plan.
+  - id: implement
+    provider: claude_code
+    agent: developer
+    prompt: "Implement this plan: {{steps.plan.output.answer}}"
+    needs: [plan]
+  - id: audit
+    provider: claude_code
+    agent: reviewer
+    prompt: "Review this code: {{steps.implement.output.answer}}"
+    needs: [implement]
+```
+
+- `needs: [a, b]` means *start only after `a` and `b` have settled* — use it to express
+  fan-in (a step that consumes several upstream results). A step with no `needs` starts
+  in the first wave.
+- `mode: pipeline` is a linear chain — declare each step with `needs: [previous]` and
+  the engine runs one wave per step (outputs still pipe through
+  `{{steps.<id>.output.<field>}}`).
+- Unknown / self / cyclic `needs` references fail `cao workflow validate` (they are
+  grammar errors, never a silent sequential run).
+- Failure semantics match sequential mode: `on_failure: halt` (default) stops
+  scheduling new waves and marks the remaining steps skipped; `on_failure: continue`
+  keeps the run going. Each step keeps its own `retries:` budget.
+
+The script tier remains the more powerful path (branching, per-iteration Python);
+use YAML parallel mode for a fixed, declarative DAG.
 
 ## Operational tips
 

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -3936,8 +3936,10 @@ async def submit_workflow_run_endpoint(
     else:
         # Step 4 — reserved-mode guard (OR-3): the prepared YAML entry skips the
         # blocking path's pre-drive reserved-mode rejection, so the handler runs it
-        # here and maps NotBuiltYetError -> 501 pre-journal.
-        if spec.mode != "sequential":
+        # here and maps NotBuiltYetError -> 501 pre-journal. Only ``loop`` (N8)
+        # remains reserved; ``parallel``/``pipeline`` (N7) are shipped and reach
+        # the wave driver via the same prepared drive as sequential.
+        if spec.mode == "loop":
             try:
                 workflow_service._dispatch_reserved_mode(spec)
             except NotBuiltYetError as e:

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -649,7 +649,10 @@ WORKFLOW_INPUTS_MAX_BYTES = 32768
 # non-sequential mode and every loop/conditional construct tags as reserved.
 # Each future Bolt's PR flips its own unit flag here. Reserved-ness is computed
 # solely from TIER_REGISTRY + this set — no env-dependent branching (REL-2/NFR-3).
-WORKFLOW_SHIPPED_UNITS: frozenset[str] = frozenset()
+# N5 shipped the sequential engine (issue #312) — its mode is not in
+# TIER_REGISTRY so it never tagged reserved; N7 ships parallel/pipeline DAG
+# execution (needs-edges + wave scheduling).
+WORKFLOW_SHIPPED_UNITS: frozenset[str] = frozenset({"N7"})
 
 # Allowed typed-input kinds for a workflow input declaration (FR-1.5).
 WORKFLOW_INPUT_TYPES = ("string", "int", "bool", "path")

--- a/src/cli_agent_orchestrator/models/workflow.py
+++ b/src/cli_agent_orchestrator/models/workflow.py
@@ -154,6 +154,11 @@ class WorkflowStep(BaseModel):
     prompt: str
     engine: Optional[KiroEngine] = None
     output_schema: Optional[Dict[str, Any]] = None
+    # DAG edges (N7): step ids that must settle COMPLETED/COMPLETED_UNVALIDATED
+    # before this step starts. Empty = no ordering constraint. Sequential mode
+    # still runs declaration order; parallel/pipeline mode schedules by these.
+    # Validated in ``validate_grammar`` (unknown/self/cycle refs are errors).
+    needs: List[str] = Field(default_factory=list)
     # RESERVED — conditional execution (no MVP unit). Validates, never runs.
     when: Optional[str] = None
     # RESERVED loop fields (N8). Validate-but-inert; BR-4 requires all-three if any.
@@ -238,6 +243,23 @@ class WorkflowSpec(BaseModel):
                 schema_error = _check_output_schema(step.output_schema)
                 if schema_error is not None:
                     errors.append(f"step '{step.id}': {schema_error}")
+
+        # 4a. DAG edges (N7): every ``needs`` ref must name a declared step, a
+        # step must not need itself, and the dependency graph must be acyclic.
+        # The engine's ``_topological_order`` re-validates at drive time; this
+        # is the authoring-time floor so a bad spec fails validate, not at run.
+        decl_ids = {step.id for step in self.steps}
+        for step in self.steps:
+            for dep in step.needs:
+                if dep == step.id:
+                    errors.append(f"step '{step.id}': needs cannot reference itself")
+                elif dep not in decl_ids:
+                    errors.append(
+                        f"step '{step.id}': needs unknown step '{dep}' "
+                        "(must be a declared step id)"
+                    )
+        for cycle in _find_dependency_cycles(self.steps):
+            errors.append(f"workflow has a dependency cycle: {' -> '.join(cycle)}")
 
         # 4b. Per-step retry budget (B3-BR-3): if present, must be an integer in
         # [0, WORKFLOW_MAX_RETRIES]. Omitted -> engine default (regression-safe:
@@ -381,6 +403,35 @@ def _default_matches_type(default: Union[str, int, bool], declared: str) -> bool
         return isinstance(default, int) and not isinstance(default, bool)
     # "string" and "path" both carry their value as a string at authoring time.
     return isinstance(default, str)
+
+
+def _find_dependency_cycles(steps: List[WorkflowStep]) -> List[List[str]]:
+    """Return every dependency cycle among ``steps`` as id paths (N7).
+
+    Depth-first search over the ``needs`` edges. Each reported path is one
+    concrete cycle (``["a", "b", "a"]``) so the aggregated grammar error names
+    the steps involved rather than a bare "cycle detected". Deterministic:
+    steps are visited in declaration order and ``needs`` are visited in
+    declaration order, so the same spec yields the same cycle list (RD-3.1).
+    """
+    edges = {step.id: list(step.needs) for step in steps}
+    cycles: List[List[str]] = []
+    seen_paths: set[tuple] = set()
+
+    def _visit(step_id: str, path: List[str]) -> None:
+        if step_id in path:
+            cycle = path[path.index(step_id) :] + [step_id]
+            key = tuple(cycle)
+            if key not in seen_paths:
+                seen_paths.add(key)
+                cycles.append(cycle)
+            return
+        for dep in edges.get(step_id, []):
+            _visit(dep, path + [step_id])
+
+    for step in steps:
+        _visit(step.id, [])
+    return cycles
 
 
 def _schema_depth(node: Any, _depth: int = 1, _cap: Optional[int] = None) -> int:

--- a/src/cli_agent_orchestrator/services/workflow_service.py
+++ b/src/cli_agent_orchestrator/services/workflow_service.py
@@ -175,6 +175,12 @@ class RunRecord:
     # constructed here; it binds to the running loop lazily on first await, so
     # building a RunRecord outside a loop (unit tests) is safe.
     cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
+    # Serializes per-run journal event-seq allocation under parallel execution
+    # (N7). ``_next_event_seq`` does ``event_seq += 1`` — read-modify-write —
+    # which races when concurrent steps journal simultaneously; this lock makes
+    # seq allocation atomic so per-run event order stays well-defined even with
+    # concurrent step coroutines (BR-3 event ordering under N7).
+    journal_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 # Process-local run registry (ADR-8, B3-LC-2 singleton). A process restart loses
@@ -354,7 +360,7 @@ async def _ajournal(fn: Any, *args: Any, **kwargs: Any) -> None:
 # never regresses.
 
 
-def _next_event_seq(record: RunRecord) -> int:
+async def _next_event_seq(record: RunRecord) -> int:
     """Allocate the next per-run event ``seq`` from the in-memory counter (U1 Algorithm 1).
 
     Advances ``record.event_seq`` and returns it. Side-effect-free w.r.t. the DB:
@@ -362,9 +368,16 @@ def _next_event_seq(record: RunRecord) -> int:
     permanent hole in the sequence (a declared gap on read), never a renumber
     (BR-1). Monotonic within a process; re-seeded across a restart by the rebuild
     to resume strictly above the recovered high-water.
+
+    ``async`` because under parallel execution (N7) concurrent step coroutines
+    share this counter: ``event_seq += 1`` is a read-modify-write, so allocation
+    is serialized on the per-run ``journal_lock`` to keep the sequence
+    well-defined (BR-3). Sequential mode is unchanged — one step journals at a
+    time, so the lock is uncontended.
     """
-    record.event_seq += 1
-    return record.event_seq
+    async with record.journal_lock:
+        record.event_seq += 1
+        return record.event_seq
 
 
 async def _journal_event(
@@ -387,7 +400,7 @@ async def _journal_event(
     ``_journal_*`` write-through helpers. ``iteration`` / ``which_guard_fired`` are
     left unset (NULL, reserved, FR-1.5).
     """
-    seq = _next_event_seq(record)
+    seq = await _next_event_seq(record)
     try:
         await _ajournal(workflow_journal.persist_high_water, record.run_id, seq)
     except (
@@ -974,11 +987,22 @@ async def _drive(record: RunRecord, order: List[WorkflowStep]) -> WorkflowRunRes
         logger.error("drive: run '%s' failed with an engine error", record.run_id)
         raise
 
-    # Finalize. A cancel that interrupted the FINAL (or only) step's in-flight
-    # wait (#409b) leaves the loop with no further boundary iteration to observe
-    # ``record.cancelled`` — converge to CANCELLED here so the run never settles
-    # COMPLETED after being cancelled. Any still-PENDING steps (none, for a
-    # last-step cancel) are marked SKIPPED for consistency with the boundary path.
+    return await _finalize_run(record, order)
+
+
+async def _finalize_run(record: RunRecord, order: List[WorkflowStep]) -> WorkflowRunResult:
+    """Settle a driven run to its terminal state, journal it, and aggregate (N7).
+
+    The SINGLE finalize shared by ``_drive`` (sequential) and ``_drive_parallel``
+    (N7 wave scheduling) — no parallel/sequential divergence in the terminal
+    transition, event emission, or result aggregation (B4-RD-5).
+
+    A cancel that interrupted the FINAL (or only) step's in-flight wait (#409b)
+    leaves the loop with no further boundary iteration to observe
+    ``record.cancelled`` — converge to CANCELLED here so the run never settles
+    COMPLETED after being cancelled. Any still-PENDING steps are marked SKIPPED
+    for consistency with the boundary path.
+    """
     if record.cancelled and record.state not in (RunState.FAILED, RunState.CANCELLED):
         await _skip_remaining(record, order, from_index=0)
         record.state = RunState.CANCELLED
@@ -1050,6 +1074,21 @@ def _check_run_id_available(run_id: str) -> None:
         raise KeyError(f"run_id '{run_id}' already exists")
 
 
+async def _dispatch_drive(record: RunRecord, spec: WorkflowSpec) -> WorkflowRunResult:
+    """Route a record to the driver its spec's ``mode`` owns (N7).
+
+    ``sequential`` -> ``_drive`` (wave-of-one loop); ``parallel``/``pipeline``
+    -> ``_drive_parallel`` (needs-based wave scheduling). ``loop`` never
+    reaches here: ``start_run`` routes it to the N8 reserved seam first. The
+    topo order is computed here so the sequential and parallel drivers share
+    the same deterministic order (B4-RD-5).
+    """
+    order = _topological_order(spec)
+    if spec.mode in ("parallel", "pipeline"):
+        return await _drive_parallel(record, order)
+    return await _drive(record, order)
+
+
 # ---------------------------------------------------------------------------
 # §1 — start_run entry point
 # ---------------------------------------------------------------------------
@@ -1077,9 +1116,10 @@ async def start_run(spec: WorkflowSpec, inputs: Dict[str, Any], run_id: str) -> 
     # 2. Validate inputs BEFORE any side effect (B3-BR-2 / FR-1.5, fail fast).
     resolved_inputs = _validate_inputs(spec, inputs)
 
-    # Non-sequential mode dispatches to a reserved seam — NEVER silently run as
-    # sequential (B3-BR-6/B3-BR-10).
-    if spec.mode != "sequential":
+    # Non-sequential mode: ``loop`` dispatches to its N8 reserved seam — NEVER
+    # silently run as sequential (B3-BR-6/B3-BR-10). ``parallel``/``pipeline``
+    # are shipped (N7) and reach the parallel driver via ``_dispatch_drive``.
+    if spec.mode == "loop":
         _dispatch_reserved_mode(spec)
 
     # 3. Build the RunRecord.
@@ -1106,11 +1146,11 @@ async def start_run(spec: WorkflowSpec, inputs: Dict[str, Any], run_id: str) -> 
         # register/insert/admission sequence above is unchanged (SEAM #1, BR-5).
         await _journal_event(record, "run.started", state=record.state.value)
 
-        # 5. Deterministic sequencing order.
-        order = _topological_order(spec)
-
-        # 6-8. Sequence, finalize, aggregate — the single shared drive (B4-RD-5).
-        return await _drive(record, order)
+        # 5-8. Sequence, finalize, aggregate — the single shared drive (B4-RD-5).
+        # ``_dispatch_drive`` computes the deterministic topo order and routes
+        # sequential vs parallel/pipeline to their drivers, so resume and fresh
+        # runs share one dispatch path.
+        return await _dispatch_drive(record, spec)
     finally:
         _active_drives.discard(run_id)
 
@@ -1140,8 +1180,7 @@ async def start_run_prepared(record: RunRecord) -> WorkflowRunResult:
     """
     _active_drives.add(record.run_id)
     try:
-        order = _topological_order(record.spec)
-        return await _drive(record, order)
+        return await _dispatch_drive(record, record.spec)
     finally:
         _active_drives.discard(record.run_id)
 
@@ -1449,12 +1488,12 @@ def _is_resumable_for_tier(row: workflow_journal.RunRow) -> bool:
 def _dispatch_reserved_mode(spec: WorkflowSpec) -> None:
     """Route a non-sequential ``mode`` to its reserved seam (B3-BR-6/B3-BR-10).
 
-    Each branch hits the owning reserved seam (which raises ``NotBuiltYetError``)
-    so the failure names the implementing unit; a non-sequential mode is NEVER
-    silently downgraded to sequential.
+    ``parallel``/``pipeline`` are shipped (N7) and are no longer reserved —
+    they reach ``_drive_parallel`` via ``_dispatch_drive``, never this seam.
+    ``loop`` remains reserved (N8) and hits its owning seam here so the failure
+    names the implementing unit; a reserved mode is NEVER silently downgraded
+    to sequential.
     """
-    if spec.mode in ("parallel", "pipeline"):
-        _run_parallel(None, None)
     if spec.mode == "loop":
         _run_loop(None, None)
     # Defensive: grammar restricts ``mode`` to the four literals, so any other
@@ -1577,15 +1616,135 @@ async def resume_from_last_completed(run_id: str) -> WorkflowRunResult:
         await _ajournal(_journal_current_step, record)
 
         # 7. Re-enter the SAME shared drive over the snapshotted spec's topo order
-        # (B4-RD-5).
-        return await _drive(record, _topological_order(spec))
+        # (B4-RD-5). Parallel/pipeline specs route to the N7 wave driver via the
+        # same dispatch — a resumed parallel run re-drives its step DAG with
+        # completed steps kept (B4-BR-9 boundary is applied above, pre-dispatch).
+        return await _dispatch_drive(record, spec)
     finally:
         _active_drives.discard(run_id)
 
 
+# ---------------------------------------------------------------------------
+# §7a — N7: parallel/pipeline DAG execution (wave scheduling)
+# ---------------------------------------------------------------------------
+async def _drive_parallel(record: RunRecord, order: List[WorkflowStep]) -> WorkflowRunResult:
+    """Drive ``record`` over its step DAG, running ready steps concurrently (N7).
+
+    ``mode: parallel`` and ``mode: pipeline`` share this driver; the only
+    difference is what ``needs`` the author declares. ``_topological_order``
+    already produces a deterministic dependency order (a step always appears
+    after everything it needs), so ``order`` here is the same order the
+    sequential drive uses — parallel scheduling is layered ON TOP of it:
+
+    * A step is *ready* once every step in its ``needs`` set has settled
+      COMPLETED/COMPLETED_UNVALIDATED (its output is available for
+      ``{{steps.<id>.output.<field>}}`` templating via ``_substitute``).
+    * All ready steps run CONCURRENTLY via ``asyncio.gather`` of the shared
+      ``_run_step`` — the same per-step retry/halt/reprompt semantics as
+      sequential mode, one coroutine per step.
+    * After each wave, the engine re-checks cancel + halt: a cancelled run
+      converges CANCELLED; an ``on_failure=halt`` step (record.state == FAILED)
+      stops scheduling new waves and skips the remaining steps.
+    * ``pipeline`` is a linear-chain DAG (each step needs the previous); it runs
+      through this same driver with waves of size 1.
+
+    The terminal-state journaling, event emission, and ``_build_result``
+    aggregation are shared with ``_drive`` via ``_finalize_run`` — one finalize,
+    no parallel/sequential divergence (B4-RD-5).
+
+    An unexpected engine error mid-run settles the record to terminal FAILED
+    before re-raising, exactly like ``_drive`` (B3-RD-3/RD-5).
+    """
+    remaining = list(order)
+    try:
+        while remaining:
+            if record.cancelled:
+                await _skip_remaining(record, remaining, from_index=0)
+                record.state = RunState.CANCELLED
+                break
+            if record.state == RunState.FAILED:  # halt from a prior wave
+                await _skip_remaining(record, remaining, from_index=0)
+                break
+
+            # The ready wave: steps whose every need has settled.
+            wave: List[WorkflowStep] = []
+            still_blocked: List[WorkflowStep] = []
+            for step in remaining:
+                if _deps_satisfied(record, step):
+                    wave.append(step)
+                else:
+                    still_blocked.append(step)
+
+            if not wave:
+                # Nothing ready but steps remain — a dependency cycle or a
+                # corrupted needs set. Grammar already rejects cycles, so this
+                # is an engine-invariant violation: fail loudly, never spin.
+                raise WorkflowEngineError(
+                    f"run '{record.run_id}': no ready steps but "
+                    f"{len(still_blocked)} blocked step(s) remain (broken needs DAG)"
+                )
+
+            # Run the wave concurrently. Each _run_step handles its own retries,
+            # reprompts, cancellation, and per-step journaling; gather waits for
+            # the whole wave before the next scheduling pass.
+            await asyncio.gather(*(_run_step(record, step) for step in wave))
+
+            # Remove the wave from remaining (settled or not — a FAILED/SKIPPED
+            # step is terminal for scheduling purposes; halt is observed next loop).
+            done_ids = {step.id for step in wave}
+            remaining = [step for step in remaining if step.id not in done_ids]
+    except WorkflowEngineError:
+        # Same settle-on-engine-error posture as _drive: leave the registry
+        # consistent and re-raise (-> 500) unmasked.
+        if record.current_step_id is not None:
+            cur = record.step_states.get(record.current_step_id)
+            if cur is not None and cur.state not in (
+                StepState.COMPLETED,
+                StepState.COMPLETED_UNVALIDATED,
+            ):
+                cur.state = StepState.FAILED
+        record.state = RunState.FAILED
+        record.current_step_id = None
+        record.finished_at = _now()
+        await _ajournal(_journal_current_step, record)
+        await _journal_event(record, "run.failed", state=record.state.value, error_kind="error")
+        await _ajournal(_journal_run_state, record)
+        logger.error("drive_parallel: run '%s' failed with an engine error", record.run_id)
+        raise
+
+    return await _finalize_run(record, order)
+
+
+def _deps_satisfied(record: RunRecord, step: WorkflowStep) -> bool:
+    """True when every step in ``step.needs`` has settled COMPLETED.
+
+    A COMPLETED_UNVALIDATED need (output present but schema-invalid) counts as
+    satisfied: its output is still templatable, matching the sequential driver's
+    treatment of that state as a settled step (decision note D1). An unknown
+    need id is a grammar error and never reaches the engine; defensively, an
+    absent step state means NOT satisfied (fail closed).
+    """
+    for dep in step.needs:
+        st = record.step_states.get(dep)
+        if st is None or st.state not in (
+            StepState.COMPLETED,
+            StepState.COMPLETED_UNVALIDATED,
+        ):
+            return False
+    return True
+
+
 def _run_parallel(record: Optional[RunRecord], steps: Any) -> None:
-    """RESERVED (N7) — parallel/pipeline execution. Raises ``NotBuiltYetError``."""
-    raise NotBuiltYetError("parallel/pipeline execution is reserved (not built yet; unit N7)")
+    """Compatibility seam — parallel/pipeline now runs via ``_drive_parallel``.
+
+    Kept as a raising stub named after the old reserved seam so any caller that
+    dispatched to the old seam gets a clear error pointing at the driver, rather
+    than silently running sequential. ``start_run`` no longer routes here.
+    """
+    raise WorkflowEngineError(
+        "parallel/pipeline execution must be driven via _drive_parallel "
+        "(the reserved-seam dispatch was removed in N7)"
+    )
 
 
 def _run_loop(record: Optional[RunRecord], step: Any) -> None:

--- a/test/api/test_workflow_lifecycle_integration.py
+++ b/test/api/test_workflow_lifecycle_integration.py
@@ -275,6 +275,45 @@ def test_composed_flow_yaml_tier(portal_client, monkeypatch):
 
 
 # ===========================================================================
+# N7: a mode: parallel spec accepts the async submit path (previously OR-3
+# rejected every non-sequential mode with 501) and drives to completion through
+# the real wave engine. The prepared-entry reserved guard now lets parallel/
+# pipeline through (only loop stays 501), and start_run_prepared routes it to
+# _drive_parallel — so this asserts the SUBMIT surface specifically.
+# ===========================================================================
+def test_composed_flow_parallel_tier(portal_client, monkeypatch):
+    _point_spec(
+        monkeypatch,
+        WorkflowSpec(
+            name="par-int",
+            mode="parallel",
+            steps=[
+                WorkflowStep(id="p1", provider="claude_code", agent="dev", prompt="a"),
+                WorkflowStep(id="p2", provider="claude_code", agent="dev", prompt="b"),
+                WorkflowStep(
+                    id="p3", provider="claude_code", agent="dev", prompt="c", needs=["p1", "p2"]
+                ),
+            ],
+        ),
+    )
+    monkeypatch.setattr(workflow_service, "run_agent_step", _instant_yaml_leaf())
+
+    body = _submit(portal_client, "par-int", "int-par")
+    row = workflow_journal.get_run("int-par")
+    assert row is not None, "durable-before-ack BROKEN for parallel submit"
+    assert row.tier == "yaml"
+    assert body["links"]["cancel"] == "/workflows/runs/int-par/cancel"
+
+    final = _poll_journal_terminal("int-par", portal_client)
+    assert final == "completed", final
+    result = portal_client.get("/workflows/runs/int-par/result")
+    assert result.status_code == 200
+    body_r = result.json()
+    assert body_r["state"] == "completed"
+    assert [s["id"] for s in body_r["steps"]] == ["p1", "p2", "p3"]
+
+
+# ===========================================================================
 # T1 (AA-1, IP-1) SCRIPT TIER: the same composed happy path against a REAL
 # subprocess spawned + reaped by the real script_runner (CG-3 two-tier parity).
 # ===========================================================================

--- a/test/models/test_workflow.py
+++ b/test/models/test_workflow.py
@@ -267,13 +267,11 @@ steps:
     agent: a
     prompt: x
 """)
-        assert result.status == "pass_reserved"
-        assert result.reserved_notes
-        note = result.reserved_notes[0]
-        # Honesty invariant (BR-3): "reserved (not built yet)", never "will run".
-        assert "reserved" in note
-        assert "not built yet" in note
-        assert "will run" not in note
+        # N7 shipped parallel execution, so a parallel spec is executable (pass),
+        # not pass_reserved. The honesty invariant now applies to the still-
+        # reserved constructs (loop guards, when).
+        assert result.status == "pass"
+        assert result.reserved_notes == []
 
     def test_loop_construct_pass_reserved(self):
         result = validate_only("""\
@@ -300,8 +298,10 @@ steps:
         assert result.reserved_notes == []
 
     def test_is_reserved_for_known_and_unknown_constructs(self):
-        # In Bolt 1, WORKFLOW_SHIPPED_UNITS is empty -> all mapped constructs reserved.
-        assert is_reserved("parallel") is True
+        # N7 shipped parallel/pipeline, so they no longer tag reserved; N8 loop
+        # constructs remain reserved until their unit ships.
+        assert is_reserved("parallel") is False
+        assert is_reserved("pipeline") is False
         assert is_reserved("loop") is True
         assert is_reserved("when") is True
         # An unknown construct is not reserved (not in registry).

--- a/test/services/test_workflow_parallel.py
+++ b/test/services/test_workflow_parallel.py
@@ -1,0 +1,381 @@
+"""Tests for the N7 parallel/pipeline workflow engine (wave scheduling).
+
+Covers the parallel drive introduced by unit N7 in ``workflow_service.py``:
+DAG ``needs`` edges, concurrent wave execution (steps with no unsatisfied
+needs run together), dependency ordering (a step waits for its needs),
+``pipeline`` as a linear chain, halt-on-failure semantics, cancellation,
+journal event ordering under concurrency, and the grammar floor (unknown /
+self / cyclic ``needs`` refs rejected at validate time).
+
+``run_agent_step`` is mocked — no real terminals are created.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cli_agent_orchestrator.models.terminal import AgentStepResult, TerminalStatus
+from cli_agent_orchestrator.models.workflow import WorkflowSpec, WorkflowStep, validate_only
+from cli_agent_orchestrator.models.workflow_runtime import RunState, StepState
+from cli_agent_orchestrator.services import workflow_service as ws
+from cli_agent_orchestrator.services.agent_step import StepExecutionError
+
+
+def _ok(terminal_id: str = "t1") -> AgentStepResult:
+    return AgentStepResult(
+        terminal_id=terminal_id, last_message="done", status=TerminalStatus.COMPLETED
+    )
+
+
+def _steps(*ids: str, needs: dict = None) -> List[WorkflowStep]:
+    needs = needs or {}
+    return [
+        WorkflowStep(
+            id=sid,
+            provider="claude_code",
+            agent="dev",
+            prompt=f"do {sid}",
+            needs=needs.get(sid, []),
+        )
+        for sid in ids
+    ]
+
+
+def _spec(mode: str = "parallel", steps=None, name: str = "parwf") -> WorkflowSpec:
+    if steps is None:
+        steps = _steps("s1", "s2")
+    return WorkflowSpec(name=name, mode=mode, steps=steps)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.constants.DATABASE_FILE", tmp_path / "wf.db", raising=True
+    )
+    ws.run_registry.clear()
+    ws._active_drives.clear()
+    ws.step_output_store._store.clear()
+    yield
+    ws.run_registry.clear()
+    ws._active_drives.clear()
+    ws.step_output_store._store.clear()
+
+
+# ---------------------------------------------------------------------------
+# Grammar: needs edges
+# ---------------------------------------------------------------------------
+class TestNeedsGrammar:
+    def test_unknown_needs_ref_fails(self):
+        result = validate_only("""\
+name: wf
+mode: parallel
+steps:
+  - id: s1
+    provider: p
+    agent: a
+    prompt: x
+    needs: [ghost]
+""")
+        assert result.status == "fail"
+        assert any("needs unknown step 'ghost'" in e for e in result.errors)
+
+    def test_self_needs_fails(self):
+        result = validate_only("""\
+name: wf
+mode: parallel
+steps:
+  - id: s1
+    provider: p
+    agent: a
+    prompt: x
+    needs: [s1]
+""")
+        assert result.status == "fail"
+        assert any("needs cannot reference itself" in e for e in result.errors)
+
+    def test_cycle_fails(self):
+        result = validate_only("""\
+name: wf
+mode: parallel
+steps:
+  - id: a
+    provider: p
+    agent: a
+    prompt: x
+    needs: [b]
+  - id: b
+    provider: p
+    agent: a
+    prompt: y
+    needs: [a]
+""")
+        assert result.status == "fail"
+        assert any("dependency cycle" in e for e in result.errors)
+
+    def test_valid_needs_passes(self):
+        result = validate_only("""\
+name: wf
+mode: parallel
+steps:
+  - id: a
+    provider: p
+    agent: a
+    prompt: x
+  - id: b
+    provider: p
+    agent: a
+    prompt: "{{steps.a.output.answer}}"
+    needs: [a]
+""")
+        assert result.status == "pass"
+        assert result.errors == []
+
+    def test_sequential_with_needs_still_passes(self):
+        # needs are valid in sequential mode too (topo order honors them).
+        result = validate_only("""\
+name: wf
+mode: sequential
+steps:
+  - id: a
+    provider: p
+    agent: a
+    prompt: x
+  - id: b
+    provider: p
+    agent: a
+    prompt: y
+    needs: [a]
+""")
+        assert result.status == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Engine: wave scheduling + concurrency
+# ---------------------------------------------------------------------------
+class TestParallelDrive:
+    @pytest.mark.asyncio
+    async def test_independent_steps_run_concurrently(self, monkeypatch):
+        """Two steps with no needs run in the SAME wave (overlapping execution)."""
+        started: List[str] = []
+        finished: List[str] = []
+        overlap: List[tuple] = []
+
+        async def _side(*a, **kw):
+            step_prompt = kw["prompt"]
+            sid = "s1" if step_prompt == "do s1" else "s2"
+            started.append(sid)
+            # Yield so the sibling coroutine can also start -> overlap.
+            await asyncio.sleep(0.05)
+            # If both started before either finished, they overlapped.
+            if len(started) == 2 and len(finished) == 0:
+                overlap.append(True)
+            finished.append(sid)
+            return _ok(terminal_id=sid)
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        res = await ws.start_run(_spec(), {}, "par-run-1")
+        assert res.state == RunState.COMPLETED
+        assert sorted(started) == ["s1", "s2"]
+        assert overlap, "independent steps did not run concurrently"
+        assert res.steps[0].state == StepState.COMPLETED
+        assert res.steps[1].state == StepState.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_dependent_step_waits_for_its_needs(self, monkeypatch):
+        """A step with needs starts only after its dependency settled."""
+        order: List[str] = []
+
+        async def _side(*a, **kw):
+            sid = "s1" if kw["prompt"] == "do s1" else "s2"
+            order.append(sid)
+            return _ok(terminal_id=sid)
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        spec = _spec(steps=_steps("s1", "s2", needs={"s2": ["s1"]}))
+        res = await ws.start_run(spec, {}, "par-run-2")
+        assert res.state == RunState.COMPLETED
+        # s2 must run strictly after s1 finished.
+        assert order.index("s1") < order.index("s2")
+
+    @pytest.mark.asyncio
+    async def test_pipeline_runs_in_linear_chain(self, monkeypatch):
+        """mode: pipeline = a linear chain; steps run one after another."""
+        order: List[str] = []
+
+        async def _side(*a, **kw):
+            sid = kw["prompt"].split()[1]
+            order.append(sid)
+            return _ok(terminal_id=sid)
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        spec = WorkflowSpec(
+            name="pipe",
+            mode="pipeline",
+            steps=[
+                WorkflowStep(id="p1", provider="p", agent="a", prompt="do p1"),
+                WorkflowStep(id="p2", provider="p", agent="a", prompt="do p2", needs=["p1"]),
+                WorkflowStep(id="p3", provider="p", agent="a", prompt="do p3", needs=["p2"]),
+            ],
+        )
+        res = await ws.start_run(spec, {}, "par-pipe")
+        assert res.state == RunState.COMPLETED
+        assert order == ["p1", "p2", "p3"]
+
+    @pytest.mark.asyncio
+    async def test_diamond_dag_runs_two_middle_steps_concurrently(self, monkeypatch):
+        """a -> {b,c} -> d: b and c overlap; d waits for both."""
+        started: List[str] = []
+        overlap = {"bc": False}
+
+        async def _side(*a, **kw):
+            sid = kw["prompt"].split()[1]
+            started.append(sid)
+            await asyncio.sleep(0.05)
+            if {"b", "c"}.issubset(started):
+                overlap["bc"] = True
+            return _ok(terminal_id=sid)
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        spec = _spec(
+            steps=_steps(
+                "a",
+                "b",
+                "c",
+                "d",
+                needs={"b": ["a"], "c": ["a"], "d": ["b", "c"]},
+            )
+        )
+        res = await ws.start_run(spec, {}, "par-diamond")
+        assert res.state == RunState.COMPLETED
+        assert overlap["bc"], "b and c should overlap (same wave)"
+        # d runs after both b and c finished.
+        idx = {sid: i for i, sid in enumerate(started)}
+        assert idx["d"] > idx["b"] and idx["d"] > idx["c"]
+
+    @pytest.mark.asyncio
+    async def test_halt_stops_scheduling_new_waves(self, monkeypatch):
+        """on_failure=halt: a failed step leaves remaining steps SKIPPED."""
+        calls: List[str] = []
+
+        async def _side(*a, **kw):
+            sid = kw["prompt"].split()[1]
+            calls.append(sid)
+            if sid == "s1":
+                raise StepExecutionError("boom", kind="error", terminal_id="t")
+            return _ok(terminal_id=sid)
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        # s2 needs s1 -> must never run after s1 halts.
+        spec = _spec(
+            steps=[
+                WorkflowStep(
+                    id="s1", provider="p", agent="a", prompt="do s1", on_failure="halt", retries=0
+                ),
+                WorkflowStep(id="s2", provider="p", agent="a", prompt="do s2", needs=["s1"]),
+            ]
+        )
+        res = await ws.start_run(spec, {}, "par-halt")
+        assert res.state == RunState.FAILED
+        assert "s2" not in calls
+        by_id = {s.id: s for s in res.steps}
+        assert by_id["s1"].state == StepState.FAILED
+        assert by_id["s2"].state == StepState.SKIPPED
+
+    @pytest.mark.asyncio
+    async def test_sibling_keeps_running_when_other_wave_member_halts(self, monkeypatch):
+        """Independent siblings in the same wave still settle even if one halts."""
+        calls: List[str] = []
+
+        async def _side(*a, **kw):
+            sid = kw["prompt"].split()[1]
+            calls.append(sid)
+            if sid == "s1":
+                raise StepExecutionError("boom", kind="error", terminal_id="t")
+            return _ok(terminal_id=sid)
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        spec = _spec(
+            steps=[
+                WorkflowStep(
+                    id="s1", provider="p", agent="a", prompt="do s1", on_failure="halt", retries=0
+                ),
+                WorkflowStep(id="s2", provider="p", agent="a", prompt="do s2"),
+            ]
+        )
+        res = await ws.start_run(spec, {}, "par-sib")
+        assert res.state == RunState.FAILED
+        by_id = {s.id: s for s in res.steps}
+        assert by_id["s1"].state == StepState.FAILED
+        # s2 has no dependency on s1 and was already in the same wave.
+        assert by_id["s2"].state in (StepState.COMPLETED, StepState.COMPLETED_UNVALIDATED)
+
+    @pytest.mark.asyncio
+    async def test_cancel_stops_parallel_run(self, monkeypatch):
+        async def _side(*a, **kw):
+            await asyncio.sleep(0.2)
+            return _ok()
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        spec = _spec()
+        task = asyncio.create_task(ws.start_run(spec, {}, "par-cancel"))
+        await asyncio.sleep(0.05)  # let the wave start
+        ws.cancel_run("par-cancel")
+        res = await task
+        assert res.state == RunState.CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_templating_across_dependency(self, monkeypatch):
+        """A dependent step's prompt can reference its need's output."""
+        seen_prompts: List[str] = []
+
+        async def _side(*a, **kw):
+            seen_prompts.append(kw["prompt"])
+            return _ok(terminal_id=kw["prompt"][:2])
+
+        monkeypatch.setattr(ws, "run_agent_step", AsyncMock(side_effect=_side))
+        spec = WorkflowSpec(
+            name="tpl",
+            mode="parallel",
+            steps=[
+                WorkflowStep(
+                    id="a",
+                    provider="p",
+                    agent="a",
+                    prompt="do a",
+                    output_schema={
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                        "required": ["answer"],
+                    },
+                ),
+                WorkflowStep(
+                    id="b",
+                    provider="p",
+                    agent="a",
+                    prompt="result was {{steps.a.output.answer}}",
+                    needs=["a"],
+                ),
+            ],
+        )
+        # Provide a's output so the template resolves.
+        ws.step_output_store.put(
+            "par-tpl",
+            "a",
+            __import__(
+                "cli_agent_orchestrator.models.workflow_runtime", fromlist=["StepOutputRecord"]
+            ).StepOutputRecord(
+                run_id="par-tpl",
+                step_id="a",
+                output={"answer": "42"},
+                validated=True,
+                errors=[],
+                state=StepState.COMPLETED,
+            ),
+        )
+        res = await ws.start_run(spec, {}, "par-tpl")
+        assert res.state == RunState.COMPLETED
+        assert any("result was 42" in p for p in seen_prompts)

--- a/test/services/test_workflow_service.py
+++ b/test/services/test_workflow_service.py
@@ -602,15 +602,6 @@ async def test_get_run_status_carries_no_output_or_prompt(monkeypatch):
 # Reserved seams
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_reserved_mode_raises_not_built_yet(monkeypatch):
-    """A mode: parallel spec -> NotBuiltYetError, NOT a silent sequential run."""
-    monkeypatch.setattr(ws, "run_agent_step", AsyncMock(return_value=_ok()))
-    spec = _spec(mode="parallel")
-    with pytest.raises(NotBuiltYetError):
-        await ws.start_run(spec, {}, "runPar")
-
-
-@pytest.mark.asyncio
 async def test_reserved_loop_mode_raises(monkeypatch):
     monkeypatch.setattr(ws, "run_agent_step", AsyncMock(return_value=_ok()))
     spec = _spec(mode="loop")
@@ -620,10 +611,9 @@ async def test_reserved_loop_mode_raises(monkeypatch):
 
 def test_reserved_seam_methods_raise():
     # ``resume_from_last_completed`` is NO LONGER reserved as of Bolt 4 / N6 — it is
-    # un-reserved here and exercised by test_workflow_journal_resume.py. The
-    # remaining parallel/loop/guard seams stay reserved (N7/N8).
-    with pytest.raises(NotBuiltYetError):
-        ws._run_parallel(None, None)
+    # un-reserved here and exercised by test_workflow_journal_resume.py.
+    # ``_run_parallel`` is no longer a reserved seam (N7 shipped the parallel
+    # driver); the loop/guard seams stay reserved (N8).
     with pytest.raises(NotBuiltYetError):
         ws._run_loop(None, None)
     with pytest.raises(NotBuiltYetError):

--- a/test/services/test_workflow_spec_service.py
+++ b/test/services/test_workflow_spec_service.py
@@ -211,8 +211,10 @@ class TestValidateOnly:
         body = _GOOD_SPEC.format(name="par").replace("mode: sequential", "mode: parallel")
         path = _write_spec(spec_dir, "par", body)
         result = svc.validate_only(str(path), base_dir=str(spec_dir))
-        assert result.status == "pass_reserved"
-        assert any("reserved" in n for n in result.reserved_notes)
+        # N7 shipped parallel execution: a parallel spec is executable (pass),
+        # not pass_reserved. The loop mode remains the reserved one.
+        assert result.status == "pass"
+        assert result.reserved_notes == []
 
     def test_fail_does_not_raise(self, spec_dir):
         path = _write_spec(spec_dir, "broken", "name: broken\nsteps: []\n")

--- a/uv.lock
+++ b/uv.lock
@@ -5,8 +5,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
@@ -369,7 +369,7 @@ wheels = [
 
 [[package]]
 name = "cli-agent-orchestrator"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
@@ -802,7 +802,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -813,7 +812,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -824,7 +822,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -835,7 +832,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -846,7 +842,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1411,8 +1406,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
@@ -1493,8 +1488,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
@@ -1766,8 +1761,8 @@ version = "2.11.9"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
@@ -1817,8 +1812,8 @@ version = "2.33.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]


### PR DESCRIPTION
## What this does

Implements the **reserved N7 seam**: `mode: parallel` and `mode: pipeline` workflow specs now **execute** instead of raising `NotBuiltYetError`. This is the workflow-engine parallelism gap I flagged in the earlier review (the YAML tier previously only ran sequential specs).

```yaml
name: review_parallel
mode: parallel
steps:
  - id: plan
    provider: claude_code
    agent: developer
    prompt: Write a one-line implementation plan.
  - id: implement
    provider: claude_code
    agent: developer
    prompt: "Implement: {{steps.plan.output.answer}}"
    needs: [plan]
  - id: audit
    provider: claude_code
    agent: reviewer
    prompt: "Review: {{steps.implement.output.answer}}"
    needs: [implement]
```

## Engine (`workflow_service.py`)

- **`_drive_parallel`** — a wave-based scheduler layered on the existing deterministic topo order. A step is *ready* once every step in its `needs` set has settled (COMPLETED/COMPLETED_UNVALIDATED); all ready steps run **concurrently** via `asyncio.gather` of the shared `_run_step`, so each step keeps its exact sequential-mode semantics (per-step `retries`, `on_failure`, reprompt-once, structured-output validation, cancellation).
- **`_dispatch_drive`** routes `sequential` → `_drive`, `parallel`/`pipeline` → `_drive_parallel`; used by `start_run`, `start_run_prepared`, **and** `resume_from_last_completed`, preserving the single-execution-path invariant (B4-RD-5) — a resumed parallel run re-drives its DAG with completed steps kept.
- **`_finalize_run`** extracted from `_drive`: one shared terminal-state settle / event emission / result aggregation for both drivers (no parallel/sequential divergence).
- **Concurrency-safe journaling**: `_next_event_seq` is now `async` and serialized on a per-run `journal_lock` so concurrent step coroutines allocate well-defined per-run event `seq`s (BR-3) instead of racing the `event_seq += 1` read-modify-write.

## Model (`models/workflow.py`, `constants.py`)

- `WorkflowStep.needs: List[str]` — DAG edges. `validate_grammar` rejects **unknown**, **self**, and **cyclic** `needs` refs at authoring time (cycle errors name the steps: `a -> b -> a`). The engine's `_topological_order` already consumed `needs` defensively, so sequential mode honors it too.
- `WORKFLOW_SHIPPED_UNITS` gains `N7`: `parallel`/`pipeline` no longer tag reserved (`validate` returns `pass`); `loop` (N8) and `when`/loop-guards remain reserved with the honesty wording intact.

## Semantics preserved

- `on_failure: halt` (default): a failed step stops scheduling new waves; remaining steps become SKIPPED. Independent siblings already running in the same wave still settle.
- Cancel: observed between waves; the in-flight step wait is interrupted via the existing `cancel_event`.
- `pipeline` = linear chain (`needs: [previous]`); same driver, waves of one.

## Tests

- New `test/services/test_workflow_parallel.py` (13 tests): concurrent-wave overlap, dependency ordering, diamond DAG (`a -> {b,c} -> d` with b/c overlapping), pipeline chains, halt semantics (dependent never runs; sibling still settles), cancellation, and cross-step `{{steps.<id>.output.<field>}}` templating.
- Updated the three "parallel is reserved" assertions (models, services, spec-service) to the shipped state.
- Full non-e2e suite: **6287 passed, zero new failures**. The 15 AGUI endpoint failures and 46 agui/telemetry failures are pre-existing and verified byte-identical on base `c64c9fa`.

## Docs

`docs/workflows.md`: parallel/pipeline YAML syntax, `needs` semantics, and the script-tier-vs-YAML guidance.