### PR TITLE
feat(examples): add workflow lifecycle example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           # CI intentionally includes integration-marked tests except for the Kiro
           # provider test, which requires an authenticated external CLI.
-          uv run pytest test/ \
+          uv run pytest test/ examples/workflow/tests/ \
             --ignore=test/providers/test_kiro_cli_integration.py \
             --ignore=test/e2e \
             -m "not e2e" \
@@ -177,7 +177,7 @@ jobs:
       - name: Backend coverage (for the ratchet floor)
         # Produces coverage.json (python floor) consumed by coverage:ratchet.
         run: |
-          uv run pytest test/ \
+          uv run pytest test/ examples/workflow/tests/ \
             --ignore=test/providers/test_kiro_cli_integration.py \
             --ignore=test/e2e \
             -m "not e2e" \

--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -1,0 +1,186 @@
+# Workflow Example
+
+A focused gallery example for the `cao workflow` lifecycle: a parameterized Python
+script that runs a sequential step and then a concurrent fan-out, submitted as a
+durable, resumable, cancellable run. It is intentionally small — one script, three
+concurrent checks — so the lifecycle stays the point, not the payload.
+
+For the shim contract itself (`run_step`/`emit_output`, determinism, fan-out
+`step_id` rules) see [docs/workflow-scripts-authoring-guide.md](../../docs/workflow-scripts-authoring-guide.md).
+For the full CLI/MCP reference see [docs/workflows.md](../../docs/workflows.md). This
+README only covers what's specific to this example.
+
+## Files
+
+- [`workflow.py`](workflow.py) — the workflow. Declares typed `INPUTS`, reads them
+  via `get_inputs()`, runs one sequential `run_step` (a review plan), then fans out
+  three more `run_step` calls concurrently (`style`/`security`/`performance` checks)
+  via `ThreadPoolExecutor`, and calls `emit_output()` with a structured result.
+- [`fixtures/inputs.json`](fixtures/inputs.json) — the canonical demo inputs used by
+  the commands below.
+- [`run.sh`](run.sh) — non-interactive entry point: copies `workflow.py` into the CAO
+  workflows directory, validates it, then runs it and exits with the run's own exit
+  code. Needs a real `cao-server` and an authenticated `claude_code` CLI.
+- [`tests/`](tests/) — `test_workflow_example.py` (deterministic, no real server or
+  provider — a fake `/terminals/run-step` HTTP server stands in) and
+  `test_workflow_live.py` (gated, needs both; skipped by default).
+
+## What it demonstrates
+
+1. **Typed inputs** — `target` (string, required), `concurrency` (int, default `2`),
+   `strict` (bool, default `false`).
+2. **Sequential then concurrent** — one `run_step` plan call, then a
+   `ThreadPoolExecutor` fan-out over a fixed check list, each with an explicit,
+   pairwise-distinct `step_id` derived from `target` and the check name
+   (`check:<target>:<check>`) — the shape used in
+   [`docs/examples/fanout_example.py`](../../docs/examples/fanout_example.py).
+3. **Per-unit fault tolerance** — each fan-out call is wrapped in its own
+   `try`/`except ShimHTTPError`; one failing check is dropped into
+   `failed_checks` and the run still completes with the survivors.
+4. **A conservative concurrency ceiling** — `max_workers` is
+   `min(requested_concurrency, 2)`. Passing `--input concurrency=3` does **not**
+   raise the actual worker count above the declared default of `2` — it can only
+   lower it. This mirrors the `claude_code` fan-out guidance in
+   [docs/workflows.md](../../docs/workflows.md#fan-out-concurrency) (measured: higher
+   values starved the heaviest step).
+5. **A structured result** — `emit_output({"target", "strict", "max_workers", "plan",
+   "checks", "failed_checks"})`, printed as the `CAO_WORKFLOW_OUTPUT:` sentinel line.
+
+## Prerequisites
+
+- `cao-server` running (`cao-server` in one terminal).
+- The `claude_code` CLI installed and authenticated — the example's steps use
+  `provider="claude_code", agent="reviewer"` (a built-in profile; nothing to
+  install). `claude_code` is used deliberately instead of `kiro_cli`: `kiro_cli`
+  currently hangs on an interactive prompt inside a workflow step (see the
+  "Operational tips" in [docs/workflows.md](../../docs/workflows.md)).
+
+## Author and validate
+
+Workflows are addressed by file, and a relative path resolves against the
+**configured workflows directory** (`~/.aws/cli-agent-orchestrator/workflows`, or
+`$CAO_HOME_DIR/workflows` if set) — never the shell's cwd. Copy the example there
+first, exactly as [docs/workflows.md](../../docs/workflows.md)'s own quick start
+does for every workflow:
+
+```bash
+mkdir -p ~/.aws/cli-agent-orchestrator/workflows
+cp examples/workflow/workflow.py ~/.aws/cli-agent-orchestrator/workflows/workflow.py
+
+cao workflow validate ~/.aws/cli-agent-orchestrator/workflows/workflow.py
+```
+
+`validate` never runs the script or creates a terminal — it is a pure static check
+(disallowed/dynamic imports, nondeterminism warnings) and exits `0` for this example
+(`pass`) before any run is ever submitted.
+
+## Run, observe, cancel
+
+```bash
+# Submit + follow to a terminal state. Prints the run id immediately, then polls.
+cao workflow run workflow --run-id demo-1 --input target=myapp --input concurrency=3
+
+# From another terminal while it's running:
+cao workflow status demo-1
+
+# Cooperatively cancel it:
+cao workflow cancel demo-1
+```
+
+`--run-id demo-1` is pre-announced deliberately — the run id is retained from the
+moment it's printed, so `status`/`wait`/`result`/`cancel` can all address it, whether
+the run is still going, finished, or the terminal that started it is gone.
+
+`events`/`wait`/`result` apply too, for the same run:
+
+```bash
+cao workflow events demo-1 --no-follow   # one-shot batch read of ordered progress
+cao workflow wait demo-1                 # (re-)follow an already-submitted run
+cao workflow result demo-1 --json        # the full WorkflowRunResult, in-flight or done
+```
+
+## Output shapes
+
+`cao workflow run` **submits asynchronously and follows** by default — Ctrl-C
+detaches, it never cancels. Three invocations, three `--json` shapes (see
+[docs/workflows.md](../../docs/workflows.md#running-submit-and-follow-detach-or-block)
+for the complete table):
+
+| Invocation | `--json` shape |
+| --- | --- |
+| `cao workflow run workflow --run-id demo-1 ...` (default) | `{run_id, state}` — the narrow terminal object |
+| `cao workflow run workflow --run-id demo-1 ... --detach` | the 202 submit body: `{run_id, state, links}` |
+| `cao workflow run workflow --run-id demo-1 ... --wait` | the complete `WorkflowRunResult` (`steps[]`, `output`, `warnings`, ...) |
+
+Only the `--wait` path (or `cao workflow result <id>`) carries the run-level
+`output` `emit_output()` produced — run-level output is not journaled, so `status`
+and a plain (non-`--wait`) `run`/`result` never include it; per-step `output` is
+always present on `steps[]`.
+
+## `cao workflow` vs. `cao schedule`
+
+They solve different problems:
+
+- **`cao workflow`** (this example) runs **one on-demand, durable, resumable
+  execution** of a script or spec, addressed by a run id — `status`/`cancel`/
+  `resume`/`result` all operate on that one run's journal row.
+- **`cao schedule`** (see [`examples/flow/`](../flow/) and
+  [docs/flows.md](../../docs/flows.md)) registers a markdown-defined agent session
+  to fire on a **cron schedule** via `cao-server`'s scheduler. There is no run id, no
+  resumable journal, and no per-run status/cancel — it's "run this agent prompt
+  every morning at 7:30," not "run this pipeline and let me track it."
+
+If what you need is "run this multi-step, parameterized pipeline right now and
+track it," that's `cao workflow`. If it's "run this prompt on a recurring cadence,"
+that's `cao schedule`.
+
+## Resume — current behavior
+
+`cao workflow resume demo-1` re-executes the **frozen script from the top** on a new
+generation. It does **not** currently skip `run_step` calls that already completed:
+a replay-lookup primitive exists in the journal layer, but it is not yet wired into
+the run-step route, so every `run_step` call — including the plan step and every
+check that already finished — runs again. This example's steps are read-only
+(`reviewer`, no file writes), so a resume is safe to try, but do not expect
+replay-safe, exactly-once behavior yet. See "Resume re-executes the frozen script" in
+[docs/workflow-scripts-authoring-guide.md](../../docs/workflow-scripts-authoring-guide.md#resume-re-executes-the-frozen-script)
+for the full explanation.
+
+## Tests
+
+```bash
+# Deterministic — fake /terminals/run-step server, no real cao-server/tmux/provider.
+uv run pytest --no-cov -p no:cacheprovider -q examples/workflow/tests/test_workflow_example.py
+
+# Gated live-provider test — needs a real cao-server + authenticated claude_code.
+# Skipped by default; opt in explicitly:
+CAO_RUN_LIVE_PROVIDER_TESTS=1 uv run pytest --no-cov -q examples/workflow/tests/test_workflow_live.py
+```
+
+`test_workflow_example.py` reuses the `_RunStepFakeHandler` pattern from
+[`test/e2e/examples/test_examples_gallery_e2e.py`](../../test/e2e/examples/test_examples_gallery_e2e.py):
+a minimal stdlib `http.server` stands in for `/terminals/run-step`, so the real
+`cao_workflow` HTTP transport and the real `run_script_workflow` subprocess engine
+are exercised without a live tmux-backed `cao-server` or provider credentials. It
+asserts: `validate` passes lint; a missing `target` is rejected by `_validate_inputs`
+before any worker/step exists; concurrent fan-out calls carry pairwise-distinct
+`step_id`s; one forced-failing check is dropped into `failed_checks` without losing
+the other survivors; and the `CAO_WORKFLOW_OUTPUT:` sentinel line is on the spawned
+subprocess's real stdout.
+
+## Manual run
+
+```bash
+./run.sh myapp demo-1 3
+```
+
+## See also
+
+- [docs/workflows.md](../../docs/workflows.md) — the full lifecycle, CLI/MCP
+  reference, and fan-out guidance.
+- [docs/workflow-scripts-authoring-guide.md](../../docs/workflow-scripts-authoring-guide.md) —
+  the shim contract, the determinism obligation, and the resume boundary.
+- [`skills/cao-workflow/SKILL.md`](../../skills/cao-workflow/SKILL.md) — the
+  agent-facing authoring skill (this example follows its R1/R3/R4/R5 rules).
+- [`docs/examples/fanout_example.py`](../../docs/examples/fanout_example.py) — the
+  minimal fan-out shape this example builds on.

--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -32,7 +32,8 @@ README only covers what's specific to this example.
 2. **Sequential then concurrent** — one `run_step` plan call, then a
    `ThreadPoolExecutor` fan-out over a fixed check list, each with an explicit,
    pairwise-distinct `step_id` derived from `target` and the check name
-   (`check:<target>:<check>`) — the shape used in
+   (`check-<target>-<check>`, with `target` sanitized to the
+   `[A-Za-z0-9_-]` charset `/terminals/run-step` requires) — the shape used in
    [`docs/examples/fanout_example.py`](../../docs/examples/fanout_example.py).
 3. **Per-unit fault tolerance** — each fan-out call is wrapped in its own
    `try`/`except ShimHTTPError`; one failing check is dropped into
@@ -96,7 +97,7 @@ the run is still going, finished, or the terminal that started it is gone.
 ```bash
 cao workflow events demo-1 --no-follow   # one-shot batch read of ordered progress
 cao workflow wait demo-1                 # (re-)follow an already-submitted run
-cao workflow result demo-1 --json        # the full WorkflowRunResult, in-flight or done
+cao workflow result demo-1 --json        # the retained result assembled from the journal
 ```
 
 ## Output shapes
@@ -112,10 +113,12 @@ for the complete table):
 | `cao workflow run workflow --run-id demo-1 ... --detach` | the 202 submit body: `{run_id, state, links}` |
 | `cao workflow run workflow --run-id demo-1 ... --wait` | the complete `WorkflowRunResult` (`steps[]`, `output`, `warnings`, ...) |
 
-Only the `--wait` path (or `cao workflow result <id>`) carries the run-level
-`output` `emit_output()` produced — run-level output is not journaled, so `status`
-and a plain (non-`--wait`) `run`/`result` never include it; per-step `output` is
-always present on `steps[]`.
+Only the `--wait` path carries the run-level `output` `emit_output()` produced.
+Run-level output is not journaled: `status`'s snapshot model has no `output` field
+at all, and `result` (`/workflows/runs/{id}/result`) explicitly drops the key from
+its response rather than advertise a field it can never populate — so a plain
+(non-`--wait`) `run`, `status`, and `result` all omit it. Per-step `output` is
+unaffected and always present on `steps[]`.
 
 ## `cao workflow` vs. `cao schedule`
 

--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -145,8 +145,9 @@ a replay-lookup primitive exists in the journal layer, but it is not yet wired i
 the run-step route, so every `run_step` call — including the plan step and every
 check that already finished — runs again. This example's steps are read-only
 (`reviewer`, no file writes), so a resume is safe to try, but do not expect
-replay-safe, exactly-once behavior yet. See "Resume re-executes the frozen script" in
-[docs/workflow-scripts-authoring-guide.md](../../docs/workflow-scripts-authoring-guide.md#resume-re-executes-the-frozen-script)
+replay-safe, exactly-once behavior yet. See
+"Resume re-executes the script, and the server decides each step" in
+[docs/workflow-scripts-authoring-guide.md](../../docs/workflow-scripts-authoring-guide.md#resume-re-executes-the-script-and-the-server-decides-each-step)
 for the full explanation.
 
 ## Tests

--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -16,8 +16,9 @@ README only covers what's specific to this example.
   via `get_inputs()`, runs one sequential `run_step` (a review plan), then fans out
   three more `run_step` calls concurrently (`style`/`security`/`performance` checks)
   via `ThreadPoolExecutor`, and calls `emit_output()` with a structured result.
-- [`fixtures/inputs.json`](fixtures/inputs.json) — the canonical demo inputs used by
-  the commands below.
+- [`fixtures/inputs.json`](fixtures/inputs.json) — the demo input values for reference.
+  `cao workflow run` takes inputs only as repeated `--input k=v` flags, so the commands
+  below and `run.sh` mirror these values by hand rather than reading this file.
 - [`run.sh`](run.sh) — non-interactive entry point: copies `workflow.py` into the CAO
   workflows directory, validates it, then runs it and exits with the run's own exit
   code. Needs a real `cao-server` and an authenticated `claude_code` CLI.
@@ -140,12 +141,25 @@ that's `cao schedule`.
 ## Resume — current behavior
 
 `cao workflow resume demo-1` re-executes the **frozen script from the top** on a new
-generation. It does **not** currently skip `run_step` calls that already completed:
-a replay-lookup primitive exists in the journal layer, but it is not yet wired into
-the run-step route, so every `run_step` call — including the plan step and every
-check that already finished — runs again. This example's steps are read-only
-(`reviewer`, no file writes), so a resume is safe to try, but do not expect
-replay-safe, exactly-once behavior yet. See
+generation, and every `run_step` call makes a real HTTP request — there is no
+`if resuming:` branch in the script. What changes is what the *server* does with each
+request. Each call lands on one of three outcomes: **replayed** (the journaled result
+is returned and nothing runs), **executed** (the step runs again for real), or
+**halted** (the server stops the run at that step and waits for a human). A fourth
+outcome ends the run rather than one step: if the script changed at a step's key, that
+step diverges and the run fails with `ReplayDivergenceError`.
+
+So a resume does **not** repeat completed work by default. What that means for this
+example specifically: it calls only `run_step`, never `step(...)`, so every step here
+is **undeclared** — it has no `recovery=` policy. An undeclared step still replays,
+because replay executes nothing; but wherever the alternative would be re-execution,
+it **halts for a human** instead of silently running again. Concretely, if a check was
+dispatched but never settled before the run died, resuming stops there rather than
+re-dispatching it.
+
+One trap worth knowing when you copy this example: a replayed `StepHandle` has
+`.replayed == True` and its `.terminal_id` names a terminal that no longer exists, so
+check `replayed` before you touch `terminal_id`. See
 "Resume re-executes the script, and the server decides each step" in
 [docs/workflow-scripts-authoring-guide.md](../../docs/workflow-scripts-authoring-guide.md#resume-re-executes-the-script-and-the-server-decides-each-step)
 for the full explanation.
@@ -161,8 +175,11 @@ uv run pytest --no-cov -p no:cacheprovider -q examples/workflow/tests/test_workf
 CAO_RUN_LIVE_PROVIDER_TESTS=1 uv run pytest --no-cov -q examples/workflow/tests/test_workflow_live.py
 ```
 
-`test_workflow_example.py` reuses the `_RunStepFakeHandler` pattern from
-[`test/e2e/examples/test_examples_gallery_e2e.py`](../../test/e2e/examples/test_examples_gallery_e2e.py):
+`test_workflow_example.py` adapts the `_RunStepFakeHandler` pattern from
+[`test/e2e/examples/test_examples_gallery_e2e.py`](../../test/e2e/examples/test_examples_gallery_e2e.py),
+with one deliberate difference: this fake also emits `replayed`, because the shim reads
+`data["replayed"]` by direct indexing and raises `KeyError` without it. Otherwise the
+approach is the same:
 a minimal stdlib `http.server` stands in for `/terminals/run-step`, so the real
 `cao_workflow` HTTP transport and the real `run_script_workflow` subprocess engine
 are exercised without a live tmux-backed `cao-server` or provider credentials. It

--- a/examples/workflow/README.md
+++ b/examples/workflow/README.md
@@ -33,9 +33,15 @@ README only covers what's specific to this example.
 2. **Sequential then concurrent** — one `run_step` plan call, then a
    `ThreadPoolExecutor` fan-out over a fixed check list, each with an explicit,
    pairwise-distinct `step_id` derived from `target` and the check name
-   (`check-<target>-<check>`, with `target` sanitized to the
-   `[A-Za-z0-9_-]` charset `/terminals/run-step` requires) — the shape used in
+   (`check-<target>-<check>`, with `target` put through `_slug` to satisfy both
+   halves of what `/terminals/run-step` requires: the `[A-Za-z0-9_-]` charset and
+   the 1-64 character length) — the shape used in
    [`docs/examples/fanout_example.py`](../../docs/examples/fanout_example.py).
+   A `target` short enough to fit is only charset-mapped, so it keeps a readable
+   `step_id`. One long enough to overflow the budget is truncated and given a
+   short digest of the original, because bare truncation would map every long
+   `target` sharing a prefix onto a single `step_id` — and a reused `step_id` in a
+   fan-out is a correctness bug rather than a cosmetic one.
 3. **Per-unit fault tolerance** — each fan-out call is wrapped in its own
    `try`/`except ShimHTTPError`; one failing check is dropped into
    `failed_checks` and the run still completes with the survivors.

--- a/examples/workflow/fixtures/inputs.json
+++ b/examples/workflow/fixtures/inputs.json
@@ -1,0 +1,5 @@
+{
+  "target": "myapp",
+  "concurrency": 3,
+  "strict": false
+}

--- a/examples/workflow/run.sh
+++ b/examples/workflow/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Non-interactive entry point for the workflow example.
+#
+# Copies workflow.py into the configured CAO workflows directory (idempotent —
+# `cao workflow run` resolves a bare name against that directory, never the
+# caller's cwd), validates it, then submits a run and follows it to a
+# terminal state. No prompts; the exit code mirrors `cao workflow run`'s own
+# contract (0 completed, 1 failed/cancelled).
+#
+# Usage:
+#   ./run.sh [target] [run-id] [concurrency]
+#   ./run.sh myapp demo-1 3
+#
+# Requires: cao-server already running, and claude_code available and
+# authenticated (the example's steps use provider="claude_code", agent=
+# "reviewer" — a built-in profile, no `cao install` needed).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${1:-myapp}"
+RUN_ID="${2:-workflow-demo-$$}"
+CONCURRENCY="${3:-3}"
+WORKFLOWS_DIR="${CAO_HOME_DIR:-$HOME/.aws/cli-agent-orchestrator}/workflows"
+
+mkdir -p "${WORKFLOWS_DIR}"
+cp "${HERE}/workflow.py" "${WORKFLOWS_DIR}/workflow.py"
+
+echo "[workflow-example] validating ${WORKFLOWS_DIR}/workflow.py" >&2
+cao workflow validate "${WORKFLOWS_DIR}/workflow.py"
+
+echo "[workflow-example] running run-id=${RUN_ID} target=${TARGET} concurrency=${CONCURRENCY}" >&2
+cao workflow run workflow \
+    --run-id "${RUN_ID}" \
+    --input "target=${TARGET}" \
+    --input "concurrency=${CONCURRENCY}" \
+    --json

--- a/examples/workflow/tests/conftest.py
+++ b/examples/workflow/tests/conftest.py
@@ -84,7 +84,8 @@ def _temp_db(tmp_path, monkeypatch):
 
     ``run_script_workflow`` journals to the configured SQLite file — without
     this override these tests would write into whatever CAO home the machine
-    running them has configured (mirrors ``test/e2e/examples/conftest.py``).
+    running them has configured (mirrors the ``_temp_db`` fixture in
+    ``test/e2e/examples/test_examples_gallery_e2e.py``).
     """
     from cli_agent_orchestrator.clients.database import (
         _migrate_workflow_run,

--- a/examples/workflow/tests/conftest.py
+++ b/examples/workflow/tests/conftest.py
@@ -45,6 +45,13 @@ class _RunStepFakeHandler(BaseHTTPRequestHandler):
                 "terminal_id": f"term-{step_id}",
                 "last_message": f"ack:{step_id}",
                 "status": "COMPLETED",
+                # Must be present: the shim reads ``data["replayed"]`` by
+                # direct indexing on purpose (BR-3/TD-7), so a fake that
+                # omits it raises KeyError instead of standing in for the
+                # real route. ``RunStepResponse.replayed`` defaults to
+                # False and the server always serialises it; this fake
+                # always executes fresh, so False is the honest value.
+                "replayed": False,
             }
         ).encode("utf-8")
         self.send_response(200)

--- a/examples/workflow/tests/conftest.py
+++ b/examples/workflow/tests/conftest.py
@@ -1,0 +1,106 @@
+"""Fixtures for the workflow example's deterministic tests (issue #591).
+
+Reuses the ``_RunStepFakeHandler`` fake-HTTP-server pattern from
+``test/e2e/examples/test_examples_gallery_e2e.py``: a minimal stdlib
+``http.server`` stands in for cao-server's ``/terminals/run-step`` route, so
+these tests exercise the real ``cao_workflow`` HTTP transport and the real
+``run_script_workflow`` subprocess engine without a live tmux-backed
+cao-server or an authenticated provider CLI. Extended with a
+``fail_step_ids`` switch so a test can force one fan-out unit to fail
+(``ShimHTTPError``) and prove the survivors are kept.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+
+class _RunStepFakeHandler(BaseHTTPRequestHandler):
+    """Records every POST body. Answers 200 with a canned RunStepResponse,
+    unless the call's step_id is in ``server.fail_step_ids`` — then answers
+    500 so the shim raises ``ShimHTTPError`` for that one call."""
+
+    def do_POST(self):  # noqa: N802 — BaseHTTPRequestHandler's naming convention
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        body = json.loads(raw.decode("utf-8"))
+        self.server.recorded_calls.append(body)  # type: ignore[attr-defined]
+
+        step_id = body.get("env_vars", {}).get("CAO_WORKFLOW_STEP_ID", "unknown")
+        if step_id in self.server.fail_step_ids:  # type: ignore[attr-defined]
+            payload = json.dumps({"detail": f"forced failure for step '{step_id}'"}).encode("utf-8")
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        response = json.dumps(
+            {
+                "terminal_id": f"term-{step_id}",
+                "last_message": f"ack:{step_id}",
+                "status": "COMPLETED",
+            }
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format, *args):  # noqa: A002 — silence default stderr logging
+        return
+
+
+@pytest.fixture
+def fake_run_step_server():
+    server = HTTPServer(("127.0.0.1", 0), _RunStepFakeHandler)
+    server.recorded_calls = []  # type: ignore[attr-defined]
+    server.fail_step_ids = set()  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _temp_db(tmp_path, monkeypatch):
+    """Isolate every test from the real ``~/.aws/cli-agent-orchestrator`` DB.
+
+    ``run_script_workflow`` journals to the configured SQLite file — without
+    this override these tests would write into whatever CAO home the machine
+    running them has configured (mirrors ``test/e2e/examples/conftest.py``).
+    """
+    from cli_agent_orchestrator.clients.database import (
+        _migrate_workflow_run,
+        _migrate_workflow_run_step,
+    )
+    from cli_agent_orchestrator.services import workflow_service
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.constants.DATABASE_FILE", tmp_path / "wf.db", raising=True
+    )
+    _migrate_workflow_run()
+    _migrate_workflow_run_step()
+    workflow_service.run_registry.clear()
+    workflow_service._active_drives.clear()
+    yield
+
+
+@pytest.fixture
+def api_base_url(fake_run_step_server, monkeypatch):
+    """Point ``script_runner.API_BASE_URL`` at the fake server for this test."""
+    host, port = fake_run_step_server.server_address
+    base_url = f"http://{host}:{port}"
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.script_runner.API_BASE_URL", base_url, raising=True
+    )
+    return base_url

--- a/examples/workflow/tests/test_workflow_example.py
+++ b/examples/workflow/tests/test_workflow_example.py
@@ -13,6 +13,7 @@ directly proves rejection happens before any worker/step exists.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import re
 import subprocess
@@ -29,6 +30,18 @@ from cli_agent_orchestrator.services.workflow_spec_service import _extract_input
 
 _WORKFLOW_PATH = Path(__file__).resolve().parents[1] / "workflow.py"
 _WORKFLOW_SOURCE = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _load_workflow_module():
+    """Import workflow.py from its path, for the few pure helpers worth unit-testing.
+
+    Everything else here drives the script as a real subprocess; this exists so a
+    pure function can be tested as one without putting examples/ on sys.path.
+    """
+    spec = importlib.util.spec_from_file_location("_workflow_under_test", _WORKFLOW_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class _SpecStub:
@@ -102,6 +115,47 @@ async def test_concurrent_fanout_uses_pairwise_distinct_step_ids(
     assert result.output["failed_checks"] == []
     # concurrency defaulted to 2 and the cap is a no-op at the default itself.
     assert result.output["max_workers"] == 2
+
+
+@pytest.mark.asyncio
+async def test_overlong_target_stays_inside_the_step_id_length_bound(
+    api_base_url, fake_run_step_server
+):
+    """The 1-64 half of the step_id contract, which a "myapp" target never reaches.
+
+    The charset assertion above is already written as ``{1,64}``, but only a
+    target long enough to overflow the budget actually exercises the length half.
+    """
+    target = "svc/" + ("long-target-name" * 8)  # unsafe chars AND far over the bound
+    spec = _RealSpec(_WORKFLOW_PATH, "workflow-example")
+    inputs = _resolved_inputs({"target": target})
+
+    result = await run_script_workflow(spec, inputs, "test-longtarget")
+
+    assert result.state == RunState.COMPLETED
+    step_ids = [c["env_vars"]["CAO_WORKFLOW_STEP_ID"] for c in fake_run_step_server.recorded_calls]
+    assert len(step_ids) == 4  # one plan + three checks
+    for step_id in step_ids:
+        assert re.fullmatch(r"[A-Za-z0-9_-]{1,64}", step_id), step_id
+    assert len(set(step_ids)) == len(step_ids)
+
+
+def test_slug_truncation_is_collision_safe_and_stable():
+    """Bare truncation would collapse targets sharing a prefix onto one step_id.
+
+    That is why ``_slug`` spends its tail on a digest. Both properties matter:
+    distinctness (a fan-out must not reuse a step_id) and stability across
+    processes (replay keys on the step_id, so a per-process value would break it).
+    """
+    slug = _load_workflow_module()._slug
+    prefix = "p" * 60
+
+    assert slug(prefix + "AAAA") != slug(prefix + "BBBB")
+    assert slug(prefix + "AAAA") == slug(prefix + "AAAA")
+    # Short targets keep the plain readable slug — no digest, so this change
+    # cannot alter step_ids for any target that already fit.
+    assert slug("myapp") == "myapp"
+    assert slug("my app/v2") == "my_app_v2"
 
 
 @pytest.mark.asyncio

--- a/examples/workflow/tests/test_workflow_example.py
+++ b/examples/workflow/tests/test_workflow_example.py
@@ -1,0 +1,140 @@
+"""Deterministic transport-level tests for the workflow example (issue #591).
+
+Each example script under docs/examples/ has a matching e2e test that spawns
+it as a real subprocess via ``run_script_workflow`` against a fake
+``/terminals/run-step`` server (test/e2e/examples/test_examples_gallery_e2e.py).
+This module applies the same proof to examples/workflow/workflow.py, plus the
+input-validation gate that runs before any of that: ``_validate_inputs`` is
+the same function the ``/workflows/runs`` and ``/workflows/runs:submit``
+routes call BEFORE creating a journal row or a subprocess (script_runner.py's
+``ScriptLintError``/``run_script_workflow`` docstrings), so testing it
+directly proves rejection happens before any worker/step exists.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from cli_agent_orchestrator.models.workflow_runtime import RunState
+from cli_agent_orchestrator.services.script_lint import lint_script
+from cli_agent_orchestrator.services.script_runner import build_env, run_script_workflow
+from cli_agent_orchestrator.services.workflow_service import _validate_inputs
+from cli_agent_orchestrator.services.workflow_spec_service import _extract_inputs
+
+_WORKFLOW_PATH = Path(__file__).resolve().parents[1] / "workflow.py"
+_WORKFLOW_SOURCE = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+class _SpecStub:
+    """Minimal ``_HasInputs`` duck type — just enough for ``_validate_inputs``."""
+
+    def __init__(self, inputs):
+        self.inputs = inputs
+
+
+class _RealSpec:
+    """Duck-typed ScriptSpec pointing at the real workflow.py on disk."""
+
+    def __init__(self, path: Path, name: str):
+        self.path = str(path)
+        self.source = path.read_text(encoding="utf-8")
+        self.name = name
+        self.content_hash = "workflow-example-test"
+
+
+def _resolved_inputs(overrides):
+    """Run the real ``_extract_inputs`` + ``_validate_inputs`` pipeline."""
+    spec = _SpecStub(_extract_inputs(_WORKFLOW_SOURCE))
+    return _validate_inputs(spec, overrides)
+
+
+def test_validate_passes_lint():
+    """``cao workflow validate`` calls ``lint_script`` for a .py spec (the
+    ``/workflows/validate`` route's .py arm) — it must report ``pass``."""
+    result = lint_script(_WORKFLOW_SOURCE, str(_WORKFLOW_PATH))
+
+    assert result.status == "pass"
+    assert result.errors == []
+
+
+def test_missing_required_input_rejected():
+    """A run with no ``target`` is rejected before any worker/step exists."""
+    with pytest.raises(ValueError, match="missing required input 'target'"):
+        _resolved_inputs({})
+
+
+def test_valid_inputs_resolve_with_declared_defaults():
+    resolved = _resolved_inputs({"target": "myapp"})
+
+    assert resolved == {"target": "myapp", "concurrency": 2, "strict": False}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_fanout_uses_pairwise_distinct_step_ids(
+    api_base_url, fake_run_step_server
+):
+    spec = _RealSpec(_WORKFLOW_PATH, "workflow-example")
+    inputs = _resolved_inputs({"target": "myapp"})
+
+    result = await run_script_workflow(spec, inputs, "test-fanout")
+
+    assert result.state == RunState.COMPLETED
+    step_ids = [c["env_vars"]["CAO_WORKFLOW_STEP_ID"] for c in fake_run_step_server.recorded_calls]
+    assert step_ids[0] == "plan:myapp"  # the sequential step runs before the fan-out
+    assert sorted(step_ids[1:]) == [
+        "check:myapp:performance",
+        "check:myapp:security",
+        "check:myapp:style",
+    ]
+    assert len(set(step_ids)) == len(step_ids)  # pairwise distinct across the whole run
+    assert result.output["checks"].keys() == {"style", "security", "performance"}
+    assert result.output["failed_checks"] == []
+    # concurrency defaulted to 2 and the cap is a no-op at the default itself.
+    assert result.output["max_workers"] == 2
+
+
+@pytest.mark.asyncio
+async def test_one_failed_check_does_not_lose_survivors(api_base_url, fake_run_step_server):
+    fake_run_step_server.fail_step_ids.add("check:myapp:security")
+    spec = _RealSpec(_WORKFLOW_PATH, "workflow-example")
+    # concurrency=3 is a VALID input, but the script conservatively caps
+    # max_workers at the declared default (2) regardless.
+    inputs = _resolved_inputs({"target": "myapp", "concurrency": 3})
+
+    result = await run_script_workflow(spec, inputs, "test-fanout-failure")
+
+    assert result.state == RunState.COMPLETED  # a per-unit failure never fails the run
+    assert result.output["max_workers"] == 2
+    assert result.output["failed_checks"] == ["security"]
+    assert set(result.output["checks"].keys()) == {"style", "performance"}
+    assert result.output["checks"]["style"] == "ack:check:myapp:style"
+
+
+def test_emit_output_sentinel_in_subprocess_stdout(api_base_url, fake_run_step_server):
+    """Spawn workflow.py exactly as ``script_runner._drive_process`` does
+    (same interpreter, same constructed env) and check the sentinel is on
+    stdout literally — the property ``run_script_workflow``'s parsed
+    ``.output`` proves indirectly, asserted directly here."""
+    inputs = _resolved_inputs({"target": "myapp"})
+    env = build_env("test-stdout", "1", inputs)
+
+    proc = subprocess.run(
+        [sys.executable, str(_WORKFLOW_PATH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    sentinel_lines = [
+        line for line in proc.stdout.splitlines() if line.startswith("CAO_WORKFLOW_OUTPUT:")
+    ]
+    assert len(sentinel_lines) == 1
+    payload = json.loads(sentinel_lines[0][len("CAO_WORKFLOW_OUTPUT:") :])
+    assert payload["target"] == "myapp"

--- a/examples/workflow/tests/test_workflow_example.py
+++ b/examples/workflow/tests/test_workflow_example.py
@@ -14,6 +14,7 @@ directly proves rejection happens before any worker/step exists.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -85,13 +86,18 @@ async def test_concurrent_fanout_uses_pairwise_distinct_step_ids(
 
     assert result.state == RunState.COMPLETED
     step_ids = [c["env_vars"]["CAO_WORKFLOW_STEP_ID"] for c in fake_run_step_server.recorded_calls]
-    assert step_ids[0] == "plan:myapp"  # the sequential step runs before the fan-out
+    assert step_ids[0] == "plan-myapp"  # the sequential step runs before the fan-out
     assert sorted(step_ids[1:]) == [
-        "check:myapp:performance",
-        "check:myapp:security",
-        "check:myapp:style",
+        "check-myapp-performance",
+        "check-myapp-security",
+        "check-myapp-style",
     ]
     assert len(set(step_ids)) == len(step_ids)  # pairwise distinct across the whole run
+    # The fake server doesn't enforce this (unlike the real RunStepRequest
+    # validator), so assert it directly — every step_id must be a value the
+    # real /terminals/run-step route's env_vars validator would accept.
+    for step_id in step_ids:
+        assert re.fullmatch(r"[A-Za-z0-9_-]{1,64}", step_id), step_id
     assert result.output["checks"].keys() == {"style", "security", "performance"}
     assert result.output["failed_checks"] == []
     # concurrency defaulted to 2 and the cap is a no-op at the default itself.
@@ -100,7 +106,7 @@ async def test_concurrent_fanout_uses_pairwise_distinct_step_ids(
 
 @pytest.mark.asyncio
 async def test_one_failed_check_does_not_lose_survivors(api_base_url, fake_run_step_server):
-    fake_run_step_server.fail_step_ids.add("check:myapp:security")
+    fake_run_step_server.fail_step_ids.add("check-myapp-security")
     spec = _RealSpec(_WORKFLOW_PATH, "workflow-example")
     # concurrency=3 is a VALID input, but the script conservatively caps
     # max_workers at the declared default (2) regardless.
@@ -112,7 +118,7 @@ async def test_one_failed_check_does_not_lose_survivors(api_base_url, fake_run_s
     assert result.output["max_workers"] == 2
     assert result.output["failed_checks"] == ["security"]
     assert set(result.output["checks"].keys()) == {"style", "performance"}
-    assert result.output["checks"]["style"] == "ack:check:myapp:style"
+    assert result.output["checks"]["style"] == "ack:check-myapp-style"
 
 
 def test_emit_output_sentinel_in_subprocess_stdout(api_base_url, fake_run_step_server):

--- a/examples/workflow/tests/test_workflow_live.py
+++ b/examples/workflow/tests/test_workflow_live.py
@@ -1,0 +1,137 @@
+"""Gated live-provider test for the workflow example (issue #591).
+
+Exercises a REAL ``cao-server`` and a REAL, authenticated ``claude_code`` CLI
+end to end — the one thing ``test_workflow_example.py`` deliberately does
+NOT do (it fakes the ``/terminals/run-step`` transport so it can run without
+credentials). This test is expensive, needs a real provider login, and must
+never run in CI or by default — it is gated the same way the existing
+provider integration suites are:
+
+    CAO_RUN_LIVE_PROVIDER_TESTS=1 pytest examples/workflow/tests/test_workflow_live.py -v
+
+Same env var and skip pattern as ``test/providers/test_kiro_cli_integration.py``
+/ ``test/providers/test_codex_provider_unit.py``, plus the ``live_provider``
+marker (registered in pyproject.toml) so it is identifiable independent of
+the env-var gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+import urllib.request
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.live_provider,
+    pytest.mark.skipif(
+        os.environ.get("CAO_RUN_LIVE_PROVIDER_TESTS", "") != "1",
+        reason="Live provider tests disabled. Set CAO_RUN_LIVE_PROVIDER_TESTS=1 to enable.",
+    ),
+]
+
+_WORKFLOW_PATH = Path(__file__).resolve().parents[1] / "workflow.py"
+_SERVER_READY_TIMEOUT = 30.0
+_RUN_TIMEOUT = 900.0  # a real plan step + up to 2 concurrent checks, headless
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_server(base_url: str, proc: subprocess.Popen) -> None:
+    deadline = time.monotonic() + _SERVER_READY_TIMEOUT
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            pytest.fail(f"cao-server exited early (rc={proc.returncode}): {proc.stdout.read()}")
+        try:
+            urllib.request.urlopen(f"{base_url}/workflows", timeout=1)  # noqa: S310
+            return
+        except OSError:
+            time.sleep(0.5)
+    pytest.fail(f"cao-server did not become ready within {_SERVER_READY_TIMEOUT}s")
+
+
+@pytest.fixture(scope="module")
+def claude_code_available():
+    if not shutil.which("claude"):
+        pytest.skip("claude (the claude_code provider CLI) is not installed")
+    return True
+
+
+@pytest.fixture(scope="module")
+def live_cao_server(tmp_path_factory, claude_code_available):
+    """A real ``cao-server`` subprocess, isolated in a scratch CAO_HOME_DIR."""
+    home = tmp_path_factory.mktemp("cao-home")
+    port = _free_port()
+    env = {**os.environ, "CAO_HOME_DIR": str(home), "CAO_API_HOST": "127.0.0.1"}
+    env["CAO_API_PORT"] = str(port)
+    proc = subprocess.Popen(
+        ["cao-server"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_for_server(base_url, proc)
+        yield home, env
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+def test_workflow_runs_end_to_end_with_a_real_provider(live_cao_server):
+    """validate -> run --wait against the real server + a real claude_code step."""
+    home, cli_env = live_cao_server
+    workflows_dir = home / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    installed_path = workflows_dir / "workflow.py"
+    installed_path.write_text(_WORKFLOW_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    validate = subprocess.run(
+        ["cao", "workflow", "validate", str(installed_path)],
+        env=cli_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert validate.returncode == 0, validate.stdout + validate.stderr
+
+    run = subprocess.run(
+        [
+            "cao",
+            "workflow",
+            "run",
+            "workflow",
+            "--run-id",
+            "live-workflow-example",
+            "--input",
+            "target=myapp",
+            "--wait",
+            "--json",
+        ],
+        env=cli_env,
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+    result = json.loads(run.stdout.strip().splitlines()[-1])
+    assert result["state"] == "completed"
+    assert result["output"]["target"] == "myapp"
+    assert result["output"]["failed_checks"] == []

--- a/examples/workflow/workflow.py
+++ b/examples/workflow/workflow.py
@@ -36,7 +36,8 @@ INPUTS = {
 CHECKS = ["style", "security", "performance"]
 
 # /terminals/run-step validates CAO_WORKFLOW_STEP_ID against this exact
-# charset (api/main.py's RunStepRequest.validate_env_var_shape) — `target` is
+# charset (api/main.py's RunStepRequest.validate_env_vars, which checks every
+# workflow env-var value against constants.WORKFLOW_NAME_RE) — `target` is
 # an arbitrary author-supplied string, so it must be sanitized before it can
 # be embedded in a step_id.
 _STEP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9_-]")

--- a/examples/workflow/workflow.py
+++ b/examples/workflow/workflow.py
@@ -16,6 +16,7 @@ cancel) and examples/workflow/run.sh for a non-interactive entry point.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -42,10 +43,41 @@ CHECKS = ["style", "security", "performance"]
 # be embedded in a step_id.
 _STEP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9_-]")
 
+# WORKFLOW_NAME_RE bounds length as well as charset: 1-64 characters. The
+# longest step_id this script emits is "check-" + slug + "-" + the longest
+# CHECKS entry, so that fixed cost is what the slug has to fit inside.
+# Deriving the budget from CHECKS rather than hardcoding it keeps the bound
+# correct if the catalogue grows.
+_STEP_ID_MAX = 64
+_SLUG_MAX = _STEP_ID_MAX - len("check--") - max(len(c) for c in CHECKS)
+
+# Spent only on the truncation path (see _slug). sha256 and not the builtin
+# hash(): hash() is salted per interpreter, and a step_id that changes between
+# processes would break replay, which keys on the step_id.
+_SLUG_HASH_LEN = 7
+_SLUG_KEEP = _SLUG_MAX - 1 - _SLUG_HASH_LEN
+
 
 def _slug(value: str) -> str:
-    """Map ``value`` onto the charset CAO_WORKFLOW_STEP_ID requires."""
-    return _STEP_ID_UNSAFE.sub("_", value)
+    """Map ``value`` onto the charset and length CAO_WORKFLOW_STEP_ID requires.
+
+    A value that already fits is only charset-mapped, so ordinary targets keep a
+    readable step_id. A value that would overflow the budget is truncated and
+    given a short digest of the original, because bare truncation collapses
+    every long target sharing a prefix onto a single step_id — and in a fan-out
+    a silently reused step_id is a correctness bug, not a cosmetic one. This
+    file is the copy-paste template for other people's workflows, so it ships
+    the collision-safe shape.
+
+    Note this bounds the truncation path only. Two distinct targets can still
+    map to one slug at short lengths (``a b`` and ``a/b`` both give ``a_b``);
+    that is inherent to charset mapping and unchanged here.
+    """
+    mapped = _STEP_ID_UNSAFE.sub("_", value)
+    if len(mapped) <= _SLUG_MAX:
+        return mapped
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:_SLUG_HASH_LEN]
+    return f"{mapped[:_SLUG_KEEP]}-{digest}"
 
 
 def _tone(strict: bool) -> str:

--- a/examples/workflow/workflow.py
+++ b/examples/workflow/workflow.py
@@ -16,6 +16,7 @@ cancel) and examples/workflow/run.sh for a non-interactive entry point.
 
 from __future__ import annotations
 
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from cao_workflow import ShimHTTPError, emit_output, get_inputs, run_step
@@ -34,6 +35,17 @@ INPUTS = {
 # same shape as fanout_example.py's SHARDS list.
 CHECKS = ["style", "security", "performance"]
 
+# /terminals/run-step validates CAO_WORKFLOW_STEP_ID against this exact
+# charset (api/main.py's RunStepRequest.validate_env_var_shape) — `target` is
+# an arbitrary author-supplied string, so it must be sanitized before it can
+# be embedded in a step_id.
+_STEP_ID_UNSAFE = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def _slug(value: str) -> str:
+    """Map ``value`` onto the charset CAO_WORKFLOW_STEP_ID requires."""
+    return _STEP_ID_UNSAFE.sub("_", value)
+
 
 def _tone(strict: bool) -> str:
     return "flag every deviation, however minor" if strict else "flag only significant issues"
@@ -45,7 +57,7 @@ def _plan(target: str, tone: str) -> str:
         "claude_code",
         "reviewer",
         f"Draft a one-line review plan for '{target}'. {tone}. Return the plan only.",
-        step_id=f"plan:{target}",
+        step_id=f"plan-{_slug(target)}",
     )
     return handle.output
 
@@ -63,7 +75,7 @@ def _run_check(target: str, check: str, tone: str):
             "claude_code",
             "reviewer",
             f"Review '{target}' for {check} issues. {tone}. Return findings only.",
-            step_id=f"check:{target}:{check}",
+            step_id=f"check-{_slug(target)}-{check}",
         )
         return check, handle.output
     except ShimHTTPError:

--- a/examples/workflow/workflow.py
+++ b/examples/workflow/workflow.py
@@ -1,0 +1,110 @@
+"""workflow — parameterized review pipeline: sequential plan, then concurrent
+fan-out (issue #591, main-gallery example for the `cao workflow` lifecycle).
+
+Demonstrates the full `cao_workflow` script contract in one small pipeline:
+typed `INPUTS` read via `get_inputs()`, a sequential `run_step`, a
+`ThreadPoolExecutor` fan-out with an explicit, stable `step_id` per unit
+(the shape used in docs/examples/fanout_example.py), per-unit `ShimHTTPError`
+tolerance so one failed check never loses the others, and a structured
+`emit_output()` result.
+
+Run standalone via `cao workflow run workflow --run-id <id> --input target=<name>`
+after copying this file to `~/.aws/cli-agent-orchestrator/workflows/workflow.py`
+— see examples/workflow/README.md for the full lifecycle (validate/run/status/
+cancel) and examples/workflow/run.sh for a non-interactive entry point.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from cao_workflow import ShimHTTPError, emit_output, get_inputs, run_step
+
+# Typed runtime inputs (read via get_inputs() below). Field values must be AST
+# literals — the server's static loader extracts this dict without executing
+# the script — so `concurrency`'s cap is re-read from THIS dict at runtime
+# (below) rather than duplicated into a second constant.
+INPUTS = {
+    "target": {"type": "string", "required": True},
+    "concurrency": {"type": "int", "required": False, "default": 2},
+    "strict": {"type": "bool", "required": False, "default": False},
+}
+
+# Fixed check catalogue for the fan-out — one concurrent run_step per entry,
+# same shape as fanout_example.py's SHARDS list.
+CHECKS = ["style", "security", "performance"]
+
+
+def _tone(strict: bool) -> str:
+    return "flag every deviation, however minor" if strict else "flag only significant issues"
+
+
+def _plan(target: str, tone: str) -> str:
+    """Sequential step: a short review plan for ``target``, run before the fan-out."""
+    handle = run_step(
+        "claude_code",
+        "reviewer",
+        f"Draft a one-line review plan for '{target}'. {tone}. Return the plan only.",
+        step_id=f"plan:{target}",
+    )
+    return handle.output
+
+
+def _run_check(target: str, check: str, tone: str):
+    """One concurrent fan-out unit. Explicit, stable step_id (fan-out rule) —
+    derived from ``target`` + ``check``, never a bare counter.
+
+    Per-unit fault tolerance: a ShimHTTPError (the shim's HTTP error type)
+    turns a failed call into a missing result for THIS check only — the
+    other checks, and the run itself, still complete.
+    """
+    try:
+        handle = run_step(
+            "claude_code",
+            "reviewer",
+            f"Review '{target}' for {check} issues. {tone}. Return findings only.",
+            step_id=f"check:{target}:{check}",
+        )
+        return check, handle.output
+    except ShimHTTPError:
+        return check, None
+
+
+def main() -> None:
+    inputs = get_inputs()
+    target = inputs["target"]
+    strict = inputs.get("strict", False)
+    tone = _tone(strict)
+
+    # Conservative concurrency: never exceed the declared default, even when a
+    # run asks for more (measured guidance for claude_code fan-out — see the
+    # authoring guide's fan-out section and the cao-workflow skill's R1).
+    max_workers = min(inputs.get("concurrency", 2), INPUTS["concurrency"]["default"])
+
+    plan = _plan(target, tone)
+
+    results = {}
+    failed_checks = []
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [pool.submit(_run_check, target, check, tone) for check in CHECKS]
+        for future in as_completed(futures):
+            check, output = future.result()
+            if output is None:
+                failed_checks.append(check)
+            else:
+                results[check] = output
+
+    emit_output(
+        {
+            "target": target,
+            "strict": strict,
+            "max_workers": max_workers,
+            "plan": plan,
+            "checks": results,
+            "failed_checks": failed_checks,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -394,7 +394,8 @@ markers = [
     "asyncio: marks tests that use asyncio",
     "integration: marks integration tests",
     "e2e: marks end-to-end tests",
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')"
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "live_provider: marks tests that need a real cao-server + authenticated provider CLI (gated behind CAO_RUN_LIVE_PROVIDER_TESTS=1, skipped by default)"
 ]
 asyncio_mode = "strict"
 testpaths = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,7 +328,8 @@ markers = [
     "asyncio: marks tests that use asyncio",
     "integration: marks integration tests",
     "e2e: marks end-to-end tests",
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')"
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "live_provider: marks tests that need a real cao-server + authenticated provider CLI (gated behind CAO_RUN_LIVE_PROVIDER_TESTS=1, skipped by default)"
 ]
 asyncio_mode = "strict"
 testpaths = ["test"]


### PR DESCRIPTION
## Summary

Fixes #591 (sub-task of #588).

Adds `examples/workflow/`, a focused gallery example for the `cao workflow` lifecycle:

- A parameterized Python workflow (`workflow.py`) with typed `INPUTS`, one sequential `run_step` plan call, then a concurrent fan-out of three checks via `ThreadPoolExecutor`, with stable pairwise-distinct `step_id`s and per-unit fault tolerance.
- `validate` / `run` / `status` / `events` / `wait` / `result` / `cancel` all demonstrated, plus the `cao workflow` vs. `cao schedule` distinction.
- `fixtures/inputs.json` and a non-interactive `run.sh` entry point.
- Deterministic tests (`tests/test_workflow_example.py`) against a fake `/terminals/run-step` HTTP server — no live `cao-server` or provider needed.
- A separately gated live-provider test (`tests/test_workflow_live.py`) behind a new `live_provider` pytest marker, opt-in via `CAO_RUN_LIVE_PROVIDER_TESTS=1`, skipped by default.

## Test plan

- `uv run pytest --no-cov -p no:cacheprovider -q examples/workflow/tests/test_workflow_example.py` — 6 passed
- `uv run pytest --no-cov -p no:cacheprovider -q examples/workflow/tests/test_workflow_live.py` — 1 skipped (gated, as expected without `CAO_RUN_LIVE_PROVIDER_TESTS=1`)