### PR TITLE
fix(inbox): confirm Codex message delivery

### DIFF
--- a/src/cli_agent_orchestrator/services/inbox_service.py
+++ b/src/cli_agent_orchestrator/services/inbox_service.py
@@ -22,6 +22,7 @@ from cli_agent_orchestrator.models.inbox import MessageStatus, OrchestrationType
 from cli_agent_orchestrator.models.provider import ProviderType
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.plugins import PluginRegistry
+from cli_agent_orchestrator.providers.codex import CodexProvider
 from cli_agent_orchestrator.providers.manager import provider_manager
 from cli_agent_orchestrator.services import terminal_service
 from cli_agent_orchestrator.services.event_bus import bus
@@ -76,7 +77,19 @@ class InboxService:
         if not messages:
             return
 
-        status = status_monitor.get_status(terminal_id)
+        cached_status = status_monitor.get_status(terminal_id)
+        status = cached_status
+        provider = None
+        rendered_status = None
+        if status == TerminalStatus.PROCESSING:
+            provider = provider_manager.get_provider(terminal_id)
+            if isinstance(provider, CodexProvider):
+                rendered_status = terminal_service._get_direct_rendered_status(
+                    terminal_id, provider
+                )
+                if rendered_status in (TerminalStatus.IDLE, TerminalStatus.COMPLETED):
+                    status = rendered_status
+
         if status not in (TerminalStatus.IDLE, TerminalStatus.COMPLETED):
             # Not ready on the normal path. Eager delivery (#251) lets providers
             # that accept input mid-turn receive messages while PROCESSING or
@@ -86,12 +99,22 @@ class InboxService:
                 TerminalStatus.PROCESSING,
                 TerminalStatus.WAITING_USER_ANSWER,
             ):
-                provider = provider_manager.get_provider(terminal_id)
+                if provider is None:
+                    provider = provider_manager.get_provider(terminal_id)
                 eager_eligible = provider is not None and getattr(
                     provider, "accepts_input_while_processing", False
                 )
             if not eager_eligible:
                 return
+
+        if provider is None:
+            try:
+                provider = provider_manager.get_provider(terminal_id)
+            except Exception:
+                provider = None
+
+        if isinstance(provider, CodexProvider) and rendered_status is None:
+            rendered_status = terminal_service._get_direct_rendered_status(terminal_id, provider)
 
         # Mark DELIVERED before sending (#164). send_input() types into the tmux
         # pane; that output flows back through the FIFO/StatusMonitor pipeline and
@@ -121,6 +144,28 @@ class InboxService:
                         sender_id=sender_id,
                         orchestration_type=OrchestrationType.SEND_MESSAGE,
                     )
+                if isinstance(provider, CodexProvider) and not (
+                    terminal_service._confirm_input_accepted_or_resubmit(
+                        terminal_id,
+                        combined,
+                        registry,
+                        sender_id,
+                        OrchestrationType.SEND_MESSAGE,
+                        provider=provider,
+                        initial_cached_status=cached_status,
+                        initial_rendered_status=rendered_status,
+                        delivery_name="Inbox delivery",
+                    )
+                ):
+                    for message in batch:
+                        update_message_status(message.id, MessageStatus.PENDING)
+                    logger.warning(
+                        "Inbox delivery to terminal %s was not accepted after "
+                        "bounded retries; leaving %d message(s) pending",
+                        terminal_id,
+                        len(batch),
+                    )
+                    continue
                 logger.info(f"Delivered {len(batch)} message(s) to terminal {terminal_id}")
             except TerminalNotFoundError as e:
                 # Pane not resolvable yet (e.g. a herdr pane that isn't mapped

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -63,7 +63,7 @@ from cli_agent_orchestrator.plugins import (
     PostKillTerminalEvent,
     PostSendMessageEvent,
 )
-from cli_agent_orchestrator.providers.base import OutputExtractionError
+from cli_agent_orchestrator.providers.base import BaseProvider, OutputExtractionError
 from cli_agent_orchestrator.providers.kiro_capabilities import (
     KiroCapabilities,
     KiroPhase0KASError,
@@ -90,7 +90,6 @@ from cli_agent_orchestrator.utils.terminal import (
     generate_session_name,
     generate_terminal_id,
     generate_window_name,
-    wait_until_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -750,44 +749,47 @@ _DEFERRED_STARTED_STATUSES = {
 }
 
 
-def _worker_is_started_direct(terminal_id: str, provider) -> bool:
-    """Direct visible-screen status check bypassing the event-driven status cache.
+def _get_direct_rendered_status(terminal_id: str, provider: BaseProvider) -> TerminalStatus:
+    """Read the current tmux pane and detect its status without the cache.
 
-    The deferred-init retry loop polls ``status_monitor.get_status()`` which
-    returns the **cached** status updated only by the event-driven pipeline
-    (pyte screener at rising-edge/quiescence edges). When that lags behind
-    reality the cached status stays IDLE even though the worker already
-    transitioned to PROCESSING.
-
-    This function does a live ``capture-pane`` to grab the visible screen
-    (not the 8 KB rolling buffer, which is too small to reliably hold the
-    footer) and calls ``provider.get_status()`` directly, catching the real
-    state so the retry loop doesn't re-deliver into a working terminal.
-
-    Only providers that set ``supports_direct_status_probe = True`` should
-    be passed to this function; the ``get_status()`` contract for other
-    providers (e.g. kiro_cli, antigravity_cli, cursor_cli) relies on
-    dispatch bookkeeping and cannot distinguish IDLE from COMPLETED on a
-    rendered capture-pane snapshot.
+    Providers with a screen detector receive the rendered lines directly.
+    The older direct-probe capability remains as a fallback for line-oriented
+    providers such as OpenCode. Unsupported providers and probe failures
+    return UNKNOWN, which callers must never treat as permission to send.
     """
+    use_screen_detector = getattr(provider, "supports_screen_detection", False) is True
+    use_direct_detector = getattr(provider, "supports_direct_status_probe", False) is True
+    if not use_screen_detector and not use_direct_detector:
+        return TerminalStatus.UNKNOWN
+
     try:
         metadata = get_terminal_metadata(terminal_id)
         if not metadata:
-            return False
+            return TerminalStatus.UNKNOWN
         session_name = metadata.get("tmux_session")
         window_name = metadata.get("tmux_window")
         if not session_name or not window_name:
-            return False
-        output = get_backend().get_history(session_name, window_name, tail_lines=200)
-        status = provider.get_status(output)
+            return TerminalStatus.UNKNOWN
+        backend = get_backend()
+        if backend.supports_event_inbox() is True:
+            return TerminalStatus.UNKNOWN
+        output = backend.get_history(session_name, window_name, tail_lines=200)
+        if use_screen_detector:
+            return provider.get_status_from_screen(output.splitlines())
+        if use_direct_detector:
+            return provider.get_status(output)
     except Exception:
         logger.debug(
             "Direct status probe for %s failed (falling through to cached path)",
             terminal_id,
             exc_info=True,
         )
-        return False
-    return status in _DEFERRED_STARTED_STATUSES
+    return TerminalStatus.UNKNOWN
+
+
+def _worker_is_started_direct(terminal_id: str, provider) -> bool:
+    """Return whether a live rendered-pane probe shows accepted input."""
+    return _get_direct_rendered_status(terminal_id, provider) in _DEFERRED_STARTED_STATUSES
 
 
 def _message_visible_in_box(terminal_id: str, message: str) -> bool:
@@ -812,6 +814,90 @@ def _message_visible_in_box(terminal_id: str, message: str) -> bool:
     return probe in re.sub(r"[^a-z0-9]", "", rendered.lower())
 
 
+def _wait_for_input_acceptance(
+    terminal_id: str,
+    provider=None,
+    initial_cached_status: Optional[TerminalStatus] = None,
+    initial_rendered_status: Optional[TerminalStatus] = None,
+) -> bool:
+    """Poll cached and rendered status for evidence that input was accepted."""
+    deadline = time.monotonic() + _DEFERRED_SUBMIT_CONFIRM_TIMEOUT
+    while time.monotonic() < deadline:
+        cached_status = status_monitor.get_status(terminal_id)
+        if cached_status in _DEFERRED_STARTED_STATUSES and cached_status != initial_cached_status:
+            return True
+        if provider is not None and (
+            getattr(provider, "supports_screen_detection", False) is True
+            or getattr(provider, "supports_direct_status_probe", False) is True
+        ):
+            rendered_status = _get_direct_rendered_status(terminal_id, provider)
+            if (
+                rendered_status in _DEFERRED_STARTED_STATUSES
+                and rendered_status != initial_rendered_status
+            ):
+                return True
+        time.sleep(0.5)
+    return False
+
+
+def _confirm_input_accepted_or_resubmit(
+    terminal_id: str,
+    message: str,
+    registry: "PluginRegistry | None",
+    sender_id: Optional[str],
+    orchestration_type: Optional[OrchestrationType],
+    provider=None,
+    initial_cached_status: Optional[TerminalStatus] = None,
+    initial_rendered_status: Optional[TerminalStatus] = None,
+    delivery_name: str = "Deferred assign",
+) -> bool:
+    """Confirm input acceptance and retry the existing tmux delivery path.
+
+    Returns True once the terminal reaches a started status, False if it remains
+    ready after all resubmit attempts.
+    """
+    if _wait_for_input_acceptance(
+        terminal_id,
+        provider,
+        initial_cached_status,
+        initial_rendered_status,
+    ):
+        return True
+
+    for attempt in range(1, _DEFERRED_SUBMIT_MAX_RESUBMITS + 1):
+        if _message_visible_in_box(terminal_id, message):
+            logger.warning(
+                "%s to %s unsubmitted (Enter swallowed); " "re-submitting via Enter (attempt %d)",
+                delivery_name,
+                terminal_id,
+                attempt,
+            )
+            send_special_key(terminal_id, "Enter")
+        else:
+            logger.warning(
+                "%s to %s not accepted (paste dropped); " "re-delivering message (attempt %d)",
+                delivery_name,
+                terminal_id,
+                attempt,
+            )
+            send_input(
+                terminal_id,
+                message,
+                registry=registry,
+                sender_id=sender_id,
+                orchestration_type=orchestration_type,
+            )
+        if _wait_for_input_acceptance(
+            terminal_id,
+            provider,
+            initial_cached_status,
+            initial_rendered_status,
+        ):
+            return True
+
+    return False
+
+
 async def _confirm_worker_started_or_resubmit(
     terminal_id: str,
     message: str,
@@ -820,64 +906,16 @@ async def _confirm_worker_started_or_resubmit(
     orchestration_type: Optional[OrchestrationType],
     provider=None,
 ) -> bool:
-    """Confirm a deferred-init worker began processing; re-submit if not.
-
-    Returns True once the terminal reaches a started status, False if it is
-    still stuck at IDLE after all resubmit attempts. Blocking tmux/DB I/O runs
-    off the loop via to_thread so concurrent deferred inits aren't frozen.
-    """
-    if await wait_until_status(
+    """Run shared submit confirmation off the deferred-init event loop."""
+    return await asyncio.to_thread(
+        _confirm_input_accepted_or_resubmit,
         terminal_id,
-        _DEFERRED_STARTED_STATUSES,
-        timeout=_DEFERRED_SUBMIT_CONFIRM_TIMEOUT,
-        polling_interval=0.5,
-    ):
-        return True
-
-    for attempt in range(1, _DEFERRED_SUBMIT_MAX_RESUBMITS + 1):
-        # The cached status_monitor status is event-driven (pyte screener at
-        # rising-edge/quiescence only) and can lag behind reality. Before
-        # re-delivering, do a direct capture-pane / visible-screen check via
-        # the provider to catch cases where the worker IS processing but the
-        # cached status hasn't caught up yet (e.g. OpenCode's ``esc interrupt``
-        # footer appearing between pyte detection edges). Only providers that
-        # opt in via ``supports_direct_status_probe = True`` take this path.
-        if provider is not None and getattr(provider, "supports_direct_status_probe", False):
-            if await asyncio.to_thread(_worker_is_started_direct, terminal_id, provider):
-                return True
-
-        if await asyncio.to_thread(_message_visible_in_box, terminal_id, message):
-            logger.warning(
-                "Deferred assign to %s unsubmitted (Enter swallowed); "
-                "re-submitting via Enter (attempt %d)",
-                terminal_id,
-                attempt,
-            )
-            await asyncio.to_thread(send_special_key, terminal_id, "Enter")
-        else:
-            logger.warning(
-                "Deferred assign to %s not accepted (paste dropped); "
-                "re-delivering message (attempt %d)",
-                terminal_id,
-                attempt,
-            )
-            await asyncio.to_thread(
-                send_input,
-                terminal_id,
-                message,
-                registry=registry,
-                sender_id=sender_id,
-                orchestration_type=orchestration_type,
-            )
-        if await wait_until_status(
-            terminal_id,
-            _DEFERRED_STARTED_STATUSES,
-            timeout=_DEFERRED_SUBMIT_CONFIRM_TIMEOUT,
-            polling_interval=0.5,
-        ):
-            return True
-
-    return False
+        message,
+        registry,
+        sender_id,
+        orchestration_type,
+        provider,
+    )
 
 
 def _schedule_deferred_init(

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -6,7 +6,7 @@ Nothing blocks on completion in that path, so a dropped submit would leave the
 worker idle forever. These cover the confirm + re-submit logic that closes it.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -42,7 +42,7 @@ class TestMessageVisibleInBox:
 class TestConfirmWorkerStartedOrResubmit:
     async def test_started_on_first_confirm_no_resubmit(self):
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=True)),
+            patch.object(ts, "_wait_for_input_acceptance", return_value=True),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
         ):
@@ -57,7 +57,7 @@ class TestConfirmWorkerStartedOrResubmit:
         # First confirm fails, box shows our text (Enter swallowed) → bare Enter,
         # second confirm succeeds.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(ts, "_wait_for_input_acceptance", side_effect=[False, True]),
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
@@ -72,7 +72,7 @@ class TestConfirmWorkerStartedOrResubmit:
     async def test_full_redeliver_when_box_empty(self):
         # First confirm fails, box empty (paste dropped) → re-deliver full msg.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
+            patch.object(ts, "_wait_for_input_acceptance", side_effect=[False, True]),
             patch.object(ts, "_message_visible_in_box", return_value=False),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
@@ -89,23 +89,22 @@ class TestConfirmWorkerStartedOrResubmit:
     async def test_returns_false_when_worker_never_starts(self):
         # Every confirm fails through all resubmit attempts.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
+            patch.object(ts, "_wait_for_input_acceptance", return_value=False),
             patch.object(ts, "_message_visible_in_box", return_value=True),
-            patch.object(ts, "send_special_key"),
+            patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input"),
         ):
             ok = await ts._confirm_worker_started_or_resubmit(
                 "t1", "Analyze the logs", None, "sup", None
             )
         assert ok is False
+        assert key.call_count == ts._DEFERRED_SUBMIT_MAX_RESUBMITS
 
     async def test_direct_probe_short_circuits_when_worker_started(self):
-        # Provider with supports_direct_status_probe=True + direct probe True →
-        # returns True without calling send_input or send_special_key.
+        # Shared acceptance wait reports the live rendered status as started.
         provider = MagicMock(supports_direct_status_probe=True)
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
-            patch.object(ts, "_worker_is_started_direct", return_value=True),
+            patch.object(ts, "_wait_for_input_acceptance", return_value=True) as wait,
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
         ):
@@ -118,15 +117,15 @@ class TestConfirmWorkerStartedOrResubmit:
                 provider=provider,
             )
         assert ok is True
+        wait.assert_called_once_with("t1", provider, None, None)
         key.assert_not_called()
         send.assert_not_called()
 
     async def test_direct_probe_falls_through_when_worker_not_started(self):
-        # Direct probe returns False → continues to existing resubmit logic.
+        # A failed acceptance wait continues to the existing Enter retry.
         provider = MagicMock(supports_direct_status_probe=True)
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
-            patch.object(ts, "_worker_is_started_direct", return_value=False),
+            patch.object(ts, "_wait_for_input_acceptance", side_effect=[False, True]),
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
@@ -144,12 +143,10 @@ class TestConfirmWorkerStartedOrResubmit:
         send.assert_not_called()
 
     async def test_direct_probe_skipped_when_provider_not_opted_in(self):
-        # Provider without supports_direct_status_probe → direct probe never
-        # invoked; falls through to existing resubmit logic.
+        # Unsupported providers still use the same cached acceptance wait.
         provider = MagicMock(supports_direct_status_probe=False)
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
-            patch.object(ts, "_worker_is_started_direct") as probe,
+            patch.object(ts, "_wait_for_input_acceptance", side_effect=[False, True]) as wait,
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key"),
             patch.object(ts, "send_input"),
@@ -163,13 +160,12 @@ class TestConfirmWorkerStartedOrResubmit:
                 provider=provider,
             )
         assert ok is True
-        probe.assert_not_called()
+        assert wait.call_count == 2
 
     async def test_provider_none_skips_direct_probe(self):
         # The existing None-provider path still works unchanged.
         with (
-            patch.object(ts, "wait_until_status", new=AsyncMock(side_effect=[False, True])),
-            patch.object(ts, "_worker_is_started_direct") as probe,
+            patch.object(ts, "_wait_for_input_acceptance", side_effect=[False, True]) as wait,
             patch.object(ts, "_message_visible_in_box", return_value=True),
             patch.object(ts, "send_special_key"),
             patch.object(ts, "send_input"),
@@ -183,25 +179,41 @@ class TestConfirmWorkerStartedOrResubmit:
                 provider=None,
             )
         assert ok is True
-        probe.assert_not_called()
+        assert wait.call_count == 2
 
 
 class TestWorkerIsStartedDirect:
     """Unit tests for the capture-pane direct status probe."""
 
     def test_returns_false_when_metadata_is_none(self):
+        provider = MagicMock(
+            supports_screen_detection=False,
+            supports_direct_status_probe=True,
+        )
         with patch.object(ts, "get_terminal_metadata", return_value=None):
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", provider) is False
 
     def test_returns_false_when_session_key_missing(self):
+        provider = MagicMock(
+            supports_screen_detection=False,
+            supports_direct_status_probe=True,
+        )
         with patch.object(ts, "get_terminal_metadata", return_value={"tmux_window": "w1"}):
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", provider) is False
 
     def test_returns_false_when_window_key_missing(self):
+        provider = MagicMock(
+            supports_screen_detection=False,
+            supports_direct_status_probe=True,
+        )
         with patch.object(ts, "get_terminal_metadata", return_value={"tmux_session": "s1"}):
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", provider) is False
 
     def test_returns_false_when_get_history_raises(self):
+        provider = MagicMock(
+            supports_screen_detection=False,
+            supports_direct_status_probe=True,
+        )
         with (
             patch.object(
                 ts,
@@ -214,10 +226,13 @@ class TestWorkerIsStartedDirect:
             patch.object(ts, "get_backend") as mock_be,
         ):
             mock_be.return_value.get_history.side_effect = Exception("capture failed")
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", provider) is False
 
     def test_returns_false_when_get_status_raises(self):
-        provider = MagicMock()
+        provider = MagicMock(
+            supports_screen_detection=False,
+            supports_direct_status_probe=True,
+        )
         provider.get_status.side_effect = Exception("parse failure")
         with (
             patch.object(
@@ -235,7 +250,10 @@ class TestWorkerIsStartedDirect:
     def test_returns_true_when_status_is_processing(self):
         from cli_agent_orchestrator.models.terminal import TerminalStatus
 
-        provider = MagicMock()
+        provider = MagicMock(
+            supports_screen_detection=False,
+            supports_direct_status_probe=True,
+        )
         provider.get_status.return_value = TerminalStatus.PROCESSING
         with (
             patch.object(
@@ -253,7 +271,10 @@ class TestWorkerIsStartedDirect:
     def test_returns_false_when_status_is_idle(self):
         from cli_agent_orchestrator.models.terminal import TerminalStatus
 
-        provider = MagicMock()
+        provider = MagicMock(
+            supports_screen_detection=False,
+            supports_direct_status_probe=True,
+        )
         provider.get_status.return_value = TerminalStatus.IDLE
         with (
             patch.object(
@@ -267,3 +288,79 @@ class TestWorkerIsStartedDirect:
             patch.object(ts, "get_backend") as mock_be,
         ):
             assert ts._worker_is_started_direct("t1", provider) is False
+
+    def test_screen_detector_receives_rendered_lines(self):
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+        provider = MagicMock(
+            supports_screen_detection=True,
+            supports_direct_status_probe=False,
+        )
+        provider.get_status_from_screen.return_value = TerminalStatus.COMPLETED
+        with (
+            patch.object(
+                ts,
+                "get_terminal_metadata",
+                return_value={
+                    "tmux_session": "s1",
+                    "tmux_window": "w1",
+                },
+            ),
+            patch.object(ts, "get_backend") as mock_be,
+        ):
+            mock_be.return_value.get_history.return_value = "response\n❯"
+            assert ts._get_direct_rendered_status("t1", provider) == TerminalStatus.COMPLETED
+
+        provider.get_status_from_screen.assert_called_once_with(["response", "❯"])
+
+
+class TestWaitForInputAcceptance:
+    def test_does_not_accept_same_rendered_completed_status_from_before_send(self):
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+        provider = MagicMock()
+        with (
+            patch.object(ts.status_monitor, "get_status", return_value=TerminalStatus.IDLE),
+            patch.object(
+                ts,
+                "_get_direct_rendered_status",
+                return_value=TerminalStatus.COMPLETED,
+            ),
+            patch.object(ts.time, "monotonic", side_effect=[0.0, 0.0, 9.0]),
+            patch.object(ts.time, "sleep"),
+        ):
+            accepted = ts._wait_for_input_acceptance(
+                "t1",
+                provider,
+                initial_cached_status=TerminalStatus.IDLE,
+                initial_rendered_status=TerminalStatus.COMPLETED,
+            )
+
+        assert accepted is False
+
+    def test_does_not_accept_stale_cached_processing_status(self):
+        from cli_agent_orchestrator.models.terminal import TerminalStatus
+
+        provider = MagicMock()
+        with (
+            patch.object(
+                ts.status_monitor,
+                "get_status",
+                return_value=TerminalStatus.PROCESSING,
+            ),
+            patch.object(
+                ts,
+                "_get_direct_rendered_status",
+                return_value=TerminalStatus.IDLE,
+            ),
+            patch.object(ts.time, "monotonic", side_effect=[0.0, 0.0, 9.0]),
+            patch.object(ts.time, "sleep"),
+        ):
+            accepted = ts._wait_for_input_acceptance(
+                "t1",
+                provider,
+                initial_cached_status=TerminalStatus.PROCESSING,
+                initial_rendered_status=TerminalStatus.IDLE,
+            )
+
+        assert accepted is False

--- a/test/services/test_inbox_service.py
+++ b/test/services/test_inbox_service.py
@@ -10,6 +10,7 @@ from cli_agent_orchestrator.backends.base import TerminalNotFoundError
 from cli_agent_orchestrator.constants import INBOX_RECONCILE_GRACE_SECONDS
 from cli_agent_orchestrator.models.inbox import InboxMessage, MessageStatus
 from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.providers.codex import CodexProvider
 from cli_agent_orchestrator.services.inbox_service import InboxService
 
 
@@ -22,6 +23,10 @@ def _make_message(id=1, receiver_id="term-1", message="hello", status=MessageSta
         status=status,
         created_at=datetime.now(),
     )
+
+
+def _codex_provider():
+    return MagicMock(spec=CodexProvider)
 
 
 class TestDeliverPending:
@@ -74,11 +79,15 @@ class TestDeliverPending:
 
     @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
     @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
     @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
     @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
-    def test_skips_when_processing(self, mock_get, mock_monitor, mock_term_svc, mock_update):
+    def test_skips_when_processing(
+        self, mock_get, mock_monitor, mock_pm, mock_term_svc, mock_update
+    ):
         mock_get.return_value = [_make_message()]
         mock_monitor.get_status.return_value = TerminalStatus.PROCESSING
+        mock_pm.get_provider.return_value = MagicMock()
 
         svc = InboxService()
         svc.deliver_pending("term-1")
@@ -209,6 +218,142 @@ class TestDeliverPending:
         # Final status is PENDING (reset after the optimistic DELIVERED), never FAILED.
         assert mock_update.call_args_list[-1] == call(1, MessageStatus.PENDING)
         assert call(1, MessageStatus.FAILED) not in mock_update.call_args_list
+
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_cached_processing_with_fresh_idle_delivers(
+        self, mock_get, mock_monitor, mock_pm, mock_term_svc, mock_update
+    ):
+        mock_get.return_value = [_make_message()]
+        mock_monitor.get_status.return_value = TerminalStatus.PROCESSING
+        mock_pm.get_provider.return_value = _codex_provider()
+        mock_term_svc._get_direct_rendered_status.return_value = TerminalStatus.IDLE
+        mock_term_svc._confirm_input_accepted_or_resubmit.return_value = True
+
+        InboxService().deliver_pending("term-1")
+
+        mock_term_svc.send_input.assert_called_once_with("term-1", "hello")
+        mock_update.assert_called_once_with(1, MessageStatus.DELIVERED)
+
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_cached_processing_with_fresh_processing_does_not_deliver(
+        self, mock_get, mock_monitor, mock_pm, mock_term_svc, mock_update
+    ):
+        mock_get.return_value = [_make_message()]
+        mock_monitor.get_status.return_value = TerminalStatus.PROCESSING
+        mock_pm.get_provider.return_value = _codex_provider()
+        mock_term_svc._get_direct_rendered_status.return_value = TerminalStatus.PROCESSING
+
+        InboxService().deliver_pending("term-1")
+
+        mock_term_svc.send_input.assert_not_called()
+        mock_update.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "fresh_status",
+        [
+            TerminalStatus.UNKNOWN,
+            TerminalStatus.WAITING_USER_ANSWER,
+            TerminalStatus.ERROR,
+        ],
+    )
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_cached_processing_with_unclear_or_blocked_fresh_status_does_not_deliver(
+        self,
+        mock_get,
+        mock_monitor,
+        mock_pm,
+        mock_term_svc,
+        mock_update,
+        fresh_status,
+    ):
+        mock_get.return_value = [_make_message()]
+        mock_monitor.get_status.return_value = TerminalStatus.PROCESSING
+        mock_pm.get_provider.return_value = _codex_provider()
+        mock_term_svc._get_direct_rendered_status.return_value = fresh_status
+
+        InboxService().deliver_pending("term-1")
+
+        mock_term_svc.send_input.assert_not_called()
+        mock_update.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_codex_accepted_send_stays_delivered_once(
+        self, mock_get, mock_monitor, mock_pm, mock_term_svc, mock_update
+    ):
+        mock_get.return_value = [_make_message()]
+        mock_monitor.get_status.return_value = TerminalStatus.IDLE
+        mock_pm.get_provider.return_value = _codex_provider()
+        mock_term_svc._confirm_input_accepted_or_resubmit.return_value = True
+
+        InboxService().deliver_pending("term-1")
+
+        mock_term_svc.send_input.assert_called_once_with("term-1", "hello")
+        mock_term_svc._confirm_input_accepted_or_resubmit.assert_called_once()
+        mock_update.assert_called_once_with(1, MessageStatus.DELIVERED)
+
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_unconfirmed_codex_send_returns_to_pending(
+        self, mock_get, mock_monitor, mock_pm, mock_term_svc, mock_update, caplog
+    ):
+        mock_get.return_value = [_make_message()]
+        mock_monitor.get_status.return_value = TerminalStatus.IDLE
+        mock_pm.get_provider.return_value = _codex_provider()
+        mock_term_svc._confirm_input_accepted_or_resubmit.return_value = False
+
+        InboxService().deliver_pending("term-1")
+
+        assert mock_update.call_args_list == [
+            call(1, MessageStatus.DELIVERED),
+            call(1, MessageStatus.PENDING),
+        ]
+        assert "not accepted after bounded retries" in caplog.text
+
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_reentrant_ready_event_does_not_duplicate_delivery(
+        self, mock_get, mock_update, mock_monitor, mock_pm, mock_term_svc
+    ):
+        message = _make_message()
+        state = {"status": MessageStatus.PENDING}
+        mock_get.side_effect = lambda *_args, **_kwargs: (
+            [message] if state["status"] == MessageStatus.PENDING else []
+        )
+        mock_update.side_effect = lambda _id, status: state.update(status=status)
+        mock_monitor.get_status.return_value = TerminalStatus.IDLE
+        mock_pm.get_provider.return_value = _codex_provider()
+        mock_term_svc._confirm_input_accepted_or_resubmit.return_value = True
+        service = InboxService()
+        mock_term_svc.send_input.side_effect = lambda *_args, **_kwargs: service.deliver_pending(
+            "term-1"
+        )
+
+        service.deliver_pending("term-1")
+
+        mock_term_svc.send_input.assert_called_once_with("term-1", "hello")
+        mock_update.assert_called_once_with(1, MessageStatus.DELIVERED)
 
 
 class TestEagerInboxDelivery:


### PR DESCRIPTION
## Summary

- Recheck the live rendered Codex pane before rejecting inbox delivery solely because cached status is `PROCESSING`.
- Confirm that Codex accepted an inbox prompt after tmux injection.
- Retry Enter when the message remains visible, or resend the complete message when it is absent.
- Return unconfirmed deliveries to `PENDING` after bounded retries while preserving the pre-send claim that prevents reentrant duplicate delivery from #164.

## Problem

A live Codex-to-Codex reproduction showed two independent delivery failures:

1. An inbox row remained `PENDING` indefinitely because the receiver's rendered pane was idle while CAO's cached status stayed `PROCESSING`. Immediate delivery and reconciliation both reused the same cached-status gate, so neither attempted tmux input.
2. A separate message was marked `DELIVERED` after successful tmux commands even though Codex did not accept or process the prompt.

The first three callbacks in the reproduction succeeded, ruling out static profile, routing, and receiver-ID failures. The fourth message was stored correctly but never reached `send_input`.

## Scope

- Uses the existing tmux backend and the confirmation/retry behavior already used for deferred assignments.
- Applies fresh readiness override and acceptance confirmation only to Codex inbox delivery.
- Leaves non-Codex providers, eager delivery, batching, plugin events, and transient `TerminalNotFoundError` handling unchanged.
- Does not add Codex App Server support, a service, dependency, protocol, or database change.

## Tests

```text
uv run pytest test/services/test_inbox_service.py test/services/test_deferred_submit_verification.py
57 passed

uv run pytest test/services/test_status_monitor.py test/providers/test_codex_provider_unit.py test/services/test_terminal_service.py test/services/test_terminal_service_coverage.py test/services/test_terminal_service_full.py test/services/test_plugin_event_emission.py test/api/test_inbox_messages.py test/api/test_lifespan_inbox.py
425 passed, 3 skipped

uv run pytest
7080 passed, 39 skipped, 140 deselected, 1 xfailed
```
