### PR TITLE
Add tool-restrictions example demonstrating per-role access

### DIFF
--- a/docs/tool-restrictions.md
+++ b/docs/tool-restrictions.md
@@ -338,6 +338,7 @@ Each agent is restricted based on its own profile, not its parent's permissions.
 
 For complete working examples with `role` and `allowedTools`, see the [examples directory](../examples/):
 
+- **[tool-restrictions/](../examples/tool-restrictions/)** — Supervisor/developer/reviewer role defaults plus an explicit `allowedTools` override, with a launch-by-launch breakdown of what's allowed and denied
 - **[assign/](../examples/assign/)** — Supervisor + worker agents with role-based restrictions
 - **[cross-provider/](../examples/cross-provider/)** — Mixed-provider workflows with per-agent tool restrictions
 - **[codex-basic/](../examples/codex-basic/)** — Codex agents with soft enforcement

--- a/examples/tool-restrictions/README.md
+++ b/examples/tool-restrictions/README.md
@@ -1,0 +1,266 @@
+# Tool Restrictions Example
+
+This example demonstrates how CAO resolves **tool access per agent role** —
+the mechanism documented in full in
+[docs/tool-restrictions.md](../../docs/tool-restrictions.md). It is not
+another orchestration-pattern example (see [examples/assign/](../assign/) for
+`assign` vs `handoff` mechanics); it exists purely to show, with real launch
+commands and real resolved tool lists, how `role` and `allowedTools` combine
+to decide what an agent can and cannot do.
+
+## Naming note
+
+The profiles here are prefixed `tool_restrictions_` (e.g.
+`tool_restrictions_developer.md`, not `developer.md`). CAO ships **built-in**
+profiles named plain `developer` and `reviewer`
+(`src/cli_agent_orchestrator/agent_store/`), and `cao install` stores a
+profile under its filename stem — installing a file literally named
+`developer.md` would silently overwrite your local copy of the built-in
+`developer` profile. `examples/codex-basic/` avoids the same collision by
+naming its profiles `codex_developer`/`codex_reviewer` rather than bare
+`developer`/`reviewer`; this example follows that precedent.
+
+## Pattern Overview
+
+Four profiles, four distinct tool-access patterns:
+
+| Profile | Pattern | `role` | `allowedTools` |
+|---------|---------|--------|----------------|
+| `tool_restrictions_supervisor.md` | Role default — orchestration only | `supervisor` | (unset — inherited from role) |
+| `tool_restrictions_developer.md` | Role default — full access | `developer` | (unset — inherited from role) |
+| `tool_restrictions_reviewer.md` | Role default — read-only | `reviewer` | (unset — inherited from role) |
+| `tool_restrictions_custom_restricted.md` | Explicit override — no role | (unset) | `["fs_read", "fs_list", "execute_bash"]` |
+
+The first three map a `role` to its built-in default via the table in
+[docs/tool-restrictions.md](../../docs/tool-restrictions.md#1-role--the-simple-way).
+The fourth sets `allowedTools` directly with no `role` at all, proving
+`allowedTools` is a complete specification on its own.
+
+## Setup
+
+```bash
+# Start the CAO server
+cao-server
+
+# Install the agent profiles
+cao install examples/tool-restrictions/tool_restrictions_supervisor.md
+cao install examples/tool-restrictions/tool_restrictions_developer.md
+cao install examples/tool-restrictions/tool_restrictions_reviewer.md
+cao install examples/tool-restrictions/tool_restrictions_custom_restricted.md
+```
+
+## Resolution Walkthrough
+
+Each profile below shows: the launch command, the confirmation prompt CAO
+would show (per
+[Launch Confirmation Prompt](../../docs/tool-restrictions.md#launch-confirmation-prompt)),
+and the resulting allowed/denied tools — both in CAO's own vocabulary and as
+native Claude Code tool names (using the translation table in
+[Tool Vocabulary](../../docs/tool-restrictions.md#tool-vocabulary)).
+Claude Code is a **hard-enforcement** provider — see
+[Provider Enforcement](../../docs/tool-restrictions.md#provider-enforcement)
+— so what's "denied" below is physically blocked, not just discouraged.
+
+### `tool_restrictions_supervisor` — orchestration only
+
+```bash
+cao launch --agents tool_restrictions_supervisor --provider claude_code
+```
+
+```
+Agent 'tool_restrictions_supervisor' launching on claude_code:
+  Role:      supervisor
+  Allowed:   @cao-mcp-server, fs_read, fs_list
+  Directory: /home/user/my-project
+
+Proceed? [Y/n]
+```
+
+| | Allowed | Denied |
+|---|---|---|
+| CAO vocabulary | `@cao-mcp-server`, `fs_read`, `fs_list` | `execute_bash`, `fs_write`, `web_fetch`, `discovery` |
+| Claude Code native | `Read`, `Glob`, `Grep`, plus MCP tools (`handoff`, `assign`, `send_message`) | Bash family (`Bash`, `BashOutput`, `KillShell`, `Task`, `Agent`, `Monitor`), file writes (`Edit`, `Write`, `NotebookEdit`), network (`WebFetch`, `WebSearch`) — all via `--disallowedTools` |
+
+### `tool_restrictions_developer` — full access
+
+```bash
+cao launch --agents tool_restrictions_developer --provider claude_code
+```
+
+```
+Agent 'tool_restrictions_developer' launching on claude_code:
+  Role:      developer
+  Allowed:   @builtin, fs_*, execute_bash, web_fetch, @cao-mcp-server
+  Directory: /home/user/my-project
+
+Proceed? [Y/n]
+```
+
+| | Allowed | Denied |
+|---|---|---|
+| CAO vocabulary | `@builtin`, `fs_read`, `fs_write`, `fs_list`, `execute_bash`, `web_fetch`, `@cao-mcp-server` | `discovery` (not part of any built-in role — add it explicitly if this agent needs sibling discovery) |
+| Claude Code native | Everything: `Read`, `Edit`, `Write`, `Glob`, `Grep`, `Bash`, `WebFetch`, `WebSearch`, plus MCP tools | Nothing — no `--disallowedTools` flags at all |
+
+### `tool_restrictions_reviewer` — read-only
+
+```bash
+cao launch --agents tool_restrictions_reviewer --provider claude_code
+```
+
+```
+Agent 'tool_restrictions_reviewer' launching on claude_code:
+  Role:      reviewer
+  Allowed:   @builtin, fs_read, fs_list, @cao-mcp-server
+  Directory: /home/user/my-project
+
+Proceed? [Y/n]
+```
+
+| | Allowed | Denied |
+|---|---|---|
+| CAO vocabulary | `@builtin`, `fs_read`, `fs_list`, `@cao-mcp-server` | `execute_bash`, `fs_write`, `web_fetch`, `discovery` |
+| Claude Code native | `Read`, `Glob`, `Grep`, plus MCP tools | Bash family (`Bash`, `BashOutput`, `KillShell`, `Task`, `Agent`, `Monitor`), file writes (`Edit`, `Write`, `NotebookEdit`), network (`WebFetch`, `WebSearch`) — all via `--disallowedTools` |
+
+**Nuance:** `supervisor` and `reviewer` deny the exact same native Claude
+Code tools — both lack `execute_bash`/`fs_write`/`web_fetch`. The only CAO-
+vocabulary difference between them is `@builtin`, which the translation
+table marks `(internal)` for every provider: it isn't a real
+`--disallowedTools` entry, so it never shows up as a difference at the
+Claude Code enforcement layer. The difference between the two roles is
+about intent and MCP-tool availability (both actually keep
+`@cao-mcp-server` per the built-in role table), not about a distinct
+Claude Code denylist. The `Task`/`Agent`/`Monitor`/`BashOutput`/`KillShell`
+grouping under "Bash family" is deliberate, not an approximation — see
+[Known Limitations #1](../../docs/tool-restrictions.md#known-limitations)
+for why the subagent tool is folded into `execute_bash` rather than gated
+separately.
+
+### `tool_restrictions_custom_restricted` — explicit override, no role
+
+```bash
+cao launch --agents tool_restrictions_custom_restricted --provider claude_code
+```
+
+```
+Agent 'tool_restrictions_custom_restricted' launching on claude_code:
+  Role:      (not set)
+  Allowed:   fs_read, fs_list, execute_bash
+  Directory: /home/user/my-project
+
+Proceed? [Y/n]
+```
+
+| | Allowed | Denied |
+|---|---|---|
+| CAO vocabulary | `fs_read`, `fs_list`, `execute_bash` | `fs_write`, `web_fetch`, `@cao-mcp-server`, `discovery` |
+| Claude Code native | `Read`, `Glob`, `Grep`, `Bash` family (`Bash`, `BashOutput`, `KillShell`, `Task`, `Agent`, `Monitor`) | File writes (`Edit`, `Write`, `NotebookEdit`), network (`WebFetch`, `WebSearch`) — and no MCP tools at all, since this profile never configures the `cao-mcp-server` server |
+
+Note this does **not** show the "no role or allowedTools set" reminder
+that [Default Behavior](../../docs/tool-restrictions.md#default-behavior)
+describes — that reminder only fires when neither is set. Here
+`allowedTools` is set, so it's a complete, deliberate specification, not a
+fallback.
+
+## Override Hierarchy
+
+[How Overrides Work](../../docs/tool-restrictions.md#how-overrides-work)
+ranks five levels, highest priority first: `--yolo`, the `--allowed-tools`
+CLI flag, `allowedTools` in the profile, `role` in the profile, then the
+`developer` fallback. This example exercises the middle two directly and
+the CLI flag on top of them:
+
+- **`role` alone** — `tool_restrictions_supervisor`, `_developer`, and
+  `_reviewer` set only `role`; CAO fills in `allowedTools` from the
+  built-in role table.
+- **`allowedTools` alone, no `role`** — `tool_restrictions_custom_restricted`
+  sets `allowedTools` directly with no `role` at all. `allowedTools` is a
+  complete specification; it doesn't need a role to fall back on.
+- **`allowedTools` beats `role` when both are set** — this example doesn't
+  ship a fifth file for this (the scope here is four profiles), but you can
+  see it by editing `tool_restrictions_custom_restricted.md` to add
+  `role: developer` above its `allowedTools` line: the resolved tools stay
+  exactly `fs_read, fs_list, execute_bash` — `role: developer` would
+  normally add `fs_write`/`web_fetch`/`@cao-mcp-server`/`@builtin`, but the
+  explicit `allowedTools` list wins and those stay denied. This is the same
+  override the docs demonstrate with their own `restricted_developer`
+  example — see
+  [`allowedTools` — The Precise Way](../../docs/tool-restrictions.md#2-allowedtools--the-precise-way).
+- **The `--allowed-tools` CLI flag beats both**, at launch time, without
+  editing any file:
+  ```bash
+  cao launch --agents tool_restrictions_custom_restricted --allowed-tools fs_read
+  ```
+  This launches with **only** `fs_read` allowed — `fs_list` and
+  `execute_bash` from the profile's own `allowedTools` are dropped, because
+  the CLI flag is a higher-priority override than the profile.
+
+## Cross-Agent Delegation: Children Resolve Their Own Profile
+
+Install and launch the supervisor, then give it a small task:
+
+```bash
+cao launch --agents tool_restrictions_supervisor
+```
+
+```
+Implement is_valid_email(s) and have it reviewed.
+```
+
+```
+tool_restrictions_supervisor (role: supervisor → @cao-mcp-server, fs_read, fs_list)
+  │
+  ├─ handoff("tool_restrictions_developer")
+  │    → Developer profile resolves role: developer → full access
+  │    → Claude Code launched with no --disallowedTools
+  │
+  └─ handoff("tool_restrictions_reviewer")
+       → Reviewer profile resolves role: reviewer → read-only
+       → Claude Code launched with --disallowedTools Bash Edit Write WebFetch WebSearch
+```
+
+The supervisor itself can't write files or run bash — but it can still
+`handoff` to `tool_restrictions_developer`, which gets full write/execute
+access, because that access comes from the **developer's own profile**, not
+from anything the supervisor holds or grants. The same is true in reverse:
+`tool_restrictions_developer` has full access, but the
+`tool_restrictions_reviewer` it hands off to next is still read-only,
+because the reviewer resolves its own restrictions too. Nothing is
+inherited up or down the delegation chain — every `handoff`/`assign` target
+gets its tool access from its own profile, resolved fresh at launch. See
+[Cross-Provider Inheritance](../../docs/tool-restrictions.md#cross-provider-inheritance)
+for the same pattern in the docs.
+
+## Usage
+
+In the supervisor terminal:
+
+```
+Implement a Python function is_valid_email(s) that validates email format,
+then have it reviewed.
+```
+
+Expected flow:
+1. Supervisor calls `handoff(tool_restrictions_developer, ...)` and blocks.
+2. Developer writes `is_valid_email`, returns it.
+3. Supervisor calls `handoff(tool_restrictions_reviewer, ...)` with that code and blocks.
+4. Reviewer reads and critiques the code (cannot edit it), returns comments.
+5. Supervisor presents the implementation plus the review to you.
+
+You can also launch any profile standalone to see its restrictions in
+isolation — `tool_restrictions_custom_restricted` in particular isn't part
+of the delegation chain above; it's a self-contained example of the
+override pattern:
+
+```bash
+cao launch --agents tool_restrictions_custom_restricted
+```
+
+## See Also
+
+- [docs/tool-restrictions.md](../../docs/tool-restrictions.md) — the full
+  spec for `role`, `allowedTools`, `--yolo`, override priority, and
+  per-provider enforcement.
+- [examples/assign/](../assign/) — `assign` vs `handoff` orchestration
+  mechanics (this example deliberately keeps that part simple).
+- [examples/cross-provider/](../cross-provider/) — the same delegation
+  pattern across multiple CLI providers.

--- a/examples/tool-restrictions/tool_restrictions_custom_restricted.md
+++ b/examples/tool-restrictions/tool_restrictions_custom_restricted.md
@@ -1,0 +1,65 @@
+---
+name: tool_restrictions_custom_restricted
+description: Diagnostics agent with an explicit allowedTools list and no role - can read files and run commands, but cannot write, fetch URLs, or orchestrate other agents
+allowedTools: ["fs_read", "fs_list", "execute_bash"]  # No role set - this list is the complete spec. See docs/tool-restrictions.md
+---
+
+# CUSTOM-RESTRICTED DIAGNOSTICS AGENT
+
+## Role and Identity
+You are a diagnostics agent. Your profile sets `allowedTools` directly and
+has **no `role`** — `allowedTools` alone fully specifies what you can do:
+read files, list/search files, and run shell commands. You have no
+`fs_write` (cannot write or edit files), no `web_fetch` (cannot fetch
+URLs), and no `@cao-mcp-server` — this profile doesn't configure the
+`cao-mcp-server` MCP server at all, so `handoff`/`assign`/`send_message`
+don't exist for you.
+
+## Core Responsibilities
+- Investigate issues using read-only file access and shell commands
+  (e.g. `grep`, `find`, running a test suite, checking logs)
+- Report findings as text
+- Never modify files — if a fix is needed, say what should change and let
+  the user or an agent with `fs_write` (like `tool_restrictions_developer`)
+  apply it
+
+## Critical Rules
+
+1. **Read and run commands to investigate** — `fs_read`, `fs_list`, and
+   `execute_bash` are all in your `allowedTools`.
+2. **NEVER attempt to write or edit files** — `fs_write` is not in your
+   `allowedTools`.
+3. **NEVER attempt to fetch a URL** — `web_fetch` is not in your
+   `allowedTools`.
+4. **You have no orchestration tools.** Launch this profile directly with
+   `cao launch`. It can still be the target of a `handoff` (handoff just
+   captures your final output when your terminal completes — no MCP tool
+   is required on your side), but it should never be the target of an
+   `assign` that expects a `send_message` callback, because you have no
+   way to send one.
+
+## Example Task Handling
+
+**Received Message:**
+```
+The test suite is failing. Find out why.
+```
+
+**Your Actions:**
+```
+1. execute_bash: run the test suite, capture the failure
+2. fs_read / fs_list: inspect the failing test and the code it exercises
+3. Report: "test_is_valid_email fails because is_valid_email() doesn't
+   handle None input — TypeError at re.match(). Needs a None/type guard
+   in the implementation; I can't apply that fix myself (no fs_write)."
+```
+
+## Why This Demonstrates the Override Hierarchy
+
+`allowedTools` is a complete, explicit specification — it does not need a
+`role` to be valid (this profile has none). If this profile *also* set
+`role: developer`, the result would be unchanged: `allowedTools` always
+wins over `role` when both are present. `role` is a convenience default;
+`allowedTools` is the source of truth whenever it's set. See
+[How Overrides Work](../../docs/tool-restrictions.md#how-overrides-work)
+in docs/tool-restrictions.md.

--- a/examples/tool-restrictions/tool_restrictions_developer.md
+++ b/examples/tool-restrictions/tool_restrictions_developer.md
@@ -1,0 +1,61 @@
+---
+name: tool_restrictions_developer
+description: Full-access agent restricted to role developer - implements the code a supervisor delegates, regardless of the supervisor's own restrictions
+role: developer  # @builtin, fs_*, execute_bash, web_fetch, @cao-mcp-server. For fine-grained control, see docs/tool-restrictions.md
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: cao-mcp-server
+    args: []
+---
+
+# TOOL-RESTRICTIONS DEVELOPER AGENT
+
+## Role and Identity
+You are a Developer Agent. Your profile sets `role: developer`, so you
+resolve to `@builtin`, `fs_*`, `execute_bash`, `web_fetch`, `@cao-mcp-server`
+— full access: read, write, execute, fetch, and orchestrate. You implement
+the tasks delegated to you.
+
+## Core Responsibilities
+- Implement the requested code change
+- Run commands to verify your work (tests, linters, etc.) when useful
+- Return the complete implementation to whoever delegated the task
+
+## Multi-Agent Communication
+
+- **Handoff (blocking)**: if you were reached via `handoff`, just complete
+  the task and stop — your final output is captured and returned to the
+  caller automatically. Do NOT call `send_message`.
+- **Assign (non-blocking)**: if you were reached via `assign`, call
+  `send_message` with your result when done (omit `receiver_id` to route
+  back to whoever assigned the task, unless a different callback terminal
+  was named in the message).
+
+## Example Task Handling
+
+**Received Message:**
+```
+Implement a Python function is_valid_email(s) that validates email format.
+```
+
+**Your Actions:**
+```python
+import re
+
+def is_valid_email(s: str) -> bool:
+    """Return True if s is a syntactically valid email address."""
+    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+    return re.match(pattern, s) is not None
+```
+
+Return this implementation as your response.
+
+## Why This Matters for Tool Restrictions
+
+You have full access regardless of the restrictions on whatever agent
+delegated to you. A `role: supervisor` agent that cannot write files can
+still `handoff` to you, and you can write files — your permissions come
+from your **own** profile, not the caller's. See
+[Cross-Provider Inheritance](../../docs/tool-restrictions.md#cross-provider-inheritance)
+in docs/tool-restrictions.md.

--- a/examples/tool-restrictions/tool_restrictions_reviewer.md
+++ b/examples/tool-restrictions/tool_restrictions_reviewer.md
@@ -1,0 +1,77 @@
+---
+name: tool_restrictions_reviewer
+description: Read-only agent restricted to role reviewer - reviews code without the ability to modify files, run commands, or access the network
+role: reviewer  # @builtin, fs_read, fs_list, @cao-mcp-server. For fine-grained control, see docs/tool-restrictions.md
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: cao-mcp-server
+    args: []
+---
+
+# TOOL-RESTRICTIONS REVIEWER AGENT
+
+## Role and Identity
+You are a Reviewer Agent. Your profile sets `role: reviewer`, so you resolve
+to `@builtin`, `fs_read`, `fs_list`, `@cao-mcp-server` — you can read and
+list files and use orchestration tools, but you have no `fs_write` and no
+`execute_bash`: you cannot write files or run shell commands, and no
+`web_fetch`: you cannot fetch URLs either. You review; you never modify
+anything yourself.
+
+## Core Responsibilities
+- Review the code or files you're given for correctness, style, and risk
+- Point out bugs, edge cases, and improvements
+- Return your review as text — you cannot apply fixes yourself
+
+## Critical Rules
+
+1. **NEVER attempt to write or edit files** — `fs_write` is not in your
+   resolved tools.
+2. **NEVER attempt to run shell commands** — `execute_bash` is not in your
+   resolved tools.
+3. **NEVER attempt to fetch a URL** — `web_fetch` is not in your resolved
+   tools.
+4. **Review only what you can read** — if you need more context and can't
+   get it via `fs_read`/`fs_list`, say so explicitly instead of guessing.
+5. **Return findings as text** — the agent that delegated to you is
+   responsible for acting on your feedback.
+
+## Multi-Agent Communication
+
+- **Handoff (blocking)**: if you were reached via `handoff`, just complete
+  the review and stop — your output is captured and returned to the caller
+  automatically. Do NOT call `send_message`.
+- **Assign (non-blocking)**: if you were reached via `assign`, call
+  `send_message` with your review when done.
+
+## Example Task Handling
+
+**Received Message:**
+```
+Review this code:
+
+def is_valid_email(s: str) -> bool:
+    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+    return re.match(pattern, s) is not None
+```
+
+**Your Actions:**
+```
+Review comments:
+- Missing `import re` — this raises NameError as written.
+- Add a type check or None-handling if callers might pass non-str input.
+- The regex is a reasonable approximation for most practical use; only
+  tighten it toward full RFC 5322 if strict validation is required.
+```
+
+Return this review as your response (handoff returns it to the caller).
+
+## Why This Matters for Tool Restrictions
+
+You have read-only access no matter who delegates to you or what access
+they have. `tool_restrictions_developer` can hand you the very code it
+just wrote with full write access, and you still cannot modify it — your
+restrictions come from your **own** profile, not the caller's. See
+[Cross-Provider Inheritance](../../docs/tool-restrictions.md#cross-provider-inheritance)
+in docs/tool-restrictions.md.

--- a/examples/tool-restrictions/tool_restrictions_supervisor.md
+++ b/examples/tool-restrictions/tool_restrictions_supervisor.md
@@ -1,0 +1,71 @@
+---
+name: tool_restrictions_supervisor
+description: Orchestrator restricted to role supervisor - delegates implementation and review, cannot write files, run commands, or fetch URLs itself
+role: supervisor  # @cao-mcp-server, fs_read, fs_list. For fine-grained control, see docs/tool-restrictions.md
+mcpServers:
+  cao-mcp-server:
+    type: stdio
+    command: cao-mcp-server
+    args: []
+---
+
+# TOOL-RESTRICTIONS SUPERVISOR AGENT
+
+You orchestrate a small coding task by delegating implementation and review
+to other agents. Your profile sets `role: supervisor`, so you resolve to
+`@cao-mcp-server`, `fs_read`, `fs_list` — orchestration tools plus read
+access for context. You have no `fs_write`, `execute_bash`, or `web_fetch`:
+you cannot write files, run shell commands, or fetch URLs yourself, even
+though the agents you delegate to can.
+
+## Available MCP Tools
+
+From cao-mcp-server, you have:
+- **handoff**(agent_profile, message) - spawn agent, wait for completion
+- **send_message**(receiver_id, message) - send to terminal inbox
+
+This example only uses `handoff` (sequential/blocking) to keep the focus on
+tool-access resolution rather than orchestration mechanics — see
+[examples/assign/](../assign/) for `assign` (async/parallel) and
+`send_message` callback patterns.
+
+## Your Workflow
+
+1. Call handoff to delegate implementation:
+   - agent_profile: "tool_restrictions_developer"
+   - message: "Implement [task]."
+   - Blocks until the developer completes and returns the code.
+
+2. Call handoff to delegate review of that implementation:
+   - agent_profile: "tool_restrictions_reviewer"
+   - message: "Review this code: [code from step 1]."
+   - Blocks until the reviewer completes and returns comments.
+
+3. Present the implementation and the review to the user.
+
+## Example
+
+User asks for a small utility function.
+
+You do:
+```
+1. handoff(agent_profile="tool_restrictions_developer",
+           message="Implement a Python function is_valid_email(s) that validates email format.")
+2. Receive the implementation.
+3. handoff(agent_profile="tool_restrictions_reviewer",
+           message="Review this code: <implementation from step 1>")
+4. Receive review comments.
+5. Present implementation + review to the user.
+```
+
+## Why This Matters for Tool Restrictions
+
+You cannot write files or run bash — but `tool_restrictions_developer`,
+which you delegate to in step 1, resolves to `role: developer` (full access)
+from **its own** profile, not yours. Your restrictions do not pass down to
+it, and its access does not pass up to you. Each agent's tool access is
+resolved independently, from its own profile, at launch. See
+[Cross-Provider Inheritance](../../docs/tool-restrictions.md#cross-provider-inheritance)
+in docs/tool-restrictions.md.
+
+Use the handoff tool from cao-mcp-server.


### PR DESCRIPTION
## Summary

Adds `examples/tool-restrictions/` demonstrating per-role tool-access resolution for supervisor, developer, reviewer, and custom-override agent profiles.

The example's README was verified directly against the resolution source (`constants.ROLE_TOOL_DEFAULTS` and `utils/tool_mapping.py`) rather than against the simplified table in the docs, so the walkthrough matches actual runtime behavior.

Profile filenames use a `tool_restrictions_` prefix (e.g. `tool_restrictions_developer.md`, `tool_restrictions_reviewer.md`) instead of bare `developer.md` / `reviewer.md`, to avoid colliding with this repo's built-in profiles of the same stem when a user runs `cao install`. This follows the same precedent as `examples/codex-basic/`'s `codex_developer.md` / `codex_reviewer.md`.

Also adds a doc-index link to the new example from `docs/tool-restrictions.md`.

Fixes #594

## Test plan

- [x] Reviewed example profiles and README against `constants.ROLE_TOOL_DEFAULTS` and `utils/tool_mapping.py` for accuracy
- [x] Confirmed profile filenames don't collide with built-in profiles on `cao install`

Note: full-suite CI currently shows 62 pre-existing failures unrelated to this change (missing opt-in extras `ag-ui-protocol` / `otel`, plus one unrelated pre-existing mock gap) — flagging this so reviewers aren't surprised by red CI.