### PR TITLE
fix(docs): replace vulnerable image-size dependency

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -3646,6 +3646,19 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/mdx-loader/node_modules/image-size": {
+      "name": "image-size-safe",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/image-size-safe/-/image-size-safe-2.0.3.tgz",
+      "integrity": "sha512-M8prcBmr9nsXwZMC4RzuOM7qvkwvQO1fN+PRxC+D8mc4pMBj2/l0e/kF7s8y3GB10O9zMSUgHHU66Y8tigWIfw==",
+      "license": "MIT",
+      "bin": {
+        "image-size-safe": "bin/image-size-safe.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
     "node_modules/@docusaurus/module-type-aliases": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
@@ -10497,18 +10510,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -52,6 +52,7 @@
   "overrides": {
     "brace-expansion": "^5.0.9",
     "fast-uri": "^3.1.5",
+    "image-size": "npm:image-size-safe@2.0.3",
     "js-yaml": "^4.3.1",
     "nanoid": "^3.3.17",
     "postcss": "^8.5.23",


### PR DESCRIPTION
## Summary

- Addresses Dependabot alerts 79 and 80 for `image-size<=2.0.2` ICNS/JXL/HEIF infinite-loop denial of service, pulled in through Docusaurus 3.10.2.
- There is no patched upstream `image-size` npm release. Alias `image-size` to `image-size-safe@2.0.3`, with the package integrity pinned in `package-lock.json`.

## Risk acceptance

The owner explicitly accepts the temporary risk of relying on the third-party `image-size-safe` fork. This fork is not upstream-authored. Remove this alias when Docusaurus or upstream adopts a maintained fixed implementation.

## Verification

Passed checks:
- lock-only install
- `npm ci`
- `npm ls`
- `npm audit` with 0 vulnerabilities
- malformed-image regression harness
- typecheck
- build
- diff check