### PR TITLE
fix(api): report output-extraction failures as 500, not 404

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -91,6 +91,7 @@ from cli_agent_orchestrator.models.memory import (
 )
 from cli_agent_orchestrator.models.terminal import Terminal, TerminalId
 from cli_agent_orchestrator.plugins import PluginRegistry
+from cli_agent_orchestrator.providers.base import OutputExtractionError
 from cli_agent_orchestrator.providers.kiro_capabilities import (
     KiroCapabilityError,
     KiroPhase0KASError,
@@ -3295,6 +3296,14 @@ async def run_step(
         # a bad request, not an unknown terminal.
         _settle_step(None, str(e))
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except OutputExtractionError as e:
+        # Also ordered before the ValueError arm it subclasses. The terminal and
+        # the route both resolved and the step ran -- only the response marker
+        # was missing -- so this is not a bad terminal reference. 500 per this
+        # endpoint's documented contract above ("any other failure -> 500",
+        # plain-string detail, no ``kind``), not 404 (issue #570).
+        _settle_step(None, str(e))
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
     except ValueError as e:
         # Unknown terminal / bad input surfaced by the terminal layer.
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -3051,6 +3051,13 @@ async def get_terminal_output(
         # transcript can't stall the whole server.
         output = await asyncio.to_thread(terminal_service.get_output, terminal_id, mode)
         return TerminalOutputResponse(output=output, mode=mode)
+    except OutputExtractionError as e:
+        # Ordered before the ValueError arm it subclasses, same as run_step: the
+        # terminal and the route both resolved -- only the response marker was
+        # missing from the scrollback -- so this is a server-side extraction
+        # failure, not a bad terminal reference. Keep it a 500, not a 404
+        # (issue #570), and a plain-string detail like the run-step arm.
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -33,6 +33,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class OutputExtractionError(ValueError):
+    """A provider ran but no usable message could be extracted from its output.
+
+    Distinct from the ``ValueError``s that name a bad terminal or provider
+    reference, which are genuine lookup failures. This one means the terminal
+    exists and the step ran; only the response marker was missing from the
+    scrollback.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` callers keep
+    working; the API boundary catches this narrower type first so an extraction
+    failure is not reported as 404 Not Found (issue #570).
+    """
+
+
 class BaseProvider(ABC):
     """Abstract base class for CLI tool providers.
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -63,6 +63,7 @@ from cli_agent_orchestrator.plugins import (
     PostKillTerminalEvent,
     PostSendMessageEvent,
 )
+from cli_agent_orchestrator.providers.base import OutputExtractionError
 from cli_agent_orchestrator.providers.kiro_capabilities import (
     KiroCapabilities,
     KiroPhase0KASError,
@@ -1453,7 +1454,11 @@ def get_output(terminal_id: str, mode: OutputMode = OutputMode.FULL) -> str:
                             terminal_id,
                             exc,
                         )
-                raise last_err  # type: ignore[misc]
+                # Re-raise as the narrower type: the terminal and provider both
+                # resolved, so this is a missing response marker, not a bad
+                # reference. Keeps the API boundary from reporting it as 404
+                # (issue #570).
+                raise OutputExtractionError(str(last_err)) from last_err
 
             # Escalating fetch: try progressively larger capture windows until
             # the response marker is found or we hit the cap.

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -1107,6 +1107,26 @@ class TestGetTerminalOutput:
         assert response.status_code == 500
         assert "Failed to get output" in response.json()["detail"]
 
+    def test_get_output_last_mode_extraction_failure_is_500(self, client):
+        """A missing response marker is a 500, not a 404 (issue #570).
+
+        mode=last takes the pinned-depth retry path that re-raises as
+        OutputExtractionError; it subclasses ValueError, so without an arm
+        ordered before the ValueError catch below it collapsed back into this
+        route's 404. Same boundary mapping as POST /terminals/run-step.
+        """
+        from cli_agent_orchestrator.providers.base import OutputExtractionError
+
+        with patch("cli_agent_orchestrator.api.main.terminal_service") as mock_svc:
+            mock_svc.get_output.side_effect = OutputExtractionError(
+                "No completion marker found after last user message"
+            )
+
+            response = client.get("/terminals/abcd1234/output?mode=last")
+
+        assert response.status_code == 500
+        assert "No completion marker" in response.json()["detail"]
+
 
 class TestDeleteTerminal:
     """Tests for DELETE /terminals/{terminal_id} endpoint."""

--- a/test/api/test_run_step_extraction_failure_status.py
+++ b/test/api/test_run_step_extraction_failure_status.py
@@ -69,3 +69,58 @@ class TestExceptionType:
     def test_carries_the_provider_message(self):
         with pytest.raises(ValueError, match=_MARKER_MISSING):
             raise OutputExtractionError(_MARKER_MISSING)
+
+
+class TestExtractionFailureSettlement:
+    """An extraction failure must settle a script step as FAILED.
+
+    The ``run_step`` boundary settles the step in its OutputExtractionError arm
+    (``_settle_step(None, str(e))``), just like the other arms that run after
+    dispatch. These assertions pin that bookkeeping so the call cannot be
+    dropped or altered without detection -- same shape as the parametrized
+    untyped-failure settlement guard in test_run_step.py.
+    """
+
+    def test_extraction_failure_settles_script_step_failed(self, client, monkeypatch):
+        from cli_agent_orchestrator.models.workflow import StepState
+        from cli_agent_orchestrator.models.workflow_runtime import RunState
+        from cli_agent_orchestrator.services import workflow_journal, workflow_service
+        from cli_agent_orchestrator.services.script_runner import ScriptRunRecord
+
+        run_id = "run-bookkeeping"
+        env_vars = {
+            "CAO_WORKFLOW_RUN_ID": run_id,
+            "CAO_WORKFLOW_GENERATION": "1",
+            "CAO_WORKFLOW_STEP_ID": "step-1",
+        }
+        record = ScriptRunRecord(
+            run_id=run_id,
+            workflow_name="wf",
+            state=RunState.RUNNING,
+            cancelled=False,
+            current_step_id=None,
+            step_states={},
+            process=None,
+            generation="1",
+            started_at="2026-07-15T00:00:00Z",
+            finished_at=None,
+        )
+        monkeypatch.setitem(workflow_service.run_registry, run_id, record)
+        monkeypatch.setattr(workflow_journal, "append_step", lambda *args, **kwargs: None)
+        monkeypatch.setattr(workflow_journal, "update_step", lambda *args, **kwargs: None)
+
+        exc = OutputExtractionError(_MARKER_MISSING)
+        with (
+            patch(
+                "cli_agent_orchestrator.services.workflow_service.check_generation",
+                return_value=None,
+            ),
+            patch(_RUN_STEP, new=AsyncMock(side_effect=exc)),
+        ):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body(env_vars=env_vars))
+
+        assert resp.status_code == 500
+        step = record.step_states["step-1"]
+        assert step.state == StepState.FAILED
+        assert step.attempts == 1
+        assert step.error == _MARKER_MISSING

--- a/test/api/test_run_step_extraction_failure_status.py
+++ b/test/api/test_run_step_extraction_failure_status.py
@@ -1,0 +1,71 @@
+"""run-step must not report an output-extraction failure as 404 (issue #570).
+
+A provider's ``extract_last_message_from_script`` raises when it cannot find a
+completion marker in the scrollback. That failure used to share ``run_step``'s
+blanket ``except ValueError`` arm with genuine bad-terminal references, so it
+surfaced as 404 Not Found -- indistinguishable from a missing route, and the
+reason the reporter in #562 went and pulled the live OpenAPI schema to check
+whether the endpoint existed at all.
+
+The terminal exists, the route exists, the step ran. Per this endpoint's own
+documented failure contract ("A bad terminal reference -> 404; any other
+failure -> 500"), it is a 500.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.constants import TERMINALS_RUN_STEP_ROUTE
+from cli_agent_orchestrator.providers.base import OutputExtractionError
+
+_RUN_STEP = "cli_agent_orchestrator.api.main.run_agent_step"
+
+# The real message from providers/opencode_cli.py.
+_MARKER_MISSING = "No completion marker found after last user message"
+
+
+def _body(**overrides):
+    base = {"provider": "opencode_cli", "agent": "developer", "prompt": "do it"}
+    base.update(overrides)
+    return base
+
+
+class TestExtractionFailureStatus:
+    def test_extraction_failure_is_not_404(self, client):
+        # The regression itself: 404 is the one status this must never be.
+        with patch(_RUN_STEP, new=AsyncMock(side_effect=OutputExtractionError(_MARKER_MISSING))):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body())
+        assert resp.status_code != 404
+
+    def test_extraction_failure_maps_to_500(self, client):
+        with patch(_RUN_STEP, new=AsyncMock(side_effect=OutputExtractionError(_MARKER_MISSING))):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body())
+        assert resp.status_code == 500
+
+    def test_detail_is_a_plain_string_without_kind(self, client):
+        # Contract: only step-execution outcomes carry the structured
+        # {"message", "kind", "terminal_id"} detail. This is not one of them.
+        with patch(_RUN_STEP, new=AsyncMock(side_effect=OutputExtractionError(_MARKER_MISSING))):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body())
+        detail = resp.json()["detail"]
+        assert isinstance(detail, str)
+        assert _MARKER_MISSING in detail
+
+    def test_bad_terminal_reference_still_maps_to_404(self, client):
+        # The other half of the contract, pinned so narrowing the arm above did
+        # not take the genuine lookup failure with it.
+        with patch(_RUN_STEP, new=AsyncMock(side_effect=ValueError("Terminal 'abc123' not found"))):
+            resp = client.post(TERMINALS_RUN_STEP_ROUTE, json=_body())
+        assert resp.status_code == 404
+
+
+class TestExceptionType:
+    def test_subclasses_value_error(self):
+        # Existing `except ValueError` callers (including the retry loops inside
+        # terminal_service.get_output) must keep catching it.
+        assert issubclass(OutputExtractionError, ValueError)
+
+    def test_carries_the_provider_message(self):
+        with pytest.raises(ValueError, match=_MARKER_MISSING):
+            raise OutputExtractionError(_MARKER_MISSING)

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -9,6 +9,7 @@ import pytest
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.models.inbox import OrchestrationType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.base import OutputExtractionError
 from cli_agent_orchestrator.services.terminal_service import (
     OutputMode,
     TerminalInputBlockedError,
@@ -1697,6 +1698,58 @@ class TestGetOutput:
         mock_pm.get_provider.return_value = None
 
         with pytest.raises(ValueError, match="Provider not found"):
+            get_output("test1234", OutputMode.LAST)
+
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_pinned_depth_extraction_failure_raises_output_extraction_error(
+        self, mock_get_metadata, mock_tmux, mock_status_monitor, mock_pm
+    ):
+        """A missing response marker is not a bad reference (issue #570).
+
+        Providers that pin ``extraction_tail_lines`` (opencode_cli, kiro_cli)
+        take the retry path, which re-raises once the attempts are spent. That
+        must surface as OutputExtractionError so the API boundary can tell it
+        apart from an unknown-terminal ValueError and stop returning 404.
+        """
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_status_monitor.get_buffer.return_value = "full output"
+        mock_provider = MagicMock()
+        mock_provider.extraction_tail_lines = 200
+        mock_provider.extraction_retries = 0
+        mock_provider.extract_last_message_from_script.side_effect = ValueError(
+            "No completion marker found after last user message"
+        )
+        mock_pm.get_provider.return_value = mock_provider
+
+        with pytest.raises(OutputExtractionError, match="No completion marker"):
+            get_output("test1234", OutputMode.LAST)
+
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.backends.registry._backend")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    def test_extraction_error_is_still_a_value_error(
+        self, mock_get_metadata, mock_tmux, mock_status_monitor, mock_pm
+    ):
+        """Callers that catch ValueError keep working (issue #570)."""
+        mock_get_metadata.return_value = {
+            "tmux_session": "cao-session",
+            "tmux_window": "developer-abcd",
+        }
+        mock_status_monitor.get_buffer.return_value = "full output"
+        mock_provider = MagicMock()
+        mock_provider.extraction_tail_lines = 200
+        mock_provider.extraction_retries = 0
+        mock_provider.extract_last_message_from_script.side_effect = ValueError("no marker")
+        mock_pm.get_provider.return_value = mock_provider
+
+        with pytest.raises(ValueError):
             get_output("test1234", OutputMode.LAST)
 
     @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")


### PR DESCRIPTION
Closes #570.

## The problem

`POST /terminals/run-step` mapped every `ValueError` to 404, so a provider that ran but produced no completion marker was indistinguishable from a missing route. In #562 the reporter went and pulled the live OpenAPI schema to check whether the endpoint existed at all, which is reasonable debugging entirely caused by the status code.

The endpoint's own docstring already says what should happen:

> A bad terminal reference -> 404; any other failure -> 500 (plain-string detail, no `kind` — these are not step-execution outcomes).

An extraction failure is not a bad terminal reference. The terminal exists, the route exists, the step ran. The adjacent endpoints map `ValueError -> 400` per B2-BR-9, so 404 was the odd one out. That answers the 422-vs-500 question the issue left open, so I went with 500 rather than picking a preference.

## The change

`OutputExtractionError` in `providers/base.py`, next to the `extract_last_message_from_script` contract it belongs to. It subclasses `ValueError` so every existing `except ValueError` caller keeps working, including the retry loops inside `get_output` itself.

`terminal_service.get_output` raises it from the pinned-depth retry path. That is the only path where an extraction failure escapes the function: the escalating-fetch path returns a `[PARTIAL RESPONSE]` string instead of raising. `opencode_cli` and `kiro_cli` are the two providers that pin `extraction_tail_lines` and take it, so the ten providers raising bare `ValueError` from their extractors stay untouched.

`run_step` catches it ahead of the `ValueError` arm it subclasses, mirroring how `KiroPhase0KASError` is already ordered there, and maps it to 500 with a plain-string detail.

One thing worth a reviewer's eye: I also settle the step as failed in that arm. Every arm that runs after dispatch does, and an extraction failure means the step ran. The old 404 arm did not settle, because a bad terminal reference means it never started. Happy to drop that if you would rather keep this change purely about the status code.

## Verification

8 new tests, all passing:

- 4 in `test/api/test_run_step_extraction_failure_status.py` covering not-404, 500, the plain-string detail shape, and that a genuine bad terminal reference still maps to 404.
- 2 pinning the exception type itself.
- 2 in `test/services/test_terminal_service_full.py` covering the actual seam, that `get_output` converts the provider's `ValueError` and that it is still catchable as `ValueError`.

I checked the regression tests fail without the fix rather than assuming: reverting only the `api/main.py` hunk turns `test_extraction_failure_is_not_404` and `test_extraction_failure_maps_to_500` red with 404, and the other four stay green.

Full suite, `pytest test/ -n 4`:

- unchanged `main`: 62 failed, 6851 passed
- this branch: 62 failed, **6859** passed

Same 62 failures both ways. They sit in `services/agui/`, `telemetry/test_otel_init.py` and `test_no_ffi_guard.py` and are unrelated to this change; the delta is exactly the 8 tests added here. `black --check src/ test/` is clean and `mypy` reports no issues on the changed sources.

Best Regards, Tarik
