### PR TITLE
feat: add MiniMax Code provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- MiniMax Code (`mcode`) provider with per-terminal authentication and profile
+  isolation, model and MCP configuration, multi-turn TUI orchestration,
+  supervisor/worker E2E coverage, and provider documentation (#624)
 - Oh My Pi (`omp`) provider with additive native configuration, profile MCP extension wiring, lifecycle detection, and supervisor/worker orchestration support (#559)
 - Add the official xAI Grok Build CLI as the `grok_cli` provider, including
   isolated per-terminal MCP configuration, native hard tool restrictions,
@@ -850,4 +853,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump to v0.51.0, update method name (#31)
 
 - accept optional U+03BB (λ) after % in kiro and q CLIs (#44)
-

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Install:
   [Kiro CLI](docs/kiro-cli.md), [Claude Code](docs/claude-code.md),
   [Codex CLI](docs/codex-cli.md), [Antigravity CLI](docs/antigravity-cli.md),
   [Hermes](docs/hermes.md), [Kimi CLI](docs/kimi-cli.md),
+  [MiniMax Code](docs/minimax-code.md),
   [GitHub Copilot CLI](docs/copilot-cli.md),
   [OpenCode CLI](docs/opencode-cli.md), [Oh My Pi(OMP) CLI](docs/omp-cli.md),
   [Cursor CLI](docs/cursor-cli.md), or
@@ -130,6 +131,7 @@ provider override while keeping the same sequence.
   [Kiro CLI](docs/kiro-cli.md), [Claude Code](docs/claude-code.md),
   [Codex CLI](docs/codex-cli.md), [Antigravity CLI](docs/antigravity-cli.md),
   [Hermes](docs/hermes.md), [Kimi CLI](docs/kimi-cli.md),
+  [MiniMax Code](docs/minimax-code.md),
   [GitHub Copilot CLI](docs/copilot-cli.md),
   [OpenCode CLI](docs/opencode-cli.md), [Oh My Pi(OMP) CLI](docs/omp-cli.md),
   [Cursor CLI](docs/cursor-cli.md), and

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -182,7 +182,7 @@ cao launch --agents code_supervisor
 
 # 或指定 provider
 cao launch --agents code_supervisor --provider claude_code
-# 可选值：kiro_cli | claude_code | codex | antigravity_cli | hermes | kimi_cli | minimax_code | copilot_cli | opencode_cli | omp | cursor_cli
+# 可选值：kiro_cli | claude_code | codex | antigravity_cli | hermes | kimi_cli | mcode | copilot_cli | opencode_cli | omp | cursor_cli
 
 # 不限制访问、跳过确认（危险）
 cao launch --agents code_supervisor --yolo
@@ -294,7 +294,7 @@ provider: claude_code
 ---
 ```
 
-有效值包括：`kiro_cli`、`claude_code`、`codex`、`antigravity_cli`、`hermes`、`kimi_cli`、`minimax_code`、`copilot_cli`、`opencode_cli`、`omp`、`cursor_cli`。初始会话始终以 `cao launch --provider` 参数为准。详见 [`examples/cross-provider/`](examples/cross-provider/)。
+有效值包括：`kiro_cli`、`claude_code`、`codex`、`antigravity_cli`、`hermes`、`kimi_cli`、`mcode`、`copilot_cli`、`opencode_cli`、`omp`、`cursor_cli`。初始会话始终以 `cao launch --provider` 参数为准。详见 [`examples/cross-provider/`](examples/cross-provider/)。
 
 ### Tool Restrictions
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/cli-agent-orchestrator.svg)](https://pypi.org/project/cli-agent-orchestrator/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/awslabs/cli-agent-orchestrator)
 
-**CLI Agent Orchestrator (CAO)** 是一个开源的多 Agent 编排框架，面向 Claude Code、Kiro CLI、Codex CLI、Antigravity CLI、Hermes Agent、Kimi CLI、GitHub Copilot CLI、OpenCode、Oh My Pi 和 Cursor CLI 等 AI 编程 CLI。CAO 会把每个 Agent 运行在隔离的 tmux 会话中，并通过 Model Context Protocol (MCP) 以 supervisor-worker 模式协调它们。一个 supervisor Agent 可以并行、串行，或以 swarm 方式把任务分派给多个专长不同的 Agent。
+**CLI Agent Orchestrator (CAO)** 是一个开源的多 Agent 编排框架，面向 Claude Code、Kiro CLI、Codex CLI、Antigravity CLI、Hermes Agent、Kimi CLI、MiniMax Code、GitHub Copilot CLI、OpenCode、Oh My Pi 和 Cursor CLI 等 AI 编程 CLI。CAO 会把每个 Agent 运行在隔离的 tmux 会话中，并通过 Model Context Protocol (MCP) 以 supervisor-worker 模式协调它们。一个 supervisor Agent 可以并行、串行，或以 swarm 方式把任务分派给多个专长不同的 Agent。
 
 📚 **[文档站点](https://awslabs.github.io/cli-agent-orchestrator/)** —— 指南、参考文档，以及两门交互式课程（英文）。
 
@@ -130,6 +130,7 @@ CAO 驱动的是已有 CLI Agent 工具，它并不会替代这些工具。使�
 | **Codex CLI** | [Provider docs](docs/codex-cli.md) · [Installation](https://github.com/openai/codex) | OpenAI API key |
 | **Hermes Agent** | [Provider docs](docs/hermes.md) | Hermes auth；可选 `hermesProfile` wrapper；在选中的 Hermes profile 中配置 `cao-mcp-server` 以启用编排工具 |
 | **Kimi CLI** | [Provider docs](docs/kimi-cli.md) · [Installation](https://platform.moonshot.cn/docs/kimi-cli) | Moonshot API key |
+| **MiniMax Code** | [Provider docs](docs/minimax-code.md) · [Installation](https://www.npmjs.com/package/@minimax-ai/code) | `mcode login` 或 BYOK 配置 |
 | **GitHub Copilot CLI** | [Provider docs](docs/copilot-cli.md) · [Installation](https://github.com/features/copilot/cli) | GitHub auth |
 | **OpenCode CLI**（实验性；多 Agent callback 暂时使用 inbox polling fallback，见 [#203](https://github.com/awslabs/cli-agent-orchestrator/issues/203)） | [Provider docs](docs/opencode-cli.md) · [Installation](https://opencode.ai) | Per-model API key |
 | **Oh My Pi** | [Provider docs](docs/omp-cli.md) · [Installation](https://github.com/can1357/oh-my-pi) | OMP authenticated model account |
@@ -181,7 +182,7 @@ cao launch --agents code_supervisor
 
 # 或指定 provider
 cao launch --agents code_supervisor --provider claude_code
-# 可选值：kiro_cli | claude_code | codex | antigravity_cli | hermes | kimi_cli | copilot_cli | opencode_cli | omp | cursor_cli
+# 可选值：kiro_cli | claude_code | codex | antigravity_cli | hermes | kimi_cli | minimax_code | copilot_cli | opencode_cli | omp | cursor_cli
 
 # 不限制访问、跳过确认（危险）
 cao launch --agents code_supervisor --yolo
@@ -293,7 +294,7 @@ provider: claude_code
 ---
 ```
 
-有效值包括：`kiro_cli`、`claude_code`、`codex`、`antigravity_cli`、`hermes`、`kimi_cli`、`copilot_cli`、`opencode_cli`、`omp`、`cursor_cli`。初始会话始终以 `cao launch --provider` 参数为准。详见 [`examples/cross-provider/`](examples/cross-provider/)。
+有效值包括：`kiro_cli`、`claude_code`、`codex`、`antigravity_cli`、`hermes`、`kimi_cli`、`minimax_code`、`copilot_cli`、`opencode_cli`、`omp`、`cursor_cli`。初始会话始终以 `cao launch --provider` 参数为准。详见 [`examples/cross-provider/`](examples/cross-provider/)。
 
 ### Tool Restrictions
 
@@ -400,7 +401,7 @@ cao skills add ./my-coding-standards --force   # 覆盖
 cao skills remove my-coding-standards
 ```
 
-Skills 会自动投递给 provider（Kiro CLI 使用原生 `skill://` resources；Claude Code / Codex / Kimi 使用运行时 prompt injection；Copilot 则烘焙进 `.agent.md`）。
+Skills 会自动投递给 provider（Kiro CLI 使用原生 `skill://` resources；Claude Code / Codex / Kimi / MiniMax Code 使用运行时 prompt injection；Copilot 则烘焙进 `.agent.md`）。
 
 完整参考，包括 authoring、loading 和 delivery mechanics，请查看 [docs/skills.md](docs/skills.md)。与 OpenClaw 或其他外部工具集成，请参考 [docs/external-tool-integration.md](docs/external-tool-integration.md)。
 

--- a/docs/agent-profile.md
+++ b/docs/agent-profile.md
@@ -72,6 +72,7 @@ Provider support for pass-through fields differs. Use the focused guides for
 [Kiro CLI](kiro-cli.md), [Claude Code](claude-code.md),
 [Codex CLI](codex-cli.md), [Antigravity CLI](antigravity-cli.md),
 [Hermes](hermes.md), [Kimi CLI](kimi-cli.md),
+[MiniMax Code](minimax-code.md),
 [GitHub Copilot CLI](copilot-cli.md), [OpenCode CLI](opencode-cli.md),
 [Cursor CLI](cursor-cli.md), and [Grok Build CLI](grok-cli.md) instead of
 relying on a duplicated compatibility catalog here.

--- a/docs/minimax-code.md
+++ b/docs/minimax-code.md
@@ -1,0 +1,147 @@
+# MiniMax Code Provider
+
+## Overview
+
+The `minimax_code` provider runs the interactive MiniMax Code CLI (`mcode`) as
+a long-lived, multi-turn agent in a CAO tmux window. CAO injects the selected
+agent profile and skill catalog in a bootstrap turn, then exposes orchestration
+tools such as `handoff`, `assign`, and `send_message` through a terminal-local
+MiniMax Plugin.
+
+The provider targets the public `@minimax-ai/code` package and its full-screen
+TUI. Status and response extraction are calibrated against `0.1.2`; a later
+release can require fixture updates if its visible markers change.
+
+## Install and authenticate
+
+Install the public package and authenticate once outside CAO:
+
+```bash
+npm install -g @minimax-ai/code
+mcode login
+mcode --version
+```
+
+MiniMax Code can also use provider credentials configured in its normal
+`config.yaml`. Never put access tokens or API keys in a CAO profile or commit
+them to a repository.
+
+## Quick start
+
+```bash
+cao install developer --provider minimax_code
+cao-server
+cao launch --agents developer --provider minimax_code
+```
+
+Pin a profile to this provider with frontmatter:
+
+```yaml
+---
+name: minimax_developer
+description: Developer backed by MiniMax Code
+provider: minimax_code
+role: developer
+---
+
+Implement the requested change and verify it.
+```
+
+MiniMax Code's public interactive CLI does not currently expose a per-session
+model flag. CAO therefore rejects `model:` in a `minimax_code` profile and
+`--model` at launch instead of silently ignoring them. Select the model in the
+normal MiniMax Code configuration before launching CAO.
+
+## Runtime behavior
+
+CAO launches a command equivalent to:
+
+```text
+env MINIMAX_DATA_DIR=<private-terminal-data> TERM=xterm-256color \
+  mcode '<profile, skill catalog, policy, and bootstrap instruction>'
+```
+
+The bootstrap asks MiniMax Code to retain the supplied instructions and reply
+with `CAO_MCODE_READY`. CAO waits for that turn to settle before delivering the
+first task. Later inbox messages use one Enter after bracketed paste. MiniMax
+Code can queue input while it is processing, so eager inbox delivery is
+supported.
+
+CAO recognizes the TUI's `Loading` or `Running` activity line as processing,
+the approval picker as waiting for a user answer, and `Completed in` followed
+by the composer as completion. Last-message extraction returns the final
+assistant block only; thinking rows, tool chrome, duration notes, and the
+composer are omitted.
+
+## Authentication and Plugin isolation
+
+Every terminal receives a deterministic private directory below:
+
+```text
+<CAO_HOME_DIR>/providers/minimax_code/<sha256-terminal-id>/
+```
+
+CAO copies only these existing authentication/configuration paths from
+`MINIMAX_DATA_DIR` (or `~/.minimax`):
+
+- `config.yaml`
+- `local-runtime.auth.json`
+- `cli-auth/`
+
+It does not copy user-installed Plugins. The private root and directories use
+mode `0700`; copied and generated files use mode `0600`. CAO deletes the exact
+terminal directory during normal cleanup and can reconstruct that cleanup
+after a `cao-server` restart.
+
+For profiles with `mcpServers`, CAO generates a local MiniMax Plugin containing
+`servers.mcp.json`. Each stdio server receives the terminal-specific
+`CAO_TERMINAL_ID`, and tool-call timeout is set to 600 seconds so synchronous
+handoffs are not cut off by the default MCP timeout. Absolute executable paths
+are converted to a bare command plus a terminal-local `PATH` prefix because
+the MiniMax Plugin schema requires PATH-resolved commands.
+
+## Tool restrictions
+
+MiniMax Code has no public native flag for CAO's `allowedTools` vocabulary.
+Restricted profiles receive the shared CAO security instructions in the
+bootstrap prompt. This is soft, advisory enforcement: the model can ignore the
+instructions, so do not use `minimax_code` for security-critical restricted
+workers. `--yolo` still resolves the CAO profile to unrestricted `['*']`.
+
+The generated Plugin includes only MCP servers declared by the selected
+profile. This narrows the injected Plugin surface but does not hard-disable
+MiniMax Code's built-in tools.
+
+## Troubleshooting
+
+### Login screen or authentication error
+
+Run `mcode login` in a normal terminal and confirm `mcode` starts successfully.
+If `MINIMAX_DATA_DIR` is set, authenticate in that same data directory.
+
+### Orchestration tools are missing
+
+Confirm `cao-mcp-server` is installed in the same Python environment as
+`cao-server`, then recreate the terminal. CAO regenerates the Plugin and its
+terminal ID at launch.
+
+### Terminal remains processing or output is incomplete
+
+Attach to the tmux session and inspect the visible `Loading`, `Running`,
+approval, and `Completed in` markers. Include a scrubbed pane capture and
+`mcode --version` when reporting a parsing regression.
+
+## Validation
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest \
+  test/providers/test_minimax_code_unit.py \
+  test/providers/test_provider_manager_unit.py -k minimax_code \
+  -q -o 'addopts='
+
+PYTHONPATH=src .venv/bin/python -m pytest -m e2e \
+  test/e2e/test_handoff.py test/e2e/test_assign.py \
+  test/e2e/test_send_message.py test/e2e/test_allowed_tools.py \
+  test/e2e/test_supervisor_orchestration.py \
+  -k MiniMaxCode -v -o 'addopts='
+```

--- a/docs/minimax-code.md
+++ b/docs/minimax-code.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `minimax_code` provider runs the interactive MiniMax Code CLI (`mcode`) as
+The `mcode` provider runs the interactive MiniMax Code CLI (`mcode`) as
 a long-lived, multi-turn agent in a CAO tmux window. CAO injects the selected
 agent profile and skill catalog in a bootstrap turn, then exposes orchestration
 tools such as `handoff`, `assign`, and `send_message` through a terminal-local
@@ -29,9 +29,9 @@ them to a repository.
 ## Quick start
 
 ```bash
-cao install developer --provider minimax_code
+cao install developer --provider mcode
 cao-server
-cao launch --agents developer --provider minimax_code
+cao launch --agents developer --provider mcode
 ```
 
 Pin a profile to this provider with frontmatter:
@@ -40,17 +40,18 @@ Pin a profile to this provider with frontmatter:
 ---
 name: minimax_developer
 description: Developer backed by MiniMax Code
-provider: minimax_code
+provider: mcode
 role: developer
 ---
 
 Implement the requested change and verify it.
 ```
 
-MiniMax Code's public interactive CLI does not currently expose a per-session
-model flag. CAO therefore rejects `model:` in a `minimax_code` profile and
-`--model` at launch instead of silently ignoring them. Select the model in the
-normal MiniMax Code configuration before launching CAO.
+MiniMax Code's public interactive CLI does not expose a model flag. CAO applies
+`model:` in an `mcode` profile or `--model` at launch by setting `defaultModel`
+only in the terminal-local copy of `config.yaml`; the explicit launch override
+wins over the profile value. The user's normal MiniMax Code configuration is
+not modified.
 
 ## Runtime behavior
 
@@ -94,18 +95,20 @@ terminal directory during normal cleanup and can reconstruct that cleanup
 after a `cao-server` restart.
 
 For profiles with `mcpServers`, CAO generates a local MiniMax Plugin containing
-`servers.mcp.json`. Each stdio server receives the terminal-specific
-`CAO_TERMINAL_ID`, and tool-call timeout is set to 600 seconds so synchronous
-handoffs are not cut off by the default MCP timeout. Absolute executable paths
-are converted to a bare command plus a terminal-local `PATH` prefix because
-the MiniMax Plugin schema requires PATH-resolved commands.
+`servers.mcp.json`. Stdio servers receive the terminal-specific
+`CAO_TERMINAL_ID`; URL-based `http` and `sse` profile entries are serialized as
+MiniMax Code's `streamable-http` and `sse` transports with their headers intact.
+Tool-call timeout is set to 600 seconds so synchronous handoffs are not cut off
+by the default MCP timeout. Absolute executable paths are converted to a bare
+command plus a terminal-local `PATH` prefix because the MiniMax Plugin schema
+requires PATH-resolved commands.
 
 ## Tool restrictions
 
 MiniMax Code has no public native flag for CAO's `allowedTools` vocabulary.
 Restricted profiles receive the shared CAO security instructions in the
 bootstrap prompt. This is soft, advisory enforcement: the model can ignore the
-instructions, so do not use `minimax_code` for security-critical restricted
+instructions, so do not use `mcode` for security-critical restricted
 workers. `--yolo` still resolves the CAO profile to unrestricted `['*']`.
 
 The generated Plugin includes only MCP servers declared by the selected

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -121,7 +121,7 @@ To advertise only a subset of skills to a given agent, set the `skills` field in
 
 This scopes the injected **catalog** only — it controls what an agent *sees* advertised, not what it can *load*. Skill resolution is unchanged: `load_skill` still resolves any installed skill by name, so this is a prompt-relevance / noise-reduction control, not an access boundary. (If you need a hard per-agent allowlist, that would have to be enforced in the `load_skill` path — out of scope here.)
 
-This applies only to the runtime-prompt providers that receive the injected catalog (Claude Code, Codex, Antigravity CLI, Kimi CLI). Providers that deliver skills natively (Kiro CLI, OpenCode, GitHub Copilot CLI) ignore the field.
+This applies only to the runtime-prompt providers that receive the injected catalog (Claude Code, Codex, Antigravity CLI, Kimi CLI, MiniMax Code). Providers that deliver skills natively (Kiro CLI, OpenCode, GitHub Copilot CLI) ignore the field.
 
 ```yaml
 ---
@@ -163,13 +163,14 @@ Skills are delivered to agents differently depending on the provider. The table 
 | Codex | Runtime prompt | Every terminal creation | `load_skill` MCP tool |
 | Antigravity CLI | Runtime prompt | Every terminal creation | `load_skill` MCP tool |
 | Kimi CLI | Runtime prompt | Every terminal creation | `load_skill` MCP tool |
+| MiniMax Code | Runtime bootstrap prompt | Every terminal creation | `load_skill` MCP tool |
 | Kiro CLI | Native `skill://` resources | Every terminal creation | Kiro progressive loading |
 | Copilot CLI | Baked into `.agent.md` at install | On `cao skills add/remove` | `load_skill` MCP tool |
 | OpenCode CLI | Native `skill` tool via `OPENCODE_CONFIG_DIR/skills` symlink | Every terminal creation | OpenCode progressive loading (also via `load_skill` MCP tool) |
 | Cursor CLI | Runtime prompt (currently disabled — see [Cursor CLI provider docs](cursor-cli.md#agent-profile-integration)) | Not injected in v2026 | `load_skill` MCP tool |
 | Hermes | Not injected — configure skills in the selected Hermes profile | N/A | N/A |
 
-### Runtime Prompt Providers (Claude Code, Codex, Antigravity CLI, Kimi CLI)
+### Runtime Prompt Providers (Claude Code, Codex, Antigravity CLI, Kimi CLI, MiniMax Code)
 
 For these providers, the skill catalog is built fresh each time a terminal is created. The catalog — a list of skill names and descriptions — is appended to the system prompt via the provider's native CLI flags.
 

--- a/docs/tool-restrictions.md
+++ b/docs/tool-restrictions.md
@@ -207,7 +207,7 @@ CAO defines a universal tool vocabulary (`execute_bash`, `fs_read`, `fs_write`, 
 | `fs_list` | `Glob`, `Grep` | `list`, `grep` | `Grep`, `Glob` |
 | `web_fetch` | `WebFetch`, `WebSearch` | (not mapped) | `WebFetch`, `WebSearch` + disabled web search |
 
-**Providers that accept CAO vocabulary directly** — Kiro CLI accepts `allowedTools` in the agent JSON at install time, using the same vocabulary as CAO. No translation needed. Kimi CLI and Codex use system prompt instructions to enforce restrictions. For all three, CAO passes the `allowedTools` list directly without translation — so no `TOOL_MAPPING` entry exists for them, and none is needed.
+**Providers that accept CAO vocabulary directly** — Kiro CLI accepts `allowedTools` in the agent JSON at install time, using the same vocabulary as CAO. No translation needed. Kimi CLI, MiniMax Code, and Codex use system prompt instructions to enforce restrictions. CAO passes the `allowedTools` list directly without translation — so no `TOOL_MAPPING` entry exists for them, and none is needed.
 
 ## How Overrides Work
 
@@ -253,6 +253,7 @@ As described in [How Tool Restrictions Are Enforced](#how-tool-restrictions-are-
 | **OpenCode CLI** | Hard | `permission:` YAML frontmatter enforced natively at install time |
 | **Grok Build CLI** | Native (mapped families) | Restricted profiles use deny-by-default `--permission-mode dontAsk` with explicit native/MCP allows and defense-in-depth denies; native subagents are disabled |
 | **Kimi CLI** | Soft | Security system prompt only |
+| **MiniMax Code** | Soft | Security bootstrap prompt only |
 | **Codex** | Soft | Security system prompt only |
 | **Antigravity CLI** | Soft | Security system prompt only |
 | **Hermes** | Profile-defined | CAO launches default `hermes` or the optional `hermesProfile` wrapper declared by the CAO profile; restrict tools in that Hermes profile |
@@ -307,7 +308,7 @@ separate from `allowedTools`, including `allowedTools: ["*"]`.
 See the [Grok Build CLI provider guide](grok-cli.md#tool-restrictions) for the
 complete mapping and isolation behavior.
 
-**Kimi CLI / Codex** — Prepends to the system prompt:
+**Kimi CLI / MiniMax Code / Codex** — Prepends to the system or bootstrap prompt:
 ```
 You may ONLY use these tools: @cao-mcp-server, fs_read, fs_list
 Do NOT attempt to use: execute_bash, fs_write
@@ -351,7 +352,7 @@ Each agent is restricted based on its own profile, not its parent's permissions.
 2. **Don't use `--yolo` in production.** It grants unrestricted access and skips all safety prompts.
 3. **Prefer hard-enforcement providers** (Claude Code, Kiro CLI, Copilot CLI) for sensitive workloads.
 4. **Review the confirmation prompt.** It shows exactly what tools are allowed and blocked before you proceed.
-5. **Kimi CLI and Codex use soft enforcement** — use these only for non-critical tasks.
+5. **Kimi CLI, MiniMax Code, and Codex use soft enforcement** — use these only for non-critical tasks.
 
 ## Known Limitations
 
@@ -359,7 +360,7 @@ Each agent is restricted based on its own profile, not its parent's permissions.
 
 2. **`@cao-mcp-server` is server-level, not per-tool control.** Grok restricted profiles translate it to an allow rule for the configured CAO MCP server; other providers generally treat it as an intent marker. No provider currently blocks individual MCP tools: once the server is available, its `handoff`, `assign`, `send_message`, and `answer_user_prompt` tools are all available. `answer_user_prompt` is exposed by the MCP server, but its structured prompt-navigation behavior is currently implemented for Hermes workers that report `waiting_user_answer`; other providers may only receive ordinary text input until they implement equivalent prompt states. Future versions may support `@cao-mcp-server:send_message` syntax for per-tool MCP control.
 
-3. **Soft enforcement is best-effort.** Kimi CLI and Codex rely on system prompt instructions to restrict tools. The agent may ignore these restrictions. Do not rely on soft enforcement for security-critical workloads.
+3. **Soft enforcement is best-effort.** Kimi CLI, MiniMax Code, and Codex rely on prompt instructions to restrict tools. The agent may ignore these restrictions. Do not rely on soft enforcement for security-critical workloads.
 
 ## Example Profiles
 

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -2263,6 +2263,7 @@ async def list_providers_endpoint() -> List[Dict]:
         "antigravity_cli": "agy",
         "omp": "omp",
         "grok_cli": "grok",
+        "minimax_code": "mcode",
     }
     result = []
     for provider, binary in provider_binaries.items():

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -2263,7 +2263,7 @@ async def list_providers_endpoint() -> List[Dict]:
         "antigravity_cli": "agy",
         "omp": "omp",
         "grok_cli": "grok",
-        "minimax_code": "mcode",
+        "mcode": "mcode",
     }
     result = []
     for provider, binary in provider_binaries.items():

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -33,7 +33,7 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     "hermes",
     "kimi_cli",
     "kiro_cli",
-    "minimax_code",
+    "mcode",
     "opencode_cli",
     "omp",
 }

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -33,6 +33,7 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     "hermes",
     "kimi_cli",
     "kiro_cli",
+    "minimax_code",
     "opencode_cli",
     "omp",
 }

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -24,6 +24,7 @@ from cli_agent_orchestrator.constants import (
 )
 from cli_agent_orchestrator.mcp_server.models import HandoffResult
 from cli_agent_orchestrator.models.inbox import OrchestrationType
+from cli_agent_orchestrator.models.provider import ProviderType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.models.workflow_runtime import ReturnAck
 from cli_agent_orchestrator.services.memory_service import (
@@ -271,9 +272,9 @@ def _create_terminal(
             params["working_directory"] = working_directory
         if child_allowed_tools:
             params["allowed_tools"] = child_allowed_tools
-        if engine is not None:
+        if provider == ProviderType.KIRO_CLI.value and engine is not None:
             params["engine"] = engine
-        if model is not None:
+        if provider != ProviderType.MINIMAX_CODE.value and model and model.strip():
             params["model"] = model
         if use_worktree:
             params["use_worktree"] = "true"
@@ -321,9 +322,9 @@ def _create_terminal(
         }
         if working_directory:
             params["working_directory"] = working_directory
-        if engine is not None:
+        if provider == ProviderType.KIRO_CLI.value and engine is not None:
             params["engine"] = engine
-        if model is not None:
+        if provider != ProviderType.MINIMAX_CODE.value and model and model.strip():
             params["model"] = model
 
         json_body = None
@@ -795,9 +796,9 @@ async def _handoff_impl(
             payload["allowed_tools"] = ctx.allowed_tools
         if working_directory:
             payload["working_directory"] = working_directory
-        if engine is not None:
+        if provider == ProviderType.KIRO_CLI.value and engine is not None:
             payload["engine"] = engine
-        if model:
+        if provider != ProviderType.MINIMAX_CODE.value and model and model.strip():
             payload["model"] = model
 
         # Allow the full step time plus the server-side ready-wait (up to 120s)

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -274,7 +274,7 @@ def _create_terminal(
             params["allowed_tools"] = child_allowed_tools
         if provider == ProviderType.KIRO_CLI.value and engine is not None:
             params["engine"] = engine
-        if provider != ProviderType.MINIMAX_CODE.value and model and model.strip():
+        if model and model.strip():
             params["model"] = model
         if use_worktree:
             params["use_worktree"] = "true"
@@ -324,7 +324,7 @@ def _create_terminal(
             params["working_directory"] = working_directory
         if provider == ProviderType.KIRO_CLI.value and engine is not None:
             params["engine"] = engine
-        if provider != ProviderType.MINIMAX_CODE.value and model and model.strip():
+        if model and model.strip():
             params["model"] = model
 
         json_body = None
@@ -798,7 +798,7 @@ async def _handoff_impl(
             payload["working_directory"] = working_directory
         if provider == ProviderType.KIRO_CLI.value and engine is not None:
             payload["engine"] = engine
-        if provider != ProviderType.MINIMAX_CODE.value and model and model.strip():
+        if model and model.strip():
             payload["model"] = model
 
         # Allow the full step time plus the server-side ready-wait (up to 120s)

--- a/src/cli_agent_orchestrator/models/provider.py
+++ b/src/cli_agent_orchestrator/models/provider.py
@@ -15,5 +15,6 @@ class ProviderType(str, Enum):
     ANTIGRAVITY_CLI = "antigravity_cli"
     OMP = "omp"
     GROK_CLI = "grok_cli"
+    MINIMAX_CODE = "minimax_code"
     # Credentials-free mock provider for tests/CI (no real CLI binary).
     MOCK_CLI = "mock_cli"

--- a/src/cli_agent_orchestrator/models/provider.py
+++ b/src/cli_agent_orchestrator/models/provider.py
@@ -15,6 +15,6 @@ class ProviderType(str, Enum):
     ANTIGRAVITY_CLI = "antigravity_cli"
     OMP = "omp"
     GROK_CLI = "grok_cli"
-    MINIMAX_CODE = "minimax_code"
+    MINIMAX_CODE = "mcode"
     # Credentials-free mock provider for tests/CI (no real CLI binary).
     MOCK_CLI = "mock_cli"

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -251,6 +251,17 @@ class BaseProvider(ABC):
         return False
 
     @property
+    def assume_processing_on_dispatch(self) -> bool:
+        """Publish PROCESSING immediately when a task is dispatched.
+
+        Most CLIs repaint quickly enough for their first activity frame to
+        drive the transition. Full-screen TUIs that can remain visually
+        unchanged just after submission opt in so callers cannot observe the
+        previous turn's cached COMPLETED state as the new turn's result.
+        """
+        return False
+
+    @property
     def extraction_retries(self) -> int:
         """Number of extraction retries for transient TUI rendering issues.
 

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -15,6 +15,7 @@ from cli_agent_orchestrator.providers.cursor_cli import CursorCliProvider
 from cli_agent_orchestrator.providers.grok_cli import GrokCliProvider
 from cli_agent_orchestrator.providers.hermes import HermesProvider
 from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
+from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
 from cli_agent_orchestrator.providers.kiro_capabilities import KiroPhase0KASError
 from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
 from cli_agent_orchestrator.providers.mock_cli import MockCliProvider
@@ -158,6 +159,16 @@ class ProviderManager:
                     skill_prompt=skill_prompt,
                     model=model,
                 )
+            elif provider_type == ProviderType.MINIMAX_CODE.value:
+                provider = MiniMaxCodeProvider(
+                    terminal_id,
+                    tmux_session,
+                    tmux_window,
+                    agent_profile,
+                    allowed_tools,
+                    skill_prompt=skill_prompt,
+                    model=model,
+                )
             # --- Credentials-free mock provider (test/CI infrastructure) ---
             elif provider_type == ProviderType.MOCK_CLI.value:
                 provider = MockCliProvider(
@@ -264,16 +275,27 @@ class ProviderManager:
             # cleanup-only adapter rather than leaking that directory.
             metadata = get_terminal_metadata(terminal_id)
             if metadata and metadata.get("provider") == ProviderType.GROK_CLI.value:
-                cleanup_provider = GrokCliProvider(
+                restored_grok_provider = GrokCliProvider(
                     terminal_id,
                     metadata["tmux_session"],
                     metadata["tmux_window"],
                     metadata.get("agent_profile"),
                 )
-                if cleanup_provider.cleanup() is False:
+                if restored_grok_provider.cleanup() is False:
                     logger.warning("Cleanup deferred for restored Grok provider: %s", terminal_id)
                     return False
                 logger.info("Cleaned up restored Grok provider for terminal: %s", terminal_id)
+            elif metadata and metadata.get("provider") == ProviderType.MINIMAX_CODE.value:
+                restored_minimax_provider = MiniMaxCodeProvider(
+                    terminal_id,
+                    metadata["tmux_session"],
+                    metadata["tmux_window"],
+                    metadata.get("agent_profile"),
+                )
+                restored_minimax_provider.cleanup()
+                logger.info(
+                    "Cleaned up restored MiniMax Code provider for terminal: %s", terminal_id
+                )
             return True
         except Exception as e:
             logger.error(f"Failed to cleanup provider for terminal {terminal_id}: {e}")

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -15,9 +15,9 @@ from cli_agent_orchestrator.providers.cursor_cli import CursorCliProvider
 from cli_agent_orchestrator.providers.grok_cli import GrokCliProvider
 from cli_agent_orchestrator.providers.hermes import HermesProvider
 from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
-from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
 from cli_agent_orchestrator.providers.kiro_capabilities import KiroPhase0KASError
 from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
+from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
 from cli_agent_orchestrator.providers.mock_cli import MockCliProvider
 from cli_agent_orchestrator.providers.omp import OmpProvider
 from cli_agent_orchestrator.providers.opencode_cli import OpenCodeCliProvider

--- a/src/cli_agent_orchestrator/providers/minimax_code.py
+++ b/src/cli_agent_orchestrator/providers/minimax_code.py
@@ -82,6 +82,8 @@ class MiniMaxCodeProvider(BaseProvider):
         self._awaiting_turn = False
         self._turn_activity_seen = False
         self._last_completion_identity: Optional[str] = None
+        self._last_completion_buffer_epoch: Optional[int] = None
+        self._status_buffer_epoch = 0
 
     supports_screen_detection = True
     supports_direct_status_probe = True
@@ -103,6 +105,18 @@ class MiniMaxCodeProvider(BaseProvider):
         self._has_received_input = True
         self._awaiting_turn = True
         self._turn_activity_seen = False
+
+    def notify_status_buffer_reset(self, epoch: int) -> None:
+        """Record the explicit rolling-buffer generation for the next turn.
+
+        Keep the prior completion fingerprint and its epoch. A retained screen
+        immediately after the reset is still stale, but an identical completion
+        may be accepted after current-turn activity is observed in the new
+        generation.
+        """
+
+        if epoch > self._status_buffer_epoch:
+            self._status_buffer_epoch = epoch
 
     @staticmethod
     def _is_substantive_user_line(line: str) -> bool:
@@ -453,6 +467,12 @@ class MiniMaxCodeProvider(BaseProvider):
         last_error = _last_match_start(_ERROR_PATTERN, clean)
         completion_identity, completion_anchored = self._latest_completion_identity(clean)
 
+        # A fast turn can emit its processing frame and completion in the same
+        # rolling-buffer generation before CAO performs an intermediate status
+        # probe. The ordering still proves current-turn activity.
+        if self._awaiting_turn and 0 <= last_processing < last_completion:
+            self._turn_activity_seen = True
+
         if last_waiting > max(last_processing, last_completion, last_ready):
             return TerminalStatus.WAITING_USER_ANSWER
         if last_processing > last_completion:
@@ -462,33 +482,44 @@ class MiniMaxCodeProvider(BaseProvider):
         if last_error > max(last_processing, last_completion, last_ready):
             return TerminalStatus.ERROR
         if last_ready >= 0:
-            if self._awaiting_turn and completion_identity == self._last_completion_identity:
-                return TerminalStatus.PROCESSING
             if self._awaiting_turn and completion_identity is None:
-                return TerminalStatus.PROCESSING
+                return TerminalStatus.IDLE
+            if self._awaiting_turn and completion_identity == self._last_completion_identity:
+                if self._last_completion_buffer_epoch == self._status_buffer_epoch:
+                    return TerminalStatus.PROCESSING
+                if not self._turn_activity_seen:
+                    # The buffer was cleared, but a full-screen TUI can retain
+                    # and redraw the previous completion without accepting the
+                    # new prompt. Do not report synthetic work to deferred-submit
+                    # confirmation; it must remain eligible for retry.
+                    return TerminalStatus.IDLE
             if self._awaiting_turn and not completion_anchored and not self._turn_activity_seen:
                 return TerminalStatus.PROCESSING
             if completion_identity is not None and self._has_received_input:
                 self._last_completion_identity = completion_identity
+                self._last_completion_buffer_epoch = self._status_buffer_epoch
                 self._awaiting_turn = False
                 self._turn_activity_seen = False
                 return TerminalStatus.COMPLETED
             if completion_identity is not None:
                 self._last_completion_identity = completion_identity
+                self._last_completion_buffer_epoch = self._status_buffer_epoch
             return TerminalStatus.IDLE
         if completion_identity is not None:
             if self._awaiting_turn and completion_identity == self._last_completion_identity:
-                return TerminalStatus.PROCESSING
+                if self._last_completion_buffer_epoch == self._status_buffer_epoch:
+                    return TerminalStatus.PROCESSING
+                if not self._turn_activity_seen:
+                    return TerminalStatus.UNKNOWN
             if self._awaiting_turn and not completion_anchored and not self._turn_activity_seen:
                 return TerminalStatus.PROCESSING
             self._last_completion_identity = completion_identity
+            self._last_completion_buffer_epoch = self._status_buffer_epoch
             if self._has_received_input:
                 self._awaiting_turn = False
                 self._turn_activity_seen = False
                 return TerminalStatus.COMPLETED
             return TerminalStatus.IDLE
-        if self._awaiting_turn:
-            return TerminalStatus.PROCESSING
         return TerminalStatus.UNKNOWN
 
     def get_status_from_screen(self, screen_lines: list[str]) -> TerminalStatus:
@@ -555,3 +586,5 @@ class MiniMaxCodeProvider(BaseProvider):
         self._awaiting_turn = False
         self._turn_activity_seen = False
         self._last_completion_identity = None
+        self._last_completion_buffer_epoch = None
+        self._status_buffer_epoch = 0

--- a/src/cli_agent_orchestrator/providers/minimax_code.py
+++ b/src/cli_agent_orchestrator/providers/minimax_code.py
@@ -1,0 +1,478 @@
+"""MiniMax Code CLI provider implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+from cli_agent_orchestrator.backends.registry import get_backend
+from cli_agent_orchestrator.constants import CAO_HOME_DIR, SECURITY_PROMPT
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.base import BaseProvider
+from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
+from cli_agent_orchestrator.utils.mcp_resolution import resolve_mcp_server_config
+from cli_agent_orchestrator.utils.terminal import wait_for_shell
+from cli_agent_orchestrator.utils.text import strip_terminal_escapes
+
+_PLUGIN_NAME = "cao-orchestrator"
+_PLUGIN_SERVER_NAME = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+_ICON_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+class ProviderError(Exception):
+    """Raised when MiniMax Code cannot be configured safely."""
+
+
+class MiniMaxCodeProvider(BaseProvider):
+    """Provider for the interactive ``mcode`` terminal UI."""
+
+    def __init__(
+        self,
+        terminal_id: str,
+        session_name: str,
+        window_name: str,
+        agent_profile: Optional[str] = None,
+        allowed_tools: Optional[list[str]] = None,
+        skill_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
+        self._agent_profile = agent_profile
+        self._model = model
+        self._initialized = False
+        self._data_dir: Optional[Path] = None
+        self._has_received_input = False
+        self._awaiting_turn = False
+        self._turn_activity_seen = False
+        self._last_completion_identity: Optional[str] = None
+
+    supports_screen_detection = True
+    supports_direct_status_probe = True
+
+    @property
+    def paste_enter_count(self) -> int:
+        return 1
+
+    @property
+    def accepts_input_while_processing(self) -> bool:
+        return True
+
+    @property
+    def blocks_orchestrated_input_while_waiting_user_answer(self) -> bool:
+        return True
+
+    @property
+    def assume_processing_on_dispatch(self) -> bool:
+        return True
+
+    def mark_input_received(self) -> None:
+        super().mark_input_received()
+        self._has_received_input = True
+        self._awaiting_turn = True
+        self._turn_activity_seen = False
+
+    @staticmethod
+    def _is_substantive_user_line(line: str) -> bool:
+        match = re.match(r"^\s*›[^\S\n]+(.*)$", line)
+        return bool(match and any(character.isalnum() for character in match.group(1)))
+
+    @classmethod
+    def _latest_completion_identity(cls, clean: str) -> tuple[Optional[str], bool]:
+        lines = clean.splitlines()
+        completion_indices = [
+            index
+            for index, line in enumerate(lines)
+            if re.match(r"^\s*└\s+Completed in\s+\d", line, re.IGNORECASE)
+        ]
+        if not completion_indices:
+            return None, False
+        completion = completion_indices[-1]
+        user = max(
+            (
+                index
+                for index, line in enumerate(lines[:completion])
+                if cls._is_substantive_user_line(line)
+            ),
+            default=-1,
+        )
+        assistants = [
+            index
+            for index in range(user + 1, completion)
+            if re.match(r"^\s*●\s+\S", lines[index])
+            and not re.match(r"^\s*●\s+Ready\s*$", lines[index])
+        ]
+        anchored = user >= 0 or bool(assistants)
+        if user >= 0:
+            start = user
+        elif assistants:
+            start = assistants[-1]
+        else:
+            # A long final answer can push both its opening ``●`` and the user
+            # row outside the fixed-height viewport while the completion note
+            # remains visible. Hash the settled tail so that case still has a
+            # completion identity; callers require observed turn activity
+            # before accepting this unanchored fallback.
+            start = max(0, completion - 30)
+        material = "\n".join(lines[start : completion + 1])
+        return hashlib.sha256(material.encode("utf-8")).hexdigest(), anchored
+
+    @staticmethod
+    def _source_data_dir() -> Path:
+        configured = os.environ.get("MINIMAX_DATA_DIR", "").strip()
+        return Path(configured).expanduser() if configured else Path.home() / ".minimax"
+
+    def _data_dir_path(self) -> Path:
+        digest = hashlib.sha256(self.terminal_id.encode("utf-8")).hexdigest()
+        return CAO_HOME_DIR / "providers" / "minimax_code" / digest
+
+    @staticmethod
+    def _secure_tree(path: Path) -> None:
+        os.chmod(path, 0o700)
+        for child in path.rglob("*"):
+            if child.is_symlink():
+                child.unlink()
+            elif child.is_dir():
+                os.chmod(child, 0o700)
+            elif child.is_file():
+                os.chmod(child, 0o600)
+
+    @classmethod
+    def _copy_auth_material(cls, source: Path, destination: Path) -> None:
+        for name in ("config.yaml", "local-runtime.auth.json"):
+            source_file = source / name
+            if source_file.is_file():
+                shutil.copyfile(source_file, destination / name)
+                os.chmod(destination / name, 0o600)
+
+        source_auth = source / "cli-auth"
+        destination_auth = destination / "cli-auth"
+        if source_auth.is_dir():
+            shutil.copytree(
+                source_auth,
+                destination_auth,
+                symlinks=False,
+                ignore_dangling_symlinks=True,
+            )
+            cls._secure_tree(destination_auth)
+
+    @staticmethod
+    def _serialize_server(name: str, raw_config: Any) -> dict[str, Any]:
+        if not _PLUGIN_SERVER_NAME.fullmatch(name):
+            raise ProviderError(f"Invalid MiniMax Code MCP server name: {name!r}")
+        config = (
+            dict(raw_config)
+            if isinstance(raw_config, dict)
+            else raw_config.model_dump(exclude_none=True)
+        )
+        config = resolve_mcp_server_config(config)
+        command = config.get("command")
+        if not isinstance(command, str) or not command:
+            raise ProviderError(f"MCP server {name!r} must define a stdio command")
+
+        env = {str(key): str(value) for key, value in (config.get("env") or {}).items()}
+        command_path = Path(command)
+        if command_path.is_absolute():
+            command = command_path.name
+            existing_path = env.get("PATH", os.environ.get("PATH", ""))
+            env["PATH"] = os.pathsep.join(
+                part for part in (str(command_path.parent), existing_path) if part
+            )
+        elif "/" in command or "\\" in command:
+            raise ProviderError(
+                f"MCP server {name!r} command must be a bare executable or absolute path"
+            )
+
+        return {
+            "type": "stdio",
+            "command": command,
+            "args": [str(arg) for arg in (config.get("args") or [])],
+            "env": env,
+            "description": f"CAO-managed MCP server {name}",
+            "timeout": 600_000,
+        }
+
+    def _write_plugin(self, data_dir: Path, mcp_servers: dict[str, Any]) -> None:
+        plugin_dir = data_dir / "plugins" / _PLUGIN_NAME
+        manifest_dir = plugin_dir / ".minimax-plugin"
+        manifest_dir.mkdir(parents=True, mode=0o700)
+        servers = {
+            name: self._serialize_server(name, raw_config)
+            for name, raw_config in mcp_servers.items()
+        }
+        for server in servers.values():
+            server["env"]["CAO_TERMINAL_ID"] = self.terminal_id
+
+        manifest = {
+            "schemaVersion": 1,
+            "name": _PLUGIN_NAME,
+            "displayName": "CAO Orchestrator",
+            "version": "1.0.0",
+            "description": "Exposes CLI Agent Orchestrator tools to this terminal.",
+            "author": "CLI Agent Orchestrator",
+            "icon": "icon.png",
+            "category": "Code",
+            "exampleQueries": ["Use CAO Orchestrator to collaborate with another agent."],
+            "apps": [],
+            "mcpServers": ["servers.mcp.json"],
+            "skills": [],
+        }
+        (manifest_dir / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
+        (plugin_dir / "servers.mcp.json").write_text(
+            json.dumps({"schemaVersion": 1, "mcpServers": servers}), encoding="utf-8"
+        )
+        (plugin_dir / "icon.png").write_bytes(_ICON_PNG)
+        self._secure_tree(plugin_dir)
+
+    def _prepare_runtime(self) -> tuple[Path, str]:
+        profile = None
+        if self._agent_profile is not None:
+            try:
+                profile = load_agent_profile(self._agent_profile)
+            except Exception as exc:
+                raise ProviderError(
+                    f"Failed to load agent profile {self._agent_profile!r}: {exc}"
+                ) from exc
+
+        if self._model or (profile is not None and profile.model):
+            raise ProviderError(
+                "MiniMax Code's interactive CLI does not expose a per-session model flag"
+            )
+
+        data_dir = self._data_dir_path()
+        if data_dir.exists():
+            shutil.rmtree(data_dir)
+        data_dir.mkdir(parents=True, mode=0o700)
+        os.chmod(data_dir, 0o700)
+        self._copy_auth_material(self._source_data_dir(), data_dir)
+        if profile is not None and profile.mcpServers:
+            self._write_plugin(data_dir, profile.mcpServers)
+        self._data_dir = data_dir
+
+        system_prompt = (profile.system_prompt or "") if profile is not None else ""
+        return data_dir, self._apply_skill_prompt(system_prompt)
+
+    def _build_command(self) -> str:
+        binary = shutil.which("mcode")
+        if not binary:
+            raise ProviderError(
+                "MiniMax Code CLI not found: install it with "
+                "'npm install -g @minimax-ai/code' and run 'mcode login'."
+            )
+
+        data_dir, bootstrap = self._prepare_runtime()
+        if self._allowed_tools and "*" not in self._allowed_tools:
+            tools = ", ".join(self._allowed_tools)
+            bootstrap = (
+                f"{SECURITY_PROMPT}\nYou only have access to these tools: {tools}\n\n"
+                f"{bootstrap}"
+            )
+        bootstrap = (
+            f"{bootstrap}\n\n"
+            "You are starting inside a CLI Agent Orchestrator terminal. "
+            "Apply the instructions above for all later turns in this session. "
+            "Do not begin any task yet. Reply exactly CAO_MCODE_READY."
+        ).strip()
+        return shlex.join(
+            [
+                "env",
+                f"MINIMAX_DATA_DIR={data_dir}",
+                "TERM=xterm-256color",
+                binary,
+                bootstrap,
+            ]
+        )
+
+    def _try_load_profile(self):
+        if self._agent_profile is None:
+            return None
+        try:
+            return load_agent_profile(self._agent_profile)
+        except Exception:
+            return None
+
+    async def _wait_for_bootstrap_ready(self, timeout: float) -> bool:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            output = await asyncio.to_thread(
+                get_backend().get_history,
+                self.session_name,
+                self.window_name,
+                strip_escapes=True,
+            )
+            has_bootstrap_response = (
+                re.search(r"(?m)^\s*●\s+CAO_MCODE_READY\s*$", output) is not None
+            )
+            if has_bootstrap_response and self.get_status(output) in {
+                TerminalStatus.IDLE,
+                TerminalStatus.COMPLETED,
+            }:
+                return True
+            await asyncio.sleep(0.5)
+        return False
+
+    async def initialize(self) -> bool:
+        init_timeout = float(self.get_init_timeout(self._try_load_profile()))
+        ready_timeout = max(120.0, init_timeout)
+        try:
+            if not await wait_for_shell(self.terminal_id, timeout=init_timeout):
+                raise TimeoutError(f"Shell initialization timed out after {init_timeout:g}s")
+
+            command = await asyncio.to_thread(self._build_command)
+            from cli_agent_orchestrator.services.status_monitor import status_monitor
+
+            status_monitor.notify_input_sent(self.terminal_id)
+            await asyncio.to_thread(
+                get_backend().send_keys,
+                self.session_name,
+                self.window_name,
+                command,
+            )
+            if not await self._wait_for_bootstrap_ready(ready_timeout):
+                raise TimeoutError(
+                    f"MiniMax Code initialization timed out after {ready_timeout:g}s"
+                )
+            self._initialized = True
+            return True
+        except Exception:
+            await asyncio.to_thread(self.cleanup)
+            raise
+
+    def get_status(self, buffer: str) -> TerminalStatus:
+        native = self._resolve_native_status(buffer)
+        if native is not None:
+            return native
+        buffer = self._resolve_buffer(buffer)
+        if not buffer:
+            return TerminalStatus.UNKNOWN
+
+        clean = strip_terminal_escapes(buffer)
+
+        def last(pattern: str) -> int:
+            return max(
+                (match.start() for match in re.finditer(pattern, clean, re.IGNORECASE)),
+                default=-1,
+            )
+
+        last_waiting = last(
+            r"Approval needed|Run this command\?|Allow for this conversation|"
+            r"Always allow this action|User prompt request"
+        )
+        last_processing = last(
+            r"[⠁-⣿◇◆]\s+(?:Loading|Running)(?:\s+\d+s)?[^\n]*(?:Enter queue|Esc stop)"
+        )
+        last_completion = last(r"(?:^|\n)\s*└\s+Completed in\s+\d")
+        last_ready = max(last(r"●\s+Ready"), last(r"Message\s+·\s+Enter send"))
+        last_error = last(
+            r"Sign in required|Authentication failed|Not authenticated|"
+            r"(?:^|\n)\s*(?:Fatal|Error):"
+        )
+        completion_identity, completion_anchored = self._latest_completion_identity(clean)
+
+        if last_waiting > max(last_processing, last_completion, last_ready):
+            return TerminalStatus.WAITING_USER_ANSWER
+        if last_processing > last_completion:
+            if self._awaiting_turn:
+                self._turn_activity_seen = True
+            return TerminalStatus.PROCESSING
+        if last_error > max(last_processing, last_completion, last_ready):
+            return TerminalStatus.ERROR
+        if last_ready >= 0:
+            if self._awaiting_turn and completion_identity == self._last_completion_identity:
+                if not self._turn_activity_seen:
+                    return TerminalStatus.PROCESSING
+            if self._awaiting_turn and completion_identity is None:
+                return TerminalStatus.PROCESSING
+            if self._awaiting_turn and not completion_anchored and not self._turn_activity_seen:
+                return TerminalStatus.PROCESSING
+            if completion_identity is not None and self._has_received_input:
+                self._last_completion_identity = completion_identity
+                self._awaiting_turn = False
+                self._turn_activity_seen = False
+                return TerminalStatus.COMPLETED
+            if completion_identity is not None:
+                self._last_completion_identity = completion_identity
+            return TerminalStatus.IDLE
+        if completion_identity is not None:
+            if self._awaiting_turn and completion_identity == self._last_completion_identity:
+                if not self._turn_activity_seen:
+                    return TerminalStatus.PROCESSING
+            if self._awaiting_turn and not completion_anchored and not self._turn_activity_seen:
+                return TerminalStatus.PROCESSING
+            self._last_completion_identity = completion_identity
+            if self._has_received_input:
+                self._awaiting_turn = False
+                self._turn_activity_seen = False
+                return TerminalStatus.COMPLETED
+            return TerminalStatus.IDLE
+        if self._awaiting_turn:
+            return TerminalStatus.PROCESSING
+        return TerminalStatus.UNKNOWN
+
+    def get_status_from_screen(self, screen_lines: list[str]) -> TerminalStatus:
+        return self.get_status("\n".join(screen_lines))
+
+    def extract_last_message_from_script(self, script_output: str) -> str:
+        clean = strip_terminal_escapes(script_output)
+        lines = clean.splitlines()
+
+        last_user = max(
+            (index for index, line in enumerate(lines) if self._is_substantive_user_line(line)),
+            default=-1,
+        )
+        completion = max(
+            (
+                index
+                for index, line in enumerate(lines)
+                if re.match(r"^\s*└\s+Completed in\s+\d", line, re.IGNORECASE)
+            ),
+            default=len(lines),
+        )
+        assistant_starts = [
+            index
+            for index in range(last_user + 1, completion)
+            if re.match(r"^\s*●\s+\S", lines[index])
+            and not re.match(r"^\s*●\s+Ready\s*$", lines[index])
+        ]
+        if not assistant_starts:
+            raise ValueError("No MiniMax Code final response found")
+
+        start = assistant_starts[-1]
+        response = [re.sub(r"^\s*●\s+", "", lines[start]).strip()]
+        for line in lines[start + 1 : completion]:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if re.match(r"^(?:├|└|Called\s|Message\s+·|/[^ ]+\s+\|)", stripped):
+                continue
+            if re.match(r"^[╭│╰]", stripped):
+                continue
+            response.append(stripped)
+
+        answer = "\n".join(response).strip()
+        if not answer:
+            raise ValueError("MiniMax Code final response was empty")
+        return answer
+
+    def exit_cli(self) -> str:
+        return "/exit"
+
+    def cleanup(self) -> None:
+        data_dir = self._data_dir or self._data_dir_path()
+        if data_dir.exists():
+            shutil.rmtree(data_dir)
+        self._data_dir = None
+        self._initialized = False
+        self._has_received_input = False
+        self._awaiting_turn = False
+        self._turn_activity_seen = False
+        self._last_completion_identity = None

--- a/src/cli_agent_orchestrator/providers/minimax_code.py
+++ b/src/cli_agent_orchestrator/providers/minimax_code.py
@@ -13,6 +13,8 @@ import shutil
 from pathlib import Path
 from typing import Any, Optional
 
+import yaml
+
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import CAO_HOME_DIR, SECURITY_PROMPT
 from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -24,9 +26,34 @@ from cli_agent_orchestrator.utils.text import strip_terminal_escapes
 
 _PLUGIN_NAME = "cao-orchestrator"
 _PLUGIN_SERVER_NAME = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+_USER_LINE_PATTERN = re.compile(r"^\s*›[^\S\n]+(.*)$")
+_COMPLETION_LINE_PATTERN = re.compile(r"^\s*└\s+Completed in\s+\d", re.IGNORECASE)
+_COMPLETION_PATTERN = re.compile(r"(?:^|\n)\s*└\s+Completed in\s+\d", re.IGNORECASE)
+_ASSISTANT_LINE_PATTERN = re.compile(r"^(?P<indent>\s*)●\s+(?P<text>\S.*)$")
+_READY_ASSISTANT_LINE_PATTERN = re.compile(r"^\s*●\s+Ready\s*$")
+_WAITING_PATTERN = re.compile(
+    r"Approval needed|Run this command\?|Allow for this conversation|"
+    r"Always allow this action|User prompt request",
+    re.IGNORECASE,
+)
+_PROCESSING_PATTERN = re.compile(
+    r"[⠁-⣿◇◆]\s+(?:Loading|Running)(?:\s+\d+s)?[^\n]*(?:Enter queue|Esc stop)",
+    re.IGNORECASE,
+)
+_READY_PATTERN = re.compile(r"●\s+Ready|Message\s+·\s+Enter send", re.IGNORECASE)
+_ERROR_PATTERN = re.compile(
+    r"Sign in required|Authentication failed|Not authenticated|" r"(?:^|\n)\s*(?:Fatal|Error):",
+    re.IGNORECASE,
+)
+_EXTRACTION_SKIP_PATTERN = re.compile(r"^(?:├|└|Called\s|Message\s+·|/[^ ]+\s+\|)")
+_BOX_CHROME_PATTERN = re.compile(r"^[╭│╰]")
 _ICON_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
 )
+
+
+def _last_match_start(pattern: re.Pattern[str], text: str) -> int:
+    return max((match.start() for match in pattern.finditer(text)), default=-1)
 
 
 class ProviderError(Exception):
@@ -71,10 +98,6 @@ class MiniMaxCodeProvider(BaseProvider):
     def blocks_orchestrated_input_while_waiting_user_answer(self) -> bool:
         return True
 
-    @property
-    def assume_processing_on_dispatch(self) -> bool:
-        return True
-
     def mark_input_received(self) -> None:
         super().mark_input_received()
         self._has_received_input = True
@@ -83,16 +106,14 @@ class MiniMaxCodeProvider(BaseProvider):
 
     @staticmethod
     def _is_substantive_user_line(line: str) -> bool:
-        match = re.match(r"^\s*›[^\S\n]+(.*)$", line)
+        match = _USER_LINE_PATTERN.match(line)
         return bool(match and any(character.isalnum() for character in match.group(1)))
 
     @classmethod
     def _latest_completion_identity(cls, clean: str) -> tuple[Optional[str], bool]:
         lines = clean.splitlines()
         completion_indices = [
-            index
-            for index, line in enumerate(lines)
-            if re.match(r"^\s*└\s+Completed in\s+\d", line, re.IGNORECASE)
+            index for index, line in enumerate(lines) if _COMPLETION_LINE_PATTERN.match(line)
         ]
         if not completion_indices:
             return None, False
@@ -108,8 +129,8 @@ class MiniMaxCodeProvider(BaseProvider):
         assistants = [
             index
             for index in range(user + 1, completion)
-            if re.match(r"^\s*●\s+\S", lines[index])
-            and not re.match(r"^\s*●\s+Ready\s*$", lines[index])
+            if _ASSISTANT_LINE_PATTERN.match(lines[index])
+            and not _READY_ASSISTANT_LINE_PATTERN.match(lines[index])
         ]
         anchored = user >= 0 or bool(assistants)
         if user >= 0:
@@ -134,6 +155,33 @@ class MiniMaxCodeProvider(BaseProvider):
     def _data_dir_path(self) -> Path:
         digest = hashlib.sha256(self.terminal_id.encode("utf-8")).hexdigest()
         return CAO_HOME_DIR / "providers" / "minimax_code" / digest
+
+    @staticmethod
+    def _managed_data_root() -> Path:
+        return CAO_HOME_DIR / "providers" / "minimax_code"
+
+    def _is_managed_data_dir(self, data_dir: Path) -> bool:
+        """Return whether recursive operations stay in CAO's managed tree."""
+
+        root = self._managed_data_root()
+        expected = self._data_dir_path()
+        if data_dir != expected or data_dir.parent != root or data_dir.is_symlink():
+            return False
+        base = root.parent.parent
+        if root.name != "minimax_code" or root.parent.name != "providers":
+            return False
+        try:
+            if any(ancestor.is_symlink() for ancestor in (base, root.parent, root)):
+                return False
+            return data_dir.parent.resolve(strict=False) == root.resolve(strict=False)
+        except OSError:
+            return False
+
+    def _require_managed_data_dir(self, data_dir: Path) -> None:
+        if not self._is_managed_data_dir(data_dir):
+            raise ProviderError(
+                f"Refusing operation outside the managed MiniMax Code data directory: {data_dir}"
+            )
 
     @staticmethod
     def _secure_tree(path: Path) -> None:
@@ -166,6 +214,30 @@ class MiniMaxCodeProvider(BaseProvider):
             cls._secure_tree(destination_auth)
 
     @staticmethod
+    def _apply_model_config(data_dir: Path, model: Optional[str]) -> None:
+        if not model or not model.strip():
+            return
+        config_path = data_dir / "config.yaml"
+        try:
+            loaded = (
+                yaml.safe_load(config_path.read_text(encoding="utf-8"))
+                if config_path.exists()
+                else {}
+            )
+        except (OSError, yaml.YAMLError) as exc:
+            raise ProviderError(f"Failed to read MiniMax Code config: {exc}") from exc
+        if loaded is None:
+            loaded = {}
+        if not isinstance(loaded, dict):
+            raise ProviderError("MiniMax Code config.yaml must contain a mapping")
+        loaded["defaultModel"] = model.strip()
+        config_path.write_text(
+            yaml.safe_dump(loaded, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        os.chmod(config_path, 0o600)
+
+    @staticmethod
     def _serialize_server(name: str, raw_config: Any) -> dict[str, Any]:
         if not _PLUGIN_SERVER_NAME.fullmatch(name):
             raise ProviderError(f"Invalid MiniMax Code MCP server name: {name!r}")
@@ -176,8 +248,26 @@ class MiniMaxCodeProvider(BaseProvider):
         )
         config = resolve_mcp_server_config(config)
         command = config.get("command")
+        url = config.get("url")
+        if not command and isinstance(url, str) and url:
+            transport = config.get("type", "http")
+            if transport == "http":
+                transport = "streamable-http"
+            if transport not in {"streamable-http", "sse"}:
+                raise ProviderError(
+                    f"MCP server {name!r} has unsupported URL transport {transport!r}"
+                )
+            return {
+                "type": transport,
+                "url": url,
+                "headers": {
+                    str(key): str(value) for key, value in (config.get("headers") or {}).items()
+                },
+                "description": f"CAO-managed MCP server {name}",
+                "timeout": 600_000,
+            }
         if not isinstance(command, str) or not command:
-            raise ProviderError(f"MCP server {name!r} must define a stdio command")
+            raise ProviderError(f"MCP server {name!r} must define a command or URL")
 
         env = {str(key): str(value) for key, value in (config.get("env") or {}).items()}
         command_path = Path(command)
@@ -210,7 +300,8 @@ class MiniMaxCodeProvider(BaseProvider):
             for name, raw_config in mcp_servers.items()
         }
         for server in servers.values():
-            server["env"]["CAO_TERMINAL_ID"] = self.terminal_id
+            if server["type"] == "stdio":
+                server["env"]["CAO_TERMINAL_ID"] = self.terminal_id
 
         manifest = {
             "schemaVersion": 1,
@@ -243,17 +334,15 @@ class MiniMaxCodeProvider(BaseProvider):
                     f"Failed to load agent profile {self._agent_profile!r}: {exc}"
                 ) from exc
 
-        if self._model or (profile is not None and profile.model):
-            raise ProviderError(
-                "MiniMax Code's interactive CLI does not expose a per-session model flag"
-            )
-
         data_dir = self._data_dir_path()
+        self._require_managed_data_dir(data_dir)
         if data_dir.exists():
             shutil.rmtree(data_dir)
         data_dir.mkdir(parents=True, mode=0o700)
         os.chmod(data_dir, 0o700)
         self._copy_auth_material(self._source_data_dir(), data_dir)
+        model = self._model or (profile.model if profile is not None else None)
+        self._apply_model_config(data_dir, model)
         if profile is not None and profile.mcpServers:
             self._write_plugin(data_dir, profile.mcpServers)
         self._data_dir = data_dir
@@ -357,25 +446,11 @@ class MiniMaxCodeProvider(BaseProvider):
 
         clean = strip_terminal_escapes(buffer)
 
-        def last(pattern: str) -> int:
-            return max(
-                (match.start() for match in re.finditer(pattern, clean, re.IGNORECASE)),
-                default=-1,
-            )
-
-        last_waiting = last(
-            r"Approval needed|Run this command\?|Allow for this conversation|"
-            r"Always allow this action|User prompt request"
-        )
-        last_processing = last(
-            r"[⠁-⣿◇◆]\s+(?:Loading|Running)(?:\s+\d+s)?[^\n]*(?:Enter queue|Esc stop)"
-        )
-        last_completion = last(r"(?:^|\n)\s*└\s+Completed in\s+\d")
-        last_ready = max(last(r"●\s+Ready"), last(r"Message\s+·\s+Enter send"))
-        last_error = last(
-            r"Sign in required|Authentication failed|Not authenticated|"
-            r"(?:^|\n)\s*(?:Fatal|Error):"
-        )
+        last_waiting = _last_match_start(_WAITING_PATTERN, clean)
+        last_processing = _last_match_start(_PROCESSING_PATTERN, clean)
+        last_completion = _last_match_start(_COMPLETION_PATTERN, clean)
+        last_ready = _last_match_start(_READY_PATTERN, clean)
+        last_error = _last_match_start(_ERROR_PATTERN, clean)
         completion_identity, completion_anchored = self._latest_completion_identity(clean)
 
         if last_waiting > max(last_processing, last_completion, last_ready):
@@ -388,8 +463,7 @@ class MiniMaxCodeProvider(BaseProvider):
             return TerminalStatus.ERROR
         if last_ready >= 0:
             if self._awaiting_turn and completion_identity == self._last_completion_identity:
-                if not self._turn_activity_seen:
-                    return TerminalStatus.PROCESSING
+                return TerminalStatus.PROCESSING
             if self._awaiting_turn and completion_identity is None:
                 return TerminalStatus.PROCESSING
             if self._awaiting_turn and not completion_anchored and not self._turn_activity_seen:
@@ -404,8 +478,7 @@ class MiniMaxCodeProvider(BaseProvider):
             return TerminalStatus.IDLE
         if completion_identity is not None:
             if self._awaiting_turn and completion_identity == self._last_completion_identity:
-                if not self._turn_activity_seen:
-                    return TerminalStatus.PROCESSING
+                return TerminalStatus.PROCESSING
             if self._awaiting_turn and not completion_anchored and not self._turn_activity_seen:
                 return TerminalStatus.PROCESSING
             self._last_completion_identity = completion_identity
@@ -430,36 +503,41 @@ class MiniMaxCodeProvider(BaseProvider):
             default=-1,
         )
         completion = max(
-            (
-                index
-                for index, line in enumerate(lines)
-                if re.match(r"^\s*└\s+Completed in\s+\d", line, re.IGNORECASE)
-            ),
+            (index for index, line in enumerate(lines) if _COMPLETION_LINE_PATTERN.match(line)),
             default=len(lines),
         )
         assistant_starts = [
             index
             for index in range(last_user + 1, completion)
-            if re.match(r"^\s*●\s+\S", lines[index])
-            and not re.match(r"^\s*●\s+Ready\s*$", lines[index])
+            if _ASSISTANT_LINE_PATTERN.match(lines[index])
+            and not _READY_ASSISTANT_LINE_PATTERN.match(lines[index])
         ]
         if not assistant_starts:
             raise ValueError("No MiniMax Code final response found")
 
         start = assistant_starts[-1]
-        response = [re.sub(r"^\s*●\s+", "", lines[start]).strip()]
+        assistant_match = _ASSISTANT_LINE_PATTERN.match(lines[start])
+        if assistant_match is None:
+            raise ValueError("No MiniMax Code final response found")
+        presentation_indent = len(assistant_match.group("indent")) + 2
+        response = [assistant_match.group("text").rstrip()]
         for line in lines[start + 1 : completion]:
             stripped = line.strip()
             if not stripped:
+                response.append("")
                 continue
-            if re.match(r"^(?:├|└|Called\s|Message\s+·|/[^ ]+\s+\|)", stripped):
+            if _EXTRACTION_SKIP_PATTERN.match(stripped):
                 continue
-            if re.match(r"^[╭│╰]", stripped):
+            if _BOX_CHROME_PATTERN.match(stripped):
                 continue
-            response.append(stripped)
+            presentation_prefix = " " * presentation_indent
+            content = (
+                line[len(presentation_prefix) :] if line.startswith(presentation_prefix) else line
+            )
+            response.append(content.rstrip())
 
-        answer = "\n".join(response).strip()
-        if not answer:
+        answer = "\n".join(response).strip("\n")
+        if not answer.strip():
             raise ValueError("MiniMax Code final response was empty")
         return answer
 
@@ -468,6 +546,7 @@ class MiniMaxCodeProvider(BaseProvider):
 
     def cleanup(self) -> None:
         data_dir = self._data_dir or self._data_dir_path()
+        self._require_managed_data_dir(data_dir)
         if data_dir.exists():
             shutil.rmtree(data_dir)
         self._data_dir = None

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -471,7 +471,7 @@ class StatusMonitor:
             except RuntimeError:
                 pass  # loop already closed during shutdown — the timer is moot
 
-    def notify_input_sent(self, terminal_id: str) -> None:
+    def notify_input_sent(self, terminal_id: str, *, assume_processing: bool = False) -> None:
         """Arm the next PROCESSING transition.
 
         Call before any send_keys / paste that initiates a new processing
@@ -481,6 +481,8 @@ class StatusMonitor:
         """
         with self._lock:
             self._allow_processing_revert[terminal_id] = True
+        if assume_processing:
+            self._apply_detection(terminal_id, TerminalStatus.PROCESSING)
 
     def clear_rolling_buffer(self, terminal_id: str, provider=None) -> None:
         """Clear ONLY the rolling byte buffer for a terminal — preserves

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -163,6 +163,7 @@ RUNTIME_SKILL_PROMPT_PROVIDERS = {
     ProviderType.ANTIGRAVITY_CLI.value,
     ProviderType.OMP.value,
     ProviderType.GROK_CLI.value,
+    ProviderType.MINIMAX_CODE.value,
 }
 
 # Providers whose tool restrictions are prompt-level text only (no native
@@ -172,6 +173,7 @@ SOFT_ENFORCEMENT_PROVIDERS = {
     ProviderType.CODEX.value,
     ProviderType.ANTIGRAVITY_CLI.value,
     ProviderType.OMP.value,
+    ProviderType.MINIMAX_CODE.value,
 }
 
 
@@ -1238,7 +1240,10 @@ def send_input(
         # IDLE/COMPLETED). Without this, sticky ready-status would block
         # the genuine PROCESSING signal that arrives once the agent starts
         # working on the new message.
-        status_monitor.notify_input_sent(terminal_id)
+        if provider and provider.assume_processing_on_dispatch is True:
+            status_monitor.notify_input_sent(terminal_id, assume_processing=True)
+        else:
+            status_monitor.notify_input_sent(terminal_id)
 
         # Clear ONLY the rolling byte buffer BEFORE sending keys, so stale idle
         # prompts from BEFORE the input can't trigger a false COMPLETED

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -136,6 +136,7 @@ class TestAgentProviders:
         assert "antigravity_cli" in names
         assert "omp" in names
         assert "grok_cli" in names
+        assert "minimax_code" in names
         for p in data:
             assert p["installed"] is True
 
@@ -168,6 +169,7 @@ class TestAgentProviders:
         assert providers_dict["copilot_cli"]["installed"] is False
         assert providers_dict["opencode_cli"]["installed"] is False
         assert providers_dict["grok_cli"]["installed"] is False
+        assert providers_dict["minimax_code"]["installed"] is False
 
     def test_list_providers_has_binary_field(self, client):
         """Each provider entry has correct binary name."""
@@ -185,6 +187,7 @@ class TestAgentProviders:
         assert providers_dict["antigravity_cli"]["binary"] == "agy"
         assert providers_dict["omp"]["binary"] == "omp"
         assert providers_dict["grok_cli"]["binary"] == "grok"
+        assert providers_dict["minimax_code"]["binary"] == "mcode"
 
 
 # ── Skills endpoint ──────────────────────────────────────────────────

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -123,7 +123,7 @@ class TestAgentProviders:
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 11
+        assert len(data) == 12
         names = [p["name"] for p in data]
         assert "kiro_cli" in names
         assert "claude_code" in names
@@ -136,7 +136,7 @@ class TestAgentProviders:
         assert "antigravity_cli" in names
         assert "omp" in names
         assert "grok_cli" in names
-        assert "minimax_code" in names
+        assert "mcode" in names
         for p in data:
             assert p["installed"] is True
 
@@ -169,7 +169,7 @@ class TestAgentProviders:
         assert providers_dict["copilot_cli"]["installed"] is False
         assert providers_dict["opencode_cli"]["installed"] is False
         assert providers_dict["grok_cli"]["installed"] is False
-        assert providers_dict["minimax_code"]["installed"] is False
+        assert providers_dict["mcode"]["installed"] is False
 
     def test_list_providers_has_binary_field(self, client):
         """Each provider entry has correct binary name."""
@@ -187,7 +187,7 @@ class TestAgentProviders:
         assert providers_dict["antigravity_cli"]["binary"] == "agy"
         assert providers_dict["omp"]["binary"] == "omp"
         assert providers_dict["grok_cli"]["binary"] == "grok"
-        assert providers_dict["minimax_code"]["binary"] == "mcode"
+        assert providers_dict["mcode"]["binary"] == "mcode"
 
 
 # ── Skills endpoint ──────────────────────────────────────────────────

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -1001,4 +1001,4 @@ def test_minimax_code_requires_workspace_access_confirmation():
         PROVIDERS_REQUIRING_WORKSPACE_ACCESS,
     )
 
-    assert "minimax_code" in PROVIDERS_REQUIRING_WORKSPACE_ACCESS
+    assert "mcode" in PROVIDERS_REQUIRING_WORKSPACE_ACCESS

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -994,3 +994,11 @@ def test_grok_cli_requires_workspace_access_confirmation():
     )
 
     assert "grok_cli" in PROVIDERS_REQUIRING_WORKSPACE_ACCESS
+
+
+def test_minimax_code_requires_workspace_access_confirmation():
+    from cli_agent_orchestrator.cli.commands.launch import (
+        PROVIDERS_REQUIRING_WORKSPACE_ACCESS,
+    )
+
+    assert "minimax_code" in PROVIDERS_REQUIRING_WORKSPACE_ACCESS

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -173,6 +173,41 @@ def require_grok(require_cao_server: CaoServer):
             shutil.copy2(source, target)
 
 
+@pytest.fixture()
+def require_minimax_code(require_cao_server: CaoServer):
+    """Skip unless MiniMax Code is installed and has reusable local authentication."""
+    if not _cli_available("mcode"):
+        pytest.skip("MiniMax Code CLI not installed; see docs/minimax-code.md for installation")
+
+    configured = os.environ.get("MINIMAX_DATA_DIR", "").strip()
+    source_home = Path(configured).expanduser() if configured else Path.home() / ".minimax"
+    auth_names = ("config.yaml", "local-runtime.auth.json", "cli-auth")
+    if not any((source_home / name).exists() for name in auth_names):
+        pytest.skip("MiniMax Code is installed but not authenticated; run `mcode login`")
+
+    isolated_home = require_cao_server.home_dir / ".minimax"
+    isolated_home.mkdir(mode=0o700, exist_ok=True)
+    for name in ("config.yaml", "local-runtime.auth.json"):
+        source = source_home / name
+        target = isolated_home / name
+        if source.is_file() and not target.exists():
+            shutil.copy2(source, target)
+            target.chmod(0o600)
+    source_cli_auth = source_home / "cli-auth"
+    target_cli_auth = isolated_home / "cli-auth"
+    if source_cli_auth.is_dir() and not target_cli_auth.exists():
+        shutil.copytree(source_cli_auth, target_cli_auth)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    isolated_store = require_cao_server.home_dir / ".aws" / "cli-agent-orchestrator" / "agent-store"
+    isolated_store.mkdir(parents=True, mode=0o700, exist_ok=True)
+    for profile_name in ("analysis_supervisor", "data_analyst", "report_generator"):
+        source = repo_root / "examples" / "assign" / f"{profile_name}.md"
+        target = isolated_store / f"{profile_name}.md"
+        if not target.exists():
+            shutil.copy2(source, target)
+
+
 def create_terminal(
     provider: str,
     agent_profile: str,

--- a/test/e2e/test_allowed_tools.py
+++ b/test/e2e/test_allowed_tools.py
@@ -945,17 +945,17 @@ class TestMiniMaxCodeAllowedTools:
     )
     def test_restricted_supervisor_refuses_bash(self, require_minimax_code):
         _run_restricted_tool_test(
-            provider="minimax_code",
+            provider="mcode",
             agent_profile="code_supervisor",
             allowed_tools="@cao-mcp-server",
         )
 
     def test_unrestricted_developer_can_bash(self, require_minimax_code):
-        _run_unrestricted_tool_test(provider="minimax_code", agent_profile="developer")
+        _run_unrestricted_tool_test(provider="mcode", agent_profile="developer")
 
     def test_allowed_tools_stored_in_metadata(self, require_minimax_code):
         _run_allowed_tools_stored_test(
-            provider="minimax_code",
+            provider="mcode",
             agent_profile="developer",
             allowed_tools="@builtin,fs_read,@cao-mcp-server",
         )

--- a/test/e2e/test_allowed_tools.py
+++ b/test/e2e/test_allowed_tools.py
@@ -933,3 +933,29 @@ class TestGrokCliAllowedTools:
             agent_profile="developer",
             allowed_tools="@builtin,fs_*,execute_bash,web_fetch,@cao-mcp-server",
         )
+
+
+@pytest.mark.e2e
+class TestMiniMaxCodeAllowedTools:
+    """E2E allowedTools tests for MiniMax Code's advisory prompt policy."""
+
+    @pytest.mark.xfail(
+        reason="MiniMax Code has prompt-level rather than native tool enforcement",
+        strict=False,
+    )
+    def test_restricted_supervisor_refuses_bash(self, require_minimax_code):
+        _run_restricted_tool_test(
+            provider="minimax_code",
+            agent_profile="code_supervisor",
+            allowed_tools="@cao-mcp-server",
+        )
+
+    def test_unrestricted_developer_can_bash(self, require_minimax_code):
+        _run_unrestricted_tool_test(provider="minimax_code", agent_profile="developer")
+
+    def test_allowed_tools_stored_in_metadata(self, require_minimax_code):
+        _run_allowed_tools_stored_test(
+            provider="minimax_code",
+            agent_profile="developer",
+            allowed_tools="@builtin,fs_read,@cao-mcp-server",
+        )

--- a/test/e2e/test_assign.py
+++ b/test/e2e/test_assign.py
@@ -716,7 +716,7 @@ class TestMiniMaxCodeAssign:
 
     def test_assign_data_analyst(self, require_minimax_code):
         _run_assign_test(
-            provider="minimax_code",
+            provider="mcode",
             agent_profile="data_analyst",
             task_message=DATA_ANALYST_TASK,
             content_keywords=DATA_ANALYST_KEYWORDS,
@@ -724,11 +724,11 @@ class TestMiniMaxCodeAssign:
 
     def test_assign_report_generator(self, require_minimax_code):
         _run_assign_test(
-            provider="minimax_code",
+            provider="mcode",
             agent_profile="report_generator",
             task_message=REPORT_GENERATOR_TASK,
             content_keywords=REPORT_GENERATOR_KEYWORDS,
         )
 
     def test_assign_with_callback(self, require_minimax_code):
-        _run_assign_with_callback_test(provider="minimax_code")
+        _run_assign_with_callback_test(provider="mcode")

--- a/test/e2e/test_assign.py
+++ b/test/e2e/test_assign.py
@@ -708,3 +708,27 @@ class TestGrokCliAssign:
     def test_assign_with_callback(self, require_grok):
         """A Grok worker sends its result back to the supervisor inbox."""
         _run_assign_with_callback_test(provider="grok_cli")
+
+
+@pytest.mark.e2e
+class TestMiniMaxCodeAssign:
+    """E2E assign tests for MiniMax Code using the examples/assign profiles."""
+
+    def test_assign_data_analyst(self, require_minimax_code):
+        _run_assign_test(
+            provider="minimax_code",
+            agent_profile="data_analyst",
+            task_message=DATA_ANALYST_TASK,
+            content_keywords=DATA_ANALYST_KEYWORDS,
+        )
+
+    def test_assign_report_generator(self, require_minimax_code):
+        _run_assign_test(
+            provider="minimax_code",
+            agent_profile="report_generator",
+            task_message=REPORT_GENERATOR_TASK,
+            content_keywords=REPORT_GENERATOR_KEYWORDS,
+        )
+
+    def test_assign_with_callback(self, require_minimax_code):
+        _run_assign_with_callback_test(provider="minimax_code")

--- a/test/e2e/test_handoff.py
+++ b/test/e2e/test_handoff.py
@@ -471,7 +471,7 @@ class TestMiniMaxCodeHandoff:
 
     def test_handoff_simple_function(self, require_minimax_code):
         _run_handoff_test(
-            provider="minimax_code",
+            provider="mcode",
             agent_profile="developer",
             task_message=(
                 "Create a Python function called 'greet' that takes a name parameter "
@@ -481,4 +481,4 @@ class TestMiniMaxCodeHandoff:
         )
 
     def test_handoff_second_task(self, require_minimax_code):
-        _run_second_task_same_terminal_test(provider="minimax_code", agent_profile="developer")
+        _run_second_task_same_terminal_test(provider="mcode", agent_profile="developer")

--- a/test/e2e/test_handoff.py
+++ b/test/e2e/test_handoff.py
@@ -463,3 +463,22 @@ class TestGrokCliHandoff:
     def test_handoff_second_task(self, require_grok):
         """Grok returns the second independent response from the same TUI session."""
         _run_second_task_same_terminal_test(provider="grok_cli", agent_profile="developer")
+
+
+@pytest.mark.e2e
+class TestMiniMaxCodeHandoff:
+    """E2E lifecycle tests for the MiniMax Code provider."""
+
+    def test_handoff_simple_function(self, require_minimax_code):
+        _run_handoff_test(
+            provider="minimax_code",
+            agent_profile="developer",
+            task_message=(
+                "Create a Python function called 'greet' that takes a name parameter "
+                "and returns 'Hello, {name}!'. Output only the function code."
+            ),
+            content_keywords=["greet", "hello", "def"],
+        )
+
+    def test_handoff_second_task(self, require_minimax_code):
+        _run_second_task_same_terminal_test(provider="minimax_code", agent_profile="developer")

--- a/test/e2e/test_send_message.py
+++ b/test/e2e/test_send_message.py
@@ -320,3 +320,11 @@ class TestGrokCliSendMessage:
     def test_send_message_to_inbox(self, require_grok):
         """Deliver an inbox message to an idle Grok terminal and process it."""
         _run_send_message_test(provider="grok_cli", agent_profile="developer")
+
+
+@pytest.mark.e2e
+class TestMiniMaxCodeSendMessage:
+    """E2E inbox delivery test for MiniMax Code."""
+
+    def test_send_message_to_inbox(self, require_minimax_code):
+        _run_send_message_test(provider="minimax_code", agent_profile="developer")

--- a/test/e2e/test_send_message.py
+++ b/test/e2e/test_send_message.py
@@ -327,4 +327,4 @@ class TestMiniMaxCodeSendMessage:
     """E2E inbox delivery test for MiniMax Code."""
 
     def test_send_message_to_inbox(self, require_minimax_code):
-        _run_send_message_test(provider="minimax_code", agent_profile="developer")
+        _run_send_message_test(provider="mcode", agent_profile="developer")

--- a/test/e2e/test_supervisor_orchestration.py
+++ b/test/e2e/test_supervisor_orchestration.py
@@ -911,3 +911,14 @@ class TestGrokCliSupervisorOrchestration:
     def test_supervisor_assign_three_analysts(self, require_grok):
         """Grok runs the maintainer-required three-analyst workflow."""
         _run_supervisor_assign_three_analysts_test(provider="grok_cli")
+
+
+@pytest.mark.e2e
+class TestMiniMaxCodeSupervisorOrchestration:
+    """E2E MCP orchestration tests for MiniMax Code."""
+
+    def test_supervisor_handoff(self, require_minimax_code):
+        _run_supervisor_handoff_test(provider="minimax_code")
+
+    def test_supervisor_assign_and_handoff(self, require_minimax_code):
+        _run_supervisor_assign_test(provider="minimax_code")

--- a/test/e2e/test_supervisor_orchestration.py
+++ b/test/e2e/test_supervisor_orchestration.py
@@ -918,7 +918,7 @@ class TestMiniMaxCodeSupervisorOrchestration:
     """E2E MCP orchestration tests for MiniMax Code."""
 
     def test_supervisor_handoff(self, require_minimax_code):
-        _run_supervisor_handoff_test(provider="minimax_code")
+        _run_supervisor_handoff_test(provider="mcode")
 
     def test_supervisor_assign_and_handoff(self, require_minimax_code):
-        _run_supervisor_assign_test(provider="minimax_code")
+        _run_supervisor_assign_test(provider="mcode")

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -103,27 +103,25 @@ class TestCreateTerminalProviderResolution:
     @patch(
         "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
     )
-    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="kiro_cli")
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="minimax_code")
     @patch("cli_agent_orchestrator.mcp_server.server.requests")
-    def test_deferred_init_sends_message_in_json_body_not_params(
+    def test_minimax_worker_omits_unsupported_engine_and_model(
         self, mock_requests, mock_resolve_provider, mock_allowed_tools
     ):
-        """defer_init must carry the prompt in the JSON body (not the query
-        string) so prompt content isn't logged in HTTP access logs and isn't
-        subject to URL-length limits."""
+        """MiniMax workers must not receive Kiro-only or unsupported launch overrides."""
         from cli_agent_orchestrator.mcp_server.server import _create_terminal
         from cli_agent_orchestrator.models.inbox import OrchestrationType
 
         metadata_response = MagicMock()
         metadata_response.json.return_value = {
-            "provider": "kiro_cli",
-            "engine": "kas",
+            "provider": "minimax_code",
+            "engine": None,
             "session_name": "cao-session",
             "allowed_tools": None,
         }
         metadata_response.raise_for_status.return_value = None
         post_response = MagicMock()
-        post_response.json.return_value = {"id": "worker-1", "provider": "kiro_cli"}
+        post_response.json.return_value = {"id": "worker-1", "provider": "minimax_code"}
         post_response.raise_for_status.return_value = None
         mock_requests.get.return_value = metadata_response
         mock_requests.post.return_value = post_response
@@ -132,17 +130,17 @@ class TestCreateTerminalProviderResolution:
             _create_terminal(
                 "reviewer",
                 working_directory=None,
+                engine="v2",
                 defer_init=True,
                 initial_message="Analyze the sensitive logs at /secret/path",
                 initial_message_orchestration_type=OrchestrationType.ASSIGN,
-                model="",
+                model="MiniMax-M2.1",
             )
 
         _, kwargs = mock_requests.post.call_args
-        # Routing flag stays in params; message payload is in the body.
         assert kwargs["params"].get("defer_init") == "true"
-        # Even an invalid empty override reaches the API validation boundary.
-        assert kwargs["params"]["model"] == ""
+        assert "engine" not in kwargs["params"]
+        assert "model" not in kwargs["params"]
         assert "initial_message" not in kwargs["params"]
         assert kwargs["json"]["initial_message"] == "Analyze the sensitive logs at /secret/path"
         assert kwargs["json"]["initial_message_orchestration_type"] == "assign"

--- a/test/mcp_server/test_assign.py
+++ b/test/mcp_server/test_assign.py
@@ -103,25 +103,25 @@ class TestCreateTerminalProviderResolution:
     @patch(
         "cli_agent_orchestrator.mcp_server.server._resolve_child_allowed_tools", return_value=None
     )
-    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="minimax_code")
+    @patch("cli_agent_orchestrator.mcp_server.server.resolve_provider", return_value="mcode")
     @patch("cli_agent_orchestrator.mcp_server.server.requests")
-    def test_minimax_worker_omits_unsupported_engine_and_model(
+    def test_mcode_worker_omits_kiro_engine_and_forwards_model(
         self, mock_requests, mock_resolve_provider, mock_allowed_tools
     ):
-        """MiniMax workers must not receive Kiro-only or unsupported launch overrides."""
+        """MCode workers omit Kiro-only engine but receive a terminal-local model."""
         from cli_agent_orchestrator.mcp_server.server import _create_terminal
         from cli_agent_orchestrator.models.inbox import OrchestrationType
 
         metadata_response = MagicMock()
         metadata_response.json.return_value = {
-            "provider": "minimax_code",
+            "provider": "mcode",
             "engine": None,
             "session_name": "cao-session",
             "allowed_tools": None,
         }
         metadata_response.raise_for_status.return_value = None
         post_response = MagicMock()
-        post_response.json.return_value = {"id": "worker-1", "provider": "minimax_code"}
+        post_response.json.return_value = {"id": "worker-1", "provider": "mcode"}
         post_response.raise_for_status.return_value = None
         mock_requests.get.return_value = metadata_response
         mock_requests.post.return_value = post_response
@@ -140,7 +140,7 @@ class TestCreateTerminalProviderResolution:
         _, kwargs = mock_requests.post.call_args
         assert kwargs["params"].get("defer_init") == "true"
         assert "engine" not in kwargs["params"]
-        assert "model" not in kwargs["params"]
+        assert kwargs["params"]["model"] == "MiniMax-M2.1"
         assert "initial_message" not in kwargs["params"]
         assert kwargs["json"]["initial_message"] == "Analyze the sensitive logs at /secret/path"
         assert kwargs["json"]["initial_message_orchestration_type"] == "assign"

--- a/test/mcp_server/test_handoff.py
+++ b/test/mcp_server/test_handoff.py
@@ -399,6 +399,28 @@ class TestHandoffModelOverride:
 
     @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
     @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
+    def test_minimax_omits_unsupported_engine_and_model(self, mock_provider, _nudge):
+        mock_provider.return_value = _ctx("minimax_code")
+
+        with patch("cli_agent_orchestrator.mcp_server.server.requests") as mock_requests:
+            mock_requests.post.return_value = _ok_run_step_response()
+            mock_requests.Timeout = Exception
+            result = asyncio.run(
+                _handoff_impl(
+                    "report_generator",
+                    "Create a report template",
+                    engine="v2",
+                    model="MiniMax-M2.1",
+                )
+            )
+
+        assert result.success is True
+        payload = mock_requests.post.call_args[1]["json"]
+        assert "engine" not in payload
+        assert "model" not in payload
+
+    @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
+    @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
     def test_model_is_forwarded_in_payload(self, mock_provider, _nudge):
         mock_provider.return_value = _ctx("claude_code")
 

--- a/test/mcp_server/test_handoff.py
+++ b/test/mcp_server/test_handoff.py
@@ -399,8 +399,8 @@ class TestHandoffModelOverride:
 
     @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
     @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")
-    def test_minimax_omits_unsupported_engine_and_model(self, mock_provider, _nudge):
-        mock_provider.return_value = _ctx("minimax_code")
+    def test_mcode_omits_kiro_engine_and_forwards_model(self, mock_provider, _nudge):
+        mock_provider.return_value = _ctx("mcode")
 
         with patch("cli_agent_orchestrator.mcp_server.server.requests") as mock_requests:
             mock_requests.post.return_value = _ok_run_step_response()
@@ -417,7 +417,7 @@ class TestHandoffModelOverride:
         assert result.success is True
         payload = mock_requests.post.call_args[1]["json"]
         assert "engine" not in payload
-        assert "model" not in payload
+        assert payload["model"] == "MiniMax-M2.1"
 
     @patch("cli_agent_orchestrator.mcp_server.server._get_cleanup_nudge", return_value="")
     @patch("cli_agent_orchestrator.mcp_server.server._resolve_handoff_provider")

--- a/test/providers/fixtures/minimax_code_completed.txt
+++ b/test/providers/fixtures/minimax_code_completed.txt
@@ -1,0 +1,12 @@
+› Explain the result.
+└ • Thought for 5.9s
+Called cao_mcp_server_h3d59107c31cf98997240.send_message
+├ Tool returned successfully
+● The integration is complete.
+  All focused checks pass.
+└ Completed in 4s · ⚡ 12.1 tok/s
+╭────────────────────────────────────────────────╮
+│ ›                                              │
+╰────────────────────────────────────────────────╯
+Message · Enter send · Shift+Enter newline
+/workspace │ Full access │ ✦ MiniMax-M3 · Thinking On

--- a/test/providers/fixtures/minimax_code_idle.txt
+++ b/test/providers/fixtures/minimax_code_idle.txt
@@ -1,0 +1,6 @@
+╭─ v0.1.2 ───────────────────────────── ● Ready ─╮
+│                                                │
+│ ›                                              │
+╰────────────────────────────────────────────────╯
+Message · Enter send · Shift+Enter newline
+/workspace │ Full access │ ✦ MiniMax-M3 · Thinking On

--- a/test/providers/fixtures/minimax_code_permission.txt
+++ b/test/providers/fixtures/minimax_code_permission.txt
@@ -1,0 +1,6 @@
+Approval needed
+Run this command?
+$ pnpm test
+1 Allow for this conversation
+2 Always allow this action
+3 Deny

--- a/test/providers/fixtures/minimax_code_processing.txt
+++ b/test/providers/fixtures/minimax_code_processing.txt
@@ -1,0 +1,3 @@
+› Inspect the repository.
+└ • Thought for 5.9s
+⠹ Loading 35s · Enter queue · Ctrl+X steer · Ctrl+O details · Esc stop

--- a/test/providers/test_minimax_code_unit.py
+++ b/test/providers/test_minimax_code_unit.py
@@ -241,6 +241,40 @@ def test_status_rejects_previous_completion_after_next_turn_dispatch():
     assert provider.get_status(current) == TerminalStatus.COMPLETED
 
 
+def test_status_buffer_reset_does_not_treat_stale_completion_as_started():
+    """A retained completion after dispatch is not current-turn activity."""
+
+    provider = make_provider(agent_profile=None)
+    previous = load_fixture("minimax_code_completed.txt")
+    assert provider.get_status(previous) == TerminalStatus.IDLE
+
+    provider.notify_status_buffer_reset(1)
+    provider.mark_input_received()
+
+    # This is the capture-pane view used by deferred-submit recovery when the
+    # paste/Enter was dropped. Reporting PROCESSING here would suppress every
+    # retry even though MiniMax has emitted no bytes for the new turn.
+    assert provider.get_status(previous) == TerminalStatus.IDLE
+
+
+def test_status_buffer_reset_accepts_fresh_byte_identical_completion_after_activity():
+    """A repeated prompt/answer can complete in a fresh buffer generation."""
+
+    provider = make_provider(agent_profile=None)
+    completed = load_fixture("minimax_code_completed.txt")
+    processing = load_fixture("minimax_code_processing.txt")
+    assert provider.get_status(completed) == TerminalStatus.IDLE
+
+    provider.notify_status_buffer_reset(1)
+    provider.mark_input_received()
+    assert provider.get_status(processing) == TerminalStatus.PROCESSING
+
+    # StatusMonitor's fresh rolling buffer now contains both the processing
+    # frame and the newly emitted completion. Its prompt/answer bytes match the
+    # prior turn, but observed activity ties them to the new generation.
+    assert provider.get_status(f"{processing}\n{completed}") == TerminalStatus.COMPLETED
+
+
 def test_status_completes_long_response_after_assistant_marker_leaves_viewport():
     provider = make_provider(agent_profile=None)
     previous = load_fixture("minimax_code_completed.txt")

--- a/test/providers/test_minimax_code_unit.py
+++ b/test/providers/test_minimax_code_unit.py
@@ -9,10 +9,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.models.terminal import TerminalStatus
-from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
+from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider, ProviderError
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -52,7 +53,12 @@ def test_prepare_runtime_isolates_auth_and_generates_private_mcp_plugin(
                 "command": "/opt/cao/bin/cao-mcp-server",
                 "args": ["--stdio"],
                 "env": {"EXISTING": "value"},
-            }
+            },
+            "remote-tools": {
+                "type": "http",
+                "url": "https://mcp.example.test/api",
+                "headers": {"Authorization": "Bearer placeholder"},
+            },
         },
     )
     provider = make_provider()
@@ -77,6 +83,7 @@ def test_prepare_runtime_isolates_auth_and_generates_private_mcp_plugin(
     manifest = json.loads((plugin / ".minimax-plugin" / "plugin.json").read_text())
     config = json.loads((plugin / "servers.mcp.json").read_text())
     server = config["mcpServers"]["cao-orchestrator"]
+    remote = config["mcpServers"]["remote-tools"]
     assert manifest["mcpServers"] == ["servers.mcp.json"]
     assert server["command"] == "cao-mcp-server"
     assert server["args"] == ["--stdio"]
@@ -84,6 +91,13 @@ def test_prepare_runtime_isolates_auth_and_generates_private_mcp_plugin(
     assert server["env"]["EXISTING"] == "value"
     assert server["env"]["PATH"].split(os.pathsep)[0] == "/opt/cao/bin"
     assert server["timeout"] == 600_000
+    assert remote == {
+        "type": "streamable-http",
+        "url": "https://mcp.example.test/api",
+        "headers": {"Authorization": "Bearer placeholder"},
+        "description": "CAO-managed MCP server remote-tools",
+        "timeout": 600_000,
+    }
     assert (plugin / "icon.png").read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
 
     assert stat.S_IMODE(data_dir.stat().st_mode) == 0o700
@@ -129,11 +143,44 @@ def test_build_command_bootstraps_profile_skills_and_soft_tool_policy(tmp_path: 
     assert "Reply exactly CAO_MCODE_READY" in bootstrap
 
 
+@pytest.mark.parametrize(
+    ("launch_model", "expected_model"),
+    [("launch/model", "launch/model"), (None, "profile/model")],
+)
+def test_prepare_runtime_applies_model_to_terminal_local_config(
+    tmp_path: Path, monkeypatch, launch_model: str | None, expected_model: str
+):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.yaml").write_text("defaultModel: original/model\n")
+    monkeypatch.setenv("MINIMAX_DATA_DIR", str(source))
+    profile = AgentProfile(
+        name="developer",
+        description="Developer",
+        model="profile/model",
+    )
+    provider = make_provider(model=launch_model)
+
+    with (
+        patch("cli_agent_orchestrator.providers.minimax_code.CAO_HOME_DIR", tmp_path / "cao"),
+        patch(
+            "cli_agent_orchestrator.providers.minimax_code.load_agent_profile",
+            return_value=profile,
+        ),
+    ):
+        data_dir, _ = provider._prepare_runtime()
+
+    config = yaml.safe_load((data_dir / "config.yaml").read_text())
+    assert config["defaultModel"] == expected_model
+
+
 def test_prompt_submission_and_lifecycle_properties():
     provider = make_provider(agent_profile=None)
     assert provider.paste_enter_count == 1
     assert provider.accepts_input_while_processing is True
-    assert provider.assume_processing_on_dispatch is True
+    # Deferred delivery confirmation must wait for observed current-turn
+    # activity; a synthetic PROCESSING state can hide a dropped paste/Enter.
+    assert provider.assume_processing_on_dispatch is False
     assert provider.blocks_orchestrated_input_while_waiting_user_answer is True
     assert provider.supports_screen_detection is True
     assert provider.supports_direct_status_probe is True
@@ -162,6 +209,12 @@ def test_status_fixtures_and_completed_turn_latch():
     assert provider.get_status(new_completed) == TerminalStatus.COMPLETED
 
 
+def test_status_reports_error_and_unknown_states():
+    provider = make_provider(agent_profile=None)
+    assert provider.get_status("") == TerminalStatus.UNKNOWN
+    assert provider.get_status("Fatal: authentication backend unavailable") == TerminalStatus.ERROR
+
+
 def test_status_rejects_previous_completion_after_next_turn_dispatch():
     provider = make_provider(agent_profile=None)
     previous = load_fixture("minimax_code_completed.txt")
@@ -169,6 +222,14 @@ def test_status_rejects_previous_completion_after_next_turn_dispatch():
 
     provider.mark_input_received()
     provider._last_dispatch_time = 0
+    assert provider.get_status(previous) == TerminalStatus.PROCESSING
+    assert (
+        provider.get_status(load_fixture("minimax_code_processing.txt"))
+        == TerminalStatus.PROCESSING
+    )
+    # A full-screen redraw may replay the previous completion after showing a
+    # current-turn spinner. Activity alone does not make identical completion
+    # content fresh.
     assert provider.get_status(previous) == TerminalStatus.PROCESSING
 
     current = previous + """\
@@ -215,15 +276,23 @@ def test_extract_last_message_ignores_empty_bottom_composer_on_second_turn():
        return n ** 2
  › Create cube_second_turn.
  ● def cube_second_turn(n):
-       return n ** 3
+       value = n ** 3
+
+       return value
    └ Completed in 2s · ⚡ 42.5 tok/s
    Message · Enter send · Shift+Enter newline
  ›  \x1b[7m█\x1b[0m
  /workspace │ Full access │ ✦ MiniMax-M3 · Thinking On
 """
     assert make_provider(agent_profile=None).extract_last_message_from_script(output) == (
-        "def cube_second_turn(n):\nreturn n ** 3"
+        "def cube_second_turn(n):\n    value = n ** 3\n\n    return value"
     )
+
+
+@pytest.mark.parametrize("output", ["Message · Enter send", "●   \n└ Completed in 1s"])
+def test_extract_last_message_rejects_missing_or_empty_response(output: str):
+    with pytest.raises(ValueError, match="No MiniMax Code final response found"):
+        make_provider(agent_profile=None).extract_last_message_from_script(output)
 
 
 @pytest.mark.asyncio
@@ -255,15 +324,74 @@ async def test_initialize_launches_mcode_and_waits_for_bootstrap_completion():
 
 
 @pytest.mark.asyncio
-async def test_initialize_failure_removes_private_runtime(tmp_path: Path):
+async def test_initialize_times_out_when_bootstrap_never_becomes_ready():
     provider = make_provider(agent_profile=None)
-    private_dir = tmp_path / "private"
-    private_dir.mkdir()
-    (private_dir / "token").write_text("secret")
-    provider._data_dir = private_dir
-
-    with patch("cli_agent_orchestrator.providers.minimax_code.wait_for_shell", return_value=False):
-        with pytest.raises(TimeoutError, match="Shell initialization timed out"):
+    with (
+        patch.object(provider, "_build_command", return_value="mcode bootstrap"),
+        patch(
+            "cli_agent_orchestrator.providers.minimax_code.wait_for_shell",
+            return_value=True,
+        ),
+        patch("cli_agent_orchestrator.providers.minimax_code.get_backend"),
+        patch.object(provider, "_wait_for_bootstrap_ready", return_value=False),
+        patch.object(provider, "cleanup") as cleanup,
+    ):
+        with pytest.raises(TimeoutError, match="MiniMax Code initialization timed out"):
             await provider.initialize()
 
+    cleanup.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_initialize_failure_removes_private_runtime(tmp_path: Path):
+    provider = make_provider(agent_profile=None)
+    cao_home = tmp_path / "cao"
+    with patch("cli_agent_orchestrator.providers.minimax_code.CAO_HOME_DIR", cao_home):
+        private_dir = provider._data_dir_path()
+        private_dir.mkdir(parents=True)
+        (private_dir / "token").write_text("secret")
+        provider._data_dir = private_dir
+
+        with patch(
+            "cli_agent_orchestrator.providers.minimax_code.wait_for_shell", return_value=False
+        ):
+            with pytest.raises(TimeoutError, match="Shell initialization timed out"):
+                await provider.initialize()
+
     assert not private_dir.exists()
+
+
+def test_cleanup_refuses_symlinked_managed_ancestor(tmp_path: Path):
+    cao_home = tmp_path / "cao"
+    managed_parent = cao_home / "providers"
+    managed_parent.mkdir(parents=True)
+    external = tmp_path / "external"
+    digest = hashlib.sha256(b"deadbeef").hexdigest()
+    escaped_data_dir = external / digest
+    escaped_data_dir.mkdir(parents=True)
+    victim = escaped_data_dir / "must-survive.txt"
+    victim.write_text("outside CAO")
+    (managed_parent / "minimax_code").symlink_to(external, target_is_directory=True)
+
+    provider = make_provider(agent_profile=None)
+    with patch("cli_agent_orchestrator.providers.minimax_code.CAO_HOME_DIR", cao_home):
+        with pytest.raises(ProviderError, match="managed MiniMax Code data directory"):
+            provider.cleanup()
+
+    assert victim.read_text() == "outside CAO"
+
+
+def test_prepare_runtime_refuses_symlinked_managed_ancestor(tmp_path: Path):
+    cao_home = tmp_path / "cao"
+    managed_parent = cao_home / "providers"
+    managed_parent.mkdir(parents=True)
+    external = tmp_path / "external"
+    external.mkdir()
+    (managed_parent / "minimax_code").symlink_to(external, target_is_directory=True)
+
+    provider = make_provider(agent_profile=None)
+    with patch("cli_agent_orchestrator.providers.minimax_code.CAO_HOME_DIR", cao_home):
+        with pytest.raises(ProviderError, match="managed MiniMax Code data directory"):
+            provider._prepare_runtime()
+
+    assert list(external.iterdir()) == []

--- a/test/providers/test_minimax_code_unit.py
+++ b/test/providers/test_minimax_code_unit.py
@@ -1,0 +1,269 @@
+"""Unit tests for the MiniMax Code provider."""
+
+import hashlib
+import json
+import os
+import shlex
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cli_agent_orchestrator.models.agent_profile import AgentProfile
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
+
+
+def make_provider(**kwargs) -> MiniMaxCodeProvider:
+    return MiniMaxCodeProvider(
+        terminal_id=kwargs.pop("terminal_id", "deadbeef"),
+        session_name="session",
+        window_name="window",
+        agent_profile=kwargs.pop("agent_profile", "developer"),
+        **kwargs,
+    )
+
+
+def test_prepare_runtime_isolates_auth_and_generates_private_mcp_plugin(
+    tmp_path: Path, monkeypatch
+):
+    source = tmp_path / "source"
+    (source / "cli-auth" / "nested").mkdir(parents=True)
+    (source / "plugins" / "personal").mkdir(parents=True)
+    (source / "config.yaml").write_text("modelSource: managed\n")
+    (source / "local-runtime.auth.json").write_text('{"token":"secret"}')
+    (source / "cli-auth" / "nested" / "session.json").write_text("secret-session")
+    (source / "plugins" / "personal" / "plugin.json").write_text("not copied")
+    monkeypatch.setenv("MINIMAX_DATA_DIR", str(source))
+
+    cao_home = tmp_path / "cao"
+    profile = AgentProfile(
+        name="developer",
+        description="Developer",
+        mcpServers={
+            "cao-orchestrator": {
+                "command": "/opt/cao/bin/cao-mcp-server",
+                "args": ["--stdio"],
+                "env": {"EXISTING": "value"},
+            }
+        },
+    )
+    provider = make_provider()
+
+    with (
+        patch("cli_agent_orchestrator.providers.minimax_code.CAO_HOME_DIR", cao_home),
+        patch(
+            "cli_agent_orchestrator.providers.minimax_code.load_agent_profile",
+            return_value=profile,
+        ),
+    ):
+        data_dir, _ = provider._prepare_runtime()
+
+    digest = hashlib.sha256(b"deadbeef").hexdigest()
+    assert data_dir == cao_home / "providers" / "minimax_code" / digest
+    assert (data_dir / "config.yaml").read_text() == "modelSource: managed\n"
+    assert (data_dir / "local-runtime.auth.json").read_text() == '{"token":"secret"}'
+    assert (data_dir / "cli-auth" / "nested" / "session.json").read_text() == "secret-session"
+    assert not (data_dir / "plugins" / "personal").exists()
+
+    plugin = data_dir / "plugins" / "cao-orchestrator"
+    manifest = json.loads((plugin / ".minimax-plugin" / "plugin.json").read_text())
+    config = json.loads((plugin / "servers.mcp.json").read_text())
+    server = config["mcpServers"]["cao-orchestrator"]
+    assert manifest["mcpServers"] == ["servers.mcp.json"]
+    assert server["command"] == "cao-mcp-server"
+    assert server["args"] == ["--stdio"]
+    assert server["env"]["CAO_TERMINAL_ID"] == "deadbeef"
+    assert server["env"]["EXISTING"] == "value"
+    assert server["env"]["PATH"].split(os.pathsep)[0] == "/opt/cao/bin"
+    assert server["timeout"] == 600_000
+    assert (plugin / "icon.png").read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+    assert stat.S_IMODE(data_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE((data_dir / "local-runtime.auth.json").stat().st_mode) == 0o600
+
+
+def test_build_command_bootstraps_profile_skills_and_soft_tool_policy(tmp_path: Path):
+    profile = AgentProfile(
+        name="reviewer",
+        description="Reviewer",
+        system_prompt="Review changes carefully.",
+    )
+    provider = make_provider(
+        agent_profile="reviewer",
+        allowed_tools=["fs_read", "fs_list"],
+        skill_prompt="## Available Skills\n- code-review",
+    )
+
+    with (
+        patch("cli_agent_orchestrator.providers.minimax_code.CAO_HOME_DIR", tmp_path),
+        patch(
+            "cli_agent_orchestrator.providers.minimax_code.load_agent_profile",
+            return_value=profile,
+        ),
+        patch(
+            "cli_agent_orchestrator.providers.minimax_code.shutil.which",
+            return_value="/usr/local/bin/mcode",
+        ),
+    ):
+        command = provider._build_command()
+
+    argv = shlex.split(command)
+    assert argv[:4] == [
+        "env",
+        f"MINIMAX_DATA_DIR={provider._data_dir}",
+        "TERM=xterm-256color",
+        "/usr/local/bin/mcode",
+    ]
+    bootstrap = argv[4]
+    assert "Review changes carefully." in bootstrap
+    assert "## Available Skills" in bootstrap
+    assert "fs_read, fs_list" in bootstrap
+    assert "Reply exactly CAO_MCODE_READY" in bootstrap
+
+
+def test_prompt_submission_and_lifecycle_properties():
+    provider = make_provider(agent_profile=None)
+    assert provider.paste_enter_count == 1
+    assert provider.accepts_input_while_processing is True
+    assert provider.assume_processing_on_dispatch is True
+    assert provider.blocks_orchestrated_input_while_waiting_user_answer is True
+    assert provider.supports_screen_detection is True
+    assert provider.supports_direct_status_probe is True
+    assert provider.exit_cli() == "/exit"
+
+
+def test_status_fixtures_and_completed_turn_latch():
+    provider = make_provider(agent_profile=None)
+    assert provider.get_status(load_fixture("minimax_code_idle.txt")) == TerminalStatus.IDLE
+    assert (
+        provider.get_status(load_fixture("minimax_code_processing.txt"))
+        == TerminalStatus.PROCESSING
+    )
+    assert (
+        provider.get_status(load_fixture("minimax_code_permission.txt"))
+        == TerminalStatus.WAITING_USER_ANSWER
+    )
+
+    completed = load_fixture("minimax_code_completed.txt")
+    assert provider.get_status(completed) == TerminalStatus.IDLE
+    provider.mark_input_received()
+    provider._last_dispatch_time = 0
+    new_completed = completed.replace("Explain the result.", "Explain the updated result.").replace(
+        "The integration is complete.", "The updated integration is complete."
+    )
+    assert provider.get_status(new_completed) == TerminalStatus.COMPLETED
+
+
+def test_status_rejects_previous_completion_after_next_turn_dispatch():
+    provider = make_provider(agent_profile=None)
+    previous = load_fixture("minimax_code_completed.txt")
+    assert provider.get_status(previous) == TerminalStatus.IDLE
+
+    provider.mark_input_received()
+    provider._last_dispatch_time = 0
+    assert provider.get_status(previous) == TerminalStatus.PROCESSING
+
+    current = previous + """\
+ › Give a different answer.
+ ● This is the new answer.
+ └ Completed in 1s · ⚡ 20 tok/s
+ Message · Enter send · Shift+Enter newline
+"""
+    assert provider.get_status(current) == TerminalStatus.COMPLETED
+
+
+def test_status_completes_long_response_after_assistant_marker_leaves_viewport():
+    provider = make_provider(agent_profile=None)
+    previous = load_fixture("minimax_code_completed.txt")
+    assert provider.get_status(previous) == TerminalStatus.IDLE
+    provider.mark_input_received()
+    assert (
+        provider.get_status(load_fixture("minimax_code_processing.txt"))
+        == TerminalStatus.PROCESSING
+    )
+
+    settled_viewport = "\n".join(
+        [f"  report line {index}" for index in range(50)]
+        + [
+            "  └ Completed in 9s · ⚡ 97.4 tok/s",
+            "  Message · Enter send · Shift+Enter newline",
+        ]
+    )
+    assert provider.get_status(settled_viewport) == TerminalStatus.COMPLETED
+
+
+def test_extract_last_message_returns_only_final_assistant_answer():
+    provider = make_provider(agent_profile=None)
+    assert (
+        provider.extract_last_message_from_script(load_fixture("minimax_code_completed.txt"))
+        == "The integration is complete.\nAll focused checks pass."
+    )
+
+
+def test_extract_last_message_ignores_empty_bottom_composer_on_second_turn():
+    output = """\
+ › Create square_first_turn.
+ ● def square_first_turn(n):
+       return n ** 2
+ › Create cube_second_turn.
+ ● def cube_second_turn(n):
+       return n ** 3
+   └ Completed in 2s · ⚡ 42.5 tok/s
+   Message · Enter send · Shift+Enter newline
+ ›  \x1b[7m█\x1b[0m
+ /workspace │ Full access │ ✦ MiniMax-M3 · Thinking On
+"""
+    assert make_provider(agent_profile=None).extract_last_message_from_script(output) == (
+        "def cube_second_turn(n):\nreturn n ** 3"
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_launches_mcode_and_waits_for_bootstrap_completion():
+    provider = make_provider(agent_profile=None)
+    backend = patch("cli_agent_orchestrator.providers.minimax_code.get_backend").start()
+    backend.return_value.send_keys.return_value = None
+    try:
+        with (
+            patch.object(provider, "_build_command", return_value="mcode bootstrap"),
+            patch(
+                "cli_agent_orchestrator.providers.minimax_code.wait_for_shell",
+                return_value=True,
+            ) as wait_shell,
+            patch.object(provider, "_wait_for_bootstrap_ready", return_value=True) as wait_status,
+            patch(
+                "cli_agent_orchestrator.services.status_monitor.status_monitor.notify_input_sent"
+            ) as notify,
+        ):
+            assert await provider.initialize() is True
+    finally:
+        patch.stopall()
+
+    wait_shell.assert_awaited_once()
+    backend.return_value.send_keys.assert_called_once_with("session", "window", "mcode bootstrap")
+    wait_status.assert_awaited_once_with(120.0)
+    notify.assert_called_once_with("deadbeef")
+    assert provider._initialized is True
+
+
+@pytest.mark.asyncio
+async def test_initialize_failure_removes_private_runtime(tmp_path: Path):
+    provider = make_provider(agent_profile=None)
+    private_dir = tmp_path / "private"
+    private_dir.mkdir()
+    (private_dir / "token").write_text("secret")
+    provider._data_dir = private_dir
+
+    with patch("cli_agent_orchestrator.providers.minimax_code.wait_for_shell", return_value=False):
+        with pytest.raises(TimeoutError, match="Shell initialization timed out"):
+            await provider.initialize()
+
+    assert not private_dir.exists()

--- a/test/providers/test_provider_manager_unit.py
+++ b/test/providers/test_provider_manager_unit.py
@@ -86,6 +86,24 @@ def test_create_provider_grok_forwards_launch_configuration():
     )
 
 
+def test_create_provider_minimax_code_forwards_launch_configuration():
+    from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
+
+    manager = ProviderManager()
+    provider = manager.create_provider(
+        ProviderType.MINIMAX_CODE.value,
+        terminal_id="t1",
+        tmux_session="s1",
+        tmux_window="w1",
+        agent_profile="developer",
+        allowed_tools=["fs_read", "fs_list"],
+        skill_prompt="runtime skill catalog",
+    )
+
+    assert isinstance(provider, MiniMaxCodeProvider)
+    assert manager.get_provider("t1") is provider
+
+
 def test_create_provider_unknown_type_raises():
     manager = ProviderManager()
     with pytest.raises(ValueError, match="Unknown provider type"):
@@ -246,6 +264,30 @@ def test_cleanup_provider_recovers_grok_home_after_restart():
         manager.cleanup_provider("restored-grok")
 
     provider_cls.assert_called_once_with("restored-grok", "s1", "w1", "developer")
+    cleanup_only_provider.cleanup.assert_called_once()
+
+
+def test_cleanup_provider_recovers_minimax_code_data_after_restart():
+    manager = ProviderManager()
+    cleanup_only_provider = MagicMock()
+    with (
+        patch(
+            "cli_agent_orchestrator.providers.manager.get_terminal_metadata",
+            return_value={
+                "provider": ProviderType.MINIMAX_CODE.value,
+                "tmux_session": "s1",
+                "tmux_window": "w1",
+                "agent_profile": "developer",
+            },
+        ),
+        patch(
+            "cli_agent_orchestrator.providers.manager.MiniMaxCodeProvider",
+            return_value=cleanup_only_provider,
+        ) as provider_cls,
+    ):
+        manager.cleanup_provider("restored-mcode")
+
+    provider_cls.assert_called_once_with("restored-mcode", "s1", "w1", "developer")
     cleanup_only_provider.cleanup.assert_called_once()
 
 

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -181,6 +181,15 @@ class TestStickyLatching:
         m.feed(TerminalStatus.PROCESSING)  # post-completion eviction flap
         assert m.status() == TerminalStatus.COMPLETED
 
+    def test_dispatch_can_publish_processing_before_first_tui_redraw(self):
+        m = _SequencedMonitor()
+        m.feed(TerminalStatus.COMPLETED)
+
+        m.sm.notify_input_sent("t1", assume_processing=True)
+
+        assert m.status() == TerminalStatus.PROCESSING
+        assert m.sm._allow_processing_revert["t1"] is False
+
     def test_arm_survives_ready_to_ready_flap(self):
         """A large paste can evict the response markers BEFORE the agent
         starts working, flapping COMPLETED → IDLE. That flap must not consume

--- a/test/services/test_terminal_service.py
+++ b/test/services/test_terminal_service.py
@@ -28,8 +28,8 @@ def test_minimax_code_uses_runtime_skills_with_soft_tool_enforcement():
         SOFT_ENFORCEMENT_PROVIDERS,
     )
 
-    assert "minimax_code" in RUNTIME_SKILL_PROMPT_PROVIDERS
-    assert "minimax_code" in SOFT_ENFORCEMENT_PROVIDERS
+    assert "mcode" in RUNTIME_SKILL_PROMPT_PROVIDERS
+    assert "mcode" in SOFT_ENFORCEMENT_PROVIDERS
 
 
 _TS = "cli_agent_orchestrator.services.terminal_service"

--- a/test/services/test_terminal_service.py
+++ b/test/services/test_terminal_service.py
@@ -22,6 +22,16 @@ def test_grok_uses_runtime_skills_with_native_tool_enforcement():
     assert "grok_cli" not in SOFT_ENFORCEMENT_PROVIDERS
 
 
+def test_minimax_code_uses_runtime_skills_with_soft_tool_enforcement():
+    from cli_agent_orchestrator.services.terminal_service import (
+        RUNTIME_SKILL_PROMPT_PROVIDERS,
+        SOFT_ENFORCEMENT_PROVIDERS,
+    )
+
+    assert "minimax_code" in RUNTIME_SKILL_PROMPT_PROVIDERS
+    assert "minimax_code" in SOFT_ENFORCEMENT_PROVIDERS
+
+
 _TS = "cli_agent_orchestrator.services.terminal_service"
 
 

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1450,6 +1450,30 @@ class TestSendInput:
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_send_input_can_publish_processing_before_tui_redraw(
+        self, mock_get_metadata, mock_tmux, mock_pm, mock_update, mock_status_monitor
+    ):
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_provider = mock_pm.get_provider.return_value
+        mock_provider.paste_enter_count = 1
+        mock_provider.paste_submit_delay = 0.3
+        mock_provider.assume_processing_on_dispatch = True
+        mock_status_monitor.get_status.return_value = TerminalStatus.COMPLETED
+
+        assert send_input("test1234", "next turn") is True
+
+        mock_status_monitor.notify_input_sent.assert_called_once_with(
+            "test1234", assume_processing=True
+        )
+
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_clears_rolling_buffer_preserving_arm(
         self,
         mock_get_metadata,

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -1450,30 +1450,6 @@ class TestSendInput:
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
     @patch("cli_agent_orchestrator.backends.registry._backend")
     @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
-    def test_send_input_can_publish_processing_before_tui_redraw(
-        self, mock_get_metadata, mock_tmux, mock_pm, mock_update, mock_status_monitor
-    ):
-        mock_get_metadata.return_value = {
-            "tmux_session": "cao-session",
-            "tmux_window": "developer-abcd",
-        }
-        mock_provider = mock_pm.get_provider.return_value
-        mock_provider.paste_enter_count = 1
-        mock_provider.paste_submit_delay = 0.3
-        mock_provider.assume_processing_on_dispatch = True
-        mock_status_monitor.get_status.return_value = TerminalStatus.COMPLETED
-
-        assert send_input("test1234", "next turn") is True
-
-        mock_status_monitor.notify_input_sent.assert_called_once_with(
-            "test1234", assume_processing=True
-        )
-
-    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
-    @patch("cli_agent_orchestrator.services.terminal_service.update_last_active")
-    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
-    @patch("cli_agent_orchestrator.backends.registry._backend")
-    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
     def test_send_input_clears_rolling_buffer_preserving_arm(
         self,
         mock_get_metadata,


### PR DESCRIPTION
## Summary

- add `minimax_code` as a first-class CAO provider for the public `@minimax-ai/code` CLI
- isolate auth/config per terminal and generate a terminal-local MiniMax Plugin for CAO MCP tools
- support multi-turn status detection, response extraction, permission states, restart-safe cleanup, profiles, skills, and documented soft tool restrictions
- normalize supervisor-created MiniMax workers so Kiro-only `engine` and unsupported inherited `model` overrides do not reach `assign` or `handoff` terminal APIs
- add unit, service, API, CLI, and real-provider orchestration coverage

Closes #624.

## Validation

- `PYTHONPATH=src .venv/bin/python -m pytest test/providers/test_minimax_code_unit.py test/providers/test_provider_manager_unit.py test/api/test_api_endpoints.py::TestAgentProviders test/cli/commands/test_launch.py::test_minimax_code_requires_workspace_access_confirmation test/services/test_terminal_service.py::test_minimax_code_uses_runtime_skills_with_soft_tool_enforcement test/services/test_status_monitor.py test/services/test_terminal_service_full.py -q -o addopts=` — 136 passed
- `PYTHONPATH=src .venv/bin/python -m pytest test/providers/test_minimax_code_unit.py test/providers/test_provider_manager_unit.py test/services/test_status_monitor.py test/services/test_terminal_service.py test/services/test_terminal_service_full.py -q -o addopts=` — 156 passed after the final type-narrowing fix
- `uv run --frozen pytest test/mcp_server/test_assign.py test/mcp_server/test_handoff.py test/providers/test_minimax_code_unit.py test/providers/test_provider_manager_unit.py -q -o 'addopts='` — 103 passed
- authenticated real `mcode` v0.1.2 serial E2E across handoff, assign, send_message, allowed-tools, and supervisor orchestration — 10 passed, 1 xpassed
- maintainer-requested authenticated `examples/assign` flow — passed in 112.77 seconds: supervisor created three analyst workers in parallel, received all analyst callbacks, sequentially handed the combined work to the report generator, and completed final synthesis with five terminals in the session
- `uv run --frozen black --check src/ test/` — 556 files unchanged
- `uv run --frozen isort --check-only src/ test/` — passed
- `PYTHONPATH=src .venv/bin/python scripts/validate_markdown_links.py` — passed
- focused mypy on the changed provider-manager seam — passed; repository-wide mypy still reports pre-existing dependency-stub and unrelated typing errors

## Notes

- MiniMax Code currently has no public per-session model flag, so explicit unsupported user launch overrides remain rejected rather than silently ignored.
- Supervisor-created child workers omit inherited Kiro-only `engine` and unsupported MiniMax `model` values at both the `assign` and `handoff` request boundaries; Kiro's explicit engine forwarding and other providers' nonblank model forwarding remain covered.
- `allowedTools` is prompt-level soft enforcement for MiniMax Code and is documented as unsuitable for security-critical restrictions.
- live-output fixtures contain only synthetic content; terminal auth material is never committed.
