### PR TITLE
feat(skills): add cao-session-liveness for verifying session state

### DIFF
--- a/docs/external-tool-integration.md
+++ b/docs/external-tool-integration.md
@@ -6,7 +6,7 @@ Any tool that loads SKILL.md files can consume these skills. [OpenClaw](https://
 
 ## What This Enables
 
-By adding the `cao-session-management` skill to an external tool, the agent in that tool can orchestrate CAO sessions via shell commands — launching supervisor agents, sending tasks, and collecting results without leaving its own chat loop.
+By adding the `cao-session-management` skill to an external tool, the agent in that tool can orchestrate CAO sessions via shell commands — launching supervisor agents, sending tasks, and collecting results without leaving its own chat loop. The companion `cao-session-liveness` skill teaches the same agent how to confirm a session is genuinely alive before it reports progress.
 
 The agent can:
 
@@ -14,6 +14,7 @@ The agent can:
 - **Send work synchronously** — block until the CAO agent completes and return results inline
 - **Send work asynchronously** — fire a task and continue, check back later for status
 - **Monitor sessions** — list active sessions, check worker status, retrieve output
+- **Verify liveness** — corroborate a reported status against terminal output, and recognize a session whose provider has already exited
 - **Shut down sessions** — clean up when done
 
 This turns any SKILL.md-compatible tool into an orchestration client for CAO's multi-agent system.
@@ -35,10 +36,15 @@ TARGET_SKILLS=~/.openclaw/workspace/skills          # OpenClaw example
 # TARGET_SKILLS=~/.hermes/skills/cli-agent-orchestrator   # Hermes Agent example
 mkdir -p "$TARGET_SKILLS"
 
-# Symlink the session management skill
-ln -sf ~/.aws/cli-agent-orchestrator/skills/cao-session-management \
-       "$TARGET_SKILLS/cao-session-management"
+# Symlink the session management skill and its liveness companion
+for skill in cao-session-management cao-session-liveness; do
+  ln -sf ~/.aws/cli-agent-orchestrator/skills/"$skill" "$TARGET_SKILLS/$skill"
+done
 ```
+
+Each skill is a self-contained `<skill-name>/SKILL.md` folder, which is the layout
+both hosts expect: OpenClaw loads them flat under its skill directory, and Hermes
+Agent nests the same folders under a category directory.
 
 Symlinks stay in sync with CAO upgrades automatically.
 
@@ -66,7 +72,23 @@ If the external tool's agent has filesystem access, tell it to install the skill
 
 The agent will read the SKILL.md, copy the folder into its own workspace, and make it available for future sessions.
 
-For Hermes Agent specifically, the agent can run `from pathlib import Path; skill_manage(action='create', name='cao-session-management', category='cli-agent-orchestrator', content=Path('~/.aws/cli-agent-orchestrator/skills/cao-session-management/SKILL.md').expanduser().read_text())` to register the skill into `~/.hermes/skills/cli-agent-orchestrator/cao-session-management/`. Note that Option C creates a copy that will go stale on CAO upgrades — prefer Option A (symlink) when a shared filesystem is available.
+For Hermes Agent specifically, the agent can register each skill under a category
+directory, which produces `~/.hermes/skills/cli-agent-orchestrator/<skill-name>/`:
+
+```python
+from pathlib import Path
+
+for skill in ("cao-session-management", "cao-session-liveness"):
+    source = Path(f"~/.aws/cli-agent-orchestrator/skills/{skill}/SKILL.md").expanduser()
+    skill_manage(
+        action="create",
+        name=skill,
+        category="cli-agent-orchestrator",
+        content=source.read_text(),
+    )
+```
+
+Note that Option C creates a copy that will go stale on CAO upgrades — prefer Option A (symlink) when a shared filesystem is available.
 
 ## Scope
 

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -38,6 +38,7 @@ SHIPPED_SKILLS: List[str] = [
     "cao-mcp-apps",
     "mcp-apps-builder",
     "cao-session-management",
+    "cao-session-liveness",
     "cao-supervisor-protocols",
     "cao-worker-protocols",
     "cao-memory",

--- a/skills/cao-session-liveness/SKILL.md
+++ b/skills/cao-session-liveness/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: cao-session-liveness
+description: Verify whether a CAO session is actually alive and what it really
+  said, before reporting progress or completion to a user. Use alongside
+  cao-session-management whenever you launch, poll, or report on a CAO session —
+  especially when a session appears stalled, a send times out, or a status value
+  looks inconsistent with the output.
+---
+
+# CAO Session Liveness
+
+Companion to `cao-session-management`, which covers the mechanics of launching
+and messaging sessions. This skill covers a single question that mechanics alone
+cannot answer: **is the session actually alive, and is the status telling me the
+truth?**
+
+## Why this matters
+
+Every CAO provider infers agent state by pattern-matching the rendered terminal
+screen. There is no structured protocol between CAO and the provider CLI. A
+provider that has exited, crashed, or stalled on an unanswerable dialog can
+leave a screen that still matches an `idle` or `processing` pattern.
+
+The consequence is specific and it is the failure this skill exists to prevent:
+**reporting progress on a session that is already dead.**
+
+## The two-signal rule
+
+Never report readiness, progress, or completion from a status value alone.
+Always corroborate with output before you tell a user anything:
+
+1. Read the status (`get_terminal_status`, or `cao session status SESSION`).
+2. Read the output tail (`read_session_output` / `get_terminal_output`, or
+   `cao session status SESSION --json` and inspect `last_output`).
+3. If the two disagree, **the output wins.**
+
+A status of `idle` with an output tail showing a shell prompt means the CLI
+exited. Report the session as dead, not as ready.
+
+## Dead-session discriminators
+
+Treat any of the following in the output tail as proof the provider is no longer
+running, regardless of the reported status:
+
+| Signal | Means |
+|---|---|
+| `Session ended.` / `Resume with: <cli> --resume-id ...` | The CLI exited on its own |
+| `error: Conflicting options:` or a usage/help banner | The CLI rejected its launch flags and never started |
+| `API Error (...)`, `400`, or a model/auth failure | The provider started but cannot reach a model |
+| A bare shell prompt with a directory and timestamp, no agent chrome | The pane fell back to the shell |
+| An output read that fails with an extraction error | No response boundary on screen; corroborate before trusting |
+
+A session parked in `waiting_user_answer` that never advances is usually stalled
+on a dialog nothing will answer. Treat it as dead weight, report it to the user,
+and do not silently kill it.
+
+### Not a dead session: a finished handoff worker
+
+A blocking `handoff` tears its worker down once it returns. The worker terminal
+ID the conductor reports was valid **during** the call and is gone afterwards, so
+querying it later is expected to fail:
+
+- `get_terminal_status` / `GET /terminals/<id>` returns not-found
+- `cao session status SESSION --workers` lists no workers
+
+Neither is evidence the conductor invented the delegation. Confirm a handoff from
+the **conductor's own transcript** — a full-mode output read showing the
+`handoff` tool call, its `agent_profile`, and the returned output — not from the
+terminal registry. Only a non-blocking `assign` leaves a worker alive to query.
+
+Do not accuse a conductor of fabricating a delegation on the strength of a
+missing terminal alone.
+
+## Verify a provider before depending on it
+
+Provider reliability varies, is version-sensitive, and changes as upstream CLIs
+release new dialogs and flags. Do not assume; verify once per environment:
+
+1. Launch a throwaway session in a scratch directory.
+2. Apply the two-signal rule.
+3. Send a trivial task with a short timeout and confirm output returns.
+4. Shut the session down.
+
+Known reliability characteristics, as context for interpreting what you see:
+
+| Provider | Detection basis | What to watch for |
+|---|---|---|
+| `kiro_cli` | Version-specific prompt, credits, and separator patterns | New startup dialogs that default to a decline option; flag combinations the installed CLI rejects |
+| `hermes` | Idle timer stable across repeated polls | Custom themes break prompt matching; slowest to confirm completion. Patterns are overridable by environment variable |
+| `opencode_cli` | Alt-screen TUI completion marker | Scrollback is roughly one viewport; a long single response can lose its own top and fail extraction |
+| `claude_code`, `codex` | Rendered-screen detection | Generally stable headless; still apply the two-signal rule |
+
+If a provider fails to launch headlessly, report the exact signature to the user
+and offer a different provider. Do not retry the same launch repeatedly — a flag
+rejection or a declining dialog will fail identically every time.
+
+## Interpreting a send that does not return
+
+- A **timeout is not a failure.** The agent is still working; the caller stopped
+  waiting. Say so, and check again later.
+- **Never re-send a task after a timeout.** The original may still be running,
+  and a duplicate risks conflicting work in the same directory.
+- A **busy terminal refuses input.** Wait for `idle` or `completed`; do not force.
+- An **async send returns nothing by design.** Poll afterwards, applying the
+  two-signal rule.
+
+## Record what each session is for
+
+CAO stores a session's name, not its purpose. An inventory of live sessions
+cannot tell you which is safe to touch.
+
+Keep a short registry outside CAO — one line per session you launch: name,
+provider, working directory, purpose, date. Update it on launch and on
+shutdown, and read it before answering any question about what a session is
+doing or before acting on one.
+
+## Do not act on sessions you did not launch
+
+Long-running sessions may hold real, unrecoverable work. Reads are always safe.
+Before sending to or shutting down a session you did not start yourself, ask the
+user first. Never issue a shutdown that targets all sessions at once.
+
+## Related
+
+- [cao-session-management](../cao-session-management/SKILL.md) — launching,
+  messaging, and worker communication mechanics

--- a/skills/cao-session-management/SKILL.md
+++ b/skills/cao-session-management/SKILL.md
@@ -119,6 +119,11 @@ polling for `completed` status.
 > `cao session send` waits for completion and returns output inline by default. With `--async`, it sends and returns immediately without waiting. With `--timeout N`, it waits up to N seconds — if the timeout expires, the agent is still running; check status later.
 > Session names in commands use the `cao-` prefixed form (e.g. `--session-name mywork` → use `cao-mywork`).
 
+A reported status is inferred from the rendered terminal screen, not from a
+structured protocol, so it can disagree with reality. Before reporting readiness,
+progress, or completion to a user, corroborate the status with an output read —
+see [cao-session-liveness](../cao-session-liveness/SKILL.md).
+
 ## Worker Communication
 
 Inside a session, the conductor talks to workers via two MCP tools:

--- a/src/cli_agent_orchestrator/skills/cao-session-liveness/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-session-liveness/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: cao-session-liveness
+description: Verify whether a CAO session is actually alive and what it really
+  said, before reporting progress or completion to a user. Use alongside
+  cao-session-management whenever you launch, poll, or report on a CAO session —
+  especially when a session appears stalled, a send times out, or a status value
+  looks inconsistent with the output.
+---
+
+# CAO Session Liveness
+
+Companion to `cao-session-management`, which covers the mechanics of launching
+and messaging sessions. This skill covers a single question that mechanics alone
+cannot answer: **is the session actually alive, and is the status telling me the
+truth?**
+
+## Why this matters
+
+Every CAO provider infers agent state by pattern-matching the rendered terminal
+screen. There is no structured protocol between CAO and the provider CLI. A
+provider that has exited, crashed, or stalled on an unanswerable dialog can
+leave a screen that still matches an `idle` or `processing` pattern.
+
+The consequence is specific and it is the failure this skill exists to prevent:
+**reporting progress on a session that is already dead.**
+
+## The two-signal rule
+
+Never report readiness, progress, or completion from a status value alone.
+Always corroborate with output before you tell a user anything:
+
+1. Read the status (`get_terminal_status`, or `cao session status SESSION`).
+2. Read the output tail (`read_session_output` / `get_terminal_output`, or
+   `cao session status SESSION --json` and inspect `last_output`).
+3. If the two disagree, **the output wins.**
+
+A status of `idle` with an output tail showing a shell prompt means the CLI
+exited. Report the session as dead, not as ready.
+
+## Dead-session discriminators
+
+Treat any of the following in the output tail as proof the provider is no longer
+running, regardless of the reported status:
+
+| Signal | Means |
+|---|---|
+| `Session ended.` / `Resume with: <cli> --resume-id ...` | The CLI exited on its own |
+| `error: Conflicting options:` or a usage/help banner | The CLI rejected its launch flags and never started |
+| `API Error (...)`, `400`, or a model/auth failure | The provider started but cannot reach a model |
+| A bare shell prompt with a directory and timestamp, no agent chrome | The pane fell back to the shell |
+| An output read that fails with an extraction error | No response boundary on screen; corroborate before trusting |
+
+A session parked in `waiting_user_answer` that never advances is usually stalled
+on a dialog nothing will answer. Treat it as dead weight, report it to the user,
+and do not silently kill it.
+
+### Not a dead session: a finished handoff worker
+
+A blocking `handoff` tears its worker down once it returns. The worker terminal
+ID the conductor reports was valid **during** the call and is gone afterwards, so
+querying it later is expected to fail:
+
+- `get_terminal_status` / `GET /terminals/<id>` returns not-found
+- `cao session status SESSION --workers` lists no workers
+
+Neither is evidence the conductor invented the delegation. Confirm a handoff from
+the **conductor's own transcript** — a full-mode output read showing the
+`handoff` tool call, its `agent_profile`, and the returned output — not from the
+terminal registry. Only a non-blocking `assign` leaves a worker alive to query.
+
+Do not accuse a conductor of fabricating a delegation on the strength of a
+missing terminal alone.
+
+## Verify a provider before depending on it
+
+Provider reliability varies, is version-sensitive, and changes as upstream CLIs
+release new dialogs and flags. Do not assume; verify once per environment:
+
+1. Launch a throwaway session in a scratch directory.
+2. Apply the two-signal rule.
+3. Send a trivial task with a short timeout and confirm output returns.
+4. Shut the session down.
+
+Known reliability characteristics, as context for interpreting what you see:
+
+| Provider | Detection basis | What to watch for |
+|---|---|---|
+| `kiro_cli` | Version-specific prompt, credits, and separator patterns | New startup dialogs that default to a decline option; flag combinations the installed CLI rejects |
+| `hermes` | Idle timer stable across repeated polls | Custom themes break prompt matching; slowest to confirm completion. Patterns are overridable by environment variable |
+| `opencode_cli` | Alt-screen TUI completion marker | Scrollback is roughly one viewport; a long single response can lose its own top and fail extraction |
+| `claude_code`, `codex` | Rendered-screen detection | Generally stable headless; still apply the two-signal rule |
+
+If a provider fails to launch headlessly, report the exact signature to the user
+and offer a different provider. Do not retry the same launch repeatedly — a flag
+rejection or a declining dialog will fail identically every time.
+
+## Interpreting a send that does not return
+
+- A **timeout is not a failure.** The agent is still working; the caller stopped
+  waiting. Say so, and check again later.
+- **Never re-send a task after a timeout.** The original may still be running,
+  and a duplicate risks conflicting work in the same directory.
+- A **busy terminal refuses input.** Wait for `idle` or `completed`; do not force.
+- An **async send returns nothing by design.** Poll afterwards, applying the
+  two-signal rule.
+
+## Record what each session is for
+
+CAO stores a session's name, not its purpose. An inventory of live sessions
+cannot tell you which is safe to touch.
+
+Keep a short registry outside CAO — one line per session you launch: name,
+provider, working directory, purpose, date. Update it on launch and on
+shutdown, and read it before answering any question about what a session is
+doing or before acting on one.
+
+## Do not act on sessions you did not launch
+
+Long-running sessions may hold real, unrecoverable work. Reads are always safe.
+Before sending to or shutting down a session you did not start yourself, ask the
+user first. Never issue a shutdown that targets all sessions at once.
+
+## Related
+
+- [cao-session-management](../cao-session-management/SKILL.md) — launching,
+  messaging, and worker communication mechanics

--- a/src/cli_agent_orchestrator/skills/cao-session-management/SKILL.md
+++ b/src/cli_agent_orchestrator/skills/cao-session-management/SKILL.md
@@ -119,6 +119,11 @@ polling for `completed` status.
 > `cao session send` waits for completion and returns output inline by default. With `--async`, it sends and returns immediately without waiting. With `--timeout N`, it waits up to N seconds — if the timeout expires, the agent is still running; check status later.
 > Session names in commands use the `cao-` prefixed form (e.g. `--session-name mywork` → use `cao-mywork`).
 
+A reported status is inferred from the rendered terminal screen, not from a
+structured protocol, so it can disagree with reality. Before reporting readiness,
+progress, or completion to a user, corroborate the status with an output read —
+see [cao-session-liveness](../cao-session-liveness/SKILL.md).
+
 ## Worker Communication
 
 Inside a session, the conductor talks to workers via two MCP tools:


### PR DESCRIPTION
## Problem / Motivation

`cao-session-management` covers the mechanics of launching and messaging sessions.
It does not cover the question those mechanics cannot answer: **is the reported
status true?**

Every provider infers agent state by pattern-matching the rendered terminal
screen — there is no structured protocol between CAO and the provider CLI. So a
provider that has exited, crashed, or stalled on an unanswerable dialog can leave
a screen that still matches an `idle` or `processing` pattern.

Observed while driving CAO from an external agent, all on one host:

| What happened | What CAO reported | What the pane showed |
|---|---|---|
| CLI exited at startup on a trust dialog defaulting to a decline option | `idle`, then `waiting_user_answer` | shell prompt, `Session ended.` |
| CLI rejected its own launch flags (`error: Conflicting options:`) | `processing` | shell prompt |
| `session send` into the first case | timed out after 121s | message delivered into a dead shell |

An agent trusting the status value alone reports progress on a session that is
already dead. That is the specific failure this skill prevents.

## Why it matters

`docs/external-tool-integration.md` invites external harnesses to drive CAO. Those
agents report to a human, and a confident "the session is working on it" about a
dead session is worse than an error — the user waits, and the work never lands.
Nothing downstream corrects it.

## What changed (motivation → approach → change)

**Symptom:** status disagrees with reality, and an agent has no rule telling it
which to trust.

**Root cause:** state is screen-scraped, so liveness is genuinely unknowable from
one signal. This is a property of the architecture, not a bug to fix in a
provider — which makes it guidance, not code.

**Change:** a new bundled skill, `cao-session-liveness`:

- a **two-signal rule** — corroborate status with an output read, and on
  disagreement the output wins
- **dead-session discriminators** an agent can match on (`Session ended.`, a
  usage/flag-conflict banner, a model/auth error, a bare shell prompt, a failed
  extraction)
- the **symmetric trap**: a blocking `handoff` tears its worker down on return, so
  an absent worker terminal and an empty `--workers` afterwards are *expected*,
  not proof of a fabricated delegation. Delegation is confirmed from the
  conductor's transcript, not the terminal registry
- **per-provider detection bases** and what to watch for
- session-purpose bookkeeping, and a don't-touch rule for sessions the agent did
  not launch

Two deliberate design calls:

**Shipped as its own folder, not as sections inside `cao-session-management`.**
Both documented external hosts consume skills as self-contained
`<skill-name>/SKILL.md` units — OpenClaw loads them flat, Hermes nests the same
folders under a category — so a separate folder is the unit that installs and
updates cleanly.

**No per-provider verdict.** The failures in the table are specific to one
installed CLI version. A verdict such as "provider X is broken headless" would go
stale the next time that CLI releases, so the skill teaches the failure
*signatures* plus a verify-once-per-environment procedure instead.

Also: added to `SHIPPED_SKILLS` so the package mirror is generated by
`scripts/sync_skills.py` rather than hand-copied; cross-linked from
`cao-session-management` where it introduces the status commands; and
`docs/external-tool-integration.md` now installs both skills using each host's own
layout.

## Tests

No new test — the change is guidance plus one allowlist entry. It is held by
existing gates:

- `scripts/sync_skills.py --check` — the drift guard, which now covers 13 shipped
  skills and fails if the package mirror diverges from the canonical tree
- repo-wide markdown link validation — 0 errors; locks the two new cross-links
- `test/utils/test_skills.py`, `test_skill_injection.py`,
  `test/cli/commands/test_skills.py`, `test_markdown_links.py` — **121 passed**

## Manual verification

The guidance was derived from live runs against a real `cao-server`, not from
reading code alone:

1. **Reproduced all three failure signatures** in the table above, each confirmed
   against the pane via a full-mode output read.
2. **Confirmed the working path end to end** — launched `code_supervisor`, applied
   the two-signal rule (`idle` + live agent chrome), sent a delegation task, and
   the supervisor handed off to `developer` on a different provider and returned
   the result in 63s.
3. **Found the ephemeral-worker false positive by acting on my own draft.** The
   returned worker ID 404'd and `--workers` was empty, which read as a fabricated
   delegation; the conductor transcript showed a real `handoff` call that had
   `Successfully handed off to developer (codex) in 29.77s`. The draft skill would
   have taught an agent to accuse a correct conductor of lying, so the
   "Not a dead session" section was added before this PR.

Full non-integration suite: 6910 passed, 80 failed. Those 80 are pre-existing on
`main` — I ran the same four files (`agui/test_run_plane`,
`agui/test_run_plane_heartbeat`, `services/test_wiki_lint`,
`telemetry/test_otel_init`) in a clean `origin/main` worktree and got an identical
31 failed / 77 passed.

<!-- no-visual-delta -->
**Why no screenshot:** documentation and skill content only — no UI surface is
touched.

Closes #645
