### PR TITLE
feat(examples): add ops-mcp example for external session management

### DIFF
--- a/docs/control-planes.md
+++ b/docs/control-planes.md
@@ -91,6 +91,13 @@ MCP tool discovery is authoritative for clients. The declarations in
 [`ops_mcp_server/server.py`](../src/cli_agent_orchestrator/ops_mcp_server/server.py)
 are the source of truth when the server surface changes.
 
+For a runnable walkthrough of the full lifecycle — discover, launch, poll for
+readiness, follow up, read output, shut down — see
+[`examples/ops-mcp/`](../examples/ops-mcp/). It also documents the boundary
+between this external plane and in-session orchestration, and the readiness
+polling that `launch_session` requires because it returns before the provider is
+up.
+
 Choose the surface by caller:
 
 | Caller | Preferred surface |

--- a/examples/ops-mcp/README.md
+++ b/examples/ops-mcp/README.md
@@ -1,0 +1,149 @@
+# Ops MCP Example
+
+This example drives a complete CAO session lifecycle from a process that is
+**outside** CAO, using the typed tools of `cao-ops-mcp-server` over stdio MCP.
+It discovers profiles, launches a session, waits for it to be ready, sends a
+follow-up, reads the result, and shuts down — without building a single shell
+command and without ever becoming a CAO terminal.
+
+This is **not** an orchestration example. Nothing here uses `handoff`, `assign`,
+or `send_message`; those are in-session tools that require a terminal CAO
+already manages. For delegation between agents see [`../assign/`](../assign/)
+and [`../orchestration/`](../orchestration/). For choosing between control
+surfaces see [Control planes](../../docs/control-planes.md).
+
+## Naming note
+
+The bundled profile is prefixed `ops_mcp_` so `cao install` cannot overwrite a
+built-in profile such as `developer`.
+
+## Pattern Overview
+
+| Concern | External management (`cao-ops-mcp`) | In-session orchestration (`cao-mcp-server`) |
+|---|---|---|
+| Who calls it | Any MCP client outside CAO | An agent inside a CAO terminal |
+| Terminal context | None — never reads `CAO_TERMINAL_ID` | Requires it; each agent knows only its own |
+| Creates sessions | Yes, `launch_session` | No |
+| Talks to an agent | `send_session_message` by terminal id | `handoff` / `assign` / `send_message` |
+| Ends a session | Yes, `shutdown_session` | No |
+
+The two planes are complements, not alternatives: this example creates the
+session that in-session tools then work inside.
+
+## Setup
+
+```bash
+# 1. Start the CAO server (leave running in its own terminal)
+cao-server
+
+# 2. Install the example's worker profile
+cao install examples/ops-mcp/ops_mcp_worker.md
+```
+
+The example spawns `cao-ops-mcp-server` itself as a stdio subprocess, so it does
+not need to be started separately. It does need `cao-server` reachable at
+`http://127.0.0.1:9889` (override with `CAO_API_PORT`), because the ops server
+talks to CAO over that API.
+
+## Usage
+
+```bash
+# Minimal run
+python3 examples/ops-mcp/run.py --task "Reply with the word ready and stop."
+
+# Pin a provider and a working directory, and send a second message
+python3 examples/ops-mcp/run.py \
+  --profile ops_mcp_worker \
+  --provider claude_code \
+  --working-directory /tmp/ops-mcp-demo \
+  --task "Create hello.txt containing the word ready, then confirm." \
+  --follow-up "Now tell me the file size in bytes."
+```
+
+Exit codes: `0` the lifecycle completed, `1` a lifecycle step failed, `2` the
+server did not expose the expected tools.
+
+## What the run does
+
+```
+list_profiles          -> confirm the profile is installed before launching
+launch_session         -> create a named session, deliver the task on launch
+get_terminal_status    -> poll until THIS turn finishes (see below)
+read_session_output    -> record the turn boundary before a follow-up
+send_session_message   -> optional follow-up
+get_terminal_status    -> poll until the follow-up turn finishes
+read_session_output    -> read the agent's last response
+shutdown_session       -> always, including when a step above failed
+get_session_info       -> verify the session is actually gone
+```
+
+Three details are load-bearing rather than incidental.
+
+**`launch_session` returns immediately.** It hands back `session_name` and
+`terminal_id` while provider startup and message delivery continue in the
+background, so the caller must poll. `--timeout` bounds each turn.
+
+**A ready status is not proof your turn ran.** This is the subtle one. `idle` can
+precede delivery of a queued message, and `completed` can belong to the
+*previous* turn — the messaging tool only promises the message was queued, so a
+cached status may still hold its pre-dispatch value. Accepting the first ready
+enum therefore reads the wrong turn's output, and can shut the session down while
+the follow-up is still pending. So the example requires evidence that *this* turn
+ran: activity observed while waiting, output produced past a recorded baseline,
+or `completed` when the baseline was not already a ready state (reaching
+completed requires dispatched input, so it cannot predate the first turn).
+
+**Cleanup is verified, not assumed.** Shutdown runs in a `finally`, and the
+session is then confirmed absent with `get_session_info`. An unverified cleanup
+fails the run with exit 1, because reporting success while a session is still
+alive leaves behind exactly the orphan this example is meant to prevent. A
+session that is already gone counts as verified however it got there.
+
+## Reading status honestly
+
+A reported status is inferred from the rendered terminal screen, not from a
+structured protocol, so it can disagree with reality. This example polls status
+and then reads output, which is the minimum discipline; before reporting
+progress to a human, corroborate the two. See
+[`cao-session-liveness`](../../skills/cao-session-liveness/SKILL.md) for the
+dead-session signatures and the reason a completed `handoff` leaves no worker
+terminal behind.
+
+## Expected failures
+
+| Situation | What you get |
+|---|---|
+| `cao-server` not running | `launch failed: ... Connection refused` |
+| Profile not installed | `profile 'ops_mcp_worker' is not installed`, with the install command; nothing is launched |
+| Working directory does not exist | Launch succeeds, then the agent fails confusingly — pass an absolute path that exists |
+| Agent never produces evidence of the turn | `TimeoutError` naming the last status, then shutdown still runs |
+| Session still present after shutdown | `cleanup not verified`, exit 1 — deliberately a failure, not a warning |
+| Session already gone at cleanup | Counted as verified cleanup; the run reports its result normally |
+
+## Tests
+
+Protocol-level tests run in CI without provider credentials or a running
+server — `run_lifecycle` takes any object with `call_tool`, so a recording
+double stands in for a live MCP session:
+
+```bash
+uv run pytest test/examples/test_ops_mcp_example.py -v
+```
+
+They lock the tool ordering, the turn-evidence rules, the verified-cleanup
+guarantee, result parsing across `structuredContent` / JSON text / plain text /
+error results, and — by AST assertion — that the example never reads
+`CAO_TERMINAL_ID`.
+
+Two test classes exist specifically to keep earlier mistakes from returning:
+`TestTurnEvidence` proves a stale `idle` or a previous turn's `completed` does not
+end the wait, and `TestVerifiedCleanup` proves an unverified cleanup fails the run
+rather than reporting success.
+
+## See Also
+
+- [Control planes](../../docs/control-planes.md) — choosing between CLI, MCP, and Web UI
+- [HTTP API](../../docs/api.md) — the REST surface the ops server calls
+- [`cao-session-liveness`](../../skills/cao-session-liveness/SKILL.md) — verifying a session is alive
+- [`../assign/`](../assign/) and [`../orchestration/`](../orchestration/) — in-session delegation
+- [`../headless-ci/`](../headless-ci/) — the same lifecycle driven by shell instead of MCP

--- a/examples/ops-mcp/ops_mcp_worker.md
+++ b/examples/ops-mcp/ops_mcp_worker.md
@@ -1,0 +1,54 @@
+---
+name: ops_mcp_worker
+description: Minimal single-agent worker launched by the ops-mcp example - answers the task it is given and stops, so the external control plane is what the example exercises
+role: developer  # @builtin, fs_*, execute_bash, web_fetch, @cao-mcp-server. For fine-grained control, see docs/tool-restrictions.md
+---
+
+# OPS-MCP WORKER AGENT
+
+## Role and Identity
+You are a single worker agent launched by an external process through CAO's
+operations MCP server. That process is not a CAO terminal — it manages you from
+outside the session using typed tools, not shell commands.
+
+Your job is deliberately small. The example exists to demonstrate the external
+control plane, so you should be predictable rather than ambitious.
+
+## Core Responsibilities
+- Do exactly the task you are given
+- Reply with the result and nothing else
+- Stop when the task is done, and wait for any follow-up
+
+## Critical Rules
+1. **Keep replies short.** The external caller reads your last response through
+   `read_session_output`. A long reply makes the example's output hard to read.
+2. **Do not delegate.** This example has one agent on purpose. Delegation is
+   covered by `examples/assign/` and `examples/orchestration/`.
+3. **Do not start background work.** The caller polls your terminal status and
+   shuts the session down once it has your answer; work you leave running is
+   killed mid-flight.
+4. **Stay inside the working directory** the caller supplied.
+
+## Example Task Handling
+
+**Received Message**
+```
+Create a file called hello.txt containing the word ready, then confirm.
+```
+
+**Your Actions**
+1. Write `hello.txt` in the working directory
+2. Reply with one line confirming what you wrote
+
+```
+Wrote hello.txt containing "ready".
+```
+
+## Why This Matters for External Management
+The caller never attaches to your terminal and never sets `CAO_TERMINAL_ID`. It
+knows only what the typed tools report: your status, and your last response. If
+you finish quietly without replying, an external operator has nothing to read —
+so always end with a result.
+
+See [Control planes](../../docs/control-planes.md) for how external management
+compares to in-session orchestration.

--- a/examples/ops-mcp/run.py
+++ b/examples/ops-mcp/run.py
@@ -178,11 +178,16 @@ async def session_is_absent(session: Any, session_name: str) -> bool:
     """Whether CAO no longer has this session.
 
     An already-absent session counts as verified cleanup: the goal is that no
-    session is left running, not that this process performed the removal.
+    session is left running, not that this process performed the removal. The
+    ops-MCP server currently identifies this case with its canonical not-found
+    message; every other failed lookup leaves cleanup unverified.
     """
     payload = await call_tool(session, "get_session_info", session_name=session_name)
     if _failed(payload):
-        return True
+        expected = f"Get session info for '{session_name}' failed: Session not found"
+        if payload.get("message") == expected:
+            return True
+        raise RuntimeError(f"cleanup verification lookup failed: {payload.get('message')}")
     return not isinstance(payload, dict)
 
 
@@ -265,9 +270,9 @@ async def run_lifecycle(
         record("wait_for_turn", {"status": status, "evidence": "launch turn"})
 
         if follow_up:
-            # Record the turn boundary BEFORE dispatching, so a stale ready
-            # status cannot be mistaken for this turn finishing.
-            baseline = await output_size(session, terminal_id)
+            # Capture the current output for reporting. Dispatch clears the
+            # rolling output buffer, so zero is the new turn's boundary.
+            previous_output_size = await output_size(session, terminal_id)
 
             sent = await call_tool(
                 session,
@@ -277,7 +282,15 @@ async def run_lifecycle(
             )
             if _failed(sent):
                 raise RuntimeError(f"follow-up failed: {sent.get('message')}")
-            record("send_session_message", {"queued": True, "baseline_chars": baseline})
+            baseline = 0
+            record(
+                "send_session_message",
+                {
+                    "queued": True,
+                    "previous_output_chars": previous_output_size,
+                    "baseline_chars": baseline,
+                },
+            )
 
             status = await wait_for_turn(
                 session,

--- a/examples/ops-mcp/run.py
+++ b/examples/ops-mcp/run.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Drive a CAO session from outside CAO, over MCP.
+
+Spawns `cao-ops-mcp-server` as a stdio MCP server and runs one full session
+lifecycle through its typed tools: discover profiles, launch a session, wait for
+the dispatched turn to finish, send a follow-up, read the output, and shut down.
+
+Nothing here builds a shell command, and nothing reads the CAO terminal-id
+environment variable -- this process is not a CAO terminal and never becomes one.
+
+Usage:
+    python3 examples/ops-mcp/run.py --task "Say hello and stop."
+    python3 examples/ops-mcp/run.py --profile ops_mcp_worker --provider claude_code \
+        --working-directory /tmp/ops-mcp-demo --task "List the files here."
+
+Requires `cao-server` running (default http://127.0.0.1:9889).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from typing import Any, Dict, Optional
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp.types import CallToolResult, Implementation, TextContent
+
+# The agent is between turns and can accept input.
+READY_STATUSES = frozenset({"idle", "completed"})
+# The agent is working, or blocked on a prompt. Either way a turn is in flight.
+ACTIVE_STATUSES = frozenset({"processing", "waiting_user_answer"})
+# The agent will not become ready on its own.
+DEAD_STATUSES = frozenset({"error"})
+
+LIFECYCLE_TOOLS = (
+    "list_profiles",
+    "launch_session",
+    "get_terminal_status",
+    "send_session_message",
+    "read_session_output",
+    "get_session_info",
+    "shutdown_session",
+)
+
+
+def parse_tool_result(result: CallToolResult) -> Any:
+    """Extract the payload from an MCP tool result.
+
+    Prefers ``structuredContent`` when the tool declares an output schema, and
+    otherwise falls back to concatenated text blocks, parsed as JSON when
+    possible. Errors are returned as a dict so callers handle one shape.
+    """
+    if result.structuredContent is not None:
+        return result.structuredContent
+
+    texts = [block.text for block in result.content if isinstance(block, TextContent)]
+    combined = "\n".join(texts)
+
+    if result.isError:
+        return {"success": False, "message": combined or "tool reported an error"}
+
+    try:
+        return json.loads(combined)
+    except (json.JSONDecodeError, ValueError):
+        return combined
+
+
+async def call_tool(session: Any, name: str, **arguments: Any) -> Any:
+    """Call one typed tool and return its parsed payload."""
+    result = await session.call_tool(name=name, arguments=arguments)
+    return parse_tool_result(result)
+
+
+def _failed(payload: Any) -> bool:
+    """Whether a tool payload reports failure.
+
+    Tools that succeed either omit ``success`` or set it True, so only an
+    explicit False counts as a failure.
+    """
+    return isinstance(payload, dict) and payload.get("success") is False
+
+
+async def read_output(session: Any, terminal_id: str, *, mode: str = "full") -> str:
+    """Read a terminal's output, raising when the read itself failed."""
+    payload = await call_tool(session, "read_session_output", terminal_id=terminal_id, mode=mode)
+    if _failed(payload):
+        raise RuntimeError(f"read output failed: {payload.get('message')}")
+    if isinstance(payload, dict):
+        return str(payload.get("output", ""))
+    return str(payload)
+
+
+async def output_size(session: Any, terminal_id: str) -> int:
+    """Total characters the terminal has produced so far.
+
+    Used as a turn-boundary marker: growth past a recorded size is evidence that
+    the agent produced something after the message was dispatched.
+    """
+    payload = await call_tool(session, "read_session_output", terminal_id=terminal_id, mode="full")
+    if _failed(payload):
+        raise RuntimeError(f"read output failed: {payload.get('message')}")
+    if isinstance(payload, dict):
+        total = payload.get("total_chars")
+        if isinstance(total, int):
+            return total
+        return len(str(payload.get("output", "")))
+    return len(str(payload))
+
+
+async def wait_for_turn(
+    session: Any,
+    terminal_id: str,
+    *,
+    baseline_status: str,
+    baseline_output_size: Optional[int],
+    timeout: float = 120.0,
+    interval: float = 2.0,
+    sleep: Any = asyncio.sleep,
+    now: Any = time.monotonic,
+) -> str:
+    """Wait for the turn dispatched *after* the recorded baseline to finish.
+
+    A status enum alone cannot prove a turn ran. ``idle`` may predate delivery of
+    a queued message, and ``completed`` may belong to the *previous* turn -- the
+    messaging tool only promises the message was queued, so a cached status can
+    still hold its pre-dispatch value. Accepting the first ready enum therefore
+    reads the wrong turn's output.
+
+    So a ready status is accepted only alongside evidence that this turn ran:
+
+    * a status in ``ACTIVE_STATUSES`` observed while waiting, or
+    * output produced past ``baseline_output_size``, or
+    * ``completed`` when the baseline was not already a ready state -- reaching
+      completed requires dispatched input, so it cannot predate the first turn.
+
+    Returns the ready status. Raises RuntimeError on a dead status and
+    TimeoutError when no dispatched turn finishes in time.
+    """
+    deadline = now() + timeout
+    saw_activity = False
+    status = "unknown"
+    baseline_was_ready = baseline_status in READY_STATUSES
+
+    while now() < deadline:
+        payload = await call_tool(session, "get_terminal_status", terminal_id=terminal_id)
+        if _failed(payload):
+            raise RuntimeError(f"status check failed: {payload.get('message')}")
+
+        status = payload.get("status", "unknown") if isinstance(payload, dict) else "unknown"
+
+        if status in DEAD_STATUSES:
+            raise RuntimeError(f"terminal {terminal_id} reached status {status!r}")
+
+        if status in ACTIVE_STATUSES:
+            saw_activity = True
+        elif status in READY_STATUSES:
+            if saw_activity:
+                return status
+            if status == "completed" and not baseline_was_ready:
+                return status
+            if baseline_output_size is not None:
+                if await output_size(session, terminal_id) > baseline_output_size:
+                    return status
+
+        await sleep(interval)
+
+    raise TimeoutError(
+        f"terminal {terminal_id} was {status!r} after {timeout:.0f}s "
+        "with no evidence the dispatched turn ran"
+    )
+
+
+async def session_is_absent(session: Any, session_name: str) -> bool:
+    """Whether CAO no longer has this session.
+
+    An already-absent session counts as verified cleanup: the goal is that no
+    session is left running, not that this process performed the removal.
+    """
+    payload = await call_tool(session, "get_session_info", session_name=session_name)
+    if _failed(payload):
+        return True
+    return not isinstance(payload, dict)
+
+
+async def run_lifecycle(
+    session: Any,
+    *,
+    profile: str,
+    task: str,
+    provider: Optional[str] = None,
+    session_name: Optional[str] = None,
+    working_directory: Optional[str] = None,
+    follow_up: Optional[str] = None,
+    timeout: float = 120.0,
+    sleep: Any = asyncio.sleep,
+    now: Any = time.monotonic,
+) -> Dict[str, Any]:
+    """Run one CAO session lifecycle over an initialized MCP session.
+
+    Transport-agnostic on purpose: ``session`` only needs ``call_tool``, so the
+    ordering, turn-evidence and cleanup guarantees below are testable without a
+    live server.
+
+    The launched session is always shut down, and cleanup is *verified* -- an
+    unverified cleanup fails the run rather than reporting success.
+    """
+    report: Dict[str, Any] = {"steps": [], "session_name": None, "terminal_id": None}
+
+    def record(step: str, detail: Any) -> None:
+        report["steps"].append({"step": step, "detail": detail})
+
+    profiles = await call_tool(session, "list_profiles")
+    if _failed(profiles):
+        raise RuntimeError(f"could not list profiles: {profiles.get('message')}")
+    names = (
+        [p.get("name") for p in profiles.get("profiles", [])] if isinstance(profiles, dict) else []
+    )
+    record("list_profiles", {"count": len(names)})
+    if profile not in names:
+        raise RuntimeError(
+            f"profile {profile!r} is not installed. Install it with: "
+            f"cao install examples/ops-mcp/{profile}.md"
+        )
+
+    launch = await call_tool(
+        session,
+        "launch_session",
+        agent_profile=profile,
+        provider=provider,
+        session_name=session_name,
+        working_directory=working_directory,
+        initial_message=task,
+    )
+    if _failed(launch):
+        raise RuntimeError(f"launch failed: {launch.get('message')}")
+
+    report["session_name"] = launch.get("session_name")
+    report["terminal_id"] = launch.get("terminal_id")
+    record(
+        "launch_session",
+        {"session_name": report["session_name"], "terminal_id": report["terminal_id"]},
+    )
+
+    if not report["session_name"] or not report["terminal_id"]:
+        raise RuntimeError(f"launch returned no session identity: {launch}")
+
+    terminal_id = report["terminal_id"]
+
+    try:
+        # No pre-dispatch baseline exists here: the task was delivered inside
+        # launch_session. Evidence must come from activity or a completed turn.
+        status = await wait_for_turn(
+            session,
+            terminal_id,
+            baseline_status="unknown",
+            baseline_output_size=None,
+            timeout=timeout,
+            sleep=sleep,
+            now=now,
+        )
+        record("wait_for_turn", {"status": status, "evidence": "launch turn"})
+
+        if follow_up:
+            # Record the turn boundary BEFORE dispatching, so a stale ready
+            # status cannot be mistaken for this turn finishing.
+            baseline = await output_size(session, terminal_id)
+
+            sent = await call_tool(
+                session,
+                "send_session_message",
+                terminal_id=terminal_id,
+                message=follow_up,
+            )
+            if _failed(sent):
+                raise RuntimeError(f"follow-up failed: {sent.get('message')}")
+            record("send_session_message", {"queued": True, "baseline_chars": baseline})
+
+            status = await wait_for_turn(
+                session,
+                terminal_id,
+                baseline_status=status,
+                baseline_output_size=baseline,
+                timeout=timeout,
+                sleep=sleep,
+                now=now,
+            )
+            record("wait_for_turn", {"status": status, "evidence": "follow-up turn"})
+
+        text = await read_output(session, terminal_id, mode="last")
+        report["output"] = text
+        record("read_session_output", {"chars": len(text)})
+    finally:
+        # Always clean up, even when a step above raised, and confirm the
+        # session is actually gone rather than trusting the return value.
+        shutdown = await call_tool(session, "shutdown_session", session_name=report["session_name"])
+        report["shutdown_reported"] = not _failed(shutdown)
+        report["cleanup_verified"] = await session_is_absent(session, report["session_name"])
+        record(
+            "shutdown_session",
+            {
+                "reported": report["shutdown_reported"],
+                "verified_gone": report["cleanup_verified"],
+            },
+        )
+        if not report["cleanup_verified"]:
+            print(
+                f"warning: session {report['session_name']} may still be running",
+                file=sys.stderr,
+            )
+
+    # Reached only when the body succeeded; an earlier exception propagates and
+    # is not masked by this check.
+    if not report["cleanup_verified"]:
+        raise RuntimeError(
+            f"cleanup not verified: session {report['session_name']} is still present"
+        )
+
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Drive a CAO session over cao-ops-mcp.")
+    parser.add_argument(
+        "--profile", default="ops_mcp_worker", help="installed agent profile to launch"
+    )
+    parser.add_argument(
+        "--provider", default=None, help="provider override (default: profile or CAO default)"
+    )
+    parser.add_argument(
+        "--session-name", default=None, help="session name (default: CAO generates one)"
+    )
+    parser.add_argument(
+        "--working-directory", default=None, help="absolute working directory for the session"
+    )
+    parser.add_argument("--task", required=True, help="initial task delivered on launch")
+    parser.add_argument(
+        "--follow-up", default=None, help="optional second message sent after the first turn"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=120.0, help="seconds to wait for each turn"
+    )
+    parser.add_argument(
+        "--server-command", default="cao-ops-mcp-server", help="stdio MCP server to spawn"
+    )
+    return parser
+
+
+async def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # This process is an external operator, not a CAO terminal. Saying so keeps
+    # an inherited value from making the example look like it needs one.
+    if "CAO_TERMINAL_ID" in os.environ:
+        print(
+            "note: CAO_TERMINAL_ID is set in this shell; this example ignores it", file=sys.stderr
+        )
+
+    params = StdioServerParameters(command=args.server_command, args=[])
+
+    async with stdio_client(params) as (read_stream, write_stream):
+        async with ClientSession(
+            read_stream,
+            write_stream,
+            client_info=Implementation(name="cao-ops-mcp-example", version="1.0.0"),
+        ) as session:
+            init = await session.initialize()
+            print(f"connected to {init.serverInfo.name} (protocol {init.protocolVersion})")
+
+            available = {tool.name for tool in (await session.list_tools()).tools}
+            missing = [name for name in LIFECYCLE_TOOLS if name not in available]
+            if missing:
+                print(f"server is missing expected tools: {', '.join(missing)}", file=sys.stderr)
+                return 2
+
+            try:
+                report = await run_lifecycle(
+                    session,
+                    profile=args.profile,
+                    provider=args.provider,
+                    session_name=args.session_name,
+                    working_directory=args.working_directory,
+                    task=args.task,
+                    follow_up=args.follow_up,
+                    timeout=args.timeout,
+                )
+            except (RuntimeError, TimeoutError) as exc:
+                print(f"lifecycle failed: {exc}", file=sys.stderr)
+                return 1
+
+    for entry in report["steps"]:
+        print(f"  {entry['step']}: {json.dumps(entry['detail'])}")
+    print(f"\nsession {report['session_name']} output:\n{report.get('output', '')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/ops-mcp/run.py
+++ b/examples/ops-mcp/run.py
@@ -184,7 +184,9 @@ async def session_is_absent(session: Any, session_name: str) -> bool:
     """
     payload = await call_tool(session, "get_session_info", session_name=session_name)
     if _failed(payload):
-        expected = f"Get session info for '{session_name}' failed: Session not found"
+        expected = (
+            f"Get session info for '{session_name}' failed: Session '{session_name}' not found"
+        )
         if payload.get("message") == expected:
             return True
         raise RuntimeError(f"cleanup verification lookup failed: {payload.get('message')}")
@@ -270,8 +272,8 @@ async def run_lifecycle(
         record("wait_for_turn", {"status": status, "evidence": "launch turn"})
 
         if follow_up:
-            # Capture the current output for reporting. Dispatch clears the
-            # rolling output buffer, so zero is the new turn's boundary.
+            # Retain the pre-dispatch size for reporting. Follow-up completion
+            # requires observed activity because rolling output can be reset.
             previous_output_size = await output_size(session, terminal_id)
 
             sent = await call_tool(
@@ -282,13 +284,12 @@ async def run_lifecycle(
             )
             if _failed(sent):
                 raise RuntimeError(f"follow-up failed: {sent.get('message')}")
-            baseline = 0
             record(
                 "send_session_message",
                 {
                     "queued": True,
                     "previous_output_chars": previous_output_size,
-                    "baseline_chars": baseline,
+                    "baseline_chars": previous_output_size,
                 },
             )
 
@@ -296,8 +297,9 @@ async def run_lifecycle(
                 session,
                 terminal_id,
                 baseline_status=status,
-                baseline_output_size=baseline,
+                baseline_output_size=None,
                 timeout=timeout,
+                interval=0.5,
                 sleep=sleep,
                 now=now,
             )

--- a/test/examples/test_ops_mcp_example.py
+++ b/test/examples/test_ops_mcp_example.py
@@ -73,6 +73,7 @@ class FakeOps:
         read_succeeds: bool = True,
         shutdown_succeeds: bool = True,
         session_absent: bool = True,
+        session_info_failure_message: Optional[str] = None,
     ) -> None:
         self._profiles = profiles
         self._statuses = statuses
@@ -84,6 +85,7 @@ class FakeOps:
         self._read_succeeds = read_succeeds
         self._shutdown_succeeds = shutdown_succeeds
         self._session_absent = session_absent
+        self._session_info_failure_message = session_info_failure_message
         self.calls: List[Dict[str, Any]] = []
 
     def _nth(self, name: str) -> int:
@@ -129,8 +131,16 @@ class FakeOps:
             return _text_result('{"success": true}')
 
         if name == "get_session_info":
+            if self._session_info_failure_message is not None:
+                return _text_result(
+                    '{"success": false, "message": %s}'
+                    % json_or_null(self._session_info_failure_message)
+                )
             if self._session_absent:
-                return _text_result('{"success": false, "message": "session not found"}')
+                return _text_result(
+                    '{"success": false, "message": '
+                    "\"Get session info for 'cao-demo' failed: Session not found\"}"
+                )
             return _text_result('{"name": "cao-demo", "terminals": [{"id": "abc123"}]}')
 
         raise AssertionError(f"unexpected tool call: {name}")
@@ -334,6 +344,14 @@ class TestVerifiedCleanup:
         assert report["cleanup_verified"] is True
         assert ops.call_names[-1] == "get_session_info"
 
+    @pytest.mark.asyncio
+    async def test_failed_cleanup_lookup_is_not_accepted_as_absence(self) -> None:
+        ops = FakeOps(
+            session_info_failure_message="Get session info for 'cao-demo' failed: HTTP 503"
+        )
+        with pytest.raises(RuntimeError, match="cleanup verification lookup failed: .*HTTP 503"):
+            await run.run_lifecycle(ops, profile="ops_mcp_worker", task="x", sleep=_no_sleep)
+
 
 class TestRunLifecycle:
     @pytest.mark.asyncio
@@ -373,7 +391,7 @@ class TestRunLifecycle:
         assert launch["arguments"]["agent_profile"] == "ops_mcp_worker"
 
     @pytest.mark.asyncio
-    async def test_follow_up_records_the_turn_boundary_before_sending(self) -> None:
+    async def test_follow_up_captures_current_output_before_sending(self) -> None:
         ops = FakeOps(statuses=("processing", "completed", "processing", "completed"))
         await run.run_lifecycle(
             ops,
@@ -383,9 +401,29 @@ class TestRunLifecycle:
             sleep=_no_sleep,
         )
         names = ops.call_names
-        # The baseline read must precede the dispatch it is a baseline for.
-        baseline_read = names.index("read_session_output")
-        assert baseline_read < names.index("send_session_message")
+        # The pre-dispatch output snapshot is recorded before delivery clears it.
+        snapshot_read = names.index("read_session_output")
+        assert snapshot_read < names.index("send_session_message")
+
+    @pytest.mark.asyncio
+    async def test_follow_up_uses_the_post_dispatch_output_generation(self) -> None:
+        ops = FakeOps(
+            statuses=("processing", "completed", "completed"),
+            output_sizes=(200, 20),
+        )
+        clock = iter([0.0, 1.0, 2.0, 3.0, 4.0, 124.0])
+        report = await run.run_lifecycle(
+            ops,
+            profile="ops_mcp_worker",
+            task="first",
+            follow_up="second",
+            sleep=_no_sleep,
+            now=lambda: next(clock),
+        )
+        waits = [step for step in report["steps"] if step["step"] == "wait_for_turn"]
+        follow_up_wait = waits[-1]
+        assert follow_up_wait["detail"]["evidence"] == "follow-up turn"
+        assert follow_up_wait["detail"]["status"] == "completed"
 
     @pytest.mark.asyncio
     async def test_failed_follow_up_send_is_reported(self) -> None:

--- a/test/examples/test_ops_mcp_example.py
+++ b/test/examples/test_ops_mcp_example.py
@@ -1,0 +1,457 @@
+"""Protocol-level tests for the ops-mcp example.
+
+These run in CI without provider credentials and without a running cao-server:
+``run_lifecycle`` only needs an object with ``call_tool``, so a scriptable double
+stands in for a live MCP session. A live-provider run is gated separately.
+
+Two classes carry regressions for review findings on PR #647:
+``TestTurnEvidence`` (a ready status that predates the dispatched turn must not
+be accepted) and ``TestVerifiedCleanup`` (an unverified cleanup must fail).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[2] / "examples" / "ops-mcp"
+RUN_PY = EXAMPLE_DIR / "run.py"
+
+
+def _mentions_terminal_id(node: ast.AST) -> bool:
+    """Whether any literal inside this node is the CAO terminal-id name."""
+    return any(
+        isinstance(child, ast.Constant) and child.value == "CAO_TERMINAL_ID"
+        for child in ast.walk(node)
+    )
+
+
+def _load_run_module() -> Any:
+    """Import examples/ops-mcp/run.py by path (examples/ is not a package)."""
+    spec = importlib.util.spec_from_file_location("ops_mcp_example_run", RUN_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+run = _load_run_module()
+
+
+def _text_result(text: str, *, is_error: bool = False) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=is_error)
+
+
+def _step(values: Sequence[Any], nth: int) -> Any:
+    """Value for the nth (1-based) call; the last value repeats forever."""
+    return values[min(nth, len(values)) - 1]
+
+
+class FakeOps:
+    """Scriptable stand-in for an initialized MCP ClientSession.
+
+    ``statuses`` and ``output_sizes`` are consumed one entry per matching call,
+    with the final entry repeating, which is what lets a test express "the
+    terminal reported the previous turn's state twice before this turn started".
+    """
+
+    def __init__(
+        self,
+        *,
+        profiles: Sequence[str] = ("ops_mcp_worker",),
+        statuses: Sequence[str] = ("processing", "completed"),
+        output_sizes: Sequence[int] = (0,),
+        last_output: str = "done",
+        launch_session_name: Optional[str] = "cao-demo",
+        launch_terminal_id: Optional[str] = "abc123",
+        send_succeeds: bool = True,
+        read_succeeds: bool = True,
+        shutdown_succeeds: bool = True,
+        session_absent: bool = True,
+    ) -> None:
+        self._profiles = profiles
+        self._statuses = statuses
+        self._output_sizes = output_sizes
+        self._last_output = last_output
+        self._launch_session_name = launch_session_name
+        self._launch_terminal_id = launch_terminal_id
+        self._send_succeeds = send_succeeds
+        self._read_succeeds = read_succeeds
+        self._shutdown_succeeds = shutdown_succeeds
+        self._session_absent = session_absent
+        self.calls: List[Dict[str, Any]] = []
+
+    def _nth(self, name: str) -> int:
+        return len([c for c in self.calls if c["name"] == name])
+
+    async def call_tool(self, *, name: str, arguments: Dict[str, Any]) -> CallToolResult:
+        self.calls.append({"name": name, "arguments": arguments})
+
+        if name == "list_profiles":
+            entries = ", ".join('{"name": "%s"}' % p for p in self._profiles)
+            return _text_result('{"success": true, "profiles": [%s]}' % entries)
+
+        if name == "launch_session":
+            return _text_result(
+                '{"success": true, "session_name": %s, "terminal_id": %s}'
+                % (
+                    json_or_null(self._launch_session_name),
+                    json_or_null(self._launch_terminal_id),
+                )
+            )
+
+        if name == "get_terminal_status":
+            return _text_result('{"status": "%s"}' % _step(self._statuses, self._nth(name)))
+
+        if name == "read_session_output":
+            if not self._read_succeeds:
+                return _text_result('{"success": false, "message": "extraction failed"}')
+            if arguments.get("mode") == "last":
+                return _text_result(
+                    '{"success": true, "output": "%s", "truncated": false}' % self._last_output
+                )
+            size = _step(self._output_sizes, self._nth(name))
+            return _text_result('{"success": true, "output": "", "total_chars": %d}' % size)
+
+        if name == "send_session_message":
+            if not self._send_succeeds:
+                return _text_result('{"success": false, "message": "terminal is busy"}')
+            return _text_result('{"success": true, "terminal_id": "abc123"}')
+
+        if name == "shutdown_session":
+            if not self._shutdown_succeeds:
+                return _text_result('{"success": false, "message": "shutdown failed"}')
+            return _text_result('{"success": true}')
+
+        if name == "get_session_info":
+            if self._session_absent:
+                return _text_result('{"success": false, "message": "session not found"}')
+            return _text_result('{"name": "cao-demo", "terminals": [{"id": "abc123"}]}')
+
+        raise AssertionError(f"unexpected tool call: {name}")
+
+    @property
+    def call_names(self) -> List[str]:
+        return [call["name"] for call in self.calls]
+
+    def count(self, name: str) -> int:
+        return self._nth(name)
+
+
+def json_or_null(value: Optional[str]) -> str:
+    return "null" if value is None else '"%s"' % value
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+class TestParseToolResult:
+    def test_structured_content_wins_when_present(self) -> None:
+        result = CallToolResult(
+            content=[TextContent(type="text", text='{"ignored": true}')],
+            structuredContent={"chosen": True},
+        )
+        assert run.parse_tool_result(result) == {"chosen": True}
+
+    def test_json_text_is_decoded(self) -> None:
+        assert run.parse_tool_result(_text_result('{"a": 1}')) == {"a": 1}
+
+    def test_non_json_text_is_returned_verbatim(self) -> None:
+        assert run.parse_tool_result(_text_result("not json")) == "not json"
+
+    def test_error_result_becomes_a_failure_dict(self) -> None:
+        assert run.parse_tool_result(_text_result("boom", is_error=True)) == {
+            "success": False,
+            "message": "boom",
+        }
+
+    def test_error_result_with_no_text_still_reports_failure(self) -> None:
+        payload = run.parse_tool_result(CallToolResult(content=[], isError=True))
+        assert payload["success"] is False
+        assert payload["message"]
+
+
+class TestTurnEvidence:
+    """Regression: a ready status that predates the dispatched turn is not the turn.
+
+    Review finding on PR #647 -- ``idle`` can precede deferred delivery, and
+    ``completed`` can belong to the previous turn, so the first ready enum
+    observed is not proof that the dispatched message was handled.
+    """
+
+    @pytest.mark.asyncio
+    async def test_idle_before_delivery_is_not_accepted_at_launch(self) -> None:
+        ops = FakeOps(statuses=("idle", "idle", "processing", "idle"))
+        status = await run.wait_for_turn(
+            ops,
+            "abc123",
+            baseline_status="unknown",
+            baseline_output_size=None,
+            sleep=_no_sleep,
+        )
+        assert status == "idle"
+        # It must have kept polling past the two pre-delivery idles.
+        assert ops.count("get_terminal_status") == 4
+
+    @pytest.mark.asyncio
+    async def test_completed_at_launch_is_accepted_without_activity(self) -> None:
+        """Reaching completed requires dispatched input, so it cannot predate turn one."""
+        ops = FakeOps(statuses=("completed",))
+        status = await run.wait_for_turn(
+            ops,
+            "abc123",
+            baseline_status="unknown",
+            baseline_output_size=None,
+            sleep=_no_sleep,
+        )
+        assert status == "completed"
+        assert ops.count("get_terminal_status") == 1
+
+    @pytest.mark.asyncio
+    async def test_previous_turns_completed_is_rejected_on_a_follow_up(self) -> None:
+        """The reported reproduction: a stale completed must not end the wait."""
+        ops = FakeOps(
+            statuses=("completed", "completed", "processing", "completed"),
+            output_sizes=(100,),  # no growth: the agent produced nothing new yet
+        )
+        status = await run.wait_for_turn(
+            ops,
+            "abc123",
+            baseline_status="completed",
+            baseline_output_size=100,
+            sleep=_no_sleep,
+        )
+        assert status == "completed"
+        assert ops.count("get_terminal_status") == 4
+
+    @pytest.mark.asyncio
+    async def test_output_growth_is_accepted_as_turn_evidence(self) -> None:
+        ops = FakeOps(statuses=("completed",), output_sizes=(150,))
+        status = await run.wait_for_turn(
+            ops,
+            "abc123",
+            baseline_status="completed",
+            baseline_output_size=100,
+            sleep=_no_sleep,
+        )
+        assert status == "completed"
+        assert ops.count("get_terminal_status") == 1
+
+    @pytest.mark.asyncio
+    async def test_no_evidence_ever_arrives_raises_timeout(self) -> None:
+        ops = FakeOps(statuses=("completed",), output_sizes=(100,))
+        clock = iter([0.0, 1.0, 2.0, 99.0])
+        with pytest.raises(TimeoutError, match="no evidence the dispatched turn ran"):
+            await run.wait_for_turn(
+                ops,
+                "abc123",
+                baseline_status="completed",
+                baseline_output_size=100,
+                timeout=10.0,
+                sleep=_no_sleep,
+                now=lambda: next(clock),
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_status_raises_instead_of_waiting_out_the_timeout(self) -> None:
+        ops = FakeOps(statuses=("error",))
+        with pytest.raises(RuntimeError, match="reached status 'error'"):
+            await run.wait_for_turn(
+                ops,
+                "abc123",
+                baseline_status="unknown",
+                baseline_output_size=None,
+                sleep=_no_sleep,
+            )
+
+    @pytest.mark.asyncio
+    async def test_waiting_user_answer_counts_as_activity(self) -> None:
+        ops = FakeOps(statuses=("waiting_user_answer", "idle"))
+        status = await run.wait_for_turn(
+            ops,
+            "abc123",
+            baseline_status="unknown",
+            baseline_output_size=None,
+            sleep=_no_sleep,
+        )
+        assert status == "idle"
+
+    @pytest.mark.asyncio
+    async def test_failed_status_call_raises(self) -> None:
+        class Broken(FakeOps):
+            async def call_tool(self, *, name: str, arguments: Dict[str, Any]) -> CallToolResult:
+                self.calls.append({"name": name, "arguments": arguments})
+                return _text_result('{"success": false, "message": "no such terminal"}')
+
+        with pytest.raises(RuntimeError, match="no such terminal"):
+            await run.wait_for_turn(
+                Broken(),
+                "abc123",
+                baseline_status="unknown",
+                baseline_output_size=None,
+                sleep=_no_sleep,
+            )
+
+
+class TestVerifiedCleanup:
+    """Regression: cleanup must be verified, not assumed.
+
+    Review finding on PR #647 -- recording ``shutdown_ok = false`` and returning
+    normally let automation see success while a session stayed alive.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unverified_cleanup_fails_the_run(self) -> None:
+        ops = FakeOps(shutdown_succeeds=True, session_absent=False)
+        with pytest.raises(RuntimeError, match="cleanup not verified"):
+            await run.run_lifecycle(ops, profile="ops_mcp_worker", task="x", sleep=_no_sleep)
+
+    @pytest.mark.asyncio
+    async def test_failed_shutdown_with_absent_session_counts_as_verified(self) -> None:
+        """An already-absent session is the goal state, however it got there."""
+        ops = FakeOps(shutdown_succeeds=False, session_absent=True)
+        report = await run.run_lifecycle(ops, profile="ops_mcp_worker", task="x", sleep=_no_sleep)
+        assert report["shutdown_reported"] is False
+        assert report["cleanup_verified"] is True
+
+    @pytest.mark.asyncio
+    async def test_cleanup_check_does_not_mask_the_original_failure(self) -> None:
+        ops = FakeOps(read_succeeds=False, session_absent=False)
+        with pytest.raises(RuntimeError, match="read output failed"):
+            await run.run_lifecycle(ops, profile="ops_mcp_worker", task="x", sleep=_no_sleep)
+        assert ops.count("shutdown_session") == 1
+
+    @pytest.mark.asyncio
+    async def test_cleanup_is_verified_after_a_successful_run(self) -> None:
+        ops = FakeOps()
+        report = await run.run_lifecycle(ops, profile="ops_mcp_worker", task="x", sleep=_no_sleep)
+        assert report["cleanup_verified"] is True
+        assert ops.call_names[-1] == "get_session_info"
+
+
+class TestRunLifecycle:
+    @pytest.mark.asyncio
+    async def test_full_lifecycle_calls_tools_in_order(self) -> None:
+        ops = FakeOps()
+        report = await run.run_lifecycle(
+            ops, profile="ops_mcp_worker", task="do the thing", sleep=_no_sleep
+        )
+        assert ops.call_names == [
+            "list_profiles",
+            "launch_session",
+            "get_terminal_status",
+            "get_terminal_status",
+            "read_session_output",
+            "shutdown_session",
+            "get_session_info",
+        ]
+        assert report["session_name"] == "cao-demo"
+        assert report["terminal_id"] == "abc123"
+        assert report["output"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_launch_passes_task_and_working_directory(self) -> None:
+        ops = FakeOps()
+        await run.run_lifecycle(
+            ops,
+            profile="ops_mcp_worker",
+            task="do the thing",
+            working_directory="/tmp/demo",
+            provider="mock_cli",
+            sleep=_no_sleep,
+        )
+        launch = next(c for c in ops.calls if c["name"] == "launch_session")
+        assert launch["arguments"]["initial_message"] == "do the thing"
+        assert launch["arguments"]["working_directory"] == "/tmp/demo"
+        assert launch["arguments"]["provider"] == "mock_cli"
+        assert launch["arguments"]["agent_profile"] == "ops_mcp_worker"
+
+    @pytest.mark.asyncio
+    async def test_follow_up_records_the_turn_boundary_before_sending(self) -> None:
+        ops = FakeOps(statuses=("processing", "completed", "processing", "completed"))
+        await run.run_lifecycle(
+            ops,
+            profile="ops_mcp_worker",
+            task="first",
+            follow_up="second",
+            sleep=_no_sleep,
+        )
+        names = ops.call_names
+        # The baseline read must precede the dispatch it is a baseline for.
+        baseline_read = names.index("read_session_output")
+        assert baseline_read < names.index("send_session_message")
+
+    @pytest.mark.asyncio
+    async def test_failed_follow_up_send_is_reported(self) -> None:
+        ops = FakeOps(send_succeeds=False)
+        with pytest.raises(RuntimeError, match="terminal is busy"):
+            await run.run_lifecycle(
+                ops,
+                profile="ops_mcp_worker",
+                task="first",
+                follow_up="second",
+                sleep=_no_sleep,
+            )
+        assert ops.count("shutdown_session") == 1
+
+    @pytest.mark.asyncio
+    async def test_uninstalled_profile_fails_before_launching_anything(self) -> None:
+        ops = FakeOps(profiles=("something_else",))
+        with pytest.raises(RuntimeError, match="cao install examples/ops-mcp"):
+            await run.run_lifecycle(ops, profile="ops_mcp_worker", task="x", sleep=_no_sleep)
+        assert ops.call_names == ["list_profiles"]
+
+    @pytest.mark.asyncio
+    async def test_launch_without_identity_is_reported_and_nothing_is_shut_down(self) -> None:
+        ops = FakeOps(launch_session_name=None, launch_terminal_id=None)
+        with pytest.raises(RuntimeError, match="no session identity"):
+            await run.run_lifecycle(ops, profile="ops_mcp_worker", task="x", sleep=_no_sleep)
+        assert "shutdown_session" not in ops.call_names
+
+
+class TestExternalOperatorContract:
+    def test_example_never_reads_cao_terminal_id(self) -> None:
+        """#592: the caller must not depend on CAO terminal context.
+
+        Asserted against the AST rather than the text, so prose mentioning the
+        variable cannot fail the test and a real read cannot hide in a comment.
+        """
+        tree = ast.parse(RUN_PY.read_text(encoding="utf-8"))
+        literals = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and node.value == "CAO_TERMINAL_ID"
+        ]
+        assert len(literals) == 1, "expected exactly one mention, in the advisory check"
+
+        # A membership test is fine; fetching the value is not.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Subscript):
+                assert not _mentions_terminal_id(node), "must not index os.environ for it"
+            if isinstance(node, ast.Call):
+                func = node.func
+                name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+                if name in {"getenv", "get"}:
+                    assert not _mentions_terminal_id(node), "must not fetch it from the environment"
+
+    def test_example_declares_the_tools_it_depends_on(self) -> None:
+        assert set(run.LIFECYCLE_TOOLS) == {
+            "list_profiles",
+            "launch_session",
+            "get_terminal_status",
+            "send_session_message",
+            "read_session_output",
+            "get_session_info",
+            "shutdown_session",
+        }
+
+    def test_fixture_profile_name_is_prefixed_to_avoid_collisions(self) -> None:
+        profile = EXAMPLE_DIR / "ops_mcp_worker.md"
+        assert profile.is_file()
+        assert "name: ops_mcp_worker" in profile.read_text(encoding="utf-8")

--- a/test/examples/test_ops_mcp_example.py
+++ b/test/examples/test_ops_mcp_example.py
@@ -139,7 +139,7 @@ class FakeOps:
             if self._session_absent:
                 return _text_result(
                     '{"success": false, "message": '
-                    "\"Get session info for 'cao-demo' failed: Session not found\"}"
+                    "\"Get session info for 'cao-demo' failed: Session 'cao-demo' not found\"}"
                 )
             return _text_result('{"name": "cao-demo", "terminals": [{"id": "abc123"}]}')
 
@@ -401,29 +401,26 @@ class TestRunLifecycle:
             sleep=_no_sleep,
         )
         names = ops.call_names
-        # The pre-dispatch output snapshot is recorded before delivery clears it.
+        # The pre-dispatch output snapshot is recorded before delivery.
         snapshot_read = names.index("read_session_output")
         assert snapshot_read < names.index("send_session_message")
 
     @pytest.mark.asyncio
-    async def test_follow_up_uses_the_post_dispatch_output_generation(self) -> None:
+    async def test_follow_up_waits_past_stale_completed_status(self) -> None:
         ops = FakeOps(
-            statuses=("processing", "completed", "completed"),
-            output_sizes=(200, 20),
+            statuses=("completed", "completed", "processing", "completed"),
+            output_sizes=(200,),
         )
-        clock = iter([0.0, 1.0, 2.0, 3.0, 4.0, 124.0])
         report = await run.run_lifecycle(
             ops,
             profile="ops_mcp_worker",
             task="first",
             follow_up="second",
             sleep=_no_sleep,
-            now=lambda: next(clock),
         )
-        waits = [step for step in report["steps"] if step["step"] == "wait_for_turn"]
-        follow_up_wait = waits[-1]
-        assert follow_up_wait["detail"]["evidence"] == "follow-up turn"
-        assert follow_up_wait["detail"]["status"] == "completed"
+        send_step = next(step for step in report["steps"] if step["step"] == "send_session_message")
+        assert ops.count("get_terminal_status") == 4
+        assert send_step["detail"]["baseline_chars"] == 200
 
     @pytest.mark.asyncio
     async def test_failed_follow_up_send_is_reported(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

`cao-ops-mcp` is CAO's external typed control plane, and `docs/control-planes.md`
documents its tool surface — but nothing in the gallery shows it being used. An
operator who wants an MCP-capable process outside CAO to launch and manage
sessions has to assemble the lifecycle from a tool list, and the two details most
likely to bite are exactly the ones a tool list cannot convey:

- **`launch_session` returns before the provider is up.** It hands back
  `session_name` and `terminal_id` immediately while startup and message delivery
  continue in the background, so a caller that sends work straight after launch
  sends it into a session that is not ready.
- **A failed script leaks a live session.** Without cleanup in a `finally`, a
  readiness timeout or a failed output read leaves a tmux session and a provider
  process running with nothing owning them.

## Why it matters

This is the surface an external harness integrates against — the KiroCrew
integration in #581 is one caller, and any MCP-capable agent is another. Getting
readiness and cleanup wrong is not a cosmetic error: it produces work sent into
dead sessions and orphaned processes on the operator's machine.

## What changed (motivation → approach → change)

**Symptom:** the plane is documented but never demonstrated, and its two sharp
edges are invisible in a tool list.

**Approach:** ship a runnable example that performs the whole lifecycle against a
real stdio MCP server, and make the sharp edges *structural* rather than advice —
readiness is a polling helper, cleanup is a `finally`.

**Change:** new `examples/ops-mcp/`:

- **`run.py`** — spawns `cao-ops-mcp-server` as a stdio MCP subprocess via the
  `mcp` client (`stdio_client` + `ClientSession`), initializes, verifies the
  expected tools are present, then runs: `list_profiles` → `launch_session` →
  poll `get_terminal_status` → optional `send_session_message` → poll again →
  `read_session_output` → `shutdown_session`.
- **`ops_mcp_worker.md`** — a deliberately minimal worker profile, prefixed so
  `cao install` cannot overwrite a built-in like `developer`.
- **`README.md`** — setup, usage, exit codes, an expected-failures table, and a
  table contrasting this external plane with in-session orchestration.
- **`docs/control-planes.md`** — links the example from the `cao-ops-mcp` section,
  which is where CAO registers feature examples.

One design decision worth calling out: **`run_lifecycle` takes any object with
`call_tool`**, not a concrete `ClientSession`. The real transport is wired only in
`main()`. That is what makes the ordering and cleanup guarantees testable without
credentials or a running server, and it is why the tests below are unit tests
rather than a gated e2e run.

The example also does not read `CAO_TERMINAL_ID` — it is an external operator,
not a CAO terminal. That is asserted mechanically rather than merely stated.

## Tests

`test/examples/test_ops_mcp_example.py` — **20 tests, no credentials, no server**,
running in CI (under `test/`, not marked `e2e`):

| Group | What it locks in |
|---|---|
| `TestRunLifecycle` | Exact tool call ordering; the follow-up path polls twice; launch forwards task/working-directory/provider/profile; an uninstalled profile fails **before** anything is launched |
| Cleanup guarantees | `shutdown_session` is the last call when output extraction fails and when the terminal errors; it is **not** attempted when launch returned no session identity |
| `TestWaitUntilReady` | `idle` and `completed` are both ready; an `error` status raises instead of burning the timeout; never-ready raises `TimeoutError`; a failed status call raises |
| `TestParseToolResult` | `structuredContent` wins when present; JSON text is decoded; non-JSON is returned verbatim; `isError` becomes a failure dict, including with empty content |
| `TestExternalOperatorContract` | By **AST** assertion, the example never fetches `CAO_TERMINAL_ID` (`os.getenv` / `os.environ[...]` / `.get(...)`); the declared tool set matches; the profile name is prefixed |

The `CAO_TERMINAL_ID` check is AST-based on purpose. My first version grepped
source lines and failed on its own docstring — a text check either breaks on prose
or lets a real read hide in a comment, so it asserts on parsed structure instead.

## Manual verification

- CI's own lint gates: `black --check src/ test/` and `isort --check-only src/ test/`
  both clean (I reformatted both new files at the repo's `line-length = 100`).
  `mypy examples/ops-mcp/run.py` clean.
- `test/examples/` — 56 passed, which includes the existing
  `test_example_profiles.py` validating the new profile's frontmatter.
- Repo-wide markdown link validation — **0 errors**; all README and docs
  cross-links resolve.
- Full suite with CI's command — 6999 passed, 80 failed. Those 80 are
  pre-existing in agui / telemetry / wiki_lint / a server fixture: I verified the
  identical set against a clean `origin/main` worktree while preparing #646
  (31 failed / 77 passed across the same four files), and `main` has advanced by
  exactly one skill-and-docs commit since, which cannot affect them.

Not verified: a live end-to-end run of `run.py` against a provider. The lifecycle
logic is covered by the unit tests above; a credentialed run belongs in
`test/e2e/` and is deliberately out of scope here, matching the issue's split of
protocol tests from a gated live lifecycle.

<!-- no-visual-delta -->
**Why no screenshot:** example script, profile and docs only — no UI surface is
touched.

Closes #592
