### PR TITLE
feat(opencode): per-role cao-mcp-server tool allowlist (token efficiency)

### DIFF
--- a/docs/tool-restrictions.md
+++ b/docs/tool-restrictions.md
@@ -122,6 +122,27 @@ This is deliberate (see the design discussion on [issue #432](https://github.com
 
 **`group` is an organizational label, not a security boundary.** On a default install with auth disabled, a worker already has local shell access, so `discovery`/`group`/session-scoping provide no isolation guarantee even when used together — see [docs/api.md](api.md) and the coexistence write-up linked above.
 
+#### OpenCode agents get a per-role MCP tool allowlist
+
+When a profile with a `role` is installed for `opencode_cli`, the cao-mcp-server
+grant in the agent's `tools` config is written **per tool** (e.g.
+`cao-mcp-server_send_message: true`) instead of the server-wide wildcard
+(`cao-mcp-server*: true`). OpenCode only advertises granted tool schemas to the
+model, so a worker carries the handful of schemas its role needs rather than
+all ~26 — a meaningful context/token saving per delegated task.
+
+- `supervisor` gets the orchestration trio (`handoff`, `assign`, `send_message`),
+  prompt answers, sibling discovery, and memory tools.
+- `developer` gets `send_message` (the assign callback), memory tools, and skill
+  load — deliberately **not** `handoff`/`assign`, so a worker cannot re-delegate.
+- `reviewer` gets `send_message`, memory, and skill load only.
+- Profiles **without** a `role` keep the server-wide grant (backward compatible);
+  third-party MCP servers are always granted server-wide (CAO has no per-tool
+  knowledge of them).
+
+This refines what the agent *sees*; the CAO `allowedTools` vocabulary above
+remains the enforcement layer for the provider-native tools.
+
 ### 3. `--yolo` — The Escape Hatch
 
 ```bash

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -435,13 +435,15 @@ def install_agent(
             # OpenCode uses a shared opencode.json for MCP declarations. Keep
             # top-level MCP entries default-denied, then re-enable them only
             # for the installed agent. A reinstall without MCP removes stale
-            # per-agent grants.
+            # per-agent grants. With a known role the cao-mcp-server grant is
+            # per-tool (role allowlist), so a worker only carries the schemas
+            # it needs instead of all ~26 (token savings per delegated task).
             if profile.mcpServers:
                 mcp_names = list(profile.mcpServers.keys())
                 for mcp_name, mcp_cfg in profile.mcpServers.items():
                     opencode_mcp_cfg = translate_mcp_server_config(dict(mcp_cfg))
                     upsert_mcp_server(mcp_name, opencode_mcp_cfg)
-                upsert_agent_tools(agent_id, mcp_names)
+                upsert_agent_tools(agent_id, mcp_names, role=profile.role)
             else:
                 remove_agent_tools(agent_id)
 

--- a/src/cli_agent_orchestrator/utils/opencode_config.py
+++ b/src/cli_agent_orchestrator/utils/opencode_config.py
@@ -12,7 +12,7 @@ invocations are not a supported scenario.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from cli_agent_orchestrator.constants import OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE, SKILLS_DIR
 from cli_agent_orchestrator.utils.mcp_resolution import resolve_cao_mcp_command
@@ -20,6 +20,54 @@ from cli_agent_orchestrator.utils.mcp_resolution import resolve_cao_mcp_command
 logger = logging.getLogger(__name__)
 
 _SCHEMA = "https://opencode.ai/config.json"
+
+# Per-role allowlists for cao-mcp-server tools, mirrored into OpenCode's
+# per-agent ``tools`` config so a worker only carries the MCP tool schemas its
+# role actually uses. OpenCode names MCP tools ``<server>_<tool>`` and agent
+# ``tools`` entries override the global default-deny (``<server>*: false``),
+# so listing the exact tools a role needs drops the other ~20 schemas (several
+# KB of context) from that agent's session. Unknown roles fall back to the
+# server-wide grant (``<server>*``) so behavior is unchanged for profiles that
+# don't declare a role. Tool names are the ``cao-mcp-server`` tool names in
+# mcp_server/server.py.
+CAO_MCP_TOOLS_BY_ROLE: Dict[str, List[str]] = {
+    # A supervisor delegates work: orchestration trio + sibling discovery +
+    # memory. It does not need the workflow_run/events machinery (those are
+    # for script-tier workers) or emit_ui.
+    "supervisor": [
+        "handoff",
+        "assign",
+        "send_message",
+        "answer_user_prompt",
+        "list_siblings",
+        "update_metadata",
+        "memory_store",
+        "memory_recall",
+        "memory_forget",
+        "load_skill",
+        "find_profiles",
+        "delete_terminal",
+    ],
+    # A worker receives work and reports back: callback + memory + skill load.
+    # It must NOT see handoff/assign (it would try to re-delegate), workflow_*
+    # (script-tier machinery), or emit_ui.
+    "developer": [
+        "send_message",
+        "memory_store",
+        "memory_recall",
+        "memory_forget",
+        "load_skill",
+        "list_siblings",
+        "update_metadata",
+    ],
+    "reviewer": [
+        "send_message",
+        "memory_store",
+        "memory_recall",
+        "memory_forget",
+        "load_skill",
+    ],
+}
 
 
 def to_opencode_agent_id(profile_name: str) -> str:
@@ -146,16 +194,40 @@ def upsert_mcp_server(name: str, config: Dict[str, Any]) -> None:
     write_config(data)
 
 
-def upsert_agent_tools(agent_name: str, mcp_names: List[str]) -> None:
+def _agent_tool_grants(mcp_names: List[str], role: Optional[str] = None) -> Dict[str, bool]:
+    """Compute the ``agent.<id>.tools`` grants for the given MCP servers.
+
+    With a known role, grant only the cao-mcp-server tools that role uses
+    (``<server>_<tool>: true``), so OpenCode only advertises those schemas to
+    the agent. With an unknown role, fall back to the server-wide wildcard
+    (``<server>*: true``) — the pre-allowlist behavior — so profiles without a
+    role keep working unchanged. Non-cao MCP servers are always granted
+    server-wide (CAO has no per-tool knowledge of third-party servers).
+    """
+    grants: Dict[str, bool] = {}
+    role_tools = CAO_MCP_TOOLS_BY_ROLE.get(role or "")
+    for name in mcp_names:
+        if name == "cao-mcp-server" and role_tools is not None:
+            for tool in role_tools:
+                grants[f"{name}_{tool}"] = True
+        else:
+            grants[f"{name}*"] = True
+    return grants
+
+
+def upsert_agent_tools(agent_name: str, mcp_names: List[str], role: Optional[str] = None) -> None:
     """Set ``agent.<agent_name>.tools`` to re-enable the listed MCP servers.
 
-    Creates or replaces the ``tools`` sub-dict for *agent_name*; other keys
-    under ``agent.<agent_name>`` (if any) are preserved.
+    With a known ``role``, the cao-mcp-server grant is per-tool
+    (``cao-mcp-server_<tool>: true``) so the agent only sees the schemas its
+    role needs; unknown roles get the server-wide wildcard (backward
+    compatible). Creates or replaces the ``tools`` sub-dict for *agent_name*;
+    other keys under ``agent.<agent_name>`` (if any) are preserved.
     """
     data = read_config()
     agents_section = data.setdefault("agent", {})
     agent_entry = agents_section.setdefault(agent_name, {})
-    agent_entry["tools"] = {f"{name}*": True for name in mcp_names}
+    agent_entry["tools"] = _agent_tool_grants(mcp_names, role)
     write_config(data)
 
 

--- a/test/cli/commands/test_install_opencode.py
+++ b/test/cli/commands/test_install_opencode.py
@@ -364,6 +364,40 @@ class TestMcpWiring:
         assert agent_tools["srv-a*"] is True
         assert agent_tools["srv-b*"] is True
 
+    def test_role_grants_only_role_mcp_tools(
+        self, runner: CliRunner, install_workspace: Dict[str, Any]
+    ):
+        """A profile with role: developer gets per-tool grants, not the wildcard."""
+        _write_profile(
+            install_workspace["local_store"] / "test-agent.md",
+            extra_frontmatter="role: developer\n",
+            mcp_servers=("  cao-mcp-server:\n" "    command: cao-mcp-server\n" "    type: local\n"),
+        )
+
+        runner.invoke(install, ["test-agent", "--provider", "opencode_cli"])
+
+        data = json.loads(install_workspace["config_file"].read_text())
+        tools = data["agent"]["test-agent"]["tools"]
+        # No server-wide wildcard: the role allowlist replaces it.
+        assert "cao-mcp-server*" not in tools
+        # Worker tools the role needs are granted per-tool.
+        assert tools["cao-mcp-server_send_message"] is True
+        assert tools["cao-mcp-server_memory_recall"] is True
+        # Supervisor-only tools are NOT advertised to a worker.
+        assert "cao-mcp-server_handoff" not in tools
+        assert "cao-mcp-server_assign" not in tools
+
+    def test_roleless_profile_keeps_server_wide_grant(
+        self, runner: CliRunner, install_workspace: Dict[str, Any]
+    ):
+        """No role -> backward-compatible server-wide grant (existing behavior)."""
+        self._mcp_profile(install_workspace["local_store"] / "test-agent.md")
+
+        runner.invoke(install, ["test-agent", "--provider", "opencode_cli"])
+
+        data = json.loads(install_workspace["config_file"].read_text())
+        assert data["agent"]["test-agent"]["tools"]["cao-mcp-server*"] is True
+
 
 # ---------------------------------------------------------------------------
 # Scenario (e): agent without MCP — already covered in TestFreshInstall

--- a/test/utils/test_opencode_config.py
+++ b/test/utils/test_opencode_config.py
@@ -299,6 +299,45 @@ class TestUpsertAgentTools:
         assert "supervisor" in data["agent"]
 
 
+class TestUpsertAgentToolsRoleAllowlist:
+    """Per-role cao-mcp-server tool allowlists (token-efficiency grant)."""
+
+    def test_known_role_grants_only_role_tools(self, tmp_config: Path):
+        upsert_agent_tools("developer", ["cao-mcp-server"], role="developer")
+        data = json.loads(tmp_config.read_text())
+        tools = data["agent"]["developer"]["tools"]
+        # Per-tool grants, never the server-wide wildcard.
+        assert "cao-mcp-server*" not in tools
+        assert tools["cao-mcp-server_send_message"] is True
+        assert tools["cao-mcp-server_memory_recall"] is True
+        # Tools the role must NOT see are absent (not advertised to the agent).
+        assert "cao-mcp-server_handoff" not in tools
+        assert "cao-mcp-server_assign" not in tools
+        assert "cao-mcp-server_emit_ui" not in tools
+
+    def test_supervisor_role_keeps_orchestration(self, tmp_config: Path):
+        upsert_agent_tools("supervisor", ["cao-mcp-server"], role="supervisor")
+        data = json.loads(tmp_config.read_text())
+        tools = data["agent"]["supervisor"]["tools"]
+        assert "cao-mcp-server*" not in tools
+        assert tools["cao-mcp-server_handoff"] is True
+        assert tools["cao-mcp-server_assign"] is True
+        assert tools["cao-mcp-server_send_message"] is True
+
+    def test_unknown_role_falls_back_to_wildcard(self, tmp_config: Path):
+        upsert_agent_tools("odd-agent", ["cao-mcp-server"], role="mystery-role")
+        data = json.loads(tmp_config.read_text())
+        assert data["agent"]["odd-agent"]["tools"] == {"cao-mcp-server*": True}
+
+    def test_other_mcp_servers_stay_server_wide(self, tmp_config: Path):
+        upsert_agent_tools("developer", ["cao-mcp-server", "jira"], role="developer")
+        data = json.loads(tmp_config.read_text())
+        tools = data["agent"]["developer"]["tools"]
+        assert tools["cao-mcp-server_send_message"] is True
+        # Third-party server: no per-tool knowledge -> server-wide grant.
+        assert tools["jira*"] is True
+
+
 class TestRemoveAgentTools:
     def test_removes_existing_agent(self, tmp_config: Path):
         upsert_agent_tools("developer", ["cao-mcp-server"])


### PR DESCRIPTION
## What and why

When CAO delegates a task (codex supervisor → opencode worker via `handoff`/`assign`), every opencode worker is granted the **entire** cao-mcp-server MCP surface (`"cao-mcp-server*": true` in `opencode.json`), so the worker carries all ~26 MCP tool schemas (~8.5K tokens) in its context per delegated task.

OpenCode names MCP tools `<server>_<tool>` and per-agent `tools` entries override the global default-deny, so the grant can be narrowed to exactly the tools a role actually uses — dropping the other ~20 schemas from the worker's context.

## Change

- **`utils/opencode_config.py`** — new `CAO_MCP_TOOLS_BY_ROLE`:
  - `supervisor`: `handoff`, `assign`, `send_message`, `answer_user_prompt`, `list_siblings`, `update_metadata`, memory trio, `load_skill`, `find_profiles`, `delete_terminal`
  - `developer`: `send_message`, memory trio, `load_skill`, `list_siblings`, `update_metadata` — deliberately **no** `handoff`/`assign`/`workflow_*`/`emit_ui`, so a worker can't re-delegate
  - `reviewer`: `send_message`, memory trio, `load_skill`
- **`upsert_agent_tools(agent_name, mcp_names, role=None)`** — writes per-tool grants (`cao-mcp-server_send_message: true`) for known roles; falls back to the server-wide wildcard for unknown roles and third-party MCP servers (backward compatible — profiles without a `role` behave exactly as before).
- **`install_service.py`** — passes `profile.role` through to the upsert.
- **`docs/tool-restrictions.md`** — documents the per-role allowlist.

## Token impact

Per opencode worker task: ~26 schemas → ~4–7 schemas depending on role. Both sides of a codex→opencode delegation pay per task on the worker side, and the supervisor (codex) still gets the orchestration trio. No engine changes; the CAO `allowedTools` vocabulary remains the enforcement layer.

## Tests

- `test/utils/test_opencode_config.py`: 4 new — known role → per-tool grants only (and handoff/assign/emit_ui absent), supervisor keeps orchestration, unknown role → wildcard fallback, third-party servers stay server-wide.
- `test/cli/commands/test_install_opencode.py`: 2 new — `role: developer` profile installed via `cao install` gets per-tool grants (no wildcard), roleless profile keeps the wildcard.
- 197 passed in the touched suites.