### PR TITLE
fix(cursor): isolate runtime MCP plugins

### DIFF
--- a/docs/cursor-cli.md
+++ b/docs/cursor-cli.md
@@ -74,7 +74,10 @@ If no boundary is detected, extraction raises `ValueError("No Cursor CLI respons
 By default, CAO launches Cursor CLI with the following flags to skip the interactive dialogs that would otherwise block headless orchestration:
 
 - `--force` — auto-approves every tool call (Bash, file writes, etc.).
-- `--approve-mcps` — pre-approves MCP servers declared via `--plugin-dir`.
+- `--plugin-dir <temporary-dir>` — loads a valid, terminal-private Agent
+  Plugin containing the worker's MCP servers.
+- `--approve-mcps` — pre-approves MCP servers declared by that temporary
+  plugin.
 
 `--trust` is **not** passed because Cursor CLI v2026+ rejects it in interactive REPL mode with `Error: --trust can only be used with --print/headless mode`. The CAO launch flow already confirms workspace trust, and the interactive REPL has no per-directory trust dialog for `--trust` to skip.
 
@@ -88,7 +91,16 @@ When launched with an agent profile (e.g., `--agents code_supervisor`), CAO:
 
 1. Loads the profile from the agent store (`~/.aws/cli-agent-orchestrator/agent-store`).
 2. Honors the profile's `model` field by passing `--model <id>` at launch (overridable via the constructor).
-3. For MCP servers: writes a synthetic Cursor plugin manifest under `~/.aws/cli-agent-orchestrator/tmp/<tid>-cursor-plugins/plugin.json` and passes the directory via `--plugin-dir`. The manifest's `mcpServers` map carries the `CAO_TERMINAL_ID` env var so MCP tools can identify the current terminal for handoff/assign operations. `--approve-mcps` is added so the REPL does not block on a per-server approval dialog.
+3. For CAO's bundled `cao-mcp-server`: creates a schema-conformant Agent
+   Plugin in a fresh, owner-only directory under CAO's temporary directory.
+   The plugin has root `plugin.json`, `mcp.json`, and a plugin-relative bridge
+   launcher; it forwards `CAO_TERMINAL_ID` and is passed with `--plugin-dir`.
+   Every terminal gets its own plugin, so parent/child workers can share a
+   project directory without MCP-name or terminal-ID collisions. CAO removes
+   the directory on cleanup and never writes `.cursor/mcp.json` in the source
+   worktree. This runtime bridge intentionally accepts only the bundled stdio
+   server (and only `CAO_TERMINAL_ID` in its environment); configure other
+   Cursor MCP servers with a Cursor-native plugin.
 4. **Does not** pass the profile body via `--system-prompt` in v2026.06.15: the backend rejects every request that carries a `--system-prompt <file>` payload with `[invalid_argument] unknown option '--system-prompt'` regardless of the file's contents (the bug is reproducible with a 3-character file). The CAO role context still reaches the agent via the `cao-mcp-server` MCP tool's handoff/assign payloads, so the agent has the right capabilities and the right inbox tools; only the role body is not pre-loaded as a system prompt. The preserved `_write_system_prompt_file` helper is ready to re-enable this path when Cursor ships a fixed client.
 
 ### Launch Command
@@ -96,7 +108,7 @@ When launched with an agent profile (e.g., `--agents code_supervisor`), CAO:
 The provider builds the command via `_build_cursor_command()`. The provider prefers the unambiguous `cursor-agent` alias (which only the Cursor CLI ships) and falls back to the documented primary `agent` name when only that is installed. When `agent` is selected the provider runs an `agent --version` probe to confirm the resolved binary is the Cursor CLI (a number of unrelated tools also install an `agent` binary on `$PATH`).
 
 ```
-cursor-agent --force [--model <id>] [--plugin-dir <path> --approve-mcps]
+cursor-agent --force [--model <id>] [--plugin-dir <temporary-dir>] [--approve-mcps]
 ```
 
 The `--print` flag is intentionally **not** passed: CAO drives the interactive REPL so the inbox service can stream follow-up prompts via MCP handoff. Print mode is a one-shot CLI flag that exits after the first response and is therefore incompatible with multi-turn CAO sessions.
@@ -202,8 +214,8 @@ If the supervisor completes the analysis work itself, the per-directory lock or 
    - If the dialog still appears, verify the `agent` (or `cursor-agent`) version supports `--force` (`agent --help`).
 
 2. **MCP Approval Dialog Blocking**
-   - The provider launches with `--approve-mcps` when the profile declares `mcpServers`, and the MCP servers are written into a `--plugin-dir` manifest.
-   - If MCP servers still prompt, check the synthesised `plugin.json` under `~/.aws/cli-agent-orchestrator/tmp/<tid>-cursor-plugins/`.
+   - The provider launches with `--plugin-dir` and `--approve-mcps` when the profile declares the bundled `cao-mcp-server`. The generated Agent Plugin is terminal-private under CAO's temporary directory; it is not a project file. Other MCP servers must use a Cursor-native plugin.
+   - If MCP servers still prompt or are absent, inspect that temporary plugin's `mcp.json` from the terminal launch command. Do not add CAO's per-terminal MCP server to `~/.cursor/mcp.json`: that would expose it to unrelated Cursor sessions.
 
 3. **Authentication Issues**
    ```bash

--- a/src/cli_agent_orchestrator/providers/cursor_cli.py
+++ b/src/cli_agent_orchestrator/providers/cursor_cli.py
@@ -18,14 +18,12 @@ relied on. The v2026 launch command the provider builds:
   per-tool approval prompts during orchestration.
 - ``--model`` selects a specific model (e.g. ``gpt-5``, ``sonnet-4``,
   ``composer-2.5``).
-- ``--plugin-dir <path>`` injects MCP server configuration. v2026
-  removed the ``--mcp <json>`` flag in favour of ``--plugin-dir``
-  pointing at a directory holding Cursor plugin manifests. The
-  provider synthesises that directory from the agent profile's
-  ``mcpServers`` map at launch time.
-- ``--approve-mcps`` pre-approves MCP servers declared via
-  ``--plugin-dir`` so the REPL does not block on a per-server
-  approval dialog.
+- ``--plugin-dir <path>`` loads a temporary, valid Agent Plugin for the
+  bundled ``cao-mcp-server`` bridge. The plugin is unique to a terminal,
+  lives under CAO's private temporary directory, and is removed during
+  cleanup; CAO never edits a project's ``.cursor/mcp.json``.
+- ``--approve-mcps`` pre-approves the plugin MCP servers so the REPL does
+  not block on a per-server approval dialog.
 
 Flags deliberately omitted for v2026.06.15:
 
@@ -41,7 +39,8 @@ Flags deliberately omitted for v2026.06.15:
   (issue #300).
 - ``--trust`` is omitted because v2026 rejects it in interactive
   REPL mode ("only works with --print/headless mode").
-- ``--mcp <json>`` is replaced by ``--plugin-dir`` as noted above.
+- ``--mcp <json>`` is not supported by the current Cursor CLI. CAO uses a
+  documented Agent Plugin passed by ``--plugin-dir`` instead.
 
 Skill catalog injection: the provider forwards the skill catalog via
 the shared ``_apply_skill_prompt`` helper from :class:`BaseProvider`
@@ -63,12 +62,15 @@ from the Claude Code provider to avoid stale-spinner false positives.
 
 import json
 import logging
+import os
 import re
 import shlex
 import shutil
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import CAO_HOME_DIR
@@ -76,7 +78,6 @@ from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
-from cli_agent_orchestrator.utils.mcp_resolution import resolve_mcp_server_config
 from cli_agent_orchestrator.utils.terminal import wait_for_shell, wait_until_status
 from cli_agent_orchestrator.utils.text import strip_terminal_escapes
 
@@ -230,12 +231,10 @@ class CursorCliProvider(BaseProvider):
         self._agent_profile = agent_profile
         self._model = model
         # Temp paths the provider has created under the CAO tmp dir.
-        # ``cleanup()`` deletes every entry in this list so the
-        # per-session files (system prompt + plugin dir) do not
-        # accumulate on disk. Initialised lazily on the first
-        # ``_build_cursor_command`` so providers that never get
-        # launched (e.g. because the binary is missing) leave the
-        # tmp dir untouched.
+        # ``cleanup()`` deletes every entry in this list so per-session files
+        # (system prompts and MCP plugins) do not accumulate on disk.
+        # Initialised lazily so providers that never launch leave the tmp dir
+        # untouched.
         self._tmp_paths: list[Path] = []
         # Turn counter. ``get_status`` returns ``IDLE`` while
         # ``_turns == 0`` (fresh spawn, no user input yet) and
@@ -252,7 +251,18 @@ class CursorCliProvider(BaseProvider):
         """Cursor CLI submits on a single Enter after bracketed paste."""
         return 1
 
-    def _build_cursor_command(self) -> str:
+    def _load_profile(self):
+        """Load the configured CAO profile with a provider-specific error."""
+        if self._agent_profile is None:
+            return None
+        try:
+            return load_agent_profile(self._agent_profile)
+        except Exception as exc:
+            raise ProviderError(
+                f"Failed to load agent profile '{self._agent_profile}': {exc}"
+            ) from exc
+
+    def _build_cursor_command(self, profile: Optional[Any] = None) -> str:
         """Build the ``agent`` (Cursor CLI) launch command.
 
         Cursor's primary command per the official documentation is
@@ -272,20 +282,14 @@ class CursorCliProvider(BaseProvider):
           '--system-prompt'`` regardless of file contents. The
           CAO role context still reaches the agent via the
           ``cao-mcp-server`` MCP tool's handoff / assign payloads.
-        - ``--plugin-dir`` injects MCP server configuration. v2026
-          removed the ``--mcp <json>`` flag in favour of
-          ``--plugin-dir <path>`` pointing at a directory that holds
-          Cursor plugin / MCP server manifests. We synthesise the
-          directory from the agent profile's ``mcpServers`` map at
-          launch time and keep it under the CAO tmp dir.
-        - ``--approve-mcps`` pre-approves MCP servers declared via
-          ``--plugin-dir`` so the REPL does not block on a per-server
-          approval dialog.
+        - ``--plugin-dir <path>`` loads a temporary Agent Plugin for the
+          bundled CAO MCP bridge without modifying the project worktree.
+        - ``--approve-mcps`` pre-approves the plugin's MCP servers.
 
         The CAO agent profile is no longer passed as ``--agent <name>``
         — that flag was removed in v2026. The profile's identity is
         preserved via the system-prompt content (the profile markdown
-        body) and the synthesised plugin-dir layout. Multi-agent
+        body) and the temporary MCP plugin. Multi-agent
         orchestration (handoff / assign) continues to work because the
         inbox / MCP tools are the same across all profiles.
 
@@ -293,12 +297,8 @@ class CursorCliProvider(BaseProvider):
         :func:`tmux_client.send_keys`. Uses :func:`shlex.join` to handle
         multiline strings and special characters correctly.
         """
-        profile = None
-        if self._agent_profile is not None:
-            try:
-                profile = load_agent_profile(self._agent_profile)
-            except Exception as exc:
-                raise ProviderError(f"Failed to load agent profile '{self._agent_profile}': {exc}")
+        if profile is None:
+            profile = self._load_profile()
 
         # Resolve the binary. ``agent`` is a common name and a
         # number of unrelated tools (e.g. the Linux ``gpg-agent``)
@@ -417,20 +417,13 @@ class CursorCliProvider(BaseProvider):
         # ``extract_last_message_from_script`` docstring to point at
         # the new behaviour.
 
-        # MCP server injection via --plugin-dir. v2026 removed
-        # ``--mcp <json>``; the replacement is ``--plugin-dir
-        # <path>`` pointing at a directory containing plugin / MCP
-        # server manifests. We synthesise the directory from the
-        # agent profile's ``mcpServers`` map at launch time, inject
-        # CAO_TERMINAL_ID into each server's env so MCP tools can
-        # identify the current terminal for handoff / assign
-        # operations, and keep the layout under the CAO tmp dir so
-        # it is removed with the session.
+        # Cursor loads local Agent Plugins supplied by --plugin-dir. A unique
+        # plugin directory isolates terminal-specific MCP environment values
+        # without touching the source worktree or sharing state with another
+        # Cursor terminal.
         if profile is not None and profile.mcpServers:
             plugin_dir = self._write_plugin_dir(profile.mcpServers)
             command_parts.extend(["--plugin-dir", plugin_dir])
-            # --approve-mcps is required to skip per-server approval
-            # dialogs on first run; otherwise the REPL blocks.
             command_parts.append("--approve-mcps")
 
         return shlex.join(command_parts)
@@ -467,65 +460,143 @@ class CursorCliProvider(BaseProvider):
         self._register_tmp_path(prompt_path)
         return str(prompt_path)
 
-    def _write_plugin_dir(self, mcp_servers) -> str:
-        """Materialise a Cursor plugin directory for the session's MCP servers.
+    @staticmethod
+    def _write_file_atomically(path: Path, contents: bytes) -> None:
+        """Write a sensitive JSON config atomically with owner-only mode."""
+        fd, temporary_name = tempfile.mkstemp(prefix=".cao-mcp-", dir=path.parent)
+        temporary_path = Path(temporary_name)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as temporary_file:
+                temporary_file.write(contents)
+                temporary_file.flush()
+                os.fsync(temporary_file.fileno())
+            os.replace(temporary_path, path)
+        except OSError:
+            try:
+                temporary_path.unlink()
+            except FileNotFoundError:
+                pass
+            raise
 
-        Cursor CLI v2026.06.15 dropped the ``--mcp <json>`` flag in
-        favour of ``--plugin-dir <path>``: a directory that holds
-        Cursor plugin manifests. We translate the CAO agent
-        profile's ``mcpServers`` map into a minimal manifest layout
-        so the same MCP servers (cao-mcp-server, ops-mcp-server,
-        etc.) start transparently under the new flag.
+    def _write_plugin_dir(self, mcp_servers: dict[str, Any]) -> str:
+        """Create an isolated Agent Plugin for CAO's runtime MCP bridge.
 
-        The synthesised directory lives under the CAO tmp dir keyed
-        by the terminal id and is registered in ``self._tmp_paths``
-        so ``cleanup()`` deletes it (and the per-session manifest
-        inside it) when the session ends.
+        Cursor Agent Plugins use a root ``plugin.json`` manifest and an
+        ``mcp.json`` file. CAO generates a schema-conformant plugin for its
+        bundled ``cao-mcp-server`` inside a fresh, owner-only directory under
+        ``CAO_TMP_DIR`` and passes it through ``--plugin-dir``. Parent and
+        child terminals therefore do not share CWD-scoped config or each
+        other's ``CAO_TERMINAL_ID``.
 
-        Args:
-            mcp_servers: The agent profile's ``mcpServers`` map. Keys
-                are server names; values are either plain dicts (from
-                YAML) or Pydantic models (from programmatic install).
-
-        Returns:
-            Absolute path to the plugin directory. Pass this to
-            ``--plugin-dir <path>``.
+        The Agent Plugin MCP schema intentionally cannot represent CAO's
+        broader provider-neutral MCP configuration safely: it has closed
+        transport variants and forbids credentials in ``env``. Reject other
+        profile MCP entries before launch instead of emitting a plugin Cursor
+        would silently skip.
         """
-        plugin_dir = self._cao_tmp_dir() / f"{self.terminal_id}-cursor-plugins"
-        plugin_dir.mkdir(parents=True, exist_ok=True)
+        plugin_dir = Path(
+            tempfile.mkdtemp(prefix=f"{self.terminal_id}-cursor-plugin-", dir=self._cao_tmp_dir())
+        )
+        try:
+            os.chmod(plugin_dir, 0o700)
+            manifest = {
+                "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+                "name": f"cao-terminal-{self.terminal_id}",
+                "description": "Ephemeral CAO MCP bridge for one Cursor terminal",
+                "version": "0.0.0",
+                "author": {"name": "cli-agent-orchestrator"},
+            }
+            mcp_config = self._cao_mcp_plugin_config(mcp_servers)
+            self._write_file_atomically(
+                plugin_dir / "plugin.json",
+                (json.dumps(manifest, indent=2, ensure_ascii=False) + "\n").encode("utf-8"),
+            )
+            self._write_file_atomically(
+                plugin_dir / "mcp.json",
+                (json.dumps(mcp_config, indent=2, ensure_ascii=False) + "\n").encode("utf-8"),
+            )
+            launcher_path = plugin_dir / "bin" / "cao-mcp-server"
+            launcher_path.parent.mkdir(mode=0o700)
+            launcher = (
+                f"#!{sys.executable}\n"
+                "from cli_agent_orchestrator.mcp_server.server import main\n\n"
+                'if __name__ == "__main__":\n'
+                "    main()\n"
+            )
+            self._write_file_atomically(launcher_path, launcher.encode("utf-8"))
+            os.chmod(launcher_path, 0o700)
+        except ProviderError:
+            shutil.rmtree(plugin_dir, ignore_errors=True)
+            raise
+        except (OSError, TypeError, ValueError) as exc:
+            shutil.rmtree(plugin_dir, ignore_errors=True)
+            raise ProviderError(f"Could not create temporary Cursor MCP plugin: {exc}") from exc
 
-        # CAO_TERMINAL_ID is forwarded into every server's env so
-        # MCP tools (cao-mcp-server, ops-mcp-server) can resolve
-        # the current terminal for handoff / assign operations. We
-        # do not override an explicit preset — the same rule the
-        # --mcp <json> path used to follow (issue #300 is the v2026
-        # equivalent).
-        servers: dict = {}
-        for server_name, server_config in mcp_servers.items():
-            if isinstance(server_config, dict):
-                servers[server_name] = dict(server_config)
-            else:
-                servers[server_name] = server_config.model_dump(exclude_none=True)
-            # Resolve the bundled cao-mcp-server console script to a
-            # PATH-independent invocation.
-            servers[server_name] = resolve_mcp_server_config(servers[server_name])
-            env = servers[server_name].get("env", {})
-            if "CAO_TERMINAL_ID" not in env:
-                env["CAO_TERMINAL_ID"] = self.terminal_id
-                servers[server_name]["env"] = env
-
-        # Cursor v2026 plugin manifests are JSON files inside the
-        # plugin dir. The exact schema is undocumented in the help
-        # text we captured; the minimum that the CLI accepts is a
-        # ``mcpServers`` object matching the well-known MCP config
-        # layout, written as ``plugin.json`` at the root. If the
-        # schema proves more strict in a later v2026 point release
-        # this layout can be tweaked without touching the rest of
-        # the provider.
-        manifest = {"mcpServers": servers}
-        (plugin_dir / "plugin.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
         self._register_tmp_path(plugin_dir)
         return str(plugin_dir)
+
+    def _cao_mcp_plugin_config(self, mcp_servers: dict[str, Any]) -> dict[str, Any]:
+        """Translate the CAO bridge profile entry into the closed MCP schema.
+
+        This provider's runtime plugin is deliberately limited to the bundled
+        stdio bridge. A profile can omit ``type`` for legacy compatibility;
+        CAO emits the required ``"stdio"`` type in the generated plugin.
+        """
+        if set(mcp_servers) != {"cao-mcp-server"}:
+            raise ProviderError(
+                "Cursor runtime MCP plugins support only the bundled "
+                "'cao-mcp-server' entry; remove other mcpServers or use a "
+                "Cursor-native plugin for them"
+            )
+
+        server_config = mcp_servers["cao-mcp-server"]
+        if isinstance(server_config, dict):
+            config = dict(server_config)
+        else:
+            config = server_config.model_dump(exclude_none=True)
+
+        supported_fields = {"type", "command", "args", "env"}
+        unsupported_fields = sorted(set(config).difference(supported_fields))
+        if unsupported_fields:
+            raise ProviderError(
+                "Cursor runtime MCP plugin cannot represent fields on "
+                "'cao-mcp-server': " + ", ".join(unsupported_fields)
+            )
+        if config.get("type") not in (None, "stdio"):
+            raise ProviderError("Cursor runtime MCP plugin requires 'cao-mcp-server' type: 'stdio'")
+        if config.get("command") != "cao-mcp-server":
+            raise ProviderError(
+                "Cursor runtime MCP plugin requires the bundled " "'cao-mcp-server' command"
+            )
+
+        args = config.get("args") or []
+        if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+            raise ProviderError("'cao-mcp-server' args must be a list of strings")
+        env = config.get("env") or {}
+        if not isinstance(env, dict) or not all(
+            isinstance(name, str) and isinstance(value, str) for name, value in env.items()
+        ):
+            raise ProviderError("'cao-mcp-server' env must be a mapping of strings")
+        unsupported_env = sorted(set(env).difference({"CAO_TERMINAL_ID"}))
+        if unsupported_env:
+            raise ProviderError(
+                "Cursor runtime MCP plugin accepts only CAO_TERMINAL_ID in "
+                "'cao-mcp-server' env; configure other values in the CAO server environment"
+            )
+
+        terminal_id = env.get("CAO_TERMINAL_ID", self.terminal_id)
+        return {
+            "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+            "mcpServers": {
+                "cao-mcp-server": {
+                    "type": "stdio",
+                    "command": "./bin/cao-mcp-server",
+                    "args": args,
+                    "env": {"CAO_TERMINAL_ID": terminal_id},
+                }
+            },
+        }
 
     def _cao_tmp_dir(self) -> Path:
         """Resolve the CAO tmp directory and create it on demand.
@@ -574,7 +645,10 @@ class CursorCliProvider(BaseProvider):
         if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
-        command = self._build_cursor_command()
+        # Load once so the command and any temporary MCP plugin are derived
+        # from the same immutable profile snapshot.
+        profile = self._load_profile()
+        command = self._build_cursor_command(profile)
         # Arm the StatusMonitor stickiness gate so the launching
         # command can drive a fresh PROCESSING transition past any
         # stale ready latch. Without this, a previously-latched
@@ -928,11 +1002,8 @@ class CursorCliProvider(BaseProvider):
         """Clean up Cursor CLI provider state.
 
         Resets the initialised flag and removes every per-session
-        temp file the provider has created under the CAO tmp dir
-        (system prompt file, plugin directory). Removing the
-        plugin directory also drops the per-session ``plugin.json``
-        manifest that forwards ``CAO_TERMINAL_ID`` into the MCP
-        server env.
+        temporary file or plugin directory the provider has created under the
+        CAO tmp dir. CAO never creates or changes project-local MCP files.
 
         Errors during cleanup are logged and swallowed — the
         session is already going away at this point and we do not

--- a/test/providers/test_cursor_cli_unit.py
+++ b/test/providers/test_cursor_cli_unit.py
@@ -1,6 +1,8 @@
 """Unit tests for the Cursor CLI provider."""
 
+import json
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -54,10 +56,11 @@ def make_provider(
     allowed_tools: list | None = None,
     model: str | None = None,
     skill_prompt: str | None = None,
+    terminal_id: str = "test-tid",
 ) -> CursorCliProvider:
     """Build a CursorCliProvider with the given configuration."""
     return CursorCliProvider(
-        terminal_id="test-tid",
+        terminal_id=terminal_id,
         session_name="test-session",
         window_name="window-0",
         agent_profile=agent_profile,
@@ -737,94 +740,148 @@ class TestBuildCommand:
         assert "--system-prompt" not in cmd
 
     @patch("cli_agent_orchestrator.providers.cursor_cli.load_agent_profile")
-    def test_mcp_servers_forwarded_via_plugin_dir(self, mock_load):
-        # v2026 removed ``--mcp <json>``. The replacement is
-        # ``--plugin-dir <path>`` pointing at a directory holding a
-        # plugin manifest. We synthesise that directory at build
-        # time; the test asserts the flag is present, points at an
-        # existing directory, and that the manifest's mcpServers
-        # map carries CAO_TERMINAL_ID.
-        import json
-        from pathlib import Path
-
+    def test_mcp_servers_materialized_in_isolated_agent_plugin(
+        self, mock_load, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CAO_TMP_DIR", str(tmp_path / "cao-tmp"))
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
         profile = MagicMock()
         profile.model = None
         profile.system_prompt = None
         profile.mcpServers = {"cao-mcp-server": {"command": "cao-mcp-server", "args": []}}
         mock_load.return_value = profile
+
         provider = make_provider(agent_profile="developer")
-        cmd = provider._build_cursor_command()
-        assert "--mcp" not in cmd
-        assert "--plugin-dir" in cmd
-        assert "--approve-mcps" in cmd
-        m = re.search(r"--plugin-dir\s+(\S+)", cmd)
-        assert m is not None, f"--plugin-dir <path> not found in: {cmd}"
-        plugin_dir = Path(m.group(1))
-        assert plugin_dir.is_dir()
-        # The synthesised manifest must include the server with the
-        # terminal id forwarded into its env.
+        command_parts = shlex.split(provider._build_cursor_command())
+        plugin_dir = Path(command_parts[command_parts.index("--plugin-dir") + 1])
+
+        assert plugin_dir.parent == tmp_path / "cao-tmp"
+        assert "--approve-mcps" in command_parts
+        assert not (worktree / ".cursor").exists()
         manifest = json.loads((plugin_dir / "plugin.json").read_text(encoding="utf-8"))
-        servers = manifest["mcpServers"]
-        assert "cao-mcp-server" in servers
-        assert servers["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "test-tid"
-
-    @patch("cli_agent_orchestrator.providers.cursor_cli.load_agent_profile")
-    def test_mcp_resolves_bundled_command_in_manifest(self, mock_load):
-        # Wiring guard: the bare cao-mcp-server command must be rewritten to
-        # a PATH-independent invocation in the written plugin manifest. A
-        # refactor that drops the resolve_mcp_server_config call fails this.
-        import json
-        from pathlib import Path
-
-        profile = MagicMock()
-        profile.model = None
-        profile.system_prompt = None
-        profile.mcpServers = {"cao-mcp-server": {"command": "cao-mcp-server", "args": []}}
-        mock_load.return_value = profile
-        provider = make_provider(agent_profile="developer")
-        MOD = "cli_agent_orchestrator.utils.mcp_resolution"
-        # NOTE: mcp_resolution and cursor_cli import the SAME shutil module
-        # object, so a blanket which->None would break the provider's own
-        # cursor-binary lookup (stubbed by the autouse fixture). Only the
-        # cao-mcp-server lookup may miss.
-        which_cursor_keeps_working = lambda name: (
-            None if name == "cao-mcp-server" else "/usr/local/bin/cursor-agent"
-        )
-        with (
-            patch(f"{MOD}._sibling_script", return_value="/venv/bin/cao-mcp-server"),
-            patch(f"{MOD}.shutil.which", side_effect=which_cursor_keeps_working),
-        ):
-            cmd = provider._build_cursor_command()
-        m = re.search(r"--plugin-dir\s+(\S+)", cmd)
-        assert m is not None
-        manifest = json.loads((Path(m.group(1)) / "plugin.json").read_text(encoding="utf-8"))
-        assert manifest["mcpServers"]["cao-mcp-server"]["command"] == "/venv/bin/cao-mcp-server"
-
-    @patch("cli_agent_orchestrator.providers.cursor_cli.load_agent_profile")
-    def test_mcp_preserves_existing_cao_terminal_id(self, mock_load):
-        # The constructor's terminal_id must NOT override an
-        # explicit preset (matches the prior --mcp behaviour).
-        import json
-        from pathlib import Path
-
-        profile = MagicMock()
-        profile.model = None
-        profile.system_prompt = None
-        profile.mcpServers = {
+        config = json.loads((plugin_dir / "mcp.json").read_text(encoding="utf-8"))
+        assert manifest["$schema"] == "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+        assert manifest["name"] == "cao-terminal-test-tid"
+        assert config["$schema"] == "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+        assert set(config) == {"$schema", "mcpServers"}
+        assert config["mcpServers"] == {
             "cao-mcp-server": {
-                "command": "cao-mcp-server",
+                "type": "stdio",
+                "command": "./bin/cao-mcp-server",
                 "args": [],
-                "env": {"CAO_TERMINAL_ID": "preset"},
+                "env": {"CAO_TERMINAL_ID": "test-tid"},
             }
         }
-        mock_load.return_value = profile
-        provider = make_provider(agent_profile="developer")
-        cmd = provider._build_cursor_command()
-        m = re.search(r"--plugin-dir\s+(\S+)", cmd)
-        assert m is not None
-        plugin_dir = Path(m.group(1))
-        manifest = json.loads((plugin_dir / "plugin.json").read_text(encoding="utf-8"))
-        assert manifest["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "preset"
+        launcher = plugin_dir / "bin" / "cao-mcp-server"
+        assert launcher.read_text(encoding="utf-8").startswith("#!")
+        assert (launcher.stat().st_mode & 0o777) == 0o700
+        assert (plugin_dir.stat().st_mode & 0o777) == 0o700
+        assert ((plugin_dir / "mcp.json").stat().st_mode & 0o777) == 0o600
+
+        provider.cleanup()
+        assert not plugin_dir.exists()
+
+    def test_mcp_plugin_uses_plugin_relative_cao_launcher(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAO_TMP_DIR", str(tmp_path))
+        provider = make_provider()
+        plugin_dir = Path(
+            provider._write_plugin_dir(
+                {"cao-mcp-server": {"type": "stdio", "command": "cao-mcp-server", "args": []}}
+            )
+        )
+        server = json.loads((plugin_dir / "mcp.json").read_text(encoding="utf-8"))["mcpServers"][
+            "cao-mcp-server"
+        ]
+        assert server["command"] == "./bin/cao-mcp-server"
+        assert not Path(server["command"]).is_absolute()
+
+    def test_mcp_preserves_existing_cao_terminal_id_in_agent_plugin(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAO_TMP_DIR", str(tmp_path))
+        plugin_dir = Path(
+            make_provider()._write_plugin_dir(
+                {
+                    "cao-mcp-server": {
+                        "command": "cao-mcp-server",
+                        "args": [],
+                        "env": {"CAO_TERMINAL_ID": "preset"},
+                    }
+                }
+            )
+        )
+        config = json.loads((plugin_dir / "mcp.json").read_text(encoding="utf-8"))
+        assert config["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "preset"
+
+    @pytest.mark.parametrize(
+        ("servers", "match"),
+        [
+            (
+                {"other-server": {"type": "stdio", "command": "other-server", "args": []}},
+                "only the bundled",
+            ),
+            (
+                {
+                    "cao-mcp-server": {
+                        "type": "stdio",
+                        "command": "/venv/bin/cao-mcp-server",
+                        "args": [],
+                    }
+                },
+                "requires the bundled",
+            ),
+            (
+                {
+                    "cao-mcp-server": {
+                        "type": "stdio",
+                        "command": "cao-mcp-server",
+                        "timeout": 30,
+                    }
+                },
+                "cannot represent fields",
+            ),
+            (
+                {
+                    "cao-mcp-server": {
+                        "type": "stdio",
+                        "command": "cao-mcp-server",
+                        "env": {"API_TOKEN": "not-a-real-token"},
+                    }
+                },
+                "accepts only CAO_TERMINAL_ID",
+            ),
+        ],
+    )
+    def test_mcp_plugin_rejects_nonportable_profile_config(
+        self, servers, match, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CAO_TMP_DIR", str(tmp_path))
+        provider = make_provider()
+        with pytest.raises(ProviderError, match=match):
+            provider._write_plugin_dir(servers)
+        assert not list(tmp_path.iterdir())
+
+    def test_mcp_plugins_are_isolated_for_concurrent_workers(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAO_TMP_DIR", str(tmp_path / "cao-tmp"))
+        first = make_provider(terminal_id="first-tid")
+        second = make_provider(terminal_id="second-tid")
+        servers = {"cao-mcp-server": {"command": "cao-mcp-server", "args": []}}
+
+        first_dir = Path(first._write_plugin_dir(servers))
+        second_dir = Path(second._write_plugin_dir(servers))
+
+        assert first_dir != second_dir
+        first_config = json.loads((first_dir / "mcp.json").read_text(encoding="utf-8"))
+        second_config = json.loads((second_dir / "mcp.json").read_text(encoding="utf-8"))
+        assert first_config["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "first-tid"
+        assert (
+            second_config["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "second-tid"
+        )
+
+        first.cleanup()
+        assert not first_dir.exists()
+        assert second_dir.exists()
+        second.cleanup()
+        assert not second_dir.exists()
 
     @patch("cli_agent_orchestrator.providers.cursor_cli.load_agent_profile")
     def test_tool_restrictions_skip_system_prompt(self, mock_load):
@@ -1066,6 +1123,38 @@ class TestBuildCommandBinaryResolution:
 
 class TestInitialize:
     @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.cursor_cli.load_agent_profile")
+    @patch("cli_agent_orchestrator.providers.cursor_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.cursor_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.cursor_cli.get_backend")
+    async def test_initialize_materializes_isolated_mcp_plugin_before_launch(
+        self, mock_backend, mock_shell, mock_wait, mock_load, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CAO_TMP_DIR", str(tmp_path / "cao-tmp"))
+        profile = MagicMock()
+        profile.model = None
+        profile.system_prompt = None
+        profile.mcpServers = {"cao-mcp-server": {"command": "cao-mcp-server", "args": []}}
+        mock_load.return_value = profile
+        mock_shell.return_value = True
+        mock_wait.return_value = True
+        provider = make_provider(agent_profile="developer")
+
+        assert await provider.initialize() is True
+        mock_load.assert_called_once_with("developer")
+        sent = mock_backend.return_value.send_keys.call_args.args[2]
+        command_parts = shlex.split(sent)
+        plugin_dir = Path(command_parts[command_parts.index("--plugin-dir") + 1])
+        config = json.loads((plugin_dir / "mcp.json").read_text(encoding="utf-8"))
+        assert config["mcpServers"]["cao-mcp-server"]["env"]["CAO_TERMINAL_ID"] == "test-tid"
+        assert "--approve-mcps" in sent
+        assert "--plugin-dir" in sent
+        assert not (tmp_path / ".cursor").exists()
+
+        provider.cleanup()
+        assert not plugin_dir.exists()
+
+    @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.cursor_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.cursor_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.cursor_cli.get_backend")
@@ -1106,17 +1195,23 @@ class TestInitialize:
             await provider.initialize()
 
     @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.cursor_cli.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.cursor_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.cursor_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.cursor_cli.get_backend")
     async def test_initialize_does_not_send_system_prompt_flag(
-        self, mock_backend, mock_shell, mock_wait
+        self, mock_backend, mock_shell, mock_wait, mock_load
     ):
         # v2026.06.15 has a confirmed bug where any request that
         # carries --system-prompt is rejected by the backend, so
         # the provider deliberately omits the flag.
         mock_shell.return_value = True
         mock_wait.return_value = True
+        profile = MagicMock()
+        profile.model = None
+        profile.system_prompt = "DEVELOPER_AGENT_BODY"
+        profile.mcpServers = None
+        mock_load.return_value = profile
         provider = make_provider(agent_profile="developer")
         await provider.initialize()
         sent = mock_backend.return_value.send_keys.call_args.args[2]
@@ -1197,27 +1292,26 @@ class TestMiscInterface:
 
     def test_cleanup_removes_tracked_tmp_paths(self, tmp_path, monkeypatch):
         # Copilot review #3412413702 (P1): cleanup() must delete
-        # the per-session temp files the provider wrote (system
-        # prompt + plugin dir). We stub _cao_tmp_dir to redirect
-        # to a temp dir and assert the files are removed on
-        # cleanup().
+        # the per-session temp files the provider wrote. We stub
+        # _cao_tmp_dir to redirect to a temp dir and assert the files
+        # are removed on cleanup().
         monkeypatch.setenv("CAO_TMP_DIR", str(tmp_path))
         provider = make_provider()
-        # Materialise a fake system-prompt file and a fake plugin
-        # dir as if a launch had run.
+        # Materialise a fake system-prompt file and an unrelated
+        # per-session directory as if a launch had run.
         prompt_path = tmp_path / f"{provider.terminal_id}-system-prompt.md"
         prompt_path.write_text("dummy")
-        plugin_dir = tmp_path / f"{provider.terminal_id}-cursor-plugins"
-        plugin_dir.mkdir()
-        (plugin_dir / "plugin.json").write_text("{}")
-        provider._tmp_paths = [prompt_path, plugin_dir]
+        extra_dir = tmp_path / f"{provider.terminal_id}-provider-state"
+        extra_dir.mkdir()
+        (extra_dir / "state.json").write_text("{}")
+        provider._tmp_paths = [prompt_path, extra_dir]
         # Sanity: the files are there before cleanup.
         assert prompt_path.exists()
-        assert plugin_dir.is_dir()
+        assert extra_dir.is_dir()
         provider.cleanup()
         # And gone after.
         assert not prompt_path.exists()
-        assert not plugin_dir.exists()
+        assert not extra_dir.exists()
         # The registry is also drained so a second cleanup is a
         # no-op (idempotent).
         assert provider._tmp_paths == []


### PR DESCRIPTION
## Summary
- materialize CAO’s bundled `cao-mcp-server` as a schema-conformant, terminal-private Agent Plugin under CAO temporary storage
- pass the plugin through `--plugin-dir` with `--approve-mcps`; no project `.cursor/mcp.json` is created or changed
- reject unsupported/nonportable MCP profile configuration before launch instead of emitting a plugin Cursor would ignore
- make command construction use one profile snapshot and add concurrent same-CWD isolation coverage

## Validation
- `UV_PROJECT_ENVIRONMENT=/private/tmp/cursor-mcp-pr-validation-venv uv run pytest test/providers/test_cursor_cli_unit.py` (93 passed)
- `black --check`, `isort --check-only`, and `git diff --check`

## Scope
This stays draft pending independent re-review. It adds the CAO runtime MCP bridge only; other MCP servers should use a Cursor-native plugin. It does not resolve Cursor account/keychain authentication.