### PR TITLE
fix(tmux): prefer server-matched MCP helper

### DIFF
--- a/docs/opencode-cli.md
+++ b/docs/opencode-cli.md
@@ -20,7 +20,7 @@ The OpenCode CLI provider enables CLI Agent Orchestrator (CAO) to work with **Op
 
 ### First-launch delay
 
-On its **first ever launch** against a fresh CAO config directory (`~/.aws/opencode/`), OpenCode runs `npm install @opencode-ai/plugin` — roughly 57 MB of dependencies that take **5–30 seconds** to install. The TUI will appear blank until the install completes. This is expected; CAO's 120-second initialization timeout covers it automatically.
+On its **first ever launch** against a fresh CAO config, OpenCode runs `npm install @opencode-ai/plugin` — roughly 57 MB of dependencies that take **5–30 seconds** to install. The TUI will appear blank until the install completes. This is expected; CAO's 120-second initialization timeout covers it automatically. CAO retains that completed dependency state for later terminal launches.
 
 Subsequent launches complete in ~2 seconds.
 
@@ -71,7 +71,7 @@ curl -X POST "http://localhost:9889/sessions?provider=opencode_cli&agent_profile
 
 ## Config Isolation
 
-CAO runs OpenCode with `OPENCODE_CONFIG_DIR` and `OPENCODE_CONFIG` both pointing at `~/.aws/opencode/`, which is separate from the user's personal OpenCode config at `~/.config/opencode/`. This means:
+CAO keeps its durable OpenCode installation state under `~/.aws/opencode/`, separate from the user's personal OpenCode config at `~/.config/opencode/`. Each launched terminal receives its own private snapshot under `~/.aws/cli-agent-orchestrator/tmp/`, and CAO points both `OPENCODE_CONFIG_DIR` and `OPENCODE_CONFIG` at that snapshot. This means:
 
 - CAO-installed agents are visible in OpenCode's agent picker alongside the built-ins
 - CAO's MCP wiring (`opencode.json`) never touches the user's personal setup
@@ -82,8 +82,7 @@ Storage layout:
 ```
 ~/.aws/opencode/
 ├── opencode.json          # MCP servers + per-agent tool gating (written by cao install)
-├── package.json           # written by opencode on first launch
-├── node_modules/          # ~57 MB, written by opencode on first launch
+├── .cao-runtime-dependencies/ # completed first-launch package cache
 └── agents/
     ├── code_supervisor.md
     ├── developer.md
@@ -235,12 +234,7 @@ Parallel `cao install --provider opencode_cli` invocations (e.g., from a batch s
 
 ### First-launch blank TUI (5–30 seconds)
 
-OpenCode installs `@opencode-ai/plugin` into `~/.aws/opencode/node_modules/` on the first launch. The terminal will appear blank until `npm install` completes. CAO's 120-second initialization timeout covers this automatically.
-
-To pre-populate `node_modules/` before the first CAO launch (optional):
-```bash
-OPENCODE_CONFIG_DIR=~/.aws/opencode opencode --help
-```
+OpenCode installs `@opencode-ai/plugin` into its first private CAO runtime config on the first launch. The terminal will appear blank until `npm install` completes. CAO retains that completed dependency state for later terminal launches, and its 120-second initialization timeout covers the first launch automatically.
 
 ### "Unknown provider" error from the server
 

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -18,7 +18,6 @@ from cli_agent_orchestrator.constants import (
     BRACKETED_PASTE_INCOMPATIBLE_SHELLS,
     TMUX_HISTORY_LINES,
 )
-from cli_agent_orchestrator.utils.mcp_resolution import cao_mcp_server_sibling_dir
 from cli_agent_orchestrator.utils.path_validation import (
     BLOCKED_SYSTEM_DIRECTORIES,
     resolve_and_validate_path,
@@ -381,22 +380,6 @@ class TmuxClient:
                     )
                 )
             }
-            # Prefer the cao-mcp-server console script that sits beside THIS
-            # interpreter on the spawned terminal's PATH, so the bundled
-            # orchestration helper resolves even when cao-server's own PATH
-            # does not include the install bin dir (unactivated venv,
-            # devcontainer, ``pip install --prefix``). Only augments when a
-            # sibling executable actually exists and there is an inherited
-            # PATH to prepend onto — a process with no PATH is left to tmux's
-            # default rather than handed a one-entry PATH. Idempotent: if the
-            # sibling dir already leads the inherited PATH it is left alone.
-            # The operator --env merge below runs AFTER this and overrides on
-            # key collision, so an explicit ``--env PATH=...`` still wins.
-            sibling_dir = cao_mcp_server_sibling_dir()
-            if sibling_dir and environment.get("PATH"):
-                path_parts = environment["PATH"].split(os.pathsep)
-                if path_parts[0] != sibling_dir:
-                    environment["PATH"] = os.pathsep.join([sibling_dir, *path_parts])
             # Operator-forwarded vars (from ``cao launch --env``) merge AFTER
             # the inherited slice and override on key collision, so an
             # explicit ``--env AWS_REGION=us-west-2`` wins over the inherited

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -18,6 +18,7 @@ from cli_agent_orchestrator.constants import (
     BRACKETED_PASTE_INCOMPATIBLE_SHELLS,
     TMUX_HISTORY_LINES,
 )
+from cli_agent_orchestrator.utils.mcp_resolution import cao_mcp_server_sibling_dir
 from cli_agent_orchestrator.utils.path_validation import (
     BLOCKED_SYSTEM_DIRECTORIES,
     resolve_and_validate_path,
@@ -380,6 +381,22 @@ class TmuxClient:
                     )
                 )
             }
+            # Prefer the cao-mcp-server console script that sits beside THIS
+            # interpreter on the spawned terminal's PATH, so the bundled
+            # orchestration helper resolves even when cao-server's own PATH
+            # does not include the install bin dir (unactivated venv,
+            # devcontainer, ``pip install --prefix``). Only augments when a
+            # sibling executable actually exists and there is an inherited
+            # PATH to prepend onto — a process with no PATH is left to tmux's
+            # default rather than handed a one-entry PATH. Idempotent: if the
+            # sibling dir already leads the inherited PATH it is left alone.
+            # The operator --env merge below runs AFTER this and overrides on
+            # key collision, so an explicit ``--env PATH=...`` still wins.
+            sibling_dir = cao_mcp_server_sibling_dir()
+            if sibling_dir and environment.get("PATH"):
+                path_parts = environment["PATH"].split(os.pathsep)
+                if path_parts[0] != sibling_dir:
+                    environment["PATH"] = os.pathsep.join([sibling_dir, *path_parts])
             # Operator-forwarded vars (from ``cao launch --env``) merge AFTER
             # the inherited slice and override on key collision, so an
             # explicit ``--env AWS_REGION=us-west-2`` wins over the inherited

--- a/src/cli_agent_orchestrator/providers/antigravity_cli.py
+++ b/src/cli_agent_orchestrator/providers/antigravity_cli.py
@@ -413,12 +413,11 @@ class AntigravityCliProvider(BaseProvider):
                     cfg = dict(server_config)
                 else:
                     cfg = server_config.model_dump(exclude_none=True)
-                # Resolve the bundled cao-mcp-server console script to a
-                # PATH-independent invocation. persisted=True: this command is
-                # written to mcp_config.json and read by agy at later launches,
-                # so prefer the stable PATH launcher over the versioned venv path.
+                # This entry is recreated for each terminal initialization, so
+                # bind the bare bundled helper to this server's current
+                # interpreter rather than an older global launcher.
                 command, args = resolve_cao_mcp_command(
-                    cfg.get("command", ""), cfg.get("args", []) or [], persisted=True
+                    cfg.get("command", ""), cfg.get("args", []) or []
                 )
                 entry: dict = {
                     "command": command,

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -219,6 +219,16 @@ class ProviderManager:
         """Cleanup provider and remove from map (used when terminal is deleted)."""
         try:
             provider = self._providers.pop(terminal_id, None)
+            if provider is None:
+                try:
+                    provider = self.get_provider(terminal_id)
+                except ValueError:
+                    # Creation may have failed before the terminal row was
+                    # committed; there is no persisted provider state to clean.
+                    return
+                # get_provider() registers an on-demand provider. Remove it
+                # before cleanup so a cleanup failure cannot retain stale state.
+                self._providers.pop(terminal_id, None)
             if provider:
                 provider.cleanup()
                 logger.info(f"Cleaned up provider for terminal: {terminal_id}")

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -17,6 +17,7 @@ The provider detects the following terminal states:
 - UNKNOWN: Fallback when no state marker matches (or empty buffer)
 """
 
+import asyncio
 import logging
 import re
 import shlex
@@ -29,7 +30,11 @@ from cli_agent_orchestrator.constants import CAO_HOME_DIR, OPENCODE_CONFIG_DIR, 
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.services.settings_service import get_server_settings
-from cli_agent_orchestrator.utils.opencode_config import prepare_opencode_runtime_config
+from cli_agent_orchestrator.utils.opencode_config import (
+    opencode_runtime_config_root,
+    prepare_opencode_runtime_config,
+    promote_opencode_runtime_dependencies,
+)
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 
 logger = logging.getLogger(__name__)
@@ -172,6 +177,10 @@ class OpenCodeCliProvider(BaseProvider):
         ):
             raise TimeoutError("OpenCode CLI initialization timed out after 120 seconds")
 
+        # A fresh private root receives OpenCode's first-run package install.
+        # Promote that completed state only after the TUI is ready, allowing
+        # future private roots to reuse it without ever rewriting shared config.
+        await asyncio.to_thread(promote_opencode_runtime_dependencies, self._config_root)
         self._initialized = True
         return True
 
@@ -466,16 +475,28 @@ class OpenCodeCliProvider(BaseProvider):
         self._initialized = False
         config_root = self._config_root
         self._config_root = None
-        if config_root is None:
+        try:
+            expected_root = opencode_runtime_config_root(
+                self.terminal_id, cao_home_dir=CAO_HOME_DIR
+            )
+        except ValueError:
+            logger.warning(
+                "Refusing to remove OpenCode config root for invalid terminal ID: %s",
+                self.terminal_id,
+            )
             return
 
-        expected_root = CAO_HOME_DIR / "tmp" / f"opencode-{self.terminal_id}"
-        if config_root != expected_root or config_root.is_symlink():
+        if config_root is not None and config_root != expected_root:
             logger.warning("Refusing to remove unexpected OpenCode config root: %s", config_root)
             return
+        if expected_root.is_symlink():
+            logger.warning("Refusing to remove symlinked OpenCode config root: %s", expected_root)
+            return
         try:
-            shutil.rmtree(config_root)
+            shutil.rmtree(expected_root)
         except FileNotFoundError:
             pass
         except OSError:
-            logger.warning("Unable to remove OpenCode config root: %s", config_root, exc_info=True)
+            logger.warning(
+                "Unable to remove OpenCode config root: %s", expected_root, exc_info=True
+            )

--- a/src/cli_agent_orchestrator/providers/opencode_cli.py
+++ b/src/cli_agent_orchestrator/providers/opencode_cli.py
@@ -20,13 +20,16 @@ The provider detects the following terminal states:
 import logging
 import re
 import shlex
+import shutil
+from pathlib import Path
 from typing import List, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
-from cli_agent_orchestrator.constants import OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE
+from cli_agent_orchestrator.constants import CAO_HOME_DIR, OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.services.settings_service import get_server_settings
+from cli_agent_orchestrator.utils.opencode_config import prepare_opencode_runtime_config
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 
 logger = logging.getLogger(__name__)
@@ -97,6 +100,7 @@ class OpenCodeCliProvider(BaseProvider):
         self._agent_profile = agent_profile or ""
         self._model = model
         self._initialized = False
+        self._config_root: Optional[Path] = None
 
     @property
     def paste_enter_count(self) -> int:
@@ -156,6 +160,7 @@ class OpenCodeCliProvider(BaseProvider):
         if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
+        self._config_root = prepare_opencode_runtime_config(self.terminal_id)
         command = self._build_launch_command()
         get_backend().send_keys(self.session_name, self.window_name, command)
 
@@ -172,9 +177,13 @@ class OpenCodeCliProvider(BaseProvider):
 
     def _build_launch_command(self) -> str:
         """Build the inline-env opencode launch command string."""
+        config_root = self._config_root or OPENCODE_CONFIG_DIR
+        config_file = (
+            config_root / "opencode.json" if self._config_root is not None else OPENCODE_CONFIG_FILE
+        )
         env_pairs = [
-            f"OPENCODE_CONFIG={OPENCODE_CONFIG_FILE}",
-            f"OPENCODE_CONFIG_DIR={OPENCODE_CONFIG_DIR}",
+            f"OPENCODE_CONFIG={shlex.quote(str(config_file))}",
+            f"OPENCODE_CONFIG_DIR={shlex.quote(str(config_root))}",
             "OPENCODE_DISABLE_AUTOUPDATE=1",
             "OPENCODE_DISABLE_MOUSE=1",
             "OPENCODE_DISABLE_TERMINAL_TITLE=1",
@@ -455,3 +464,18 @@ class OpenCodeCliProvider(BaseProvider):
     def cleanup(self) -> None:
         """Clean up OpenCode provider state."""
         self._initialized = False
+        config_root = self._config_root
+        self._config_root = None
+        if config_root is None:
+            return
+
+        expected_root = CAO_HOME_DIR / "tmp" / f"opencode-{self.terminal_id}"
+        if config_root != expected_root or config_root.is_symlink():
+            logger.warning("Refusing to remove unexpected OpenCode config root: %s", config_root)
+            return
+        try:
+            shutil.rmtree(config_root)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.warning("Unable to remove OpenCode config root: %s", config_root, exc_info=True)

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -320,19 +320,6 @@ def install_agent(
                     )
                 provider = DEFAULT_PROVIDER
 
-        # Resolve the bundled cao-mcp-server console script to a PATH-independent
-        # invocation before materializing provider configs. The
-        # configs Kiro/Q write to disk are consumed verbatim by those CLIs, so
-        # resolution must happen here rather than at launch time. persisted=True
-        # prefers the stable PATH launcher (e.g. ~/.local/bin/cao-mcp-server)
-        # over the versioned venv-internal path, so a later `uv tool upgrade`
-        # does not leave the written config pointing at a relocated binary.
-        if profile.mcpServers:
-            profile.mcpServers = {
-                name: resolve_mcp_server_config(dict(cfg), persisted=True)
-                for name, cfg in profile.mcpServers.items()
-            }
-
         unresolved_vars = sorted(set(re.findall(r"\$\{(\w+)\}", resolved_content)))
         context_file = _write_context_file(profile.name, raw_content)
 
@@ -349,6 +336,14 @@ def install_agent(
                     "render KAS profiles or translate allowedTools/toolsSettings to Cedar. "
                     "Set engine: v2 or wait for a later migration phase."
                 )
+            # Kiro consumes this durable agent JSON at later launches. Keep
+            # its stable PATH-launcher preference rather than pinning the
+            # versioned interpreter sibling into a long-lived config.
+            if profile.mcpServers:
+                profile.mcpServers = {
+                    name: resolve_mcp_server_config(dict(cfg), persisted=True)
+                    for name, cfg in profile.mcpServers.items()
+                }
             KIRO_AGENTS_DIR.mkdir(parents=True, exist_ok=True)
             # Kiro natively supports skill:// resources with progressive loading
             # (metadata at startup, full content on demand).

--- a/src/cli_agent_orchestrator/utils/mcp_resolution.py
+++ b/src/cli_agent_orchestrator/utils/mcp_resolution.py
@@ -8,15 +8,19 @@ non-standard location). When it fails to resolve, the agent starts without its
 orchestration tools (handoff / assign / send_message) and silently no-ops.
 
 ``resolve_cao_mcp_command`` rewrites the bare command to a PATH-independent
-invocation, mirroring the three-tier fallback the Copilot provider already used
-inline:
+invocation:
 
-    1. the ``cao-mcp-server`` script sitting next to the running interpreter
+    1. Runtime configs use the ``cao-mcp-server`` script sitting next to the
+       running interpreter
        (the same environment that launched cao-server — the common case for
-       ``uv tool install`` / ``pipx``), then
-    2. ``cao-mcp-server`` as resolved on ``PATH``, then
-    3. ``<python> -m cli_agent_orchestrator.mcp_server.server`` — always
-       runnable because it does not depend on a console script being on PATH.
+       ``uv tool install`` / ``pipx``), then the current interpreter's module
+       entrypoint.
+    2. Persisted configs may prefer ``cao-mcp-server`` as resolved on ``PATH``
+       so a stable launcher can survive an upgrade, then fall back to the
+       interpreter sibling/module target.
+
+The module entrypoint (``<python> -m cli_agent_orchestrator.mcp_server.server``)
+is always runnable because it does not depend on a console script being on PATH.
 
 Any command other than the bare ``cao-mcp-server`` (e.g. a user's custom MCP
 server, or an explicit absolute path) passes through unchanged.
@@ -26,7 +30,7 @@ import logging
 import shutil
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -52,22 +56,6 @@ def _sibling_script() -> str:
     return str(sibling) if sibling.exists() else ""
 
 
-def cao_mcp_server_sibling_dir() -> str:
-    """Directory holding the ``cao-mcp-server`` script beside the interpreter.
-
-    Companion to :func:`_sibling_script` for callers that need to put the
-    bundled helper on ``PATH`` (e.g. spawned agent tmux terminals) rather than
-    invoke it directly. Returns the script's parent directory when a sibling
-    console script exists next to :data:`sys.executable`, and ``""``
-    otherwise — so callers can treat an empty result as "no augmentation
-    available" and leave the inherited ``PATH`` untouched. An operator-supplied
-    ``PATH`` is still expected to win over any augmentation applied by the
-    caller.
-    """
-    sibling = _sibling_script()
-    return str(Path(sibling).parent) if sibling else ""
-
-
 def resolve_cao_mcp_command(
     command: str, args: List[str], *, persisted: bool = False
 ) -> Tuple[str, List[str]]:
@@ -78,8 +66,9 @@ def resolve_cao_mcp_command(
     the result is written to disk:
 
     - ``persisted=False`` (default, runtime providers that rebuild the launch
-      config every time): prefer the script next to the running interpreter —
-      an exact, hijack-proof match recomputed each launch.
+      config every time): prefer the script next to the running interpreter,
+      then its module entrypoint. Do not resolve a global PATH launcher, which
+      could belong to an older CAO installation.
     - ``persisted=True`` (the resolved command is written to a config file the
       provider reads later, e.g. Kiro/Q agent JSON): prefer the script as
       resolved on ``PATH``. Tool installers (uv, pipx) keep a *stable* launcher
@@ -104,15 +93,9 @@ def resolve_cao_mcp_command(
         return command, list(args)
 
     sibling = _sibling_script()
-    on_path = shutil.which(CAO_MCP_SERVER_COMMAND)
-    order = (
-        [("PATH", on_path), ("sibling", sibling)]
-        if persisted
-        else [
-            ("sibling", sibling),
-            ("PATH", on_path),
-        ]
-    )
+    order: List[Tuple[str, Optional[str]]] = [("sibling", sibling)]
+    if persisted:
+        order.insert(0, ("PATH", shutil.which(CAO_MCP_SERVER_COMMAND)))
     for label, candidate in order:
         if candidate:
             logger.debug("Resolved %s via %s: %s", command, label, candidate)

--- a/src/cli_agent_orchestrator/utils/mcp_resolution.py
+++ b/src/cli_agent_orchestrator/utils/mcp_resolution.py
@@ -52,6 +52,22 @@ def _sibling_script() -> str:
     return str(sibling) if sibling.exists() else ""
 
 
+def cao_mcp_server_sibling_dir() -> str:
+    """Directory holding the ``cao-mcp-server`` script beside the interpreter.
+
+    Companion to :func:`_sibling_script` for callers that need to put the
+    bundled helper on ``PATH`` (e.g. spawned agent tmux terminals) rather than
+    invoke it directly. Returns the script's parent directory when a sibling
+    console script exists next to :data:`sys.executable`, and ``""``
+    otherwise — so callers can treat an empty result as "no augmentation
+    available" and leave the inherited ``PATH`` untouched. An operator-supplied
+    ``PATH`` is still expected to win over any augmentation applied by the
+    caller.
+    """
+    sibling = _sibling_script()
+    return str(Path(sibling).parent) if sibling else ""
+
+
 def resolve_cao_mcp_command(
     command: str, args: List[str], *, persisted: bool = False
 ) -> Tuple[str, List[str]]:

--- a/src/cli_agent_orchestrator/utils/mcp_resolution.py
+++ b/src/cli_agent_orchestrator/utils/mcp_resolution.py
@@ -28,9 +28,10 @@ server, or an explicit absolute path) passes through unchanged.
 
 import logging
 import shutil
+import stat
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,12 @@ _SCRIPT_FILENAME = (
     f"{CAO_MCP_SERVER_COMMAND}.exe" if sys.platform == "win32" else CAO_MCP_SERVER_COMMAND
 )
 
+# Bound the inspection of a legacy absolute console-script path.  A CAO
+# generated wrapper is only a few hundred bytes; a bounded read keeps a
+# configuration refresh from following an arbitrary large user-owned file.
+_MAX_CONSOLE_SCRIPT_BYTES = 64 * 1024
+_CONSOLE_SCRIPT_MODULE_IMPORT = b"from cli_agent_orchestrator.mcp_server.server import main"
+
 
 def _sibling_script() -> str:
     """Absolute path to cao-mcp-server next to the running interpreter, or ""."""
@@ -54,6 +61,59 @@ def _sibling_script() -> str:
         return ""
     sibling = Path(sys.executable).with_name(_SCRIPT_FILENAME)
     return str(sibling) if sibling.exists() else ""
+
+
+def get_cao_mcp_server_profile_args(command: Any) -> Optional[List[str]]:
+    """Return profile args when a stored OpenCode command is CAO-owned.
+
+    OpenCode stores a local MCP launch as one argv list.  Its old entries may
+    contain the bare helper, the module fallback, or an absolute console-script
+    path created by a prior CAO install.  Only the first two forms and an
+    absolute, regular script carrying CAO's exact console-script import are
+    safe to refresh.  In particular, a user executable merely named
+    ``cao-mcp-server`` is not CAO-owned.
+
+    ``None`` means the stored command is unrecognized and must be preserved
+    byte-for-byte.  A returned list is a fresh copy of the user profile args.
+    """
+    if (
+        not isinstance(command, list)
+        or not command
+        or not all(isinstance(part, str) for part in command)
+    ):
+        return None
+
+    executable = command[0]
+    if executable == CAO_MCP_SERVER_COMMAND:
+        return list(command[1:])
+
+    if len(command) >= 3 and command[1] == "-m" and command[2] == CAO_MCP_SERVER_MODULE:
+        return list(command[3:])
+
+    if _is_cao_mcp_console_script(executable):
+        return list(command[1:])
+    return None
+
+
+def _is_cao_mcp_console_script(executable: str) -> bool:
+    """Whether *executable* is a bounded, generated CAO console script.
+
+    Inspect only absolute regular files and fail closed on all filesystem
+    errors.  This provenance check supports migration of a prior CAO install
+    without taking ownership of an unrelated same-basename custom command.
+    """
+    path = Path(executable)
+    if not path.is_absolute():
+        return False
+    try:
+        file_stat = path.stat()
+        if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_size > _MAX_CONSOLE_SCRIPT_BYTES:
+            return False
+        with path.open("rb") as file:
+            contents = file.read(_MAX_CONSOLE_SCRIPT_BYTES + 1)
+    except OSError:
+        return False
+    return len(contents) <= _MAX_CONSOLE_SCRIPT_BYTES and _CONSOLE_SCRIPT_MODULE_IMPORT in contents
 
 
 def resolve_cao_mcp_command(

--- a/src/cli_agent_orchestrator/utils/opencode_config.py
+++ b/src/cli_agent_orchestrator/utils/opencode_config.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
@@ -34,7 +35,21 @@ logger = logging.getLogger(__name__)
 
 _SCHEMA = "https://opencode.ai/config.json"
 _RUNTIME_CONFIG_NAME = "opencode.json"
-_CONFIG_FILES_NOT_TO_LINK = {_RUNTIME_CONFIG_NAME, "opencode.jsonc"}
+_RUNTIME_DEPENDENCY_CACHE_NAME = ".cao-runtime-dependencies"
+_RUNTIME_DEPENDENCY_COMPLETE_MARKER_NAME = ".cao-complete"
+_RUNTIME_DEPENDENCY_COMPLETE_MARKER = "cao-opencode-runtime-dependencies-v1\n"
+_RUNTIME_DEPENDENCY_FILE_NAMES = ("package.json", "package-lock.json")
+_RUNTIME_DEPENDENCY_DIRECTORY_NAME = "node_modules"
+_RUNTIME_DEPENDENCY_NAMES = {
+    *_RUNTIME_DEPENDENCY_FILE_NAMES,
+    _RUNTIME_DEPENDENCY_DIRECTORY_NAME,
+}
+_CONFIG_FILES_NOT_TO_LINK = {
+    _RUNTIME_CONFIG_NAME,
+    "opencode.jsonc",
+    _RUNTIME_DEPENDENCY_CACHE_NAME,
+    *_RUNTIME_DEPENDENCY_NAMES,
+}
 _TERMINAL_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
 
 
@@ -125,17 +140,24 @@ def prepare_opencode_runtime_config(terminal_id: str) -> Path:
     os.chmod(root, 0o700)
 
     _link_shared_config_siblings(root)
+    _link_runtime_dependency_assets(root)
     data = copy.deepcopy(read_config())
     _refresh_cao_mcp_commands(data)
     _write_runtime_config(root / _RUNTIME_CONFIG_NAME, data)
     return root
 
 
-def _runtime_config_root(terminal_id: str) -> Path:
+def opencode_runtime_config_root(terminal_id: str, *, cao_home_dir: Path | None = None) -> Path:
     """Return the owned runtime root for a safe terminal identifier."""
     if not _TERMINAL_ID_PATTERN.fullmatch(terminal_id):
         raise ValueError(f"Invalid terminal ID for OpenCode runtime config: {terminal_id!r}")
-    return CAO_HOME_DIR / "tmp" / f"opencode-{terminal_id}"
+    home_dir = cao_home_dir if cao_home_dir is not None else CAO_HOME_DIR
+    return home_dir / "tmp" / f"opencode-{terminal_id}"
+
+
+def _runtime_config_root(terminal_id: str) -> Path:
+    """Return the configured CAO-owned runtime root for *terminal_id*."""
+    return opencode_runtime_config_root(terminal_id)
 
 
 def _link_shared_config_siblings(root: Path) -> None:
@@ -152,16 +174,152 @@ def _link_shared_config_siblings(root: Path) -> None:
         destination.symlink_to(source, target_is_directory=source.is_dir())
 
 
+def promote_opencode_runtime_dependencies(runtime_root: Path) -> None:
+    """Persist complete first-launch package state for later private roots.
+
+    OpenCode installs its plugin dependencies beside the runtime config when a
+    CAO config is empty.  That runtime root is terminal-scoped and cleaned up,
+    so copy a *complete* package set into CAO's private cache after the TUI is
+    ready.  A later root only links a completed source; it never consumes a
+    partial install.
+
+    The cache is CAO-owned but lives below the shared OpenCode config so it
+    survives individual terminal cleanup.  It intentionally never rewrites
+    the shared ``opencode.json`` or user-managed package assets.
+    """
+    if not _has_complete_runtime_dependencies(runtime_root):
+        return
+
+    cache_root = _runtime_dependency_cache_root()
+    if cache_root.exists() or cache_root.is_symlink():
+        if _has_complete_runtime_dependencies(cache_root, require_marker=True):
+            return
+        if cache_root.is_symlink() or not cache_root.is_dir():
+            logger.warning(
+                "OpenCode dependency cache is not a real directory; leaving it untouched: %s",
+                cache_root,
+            )
+            return
+        # This hidden directory is CAO-owned. A markerless cache is from an
+        # interrupted or pre-marker publication and is never linked into a
+        # runtime root, so remove it before publishing the known-ready state.
+        try:
+            shutil.rmtree(cache_root)
+        except OSError:
+            logger.warning("Unable to clear incomplete OpenCode dependency cache: %s", cache_root)
+            return
+
+    try:
+        OPENCODE_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        temporary_root = Path(
+            tempfile.mkdtemp(prefix=f".{_RUNTIME_DEPENDENCY_CACHE_NAME}.", dir=OPENCODE_CONFIG_DIR)
+        )
+    except OSError:
+        logger.warning("Unable to create OpenCode dependency cache", exc_info=True)
+        return
+
+    try:
+        os.chmod(temporary_root, 0o700)
+        for filename in _RUNTIME_DEPENDENCY_FILE_NAMES:
+            source = runtime_root / filename
+            if source.is_file():
+                shutil.copy2(source, temporary_root / filename)
+        shutil.copytree(
+            runtime_root / _RUNTIME_DEPENDENCY_DIRECTORY_NAME,
+            temporary_root / _RUNTIME_DEPENDENCY_DIRECTORY_NAME,
+            symlinks=True,
+        )
+        marker = temporary_root / _RUNTIME_DEPENDENCY_COMPLETE_MARKER_NAME
+        marker.write_text(_RUNTIME_DEPENDENCY_COMPLETE_MARKER, encoding="utf-8")
+        os.chmod(marker, 0o600)
+        try:
+            temporary_root.rename(cache_root)
+        except OSError:
+            if not _has_complete_runtime_dependencies(cache_root, require_marker=True):
+                logger.warning(
+                    "Unable to publish OpenCode dependency cache: %s", cache_root, exc_info=True
+                )
+    except OSError:
+        logger.warning("Unable to populate OpenCode dependency cache", exc_info=True)
+    finally:
+        if temporary_root.exists() and not temporary_root.is_symlink():
+            shutil.rmtree(temporary_root, ignore_errors=True)
+
+
+def _link_runtime_dependency_assets(root: Path) -> None:
+    """Link a complete shared or CAO-cached package set into *root*."""
+    source_root = _runtime_dependency_source()
+    if source_root is None:
+        return
+
+    for name in _RUNTIME_DEPENDENCY_NAMES:
+        source = source_root / name
+        if not source.exists():
+            continue
+        destination = root / name
+        if destination.exists() or destination.is_symlink():
+            continue
+        destination.symlink_to(source, target_is_directory=source.is_dir())
+
+
+def _runtime_dependency_source() -> Path | None:
+    """Return CAO's completed package source without exposing partial state."""
+    cache_root = _runtime_dependency_cache_root()
+    if _has_complete_runtime_dependencies(cache_root, require_marker=True):
+        return cache_root
+    return None
+
+
+def _runtime_dependency_cache_root() -> Path:
+    """Return CAO's persistent OpenCode first-launch dependency cache path."""
+    return OPENCODE_CONFIG_DIR / _RUNTIME_DEPENDENCY_CACHE_NAME
+
+
+def _has_complete_runtime_dependencies(root: Path, *, require_marker: bool = False) -> bool:
+    """Whether *root* has the minimum safe OpenCode package state."""
+    has_dependencies = (
+        root.is_dir()
+        and not root.is_symlink()
+        and (root / "package.json").is_file()
+        and (root / _RUNTIME_DEPENDENCY_DIRECTORY_NAME).is_dir()
+    )
+    if not has_dependencies or not require_marker:
+        return has_dependencies
+
+    marker = root / _RUNTIME_DEPENDENCY_COMPLETE_MARKER_NAME
+    try:
+        return (
+            marker.is_file()
+            and not marker.is_symlink()
+            and marker.read_text(encoding="utf-8") == _RUNTIME_DEPENDENCY_COMPLETE_MARKER
+        )
+    except OSError:
+        return False
+
+
 def _refresh_cao_mcp_commands(data: Dict[str, Any]) -> None:
     """Refresh only verifiably CAO-owned local OpenCode MCP commands."""
     mcp_servers = data.get("mcp")
     if not isinstance(mcp_servers, dict):
         return
 
-    for server_config in mcp_servers.values():
+    for server_name, server_config in mcp_servers.items():
         if not isinstance(server_config, dict):
             continue
         profile_args = get_cao_mcp_server_profile_args(server_config.get("command"))
+        # CAO owns the reserved entry name.  Versions before runtime snapshots
+        # persisted an interpreter-sibling helper here; after that venv is
+        # removed we cannot prove the old file's provenance, but the reserved
+        # name remains CAO-managed and its trailing profile args are safe to
+        # retain.  Other entries stay fail-closed and byte-for-byte untouched.
+        if profile_args is None and server_name == CAO_MCP_SERVER_COMMAND:
+            command = server_config.get("command")
+            if (
+                isinstance(command, list)
+                and command
+                and all(isinstance(part, str) for part in command)
+            ):
+                profile_args = list(command[1:])
         if profile_args is None:
             continue
         command, args = resolve_cao_mcp_command(CAO_MCP_SERVER_COMMAND, profile_args)
@@ -204,12 +362,12 @@ def translate_mcp_server_config(cao_config: Dict[str, Any]) -> Dict[str, Any]:
     - ``"enabled": true`` added
     - ``env`` → ``environment`` (OpenCode's key for process env vars)
     """
-    # Resolve only the bare bundled helper to the current CAO interpreter's
-    # sibling/module target before flattening it into OpenCode's command list.
-    # A globally resolved launcher may belong to an older CAO installation.
-    command_str, args = resolve_cao_mcp_command(
-        cao_config.get("command", ""), cao_config.get("args", []) or []
-    )
+    # Keep the bundled helper in its canonical bare form in CAO's durable
+    # template.  Every terminal snapshots and resolves it from the active
+    # server process, so an upgrade cannot strand this config with an obsolete
+    # virtual-environment sibling path.
+    command_str = cao_config.get("command", "")
+    args = cao_config.get("args", []) or []
     full_command: List[str] = ([command_str] if command_str else []) + list(args)
 
     result: Dict[str, Any] = {

--- a/src/cli_agent_orchestrator/utils/opencode_config.py
+++ b/src/cli_agent_orchestrator/utils/opencode_config.py
@@ -109,12 +109,11 @@ def translate_mcp_server_config(cao_config: Dict[str, Any]) -> Dict[str, Any]:
     - ``"enabled": true`` added
     - ``env`` → ``environment`` (OpenCode's key for process env vars)
     """
-    # Resolve the bundled cao-mcp-server console script to a PATH-independent
-    # invocation before flattening into OpenCode's command list.
-    # persisted=True: OpenCode reads this from opencode.json at launch, so prefer
-    # the stable PATH launcher over a versioned venv path that upgrades relocate.
+    # Resolve only the bare bundled helper to the current CAO interpreter's
+    # sibling/module target before flattening it into OpenCode's command list.
+    # A globally resolved launcher may belong to an older CAO installation.
     command_str, args = resolve_cao_mcp_command(
-        cao_config.get("command", ""), cao_config.get("args", []) or [], persisted=True
+        cao_config.get("command", ""), cao_config.get("args", []) or []
     )
     full_command: List[str] = ([command_str] if command_str else []) + list(args)
 

--- a/src/cli_agent_orchestrator/utils/opencode_config.py
+++ b/src/cli_agent_orchestrator/utils/opencode_config.py
@@ -9,17 +9,33 @@ No file locking is applied; concurrent ``cao install --provider opencode_cli``
 invocations are not a supported scenario.
 """
 
+import copy
 import json
 import logging
+import os
+import re
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
 
-from cli_agent_orchestrator.constants import OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE, SKILLS_DIR
-from cli_agent_orchestrator.utils.mcp_resolution import resolve_cao_mcp_command
+from cli_agent_orchestrator.constants import (
+    CAO_HOME_DIR,
+    OPENCODE_CONFIG_DIR,
+    OPENCODE_CONFIG_FILE,
+    SKILLS_DIR,
+)
+from cli_agent_orchestrator.utils.mcp_resolution import (
+    CAO_MCP_SERVER_COMMAND,
+    get_cao_mcp_server_profile_args,
+    resolve_cao_mcp_command,
+)
 
 logger = logging.getLogger(__name__)
 
 _SCHEMA = "https://opencode.ai/config.json"
+_RUNTIME_CONFIG_NAME = "opencode.json"
+_CONFIG_FILES_NOT_TO_LINK = {_RUNTIME_CONFIG_NAME, "opencode.jsonc"}
+_TERMINAL_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def to_opencode_agent_id(profile_name: str) -> str:
@@ -90,6 +106,85 @@ def write_config(data: Dict[str, Any]) -> None:
         json.dumps(data, indent=2) + "\n",
         encoding="utf-8",
     )
+
+
+def prepare_opencode_runtime_config(terminal_id: str) -> Path:
+    """Create a private, per-terminal OpenCode config snapshot.
+
+    The shared config is installation/user state and must never be rewritten at
+    launch.  A private snapshot can instead replace stale CAO-owned MCP helper
+    paths with the current process's helper while retaining every user-owned
+    command and argument exactly as stored.
+    """
+    root = _runtime_config_root(terminal_id)
+    if root.is_symlink() or (root.exists() and not root.is_dir()):
+        raise RuntimeError(f"Refusing symlinked or non-directory OpenCode runtime root: {root}")
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError(f"Refusing symlinked or non-directory OpenCode runtime root: {root}")
+    os.chmod(root, 0o700)
+
+    _link_shared_config_siblings(root)
+    data = copy.deepcopy(read_config())
+    _refresh_cao_mcp_commands(data)
+    _write_runtime_config(root / _RUNTIME_CONFIG_NAME, data)
+    return root
+
+
+def _runtime_config_root(terminal_id: str) -> Path:
+    """Return the owned runtime root for a safe terminal identifier."""
+    if not _TERMINAL_ID_PATTERN.fullmatch(terminal_id):
+        raise ValueError(f"Invalid terminal ID for OpenCode runtime config: {terminal_id!r}")
+    return CAO_HOME_DIR / "tmp" / f"opencode-{terminal_id}"
+
+
+def _link_shared_config_siblings(root: Path) -> None:
+    """Expose shared assets in a runtime root without copying user state."""
+    if not OPENCODE_CONFIG_DIR.exists():
+        return
+
+    for source in OPENCODE_CONFIG_DIR.iterdir():
+        if source.name in _CONFIG_FILES_NOT_TO_LINK:
+            continue
+        destination = root / source.name
+        if destination.exists() or destination.is_symlink():
+            continue
+        destination.symlink_to(source, target_is_directory=source.is_dir())
+
+
+def _refresh_cao_mcp_commands(data: Dict[str, Any]) -> None:
+    """Refresh only verifiably CAO-owned local OpenCode MCP commands."""
+    mcp_servers = data.get("mcp")
+    if not isinstance(mcp_servers, dict):
+        return
+
+    for server_config in mcp_servers.values():
+        if not isinstance(server_config, dict):
+            continue
+        profile_args = get_cao_mcp_server_profile_args(server_config.get("command"))
+        if profile_args is None:
+            continue
+        command, args = resolve_cao_mcp_command(CAO_MCP_SERVER_COMMAND, profile_args)
+        server_config["command"] = [command, *args]
+
+
+def _write_runtime_config(path: Path, data: Dict[str, Any]) -> None:
+    """Atomically write a private config with owner-only file permissions."""
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as file:
+            file.write(json.dumps(data, indent=2) + "\n")
+            file.flush()
+            os.fchmod(file.fileno(), 0o600)
+            os.fsync(file.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
 
 def translate_mcp_server_config(cao_config: Dict[str, Any]) -> Dict[str, Any]:

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -103,25 +103,15 @@ class TestCreateSession:
 class TestCreateSessionEnvironmentFiltering:
     """Tests for environment variable filtering in create_session (#242)."""
 
-    def _get_passed_environment(self, tmux, tmp_path, env_override):
+    def _get_passed_environment(self, tmux, tmp_path, env_override, extra_env=None):
         mock_window = MagicMock()
         mock_window.name = "w"
         mock_session = MagicMock()
         mock_session.windows = [mock_window]
         tmux.server.new_session.return_value = mock_session
 
-        # Pin the sibling helper dir to "" so these tests assert env FILTERING
-        # only, independent of whether a real cao-mcp-server sits beside this
-        # test interpreter. PATH augmentation is covered by
-        # TestCreateSessionSiblingPath.
-        with (
-            patch.dict(os.environ, env_override, clear=True),
-            patch(
-                "cli_agent_orchestrator.clients.tmux.cao_mcp_server_sibling_dir",
-                return_value="",
-            ),
-        ):
-            tmux.create_session("ses", "w", "tid1", str(tmp_path))
+        with patch.dict(os.environ, env_override, clear=True):
+            tmux.create_session("ses", "w", "tid1", str(tmp_path), extra_env=extra_env)
 
         return tmux.server.new_session.call_args.kwargs["environment"]
 
@@ -230,87 +220,15 @@ class TestCreateSessionEnvironmentFiltering:
         assert "RANDOM_VAR" not in env
         assert "MY_CUSTOM_THING" not in env
 
-
-# ── create_session: cao-mcp-server sibling PATH skew ────────────────
-
-
-class TestCreateSessionSiblingPath:
-    """PATH skew fix: prefer the cao-mcp-server beside the running cao-server
-    interpreter on the spawned terminal's PATH, without breaking operator
-    overrides or no-sibling/custom launches.
-
-    The sibling detector (``cao_mcp_server_sibling_dir``) is patched directly
-    so these tests stay hermetic — no real interpreter filesystem layout is
-    asserted here (that is ``test_mcp_resolution.py``'s job).
-    """
-
-    _SIBLING_PATCH = "cli_agent_orchestrator.clients.tmux.cao_mcp_server_sibling_dir"
-
-    def _get_passed_environment(self, tmux, tmp_path, env_override, sibling_dir, extra_env=None):
-        mock_window = MagicMock()
-        mock_window.name = "w"
-        mock_session = MagicMock()
-        mock_session.windows = [mock_window]
-        tmux.server.new_session.return_value = mock_session
-
-        with (
-            patch.dict(os.environ, env_override, clear=True),
-            patch(self._SIBLING_PATCH, return_value=sibling_dir, create=True),
-        ):
-            tmux.create_session("ses", "w", "tid1", str(tmp_path), extra_env=extra_env)
-
-        return tmux.server.new_session.call_args.kwargs["environment"]
-
-    def test_sibling_dir_prepended_to_inherited_path(self, tmux, tmp_path):
-        """A sibling helper dir is prepended so the bundled helper resolves first."""
+    def test_operator_path_is_forwarded_unchanged(self, tmux, tmp_path):
+        """``cao launch --env PATH=...`` remains the pane's user-command PATH."""
         env = self._get_passed_environment(
             tmux,
             tmp_path,
-            {"HOME": "/h", "PATH": "/usr/bin:/bin"},
-            sibling_dir="/venv/bin",
-        )
-        assert env["PATH"] == f"/venv/bin{os.pathsep}/usr/bin:/bin"
-
-    def test_no_sibling_keeps_inherited_path_unchanged(self, tmux, tmp_path):
-        """No sibling executable → inherited PATH is retained verbatim."""
-        env = self._get_passed_environment(
-            tmux,
-            tmp_path,
-            {"HOME": "/h", "PATH": "/usr/bin:/bin"},
-            sibling_dir="",
-        )
-        assert env["PATH"] == "/usr/bin:/bin"
-
-    def test_operator_supplied_path_wins_over_sibling(self, tmux, tmp_path):
-        """An explicit ``--env PATH=...`` overrides; the sibling is NOT prepended."""
-        env = self._get_passed_environment(
-            tmux,
-            tmp_path,
-            {"HOME": "/h", "PATH": "/usr/bin"},
-            sibling_dir="/venv/bin",
+            {"HOME": "/home/user", "PATH": "/inherited/bin"},
             extra_env={"PATH": "/operator/bin"},
         )
         assert env["PATH"] == "/operator/bin"
-
-    def test_sibling_not_duplicated_when_already_first(self, tmux, tmp_path):
-        """Idempotent: don't prepend a dir that already leads the inherited PATH."""
-        env = self._get_passed_environment(
-            tmux,
-            tmp_path,
-            {"HOME": "/h", "PATH": "/venv/bin:/usr/bin"},
-            sibling_dir="/venv/bin",
-        )
-        assert env["PATH"] == "/venv/bin:/usr/bin"
-
-    def test_no_inherited_path_is_not_invented_from_sibling(self, tmux, tmp_path):
-        """If the process env has no PATH, don't synthesize one of just the sibling dir."""
-        env = self._get_passed_environment(
-            tmux,
-            tmp_path,
-            {"HOME": "/h"},
-            sibling_dir="/venv/bin",
-        )
-        assert "PATH" not in env
 
 
 # ── create_window ────────────────────────────────────────────────────

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -110,7 +110,17 @@ class TestCreateSessionEnvironmentFiltering:
         mock_session.windows = [mock_window]
         tmux.server.new_session.return_value = mock_session
 
-        with patch.dict(os.environ, env_override, clear=True):
+        # Pin the sibling helper dir to "" so these tests assert env FILTERING
+        # only, independent of whether a real cao-mcp-server sits beside this
+        # test interpreter. PATH augmentation is covered by
+        # TestCreateSessionSiblingPath.
+        with (
+            patch.dict(os.environ, env_override, clear=True),
+            patch(
+                "cli_agent_orchestrator.clients.tmux.cao_mcp_server_sibling_dir",
+                return_value="",
+            ),
+        ):
             tmux.create_session("ses", "w", "tid1", str(tmp_path))
 
         return tmux.server.new_session.call_args.kwargs["environment"]
@@ -219,6 +229,88 @@ class TestCreateSessionEnvironmentFiltering:
         )
         assert "RANDOM_VAR" not in env
         assert "MY_CUSTOM_THING" not in env
+
+
+# ── create_session: cao-mcp-server sibling PATH skew ────────────────
+
+
+class TestCreateSessionSiblingPath:
+    """PATH skew fix: prefer the cao-mcp-server beside the running cao-server
+    interpreter on the spawned terminal's PATH, without breaking operator
+    overrides or no-sibling/custom launches.
+
+    The sibling detector (``cao_mcp_server_sibling_dir``) is patched directly
+    so these tests stay hermetic — no real interpreter filesystem layout is
+    asserted here (that is ``test_mcp_resolution.py``'s job).
+    """
+
+    _SIBLING_PATCH = "cli_agent_orchestrator.clients.tmux.cao_mcp_server_sibling_dir"
+
+    def _get_passed_environment(self, tmux, tmp_path, env_override, sibling_dir, extra_env=None):
+        mock_window = MagicMock()
+        mock_window.name = "w"
+        mock_session = MagicMock()
+        mock_session.windows = [mock_window]
+        tmux.server.new_session.return_value = mock_session
+
+        with (
+            patch.dict(os.environ, env_override, clear=True),
+            patch(self._SIBLING_PATCH, return_value=sibling_dir, create=True),
+        ):
+            tmux.create_session("ses", "w", "tid1", str(tmp_path), extra_env=extra_env)
+
+        return tmux.server.new_session.call_args.kwargs["environment"]
+
+    def test_sibling_dir_prepended_to_inherited_path(self, tmux, tmp_path):
+        """A sibling helper dir is prepended so the bundled helper resolves first."""
+        env = self._get_passed_environment(
+            tmux,
+            tmp_path,
+            {"HOME": "/h", "PATH": "/usr/bin:/bin"},
+            sibling_dir="/venv/bin",
+        )
+        assert env["PATH"] == f"/venv/bin{os.pathsep}/usr/bin:/bin"
+
+    def test_no_sibling_keeps_inherited_path_unchanged(self, tmux, tmp_path):
+        """No sibling executable → inherited PATH is retained verbatim."""
+        env = self._get_passed_environment(
+            tmux,
+            tmp_path,
+            {"HOME": "/h", "PATH": "/usr/bin:/bin"},
+            sibling_dir="",
+        )
+        assert env["PATH"] == "/usr/bin:/bin"
+
+    def test_operator_supplied_path_wins_over_sibling(self, tmux, tmp_path):
+        """An explicit ``--env PATH=...`` overrides; the sibling is NOT prepended."""
+        env = self._get_passed_environment(
+            tmux,
+            tmp_path,
+            {"HOME": "/h", "PATH": "/usr/bin"},
+            sibling_dir="/venv/bin",
+            extra_env={"PATH": "/operator/bin"},
+        )
+        assert env["PATH"] == "/operator/bin"
+
+    def test_sibling_not_duplicated_when_already_first(self, tmux, tmp_path):
+        """Idempotent: don't prepend a dir that already leads the inherited PATH."""
+        env = self._get_passed_environment(
+            tmux,
+            tmp_path,
+            {"HOME": "/h", "PATH": "/venv/bin:/usr/bin"},
+            sibling_dir="/venv/bin",
+        )
+        assert env["PATH"] == "/venv/bin:/usr/bin"
+
+    def test_no_inherited_path_is_not_invented_from_sibling(self, tmux, tmp_path):
+        """If the process env has no PATH, don't synthesize one of just the sibling dir."""
+        env = self._get_passed_environment(
+            tmux,
+            tmp_path,
+            {"HOME": "/h"},
+            sibling_dir="/venv/bin",
+        )
+        assert "PATH" not in env
 
 
 # ── create_window ────────────────────────────────────────────────────

--- a/test/providers/test_antigravity_cli_unit.py
+++ b/test/providers/test_antigravity_cli_unit.py
@@ -294,9 +294,8 @@ def test_mcp_registration_writes_config(tmp_path, monkeypatch):
 
 def test_mcp_registration_resolves_bundled_command(tmp_path, monkeypatch):
     """The bundled bare `cao-mcp-server` command is resolved to a PATH-
-    independent invocation before it is written to mcp_config.json. agy reads
-    that file at a later launch (persisted=True), so the stable PATH launcher
-    is preferred over the versioned interpreter-sibling path."""
+    independent invocation before it is written for this terminal's agy launch.
+    Its current interpreter-sibling helper wins over an older global launcher."""
     from cli_agent_orchestrator.models.agent_profile import AgentProfile
 
     cfg = tmp_path / "mcp_config.json"
@@ -304,7 +303,12 @@ def test_mcp_registration_resolves_bundled_command(tmp_path, monkeypatch):
         name="reviewer_gemini",
         description="Reviewer",
         system_prompt="You review code.",
-        mcpServers={"cao-mcp-server": {"command": "cao-mcp-server", "args": []}},
+        mcpServers={
+            "cao-mcp-server": {
+                "command": "cao-mcp-server",
+                "args": ["--log-level", "debug"],
+            }
+        },
     )
     p = make_provider(agent_profile="reviewer_gemini")
     MOD = "cli_agent_orchestrator.utils.mcp_resolution"
@@ -325,10 +329,8 @@ def test_mcp_registration_resolves_bundled_command(tmp_path, monkeypatch):
         import json
 
         entry = json.loads(cfg.read_text())["mcpServers"]["cao-mcp-server-test-tid"]
-        # persisted=True prefers the stable PATH launcher, not the bare command
-        # or the versioned sibling.
-        assert entry["command"] == "/home/u/.local/bin/cao-mcp-server"
-        assert entry["args"] == []
+        assert entry["command"] == "/versioned/venv/bin/cao-mcp-server"
+        assert entry["args"] == ["--log-level", "debug"]
 
 
 # --------------------------------------------------------------------------- #

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -577,6 +577,27 @@ class TestInitialize:
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
+    async def test_initialize_promotes_dependencies_after_ready(
+        self, mock_tmux, mock_shell, mock_wait, monkeypatch: pytest.MonkeyPatch
+    ):
+        mock_shell.return_value = True
+        mock_wait.return_value = True
+        promoted = []
+        monkeypatch.setattr(
+            opencode_provider_module,
+            "promote_opencode_runtime_dependencies",
+            promoted.append,
+        )
+
+        provider = make_provider()
+        assert await provider.initialize() is True
+
+        assert promoted == [provider._config_root]
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.opencode_cli.get_backend")
     async def test_initialize_uses_120s_timeout(self, mock_tmux, mock_shell, mock_wait):
         mock_shell.return_value = True
         mock_wait.return_value = True
@@ -680,6 +701,20 @@ class TestMiscInterface:
         provider._initialized = True
         provider.cleanup()
         assert provider._initialized is False
+
+    def test_cleanup_removes_runtime_root_after_provider_reconstruction(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Restart reconstruction has no in-memory root but must still clean it."""
+        cao_home = tmp_path / "cao-home"
+        runtime_root = cao_home / "tmp" / "opencode-test-tid"
+        runtime_root.mkdir(parents=True)
+        (runtime_root / "opencode.json").write_text("{}\n", encoding="utf-8")
+        monkeypatch.setattr(opencode_provider_module, "CAO_HOME_DIR", cao_home)
+
+        make_provider().cleanup()
+
+        assert not runtime_root.exists()
 
     def test_get_idle_pattern_for_log_returns_ctrl_p_pattern(self):
         pattern = make_provider().get_idle_pattern_for_log()

--- a/test/providers/test_opencode_cli_unit.py
+++ b/test/providers/test_opencode_cli_unit.py
@@ -1,11 +1,16 @@
 """Unit tests for the OpenCode CLI provider."""
 
+import json
 import re
+import shlex
+import stat
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import cli_agent_orchestrator.providers.opencode_cli as opencode_provider_module
+import cli_agent_orchestrator.utils.opencode_config as opencode_config_module
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.opencode_cli import (
     ANSI_CODE_PATTERN,
@@ -17,6 +22,7 @@ from cli_agent_orchestrator.providers.opencode_cli import (
     USER_MESSAGE_PATTERN,
     OpenCodeCliProvider,
 )
+from cli_agent_orchestrator.utils.mcp_resolution import CAO_MCP_SERVER_MODULE
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -32,10 +38,12 @@ def load_ansi_fixture(name: str) -> str:
 
 
 def make_provider(
-    agent_profile: str = "developer", model: str | None = None
+    agent_profile: str = "developer",
+    model: str | None = None,
+    terminal_id: str = "test-tid",
 ) -> OpenCodeCliProvider:
     return OpenCodeCliProvider(
-        terminal_id="test-tid",
+        terminal_id=terminal_id,
         session_name="test-session",
         window_name="window-0",
         agent_profile=agent_profile,
@@ -406,6 +414,155 @@ class TestExtractLastMessage:
 
 
 class TestInitialize:
+    @pytest.fixture(autouse=True)
+    def stub_private_config(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        """Keep mocked provider lifecycle tests away from shared OpenCode state."""
+        monkeypatch.setattr(
+            opencode_provider_module,
+            "prepare_opencode_runtime_config",
+            lambda _terminal_id: tmp_path / "opencode-runtime",
+            raising=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_initialize_uses_private_config_and_refreshes_only_owned_helpers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Launch snapshots shared config without rewriting user-owned state."""
+        shared_config_dir = tmp_path / "shared-opencode"
+        config_file = shared_config_dir / "opencode.json"
+        old_helper = tmp_path / "old-install" / "cao-mcp-server"
+        old_helper.parent.mkdir(parents=True)
+        old_helper.write_text(
+            "from cli_agent_orchestrator.mcp_server.server import main\n",
+            encoding="utf-8",
+        )
+        custom_helper = tmp_path / "custom" / "cao-mcp-server"
+        custom_helper.parent.mkdir(parents=True)
+        custom_helper.write_text("#!/bin/sh\necho custom\n", encoding="utf-8")
+        custom_server = {
+            "type": "local",
+            "command": [str(custom_helper), "--custom-flag"],
+            "enabled": True,
+        }
+        (shared_config_dir / "agents").mkdir(parents=True)
+        (shared_config_dir / "plugin-state.json").write_text("{}", encoding="utf-8")
+        (shared_config_dir / "opencode.jsonc").write_text("{}", encoding="utf-8")
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "orchestration-alias": {
+                            "type": "local",
+                            "command": [str(old_helper), "--verbose"],
+                            "enabled": True,
+                        },
+                        "bare-alias": {"type": "local", "command": ["cao-mcp-server", "--bare"]},
+                        "module-alias": {
+                            "type": "local",
+                            "command": [
+                                "/old-install/python",
+                                "-m",
+                                CAO_MCP_SERVER_MODULE,
+                                "--module",
+                            ],
+                        },
+                        "user-server": custom_server,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        source_before = config_file.read_text(encoding="utf-8")
+        cao_home = tmp_path / "cao home;$runtime"
+
+        monkeypatch.setattr(opencode_config_module, "OPENCODE_CONFIG_DIR", shared_config_dir)
+        monkeypatch.setattr(opencode_config_module, "OPENCODE_CONFIG_FILE", config_file)
+        monkeypatch.setattr(opencode_config_module, "CAO_HOME_DIR", cao_home, raising=False)
+        monkeypatch.setattr(opencode_provider_module, "CAO_HOME_DIR", cao_home, raising=False)
+        monkeypatch.setattr(opencode_provider_module, "OPENCODE_CONFIG_DIR", shared_config_dir)
+        monkeypatch.setattr(opencode_provider_module, "OPENCODE_CONFIG_FILE", config_file)
+        monkeypatch.setattr(
+            opencode_provider_module,
+            "prepare_opencode_runtime_config",
+            getattr(opencode_config_module, "prepare_opencode_runtime_config", None),
+            raising=False,
+        )
+        current_helper = ["/new-install/one/cao-mcp-server"]
+        monkeypatch.setattr(
+            opencode_config_module,
+            "resolve_cao_mcp_command",
+            lambda command, args: (current_helper[0], list(args)),
+        )
+
+        async def shell_ready(*_args, **_kwargs):
+            return True
+
+        async def opencode_ready(*_args, **_kwargs):
+            return True
+
+        backend = MagicMock()
+        monkeypatch.setattr(opencode_provider_module, "wait_for_shell", shell_ready)
+        monkeypatch.setattr(opencode_provider_module, "wait_until_status", opencode_ready)
+        monkeypatch.setattr(opencode_provider_module, "get_backend", lambda: backend)
+        monkeypatch.setattr(
+            opencode_provider_module,
+            "get_server_settings",
+            lambda: {"provider_init_timeout": 1},
+        )
+
+        provider = make_provider()
+        assert await provider.initialize() is True
+
+        private_root = cao_home / "tmp" / "opencode-test-tid"
+        private_config = private_root / "opencode.json"
+        data = json.loads(private_config.read_text(encoding="utf-8"))
+        assert data["mcp"]["orchestration-alias"]["command"] == [
+            "/new-install/one/cao-mcp-server",
+            "--verbose",
+        ]
+        assert data["mcp"]["bare-alias"]["command"] == [
+            "/new-install/one/cao-mcp-server",
+            "--bare",
+        ]
+        assert data["mcp"]["module-alias"]["command"] == [
+            "/new-install/one/cao-mcp-server",
+            "--module",
+        ]
+        assert data["mcp"]["user-server"] == custom_server
+        assert config_file.read_text(encoding="utf-8") == source_before
+        assert stat.S_IMODE(private_root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(private_config.stat().st_mode) == 0o600
+        assert (private_root / "agents").is_symlink()
+        assert (private_root / "agents").resolve() == (shared_config_dir / "agents").resolve()
+        assert (private_root / "plugin-state.json").is_symlink()
+        assert not (private_root / "opencode.jsonc").exists()
+        launch_command = backend.send_keys.call_args.args[2]
+        assert f"OPENCODE_CONFIG={shlex.quote(str(private_config))}" in launch_command
+        assert f"OPENCODE_CONFIG_DIR={shlex.quote(str(private_root))}" in launch_command
+        assert shlex.split(launch_command)[:2] == [
+            f"OPENCODE_CONFIG={private_config}",
+            f"OPENCODE_CONFIG_DIR={private_root}",
+        ]
+
+        current_helper[0] = "/new-install/two/cao-mcp-server"
+        second_provider = make_provider(terminal_id="test-tid-two")
+        assert await second_provider.initialize() is True
+        second_root = cao_home / "tmp" / "opencode-test-tid-two"
+        second_data = json.loads((second_root / "opencode.json").read_text(encoding="utf-8"))
+        assert second_data["mcp"]["orchestration-alias"]["command"] == [
+            "/new-install/two/cao-mcp-server",
+            "--verbose",
+        ]
+        assert data["mcp"]["orchestration-alias"]["command"][0] == "/new-install/one/cao-mcp-server"
+
+        provider.cleanup()
+        assert not private_root.exists()
+        assert second_root.exists()
+        assert config_file.read_text(encoding="utf-8") == source_before
+        second_provider.cleanup()
+        assert not second_root.exists()
+
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.opencode_cli.wait_for_shell")

--- a/test/providers/test_provider_manager_unit.py
+++ b/test/providers/test_provider_manager_unit.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import cli_agent_orchestrator.providers.opencode_cli as opencode_provider_module
 from cli_agent_orchestrator.models.provider import ProviderType
 from cli_agent_orchestrator.providers.codex import CodexProvider
 from cli_agent_orchestrator.providers.copilot_cli import CopilotCliProvider
@@ -110,6 +111,43 @@ def test_cleanup_provider_calls_cleanup_and_removes():
     manager.cleanup_provider("t1")
 
     provider.cleanup.assert_called_once()
+    assert manager._providers.get("t1") is None
+
+
+def test_cleanup_provider_reconstructs_persisted_terminal_after_restart():
+    """Deletion must reach provider-owned cleanup after process restart."""
+    manager = ProviderManager()
+    restored_provider = MagicMock()
+
+    with patch.object(manager, "get_provider", return_value=restored_provider) as get_provider:
+        manager.cleanup_provider("t1")
+
+    get_provider.assert_called_once_with("t1")
+    restored_provider.cleanup.assert_called_once()
+    assert manager._providers.get("t1") is None
+
+
+def test_cleanup_provider_removes_opencode_runtime_after_restart(tmp_path, monkeypatch):
+    """The actual OpenCode cleanup path runs after manager reconstruction."""
+    manager = ProviderManager()
+    cao_home = tmp_path / "cao-home"
+    runtime_root = cao_home / "tmp" / "opencode-t1"
+    runtime_root.mkdir(parents=True)
+    (runtime_root / "opencode.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(opencode_provider_module, "CAO_HOME_DIR", cao_home)
+
+    with patch(
+        "cli_agent_orchestrator.providers.manager.get_terminal_metadata",
+        return_value={
+            "provider": ProviderType.OPENCODE_CLI.value,
+            "tmux_session": "s1",
+            "tmux_window": "w1",
+            "agent_profile": "developer",
+        },
+    ):
+        manager.cleanup_provider("t1")
+
+    assert not runtime_root.exists()
     assert manager._providers.get("t1") is None
 
 

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -288,13 +288,15 @@ class TestInstallAgent:
         # persisted=True prefers the stable PATH launcher.
         assert entry["command"] == "/home/u/.local/bin/cao-mcp-server"
 
-    def test_install_opencode_uses_current_sibling_not_old_global_helper(
+    def test_install_opencode_keeps_bundled_helper_canonical(
         self, install_paths: dict[str, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """OpenCode's actual MCP command binds the bare bundled helper to CAO.
+        """OpenCode's durable MCP entry never records an installation path.
 
-        The old global executable simulates a stale installation on PATH.  A
-        custom entry and both servers' caller-supplied args must remain intact.
+        The old global executable simulates a stale installation on PATH.
+        Runtime snapshots, rather than this durable config, resolve the bare
+        helper against the active CAO server. A custom entry and both servers'
+        caller-supplied args must remain intact.
         """
         profile_text = (
             "---\n"
@@ -316,23 +318,18 @@ class TestInstallAgent:
             profile_text, encoding="utf-8"
         )
 
-        sibling = tmp_path / "server-bin" / "cao-mcp-server"
-        sibling.parent.mkdir()
-        sibling.touch()
         old_global = tmp_path / "old-global" / "cao-mcp-server"
         old_global.parent.mkdir()
         old_global.write_text("#!/bin/sh\n", encoding="utf-8")
         old_global.chmod(0o755)
         monkeypatch.setenv("PATH", str(old_global.parent))
 
-        MOD = "cli_agent_orchestrator.utils.mcp_resolution"
-        with patch(f"{MOD}._sibling_script", return_value=str(sibling)):
-            result = install_agent("opencode-agent", "opencode_cli")
+        result = install_agent("opencode-agent", "opencode_cli")
 
         assert result.success is True
         config = json.loads(install_paths["opencode_config_file"].read_text())
         assert config["mcp"]["cao-mcp-server"]["command"] == [
-            str(sibling),
+            "cao-mcp-server",
             "--log-level",
             "debug",
         ]

--- a/test/services/test_install_service.py
+++ b/test/services/test_install_service.py
@@ -44,6 +44,10 @@ def install_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, 
     context_dir = tmp_path / "agent-context"
     kiro_dir = tmp_path / "kiro"
     copilot_dir = tmp_path / "copilot"
+    opencode_agents_dir = tmp_path / "opencode-agents"
+    opencode_config_dir = tmp_path / "opencode"
+    opencode_config_file = opencode_config_dir / "opencode.json"
+    skills_dir = tmp_path / "skills"
     provider_dir = tmp_path / "provider"
     extra_dir = tmp_path / "extra"
     env_file = tmp_path / ".env"
@@ -53,6 +57,8 @@ def install_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, 
         context_dir,
         kiro_dir,
         copilot_dir,
+        opencode_agents_dir,
+        skills_dir,
         provider_dir,
         extra_dir,
     ):
@@ -75,6 +81,19 @@ def install_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, 
         "cli_agent_orchestrator.services.install_service.COPILOT_AGENTS_DIR",
         copilot_dir,
     )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.install_service.OPENCODE_AGENTS_DIR",
+        opencode_agents_dir,
+    )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.utils.opencode_config.OPENCODE_CONFIG_DIR",
+        opencode_config_dir,
+    )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.utils.opencode_config.OPENCODE_CONFIG_FILE",
+        opencode_config_file,
+    )
+    monkeypatch.setattr("cli_agent_orchestrator.utils.opencode_config.SKILLS_DIR", skills_dir)
     monkeypatch.setattr("cli_agent_orchestrator.utils.env.CAO_ENV_FILE", env_file)
     monkeypatch.setattr(
         "cli_agent_orchestrator.services.settings_service.get_agent_dirs",
@@ -90,6 +109,8 @@ def install_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, 
         "context_dir": context_dir,
         "kiro_dir": kiro_dir,
         "copilot_dir": copilot_dir,
+        "opencode_agents_dir": opencode_agents_dir,
+        "opencode_config_file": opencode_config_file,
         "provider_dir": provider_dir,
         "extra_dir": extra_dir,
         "env_file": env_file,
@@ -266,6 +287,56 @@ class TestInstallAgent:
         entry = kiro_config["mcpServers"]["cao-mcp-server"]
         # persisted=True prefers the stable PATH launcher.
         assert entry["command"] == "/home/u/.local/bin/cao-mcp-server"
+
+    def test_install_opencode_uses_current_sibling_not_old_global_helper(
+        self, install_paths: dict[str, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """OpenCode's actual MCP command binds the bare bundled helper to CAO.
+
+        The old global executable simulates a stale installation on PATH.  A
+        custom entry and both servers' caller-supplied args must remain intact.
+        """
+        profile_text = (
+            "---\n"
+            "name: opencode-agent\n"
+            "description: Test agent\n"
+            "role: developer\n"
+            "mcpServers:\n"
+            "  cao-mcp-server:\n"
+            "    command: cao-mcp-server\n"
+            "    args: [--log-level, debug]\n"
+            "  user-server:\n"
+            "    command: custom-mcp\n"
+            "    args: [--port, '9876']\n"
+            "prompt: |\n  Do work\n"
+            "---\n"
+            "Body.\n"
+        )
+        (install_paths["local_store_dir"] / "opencode-agent.md").write_text(
+            profile_text, encoding="utf-8"
+        )
+
+        sibling = tmp_path / "server-bin" / "cao-mcp-server"
+        sibling.parent.mkdir()
+        sibling.touch()
+        old_global = tmp_path / "old-global" / "cao-mcp-server"
+        old_global.parent.mkdir()
+        old_global.write_text("#!/bin/sh\n", encoding="utf-8")
+        old_global.chmod(0o755)
+        monkeypatch.setenv("PATH", str(old_global.parent))
+
+        MOD = "cli_agent_orchestrator.utils.mcp_resolution"
+        with patch(f"{MOD}._sibling_script", return_value=str(sibling)):
+            result = install_agent("opencode-agent", "opencode_cli")
+
+        assert result.success is True
+        config = json.loads(install_paths["opencode_config_file"].read_text())
+        assert config["mcp"]["cao-mcp-server"]["command"] == [
+            str(sibling),
+            "--log-level",
+            "debug",
+        ]
+        assert config["mcp"]["user-server"]["command"] == ["custom-mcp", "--port", "9876"]
 
     def test_install_rejects_kas_profile_before_writing_kiro_config(
         self, install_paths: dict[str, Path]

--- a/test/utils/test_mcp_resolution.py
+++ b/test/utils/test_mcp_resolution.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from cli_agent_orchestrator.utils.mcp_resolution import (
     CAO_MCP_SERVER_MODULE,
+    get_cao_mcp_server_profile_args,
     resolve_cao_mcp_command,
     resolve_mcp_server_config,
 )
@@ -26,6 +27,55 @@ class TestPassthrough:
         assert args == original
         args.append("mutated")
         assert original == ["--from", "pkg"]
+
+
+class TestStoredCaoCommandRecognition:
+    """Only verifiable stored CAO commands can be refreshed at runtime."""
+
+    def test_bare_helper_preserves_profile_args(self):
+        assert get_cao_mcp_server_profile_args(["cao-mcp-server", "--verbose"]) == ["--verbose"]
+
+    def test_module_fallback_preserves_only_profile_args(self):
+        assert get_cao_mcp_server_profile_args(
+            ["/old-install/python", "-m", CAO_MCP_SERVER_MODULE, "--verbose"]
+        ) == ["--verbose"]
+
+    def test_generated_console_script_is_recognized(self, tmp_path):
+        helper = tmp_path / "cao-mcp-server"
+        helper.write_text(
+            "from cli_agent_orchestrator.mcp_server.server import main\n",
+            encoding="utf-8",
+        )
+
+        assert get_cao_mcp_server_profile_args([str(helper), "--verbose"]) == ["--verbose"]
+
+    def test_same_basename_custom_script_is_not_recognized(self, tmp_path):
+        helper = tmp_path / "cao-mcp-server"
+        helper.write_text("#!/bin/sh\necho custom\n", encoding="utf-8")
+
+        assert get_cao_mcp_server_profile_args([str(helper), "--custom"]) is None
+
+    def test_missing_console_script_is_not_recognized(self, tmp_path):
+        assert get_cao_mcp_server_profile_args([str(tmp_path / "cao-mcp-server")]) is None
+
+    def test_unreadable_console_script_is_not_recognized(self, tmp_path):
+        helper = tmp_path / "cao-mcp-server"
+        helper.write_text(
+            "from cli_agent_orchestrator.mcp_server.server import main\n",
+            encoding="utf-8",
+        )
+
+        with patch(f"{MOD}.Path.open", side_effect=OSError("denied")):
+            assert get_cao_mcp_server_profile_args([str(helper)]) is None
+
+    def test_oversized_console_script_is_not_recognized(self, tmp_path):
+        helper = tmp_path / "cao-mcp-server"
+        helper.write_text(
+            "from cli_agent_orchestrator.mcp_server.server import main\n" + "x" * 65536,
+            encoding="utf-8",
+        )
+
+        assert get_cao_mcp_server_profile_args([str(helper)]) is None
 
 
 class TestSiblingScript:

--- a/test/utils/test_mcp_resolution.py
+++ b/test/utils/test_mcp_resolution.py
@@ -61,6 +61,44 @@ class TestSiblingScript:
             assert _sibling_script() == ""
 
 
+class TestSiblingDir:
+    """cao_mcp_server_sibling_dir: the *directory* of the interpreter-sibling
+    helper, for callers that put it on PATH rather than invoke it directly."""
+
+    def test_returns_parent_dir_when_script_exists(self, tmp_path):
+        from cli_agent_orchestrator.utils.mcp_resolution import (
+            _SCRIPT_FILENAME,
+            cao_mcp_server_sibling_dir,
+        )
+
+        fake_python = tmp_path / "python3"
+        fake_python.touch()
+        (tmp_path / _SCRIPT_FILENAME).touch()
+        with patch(f"{MOD}.sys") as mock_sys:
+            mock_sys.executable = str(fake_python)
+            assert cao_mcp_server_sibling_dir() == str(tmp_path)
+
+    def test_returns_empty_when_script_missing(self, tmp_path):
+        from cli_agent_orchestrator.utils.mcp_resolution import (
+            cao_mcp_server_sibling_dir,
+        )
+
+        fake_python = tmp_path / "python3"
+        fake_python.touch()
+        with patch(f"{MOD}.sys") as mock_sys:
+            mock_sys.executable = str(fake_python)
+            assert cao_mcp_server_sibling_dir() == ""
+
+    def test_returns_empty_for_empty_sys_executable(self):
+        from cli_agent_orchestrator.utils.mcp_resolution import (
+            cao_mcp_server_sibling_dir,
+        )
+
+        with patch(f"{MOD}.sys") as mock_sys:
+            mock_sys.executable = ""
+            assert cao_mcp_server_sibling_dir() == ""
+
+
 class TestArgsPreservation:
     """Caller-supplied args survive resolution in every tier."""
 

--- a/test/utils/test_mcp_resolution.py
+++ b/test/utils/test_mcp_resolution.py
@@ -61,44 +61,6 @@ class TestSiblingScript:
             assert _sibling_script() == ""
 
 
-class TestSiblingDir:
-    """cao_mcp_server_sibling_dir: the *directory* of the interpreter-sibling
-    helper, for callers that put it on PATH rather than invoke it directly."""
-
-    def test_returns_parent_dir_when_script_exists(self, tmp_path):
-        from cli_agent_orchestrator.utils.mcp_resolution import (
-            _SCRIPT_FILENAME,
-            cao_mcp_server_sibling_dir,
-        )
-
-        fake_python = tmp_path / "python3"
-        fake_python.touch()
-        (tmp_path / _SCRIPT_FILENAME).touch()
-        with patch(f"{MOD}.sys") as mock_sys:
-            mock_sys.executable = str(fake_python)
-            assert cao_mcp_server_sibling_dir() == str(tmp_path)
-
-    def test_returns_empty_when_script_missing(self, tmp_path):
-        from cli_agent_orchestrator.utils.mcp_resolution import (
-            cao_mcp_server_sibling_dir,
-        )
-
-        fake_python = tmp_path / "python3"
-        fake_python.touch()
-        with patch(f"{MOD}.sys") as mock_sys:
-            mock_sys.executable = str(fake_python)
-            assert cao_mcp_server_sibling_dir() == ""
-
-    def test_returns_empty_for_empty_sys_executable(self):
-        from cli_agent_orchestrator.utils.mcp_resolution import (
-            cao_mcp_server_sibling_dir,
-        )
-
-        with patch(f"{MOD}.sys") as mock_sys:
-            mock_sys.executable = ""
-            assert cao_mcp_server_sibling_dir() == ""
-
-
 class TestArgsPreservation:
     """Caller-supplied args survive resolution in every tier."""
 
@@ -145,14 +107,19 @@ class TestRuntimeResolution:
         assert cmd == "/venv/bin/cao-mcp-server"
         assert args == []
 
-    def test_falls_back_to_path_when_no_sibling(self):
+    def test_falls_back_to_module_when_no_sibling_even_if_path_has_helper(self):
         with (
             patch(f"{MOD}._sibling_script", return_value=""),
-            patch(f"{MOD}.shutil.which", return_value="/usr/local/bin/cao-mcp-server"),
+            patch(
+                f"{MOD}.shutil.which", return_value="/usr/local/bin/cao-mcp-server"
+            ) as mock_which,
+            patch(f"{MOD}.sys") as mock_sys,
         ):
+            mock_sys.executable = "/current/venv/bin/python3"
             cmd, args = resolve_cao_mcp_command("cao-mcp-server", [])
-        assert cmd == "/usr/local/bin/cao-mcp-server"
-        assert args == []
+        mock_which.assert_not_called()
+        assert cmd == "/current/venv/bin/python3"
+        assert args == ["-m", CAO_MCP_SERVER_MODULE]
 
     def test_falls_back_to_module_entrypoint(self):
         """No sibling, nothing on PATH → run the module via the interpreter."""
@@ -209,7 +176,9 @@ class TestResolveMcpServerConfig:
         with (
             patch(f"{MOD}._sibling_script", return_value=""),
             patch(f"{MOD}.shutil.which", return_value="/usr/local/bin/cao-mcp-server"),
+            patch(f"{MOD}.sys") as mock_sys,
         ):
+            mock_sys.executable = "/current/venv/bin/python3"
             out = resolve_mcp_server_config(
                 {
                     "type": "stdio",
@@ -218,8 +187,8 @@ class TestResolveMcpServerConfig:
                     "env": {"CAO_TERMINAL_ID": "abc"},
                 }
             )
-        assert out["command"] == "/usr/local/bin/cao-mcp-server"
-        assert out["args"] == []
+        assert out["command"] == "/current/venv/bin/python3"
+        assert out["args"] == ["-m", CAO_MCP_SERVER_MODULE]
         assert out["type"] == "stdio"
         assert out["env"] == {"CAO_TERMINAL_ID": "abc"}
 
@@ -241,11 +210,13 @@ class TestResolveMcpServerConfig:
         with (
             patch(f"{MOD}._sibling_script", return_value=""),
             patch(f"{MOD}.shutil.which", return_value="/usr/local/bin/cao-mcp-server"),
+            patch(f"{MOD}.sys") as mock_sys,
         ):
+            mock_sys.executable = "/current/venv/bin/python3"
             once = resolve_mcp_server_config({"command": "cao-mcp-server", "args": []})
             twice = resolve_mcp_server_config(once)
         assert once == twice
-        assert twice["command"] == "/usr/local/bin/cao-mcp-server"
+        assert twice["command"] == "/current/venv/bin/python3"
 
     def test_persisted_forwarded(self):
         with (

--- a/test/utils/test_opencode_config.py
+++ b/test/utils/test_opencode_config.py
@@ -1,6 +1,7 @@
 """Unit tests for the opencode.json read-modify-write helper."""
 
 import json
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
@@ -140,9 +141,9 @@ class TestTranslateMcpServerConfig:
     def test_custom_uvx_entry_passes_through(self):
         """A user-defined uvx-based MCP server is translated verbatim.
 
-        Only the bundled ``cao-mcp-server`` command is rewritten (see
-        test_bundled_cao_mcp_server_command_is_resolved); any other command —
-        including a user's own ``uvx --from ...`` server — flattens unchanged.
+        Only the bundled ``cao-mcp-server`` command receives CAO ownership
+        handling at runtime; any other command — including a user's own
+        ``uvx --from ...`` server — flattens unchanged.
         """
         cao_cfg = {
             "type": "stdio",
@@ -156,22 +157,19 @@ class TestTranslateMcpServerConfig:
             "enabled": True,
         }
 
-    def test_bundled_cao_mcp_server_command_is_resolved(self):
-        """The bare cao-mcp-server command is resolved to a PATH-independent form.
+    def test_bundled_cao_mcp_server_command_stays_canonical_until_runtime(self):
+        """The durable template keeps the CAO-owned command upgrade-safe.
 
-        The bundled profiles declare ``command: cao-mcp-server``; the translator
-        resolves it so OpenCode launches it without depending on
-        the script being on the agent subprocess's PATH.
+        Runtime snapshots resolve this bare form with the active server
+        interpreter.  Persisting an absolute sibling path here would become
+        stale when a prior virtual environment is removed.
         """
         result = translate_mcp_server_config(
             {"type": "stdio", "command": "cao-mcp-server", "args": []}
         )
         assert result["type"] == "local"
         assert result["enabled"] is True
-        # Resolved away from the bare console-script name into a concrete
-        # invocation (abs path to the script, or `<python> -m ...`).
-        assert result["command"][0] != "cao-mcp-server"
-        assert result["command"]  # non-empty
+        assert result["command"] == ["cao-mcp-server"]
 
 
 class TestReadConfig:
@@ -206,6 +204,134 @@ class TestWriteConfig:
 
 
 class TestRuntimeConfig:
+    def test_refreshes_removed_legacy_helper_for_reserved_cao_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A prior CAO sibling path remains refreshable after an upgrade."""
+        shared_config_dir = tmp_path / "shared-opencode"
+        shared_config_dir.mkdir()
+        config_file = shared_config_dir / "opencode.json"
+        removed_helper = tmp_path / "removed-venv" / "cao-mcp-server"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "cao-mcp-server": {
+                            "type": "local",
+                            "command": [str(removed_helper), "--verbose"],
+                        },
+                        "custom-server": {
+                            "type": "local",
+                            "command": [str(removed_helper), "--custom"],
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cao_home = tmp_path / "cao-home"
+        monkeypatch.setattr(cfg_module, "CAO_HOME_DIR", cao_home)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_DIR", shared_config_dir)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_FILE", config_file)
+        monkeypatch.setattr(
+            cfg_module,
+            "resolve_cao_mcp_command",
+            lambda command, args: ("/new-venv/cao-mcp-server", list(args)),
+        )
+
+        runtime_root = prepare_opencode_runtime_config("terminal")
+        runtime = json.loads((runtime_root / "opencode.json").read_text(encoding="utf-8"))
+        assert runtime["mcp"]["cao-mcp-server"]["command"] == [
+            "/new-venv/cao-mcp-server",
+            "--verbose",
+        ]
+        assert runtime["mcp"]["custom-server"]["command"] == [
+            str(removed_helper),
+            "--custom",
+        ]
+
+    def test_promotes_first_launch_dependencies_for_later_runtime_roots(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The first private launch seeds a persistent dependency cache once."""
+        shared_config_dir = tmp_path / "shared-opencode"
+        shared_config_dir.mkdir()
+        config_file = shared_config_dir / "opencode.json"
+        config_file.write_text("{}\n", encoding="utf-8")
+        cao_home = tmp_path / "cao-home"
+        monkeypatch.setattr(cfg_module, "CAO_HOME_DIR", cao_home)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_DIR", shared_config_dir)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_FILE", config_file)
+
+        first_root = prepare_opencode_runtime_config("first")
+        (first_root / "package.json").write_text('{"dependencies": {}}\n', encoding="utf-8")
+        (first_root / "package-lock.json").write_text('{"lockfileVersion": 3}\n', encoding="utf-8")
+        (first_root / "node_modules").mkdir()
+        (first_root / "node_modules" / "installed.txt").write_text("ready\n", encoding="utf-8")
+
+        promote = getattr(cfg_module, "promote_opencode_runtime_dependencies")
+        promote(first_root)
+
+        second_root = prepare_opencode_runtime_config("second")
+        assert (second_root / "package.json").is_symlink()
+        assert (second_root / "package-lock.json").is_symlink()
+        assert (second_root / "node_modules").is_symlink()
+        assert (second_root / "node_modules" / "installed.txt").read_text(
+            encoding="utf-8"
+        ) == "ready\n"
+        assert (shared_config_dir / ".cao-runtime-dependencies" / ".cao-complete").read_text(
+            encoding="utf-8"
+        ) == "cao-opencode-runtime-dependencies-v1\n"
+
+    def test_does_not_reuse_unverified_shared_dependencies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Only CAO's completed cache can seed a private runtime root."""
+        shared_config_dir = tmp_path / "shared-opencode"
+        shared_config_dir.mkdir()
+        config_file = shared_config_dir / "opencode.json"
+        config_file.write_text("{}\n", encoding="utf-8")
+        (shared_config_dir / "package.json").write_text("{}\n", encoding="utf-8")
+        (shared_config_dir / "node_modules").mkdir()
+        (shared_config_dir / "node_modules" / "installed.txt").write_text(
+            "shared\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(cfg_module, "CAO_HOME_DIR", tmp_path / "cao-home")
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_DIR", shared_config_dir)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_FILE", config_file)
+
+        runtime_root = prepare_opencode_runtime_config("terminal")
+
+        assert not (runtime_root / "package.json").exists()
+        assert not (runtime_root / "node_modules").exists()
+        assert not (shared_config_dir / ".cao-runtime-dependencies").exists()
+
+    def test_dependency_promotion_failure_does_not_break_ready_terminal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Best-effort caching cannot turn a ready OpenCode launch into failure."""
+        shared_config_dir = tmp_path / "shared-opencode"
+        shared_config_dir.mkdir()
+        config_file = shared_config_dir / "opencode.json"
+        config_file.write_text("{}\n", encoding="utf-8")
+        monkeypatch.setattr(cfg_module, "CAO_HOME_DIR", tmp_path / "cao-home")
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_DIR", shared_config_dir)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_FILE", config_file)
+
+        runtime_root = prepare_opencode_runtime_config("terminal")
+        (runtime_root / "package.json").write_text("{}\n", encoding="utf-8")
+        (runtime_root / "node_modules").mkdir()
+        monkeypatch.setattr(
+            cfg_module.shutil,
+            "copytree",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(shutil.Error([("src", "dst", "boom")])),
+        )
+
+        cfg_module.promote_opencode_runtime_dependencies(runtime_root)
+
+        assert not (shared_config_dir / ".cao-runtime-dependencies").exists()
+
     def test_rejects_existing_symlinked_root_without_touching_target(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):

--- a/test/utils/test_opencode_config.py
+++ b/test/utils/test_opencode_config.py
@@ -9,6 +9,7 @@ import pytest
 import cli_agent_orchestrator.utils.opencode_config as cfg_module
 from cli_agent_orchestrator.utils.opencode_config import (
     ensure_skills_symlink,
+    prepare_opencode_runtime_config,
     read_config,
     remove_agent_tools,
     translate_mcp_server_config,
@@ -202,6 +203,38 @@ class TestWriteConfig:
     def test_file_ends_with_newline(self, tmp_config: Path):
         write_config({"x": 1})
         assert tmp_config.read_text(encoding="utf-8").endswith("\n")
+
+
+class TestRuntimeConfig:
+    def test_rejects_existing_symlinked_root_without_touching_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        shared_config_dir = tmp_path / "shared-opencode"
+        shared_config_dir.mkdir()
+        shared_config = shared_config_dir / "opencode.json"
+        shared_config.write_text('{"shared": true}\n', encoding="utf-8")
+        source_before = shared_config.read_text(encoding="utf-8")
+
+        cao_home = tmp_path / "cao-home"
+        target_root = tmp_path / "shared-target"
+        target_root.mkdir()
+        target_config = target_root / "opencode.json"
+        target_config.write_text('{"target": true}\n', encoding="utf-8")
+        target_before = target_config.read_text(encoding="utf-8")
+
+        runtime_root = cao_home / "tmp" / "opencode-terminal"
+        runtime_root.parent.mkdir(parents=True)
+        runtime_root.symlink_to(target_root, target_is_directory=True)
+
+        monkeypatch.setattr(cfg_module, "CAO_HOME_DIR", cao_home)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_DIR", shared_config_dir)
+        monkeypatch.setattr(cfg_module, "OPENCODE_CONFIG_FILE", shared_config)
+
+        with pytest.raises(RuntimeError, match="symlinked or non-directory"):
+            prepare_opencode_runtime_config("terminal")
+
+        assert target_config.read_text(encoding="utf-8") == target_before
+        assert shared_config.read_text(encoding="utf-8") == source_before
 
 
 class TestUpsertMcpServer:


### PR DESCRIPTION
## Why

Built-in profiles invoke `cao-mcp-server` by name. If `cao-server` is running from a newer worktree or virtual environment while its inherited `PATH` resolves an older globally installed `cao-mcp-server`, tmux-created agents start the mismatched helper instead. In the observed Pi-provider setup, that stale helper did not recognize the selected Pi provider, so a new worker silently fell back to OpenCode.

## Change

- For tmux-created agent sessions, prefer the `cao-mcp-server` installed beside the interpreter running `cao-server` by prepending its directory to inherited `PATH`.
- Preserve explicit `cao launch --env PATH=...` precedence by merging operator environment overrides afterward.
- Leave custom/no-sibling launches unchanged; worker windows receive the value through tmux session-environment inheritance.
- Add hermetic regression coverage for sibling discovery and PATH composition.

## Validation

- `.venv/bin/python -m pytest --no-cov -q test/clients/ test/utils/test_mcp_resolution.py test/backends/test_tmux_backend.py test/providers/test_tmux_working_directory.py -m "not integration"` (321 passed, 1 skipped)
- `.venv/bin/black --check` on changed files
- `.venv/bin/isort --check-only` on changed files
- `.venv/bin/mypy src/cli_agent_orchestrator/clients/tmux.py src/cli_agent_orchestrator/utils/mcp_resolution.py`
- `git diff --check`