### PR TITLE
feat(workflow): frozen execution manifest, plan approval, and frozen run memory (#583 Bolt 2)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -313,7 +313,7 @@ a sentinel where a human decision was required. Re-raise when `.status == 409`.
 
 ## CLI reference
 
-All twelve verbs live under `cao workflow`.
+All thirteen verbs live under `cao workflow`.
 
 | Verb | Flags | Description |
 | --- | --- | --- |
@@ -329,10 +329,11 @@ All twelve verbs live under `cao workflow`.
 | `events <run_id>` | `--follow/--no-follow`, `--after-seq <n>`, `--json` | Stream live per-run ordered progress (SSE). `--no-follow` does a one-shot batch read. Requires the events route from issue #504 — on a build without it, both modes report that the stream is unavailable and point at `wait`/`status`, rather than claiming the run is unknown. |
 | `resume <run_id>` | `--decide STEP_ID=rerun\|skip` (repeatable), `--json` | Resume a crashed/failed run from its journal (blocks). Each step is replayed, executed, or halted. `--decide` resolves a halted step and authorises **exactly one attempt** — see Halts and `--decide` above. |
 | `cancel <run_id>` | — | Cooperatively cancel a running workflow. |
+| `approve <plan_id>` | `--json` | Approve a plan identifier so runs of that plan may start. Idempotent — a repeat reports the original approver and timestamp rather than overwriting them. **There is no revoke.** Requires the `cao:admin` scope when auth is enabled. Exit 0 approved (whether newly or already), 1 rejected/unreachable. See [Plan approval](#plan-approval-script-tier) below. |
 
 ## MCP tool reference (from inside an agent session)
 
-Ten workflow tools are exposed over MCP. Each returns a structured `{ok, ...}` envelope on
+Eleven workflow tools are exposed over MCP. Each returns a structured `{ok, ...}` envelope on
 every path and never raises into the agent loop.
 
 | Tool | Description |
@@ -347,6 +348,7 @@ every path and never raises into the agent loop.
 | `workflow_resume` | Resume a crashed/failed run from its journal. Each step is replayed, executed, or halted; a `decisions` map (`{step_id: "rerun"\|"skip"}`) resolves a halted step and authorises **exactly one attempt**. |
 | `workflow_cancel` | Cooperatively cancel a running workflow. |
 | `workflow_return` | Called by a worker to hand its structured step output back to the run. |
+| `workflow_plan_approval` | **Read-only.** Report a run's plan identifier and whether that plan is approved. There is deliberately **no MCP tool that grants an approval** — see the asymmetry note below. |
 
 ### CLI ↔ MCP name mapping
 
@@ -359,6 +361,8 @@ before assuming a verb and a tool with similar names do the same thing:
 | List workflow **runs** | `runs` | `workflow_list` |
 | Submit asynchronously | `run` (the default) | `workflow_start` |
 | Run inline / blocking | `run --wait` | `workflow_run` |
+| **Grant** a plan approval | `approve <plan_id>` | *(none — deliberately)* |
+| **Report** a plan's approval | *(none)* | `workflow_plan_approval` |
 
 > **`list` and `workflow_list` are false friends.** The CLI's `list` lists **specs**; the
 > MCP `workflow_list` lists **runs**. An agent reaching for "the list tool" expecting specs
@@ -367,6 +371,78 @@ before assuming a verb and a tool with similar names do the same thing:
 > `run` and `workflow_run` are also not equivalent: the CLI's bare `run` submits
 > asynchronously and follows, whereas the MCP `workflow_run` blocks inline. The MCP
 > counterpart of the CLI default is `workflow_start`.
+>
+> **Approval is asymmetric on purpose, not by omission.** The CLI can grant an approval and MCP
+> cannot; MCP can report one and the CLI has no dedicated verb for that (`cao workflow approve`
+> reports the existing record when it finds one). An MCP grant tool would let an agent approve the
+> plan it just wrote, which is precisely what the approval gate exists to prevent. An agent that meets
+> a refusal should call `workflow_plan_approval` and ask the human to run `cao workflow approve`.
+
+## Plan approval (script tier)
+
+**Nothing in this section applies to YAML workflows**, and nothing in it is active by default.
+
+A script-tier run freezes an **execution manifest** at run start — the workflow's source hash, its
+resolved inputs, and the repository/worktree baseline — and derives a **plan identifier** (`plan_id`,
+of the form `plan-v1:<digest>`) from the execution-affecting fields. Change any of them and the
+`plan_id` changes, which is the mechanism by which a changed plan needs its own approval.
+
+### Enabling it
+
+Approval enforcement is **off by default**. With it off, `plan_id`s are still computed and frozen, and
+runs start regardless of whether an approval exists.
+
+```bash
+# per-invocation, e.g. to try it out
+CAO_WORKFLOW_REQUIRE_APPROVAL=1 cao workflow run my-script
+
+# persistently: set workflow.require_approval = true in settings.json
+```
+
+> **The environment variable can only turn enforcement ON.** Setting it to `0`/`false` does **not**
+> disable a gate that `settings.json` has enabled — only `settings.json` can turn it off. This departs
+> from every other CAO setting, where the environment variable wins outright. The reason is that a
+> control anything able to set an environment variable could switch off is not a control.
+
+### The first run of any plan is refused
+
+A `plan_id` does not exist until a run starts and computes it, so **a new or changed plan cannot have
+been approved yet**. The loop is:
+
+```bash
+cao workflow run my-script          # refused; the error carries the plan_id
+cao workflow approve plan-v1:<digest>
+cao workflow run my-script          # starts
+```
+
+This friction is temporary rather than intrinsic — the authoring sequence that presents a plan and
+takes approval *before* running is a later piece of work.
+
+### What approval is, and is not
+
+- **Idempotent.** Approving twice changes nothing and reports the original approver and timestamp, so
+  "I just approved this" is distinguishable from "this was approved earlier by someone else".
+- **Not revocable.** There is deliberately no revoke, update or expiry. An update path could point an
+  existing approval at a changed plan, which would let work nobody reviewed execute with a genuine
+  approval behind it.
+- **Recorded with the local OS account as the approver.** That value is **provenance, not identity** —
+  nothing verifies it.
+- **A same-user local control, not a privilege boundary.** CAO runs as the invoking user, so a
+  determined local script can edit the settings or the approval record directly. What the gate provides
+  is that a changed plan cannot execute *unnoticed* under an approval granted for a different plan.
+- **Fail-closed while enabled**: a run whose manifest is missing or unreadable is refused rather than
+  admitted.
+
+### Two things not yet implemented
+
+Stated here because their absence is easy to assume away:
+
+1. **Stale source-hash rejection.** A `plan_id` changes when the source changes, but an update
+   presenting a stale expected source hash is **not** rejected. Do not rely on such a check running.
+2. **Six manifest fields are omitted rather than recorded** — provider, model, profile, permissions,
+   limits and retry policy. Script-tier steps are discovered by executing the Python, so those values
+   have no run-level existence at freeze time; they are covered transitively by the source hash,
+   because changing any of them means editing the script.
 
 ## See also
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -393,11 +393,19 @@ Approval enforcement is **off by default**. With it off, `plan_id`s are still co
 runs start regardless of whether an approval exists.
 
 ```bash
-# per-invocation, e.g. to try it out
-CAO_WORKFLOW_REQUIRE_APPROVAL=1 cao workflow run my-script
+# start the CAO server with approval enforcement enabled
+CAO_WORKFLOW_REQUIRE_APPROVAL=1 cao-server
 
-# persistently: set workflow.require_approval = true in settings.json
+# invoke the CLI client normally
+cao workflow run my-script
+
+# alternatively, persist workflow.require_approval = true in the server's settings.json
 ```
+
+> **The variable configures the server, not the CLI client.** Setting
+> `CAO_WORKFLOW_REQUIRE_APPROVAL=1` only on a short-lived `cao workflow run` invocation does not
+> configure an already-running CAO server. Set it in the environment that launches that server, or use
+> `settings.json`.
 
 > **The environment variable can only turn enforcement ON.** Setting it to `0`/`false` does **not**
 > disable a gate that `settings.json` has enabled — only `settings.json` can turn it off. This departs

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -433,6 +433,23 @@ takes approval *before* running is a later piece of work.
 - **Fail-closed while enabled**: a run whose manifest is missing or unreadable is refused rather than
   admitted.
 
+### Memory is frozen too, and the copy the agent sees is redacted
+
+A script-tier run resolves CAO memory **once**, at its first terminal, and records the content, its source and a
+hash of the **full** resolved content into the same manifest. Every later terminal of that run — and every resume,
+however long afterwards — is given that recorded copy. **Editing CAO memory after a failure therefore does not
+change what a resumed run sees.**
+
+One consequence is worth stating plainly, because it differs from a non-workflow terminal:
+
+> **On a workflow-driven terminal the injected memory block is the frozen, REDACTED copy**, and it is truncated if
+> the manifest's size bound bites (recorded as `memory.truncated`). A terminal you start yourself still receives
+> the live, unredacted block. The frozen copy is what makes a replay byte-identical to the original run — and it
+> means a secret sitting in curated memory stops reaching the agent's context on this path.
+
+The recorded hash covers the full resolved content, taken **before** redaction, so it identifies what was resolved
+rather than what survived the redaction rules of the day.
+
 ### Two things not yet implemented
 
 Stated here because their absence is easy to assume away:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -111,6 +111,7 @@ from cli_agent_orchestrator.security.auth import (
 )
 from cli_agent_orchestrator.services import (
     flow_service,
+    manifest_freeze,
     secret_gate,
     session_service,
     terminal_service,
@@ -4283,6 +4284,15 @@ async def submit_workflow_run_endpoint(
                 started_at,
                 "script",
                 "1",
+                # issue #583 Bolt 2, ``manifest-freeze``: the frozen manifest rides the SAME
+                # INSERT as the run row (ADR-583-4's no-two-writes lesson). This is the ASYNC
+                # script arm; the blocking arm freezes in ``script_runner`` the same way, and
+                # BOTH script entry points must freeze or a run's approvability would depend on
+                # which route started it. ``build_manifest_json`` is total and returns None on
+                # failure, which writes NULL and fails CLOSED at the approval gate.
+                manifest_freeze.build_manifest_json(
+                    source_hash=spec.content_hash, inputs=body.inputs
+                ),
             )
         except sqlite3.IntegrityError:
             # TOCTOU (PR #525 review): step 0's uniqueness check and this insert are

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -4810,7 +4810,7 @@ async def submit_workflow_run_endpoint(
         manifest_json = await asyncio.to_thread(
             manifest_freeze.build_manifest_json,
             source_hash=spec.content_hash,
-            inputs=body.inputs,
+            inputs=resolved,
         )
         try:
             approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -122,6 +122,9 @@ from cli_agent_orchestrator.security.auth import (
     require_any_scope,
 )
 from cli_agent_orchestrator.services import (
+    approval_gate,
+    approval_provenance,
+    approval_store,
     flow_service,
     manifest_freeze,
     secret_gate,
@@ -4434,6 +4437,144 @@ async def _run_in_background(
         _failed_backstop("drive raised")
 
 
+class PlanApprovalRequest(BaseModel):
+    """Body of the approve-a-plan request (issue #583 Bolt 2, unit ``approval-operation``).
+
+    ``plan_id`` IS A BODY FIELD AND NEVER A PATH SEGMENT, on purpose. It contains a ``:``
+    (``plan-v1:…``) and ``approval_store`` requires it be stored and compared VERBATIM, never parsed
+    and never normalised — a normalisation is how two distinct plans could come to share one
+    approval. A path segment invites percent-encoding, decoding and normalisation from every layer
+    between the client and this handler; a body field makes verbatimness a property of the transport
+    instead of a hope.
+
+    THERE IS NO ``approved_by`` FIELD, also on purpose. Accepting one would create free text that
+    nothing can verify and that any caller could set to any value — the appearance of accountability
+    with none of the substance. It is resolved server-side instead, which at least makes it a true
+    statement about which local account performed the call.
+    """
+
+    plan_id: str
+
+
+@app.post("/workflows/plans/approve")
+async def approve_workflow_plan_endpoint(
+    body: PlanApprovalRequest,
+    # SCOPE_ADMIN ONLY, AND DELIBERATELY NARROWER THAN EVERY SIBLING WORKFLOW ENDPOINT, which accept
+    # ``SCOPE_WRITE, SCOPE_ADMIN``. DO NOT "align" this with them — widening it silently defeats the
+    # control. Approving a plan is an AUTHORISATION act rather than ordinary data mutation, and the
+    # MCP surface deliberately ships no grant tool so an agent cannot approve the plan it just wrote
+    # (issue #583 Bolt 2 ``approval-operation`` Q1). But the MCP boundary reaches the backplane over
+    # HTTP — that is exactly what ``test_http_only_boundary.py`` enforces — so if this endpoint
+    # accepted ``cao:write`` and an agent's token were write-scoped, the agent could grant by calling
+    # here directly and the missing tool would be a speed bump rather than a control.
+    #
+    # Honest caveat, recorded rather than implied away: ``require_any_scope`` is default-off, so in a
+    # default install this changes nothing. ``SCOPE_WRITE, SCOPE_ADMIN`` is equally inert there; the
+    # two differ ONLY when auth is enabled, which is the one case the distinction was asked for.
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_ADMIN)),
+) -> Dict:
+    """Approve a plan identifier so its runs may start (issue #583 FR-8).
+
+    Idempotent: approving an already-approved plan changes nothing and SAYS SO, reporting the
+    ORIGINAL ``approved_at``/``approved_by``. ``approval_store.grant`` is ``INSERT OR IGNORE``
+    because an update path could transfer an existing approval to a changed plan, so a plain
+    "success" here would leave an operator unable to tell "I have just approved this" from "this was
+    approved last week by someone else and my grant did nothing".
+
+    Success is derived from a READ-BACK rather than from the absence of an exception, because
+    ``INSERT OR IGNORE`` succeeds silently whether or not it inserted. A missing row afterwards is
+    an error, never a cheerful success — this unit's worst failure mode is a command that appears to
+    work, leaving the operator to meet the same refusal on the next run with no explanation.
+    """
+    plan_id = body.plan_id
+    if not plan_id or not plan_id.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="plan_id is required")
+
+    existing = await asyncio.to_thread(approval_store.get_approval, plan_id)
+    if existing is not None:
+        logger.info(
+            "workflow plan approval: %s was already approved at %s by %s (no change)",
+            plan_id,
+            existing.approved_at,
+            existing.approved_by,
+        )
+        return {
+            "plan_id": plan_id,
+            "approved": True,
+            "changed": False,
+            "approved_at": existing.approved_at,
+            "approved_by": existing.approved_by,
+        }
+
+    approved_by = approval_provenance.local_account()
+    try:
+        await asyncio.to_thread(approval_store.grant, plan_id, approved_by)
+        recorded = await asyncio.to_thread(approval_store.get_approval, plan_id)
+    except Exception as e:  # noqa: BLE001 — surfaced, never swallowed into a false success
+        logger.error("workflow plan approval: grant for %s failed: %s", plan_id, e)
+        raise HTTPException(status_code=500, detail=f"could not record approval: {e}")
+
+    if recorded is None:
+        # A database fault that ``approval_store`` converted to a quiet None. Correct for the GATE,
+        # which must fail closed; wrong to read here as "not approved yet, all fine".
+        logger.error("workflow plan approval: grant for %s did not persist", plan_id)
+        raise HTTPException(status_code=500, detail="approval did not persist")
+
+    logger.info("workflow plan approval: %s approved by %s", plan_id, recorded.approved_by)
+    return {
+        # Echoed VERBATIM. Returning a normalised form would teach a caller that some other
+        # spelling is equivalent, which is exactly the equivalence approval_store forbids.
+        "plan_id": plan_id,
+        "approved": True,
+        "changed": True,
+        "approved_at": recorded.approved_at,
+        "approved_by": recorded.approved_by,
+    }
+
+
+@app.get("/workflows/runs/{run_id}/plan")
+async def get_workflow_run_plan_endpoint(
+    run_id: str,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Dict:
+    """Report a run's plan identifier and whether it is approved (issue #583 FR-8).
+
+    READ-ONLY, and a NEW route rather than an extension of ``GET /workflows/runs/{run_id}``: adding
+    fields to a shipped response would change a surface every existing caller already parses, which
+    C-1 forbids.
+
+    This is what the read-only MCP tool consults, so an agent that meets an approval refusal can tell
+    the operator WHICH ``plan_id`` to approve. It cannot grant one — that is the CLI's, behind
+    ``cao:admin``.
+
+    ``plan_id`` is ``None`` for a YAML run (which never freezes a manifest) and for a script run whose
+    freeze failed. Both are reported as ``None`` rather than as "unapproved", because "this run has no
+    plan identifier" and "this plan is not approved" call for entirely different operator actions.
+    """
+    # Imported locally, matching the other run-row handlers in this module (see the resume endpoint).
+    from cli_agent_orchestrator.services import workflow_journal
+
+    row = await asyncio.to_thread(workflow_journal.get_run, run_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"unknown run '{run_id}'")
+
+    # Reuses the gate's extractor rather than parsing the manifest a second way: two extractors
+    # disagreeing about what a run's plan_id is would be worse than either being wrong alone.
+    plan_id = approval_gate.plan_id_from_manifest(row.manifest_json)
+    if plan_id is None:
+        return {"run_id": run_id, "tier": row.tier, "plan_id": None, "approved": None}
+
+    approval = await asyncio.to_thread(approval_store.get_approval, plan_id)
+    return {
+        "run_id": run_id,
+        "tier": row.tier,
+        "plan_id": plan_id,
+        "approved": approval is not None,
+        "approved_at": approval.approved_at if approval else None,
+        "approved_by": approval.approved_by if approval else None,
+    }
+
+
 @app.post("/workflows/runs")
 async def start_workflow_run_endpoint(
     body: WorkflowRunRequest,
@@ -4657,6 +4798,22 @@ async def submit_workflow_run_endpoint(
         spec_snapshot = json.dumps(
             {"source": spec.source, "path": spec.path, "content_hash": spec.content_hash}
         )
+        # Step 4b — approval gate (issue #583 Bolt 2, ``approval-gate``). Built ONCE here and handed
+        # to the INSERT below unchanged, so the manifest that is CHECKED is byte-identical to the one
+        # STORED. Gating BEFORE the INSERT means a refused start leaves no ``workflow_run`` row: every
+        # first run of a new plan is refused by design, so recording them would durably record runs
+        # that never happened. The blocking arm in ``script_runner`` gates identically at its Step 0b,
+        # because otherwise a run's approvability would depend on which route started it. No-ops
+        # entirely when enforcement is disabled, which is the default.
+        manifest_json = manifest_freeze.build_manifest_json(
+            source_hash=spec.content_hash, inputs=body.inputs
+        )
+        try:
+            approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)
+        except approval_gate.PlanApprovalRequiredError as e:
+            # 403, distinct from this endpoint's 409 (run_id collision) and 422 (lint / corrupt), so a
+            # caller can tell "needs approval" from "the run broke".
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
         # Step 5 — the script row is a single INSERT (no seed steps), already
         # atomic on its own connection. This is the one deliberate deviation from
         # the engines' best-effort write: awaited, and its failure aborts with 500.
@@ -4677,9 +4834,9 @@ async def submit_workflow_run_endpoint(
                 # BOTH script entry points must freeze or a run's approvability would depend on
                 # which route started it. ``build_manifest_json`` is total and returns None on
                 # failure, which writes NULL and fails CLOSED at the approval gate.
-                manifest_freeze.build_manifest_json(
-                    source_hash=spec.content_hash, inputs=body.inputs
-                ),
+                # ``approval-gate`` (Bolt 2 unit 7) built this value at Step 4b and has already gated
+                # on it; reusing it rather than rebuilding is what makes checked-equals-stored true.
+                manifest_json,
             )
         except sqlite3.IntegrityError:
             # TOCTOU (PR #525 review): step 0's uniqueness check and this insert are
@@ -6041,6 +6198,13 @@ async def resume_workflow_run_endpoint(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail=f"unknown run '{run_id}'"
             )
+        except approval_gate.PlanApprovalRequiredError as e:
+            # issue #583 Bolt 2, ``approval-gate``: 403, and it must be caught HERE rather than left
+            # to the arms below. ``PlanApprovalRequiredError`` is deliberately not a ``ValueError``
+            # precisely so the trailing 400 arm cannot claim it, and not a ``ResumeNotAllowedError``
+            # because 409 means "this run cannot be resumed" — a fact about the run — whereas this is
+            # a fact about the plan, and the operator's next action is completely different.
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
         except workflow_service.ResumeNotAllowedError as e:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
         except workflow_service.ResumeCorruptError as e:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -110,6 +110,9 @@ from cli_agent_orchestrator.security.auth import (
     require_any_scope,
 )
 from cli_agent_orchestrator.services import (
+    approval_gate,
+    approval_provenance,
+    approval_store,
     flow_service,
     manifest_freeze,
     secret_gate,
@@ -4047,6 +4050,144 @@ async def _run_in_background(
         _failed_backstop("drive raised")
 
 
+class PlanApprovalRequest(BaseModel):
+    """Body of the approve-a-plan request (issue #583 Bolt 2, unit ``approval-operation``).
+
+    ``plan_id`` IS A BODY FIELD AND NEVER A PATH SEGMENT, on purpose. It contains a ``:``
+    (``plan-v1:…``) and ``approval_store`` requires it be stored and compared VERBATIM, never parsed
+    and never normalised — a normalisation is how two distinct plans could come to share one
+    approval. A path segment invites percent-encoding, decoding and normalisation from every layer
+    between the client and this handler; a body field makes verbatimness a property of the transport
+    instead of a hope.
+
+    THERE IS NO ``approved_by`` FIELD, also on purpose. Accepting one would create free text that
+    nothing can verify and that any caller could set to any value — the appearance of accountability
+    with none of the substance. It is resolved server-side instead, which at least makes it a true
+    statement about which local account performed the call.
+    """
+
+    plan_id: str
+
+
+@app.post("/workflows/plans/approve")
+async def approve_workflow_plan_endpoint(
+    body: PlanApprovalRequest,
+    # SCOPE_ADMIN ONLY, AND DELIBERATELY NARROWER THAN EVERY SIBLING WORKFLOW ENDPOINT, which accept
+    # ``SCOPE_WRITE, SCOPE_ADMIN``. DO NOT "align" this with them — widening it silently defeats the
+    # control. Approving a plan is an AUTHORISATION act rather than ordinary data mutation, and the
+    # MCP surface deliberately ships no grant tool so an agent cannot approve the plan it just wrote
+    # (issue #583 Bolt 2 ``approval-operation`` Q1). But the MCP boundary reaches the backplane over
+    # HTTP — that is exactly what ``test_http_only_boundary.py`` enforces — so if this endpoint
+    # accepted ``cao:write`` and an agent's token were write-scoped, the agent could grant by calling
+    # here directly and the missing tool would be a speed bump rather than a control.
+    #
+    # Honest caveat, recorded rather than implied away: ``require_any_scope`` is default-off, so in a
+    # default install this changes nothing. ``SCOPE_WRITE, SCOPE_ADMIN`` is equally inert there; the
+    # two differ ONLY when auth is enabled, which is the one case the distinction was asked for.
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_ADMIN)),
+) -> Dict:
+    """Approve a plan identifier so its runs may start (issue #583 FR-8).
+
+    Idempotent: approving an already-approved plan changes nothing and SAYS SO, reporting the
+    ORIGINAL ``approved_at``/``approved_by``. ``approval_store.grant`` is ``INSERT OR IGNORE``
+    because an update path could transfer an existing approval to a changed plan, so a plain
+    "success" here would leave an operator unable to tell "I have just approved this" from "this was
+    approved last week by someone else and my grant did nothing".
+
+    Success is derived from a READ-BACK rather than from the absence of an exception, because
+    ``INSERT OR IGNORE`` succeeds silently whether or not it inserted. A missing row afterwards is
+    an error, never a cheerful success — this unit's worst failure mode is a command that appears to
+    work, leaving the operator to meet the same refusal on the next run with no explanation.
+    """
+    plan_id = body.plan_id
+    if not plan_id or not plan_id.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="plan_id is required")
+
+    existing = await asyncio.to_thread(approval_store.get_approval, plan_id)
+    if existing is not None:
+        logger.info(
+            "workflow plan approval: %s was already approved at %s by %s (no change)",
+            plan_id,
+            existing.approved_at,
+            existing.approved_by,
+        )
+        return {
+            "plan_id": plan_id,
+            "approved": True,
+            "changed": False,
+            "approved_at": existing.approved_at,
+            "approved_by": existing.approved_by,
+        }
+
+    approved_by = approval_provenance.local_account()
+    try:
+        await asyncio.to_thread(approval_store.grant, plan_id, approved_by)
+        recorded = await asyncio.to_thread(approval_store.get_approval, plan_id)
+    except Exception as e:  # noqa: BLE001 — surfaced, never swallowed into a false success
+        logger.error("workflow plan approval: grant for %s failed: %s", plan_id, e)
+        raise HTTPException(status_code=500, detail=f"could not record approval: {e}")
+
+    if recorded is None:
+        # A database fault that ``approval_store`` converted to a quiet None. Correct for the GATE,
+        # which must fail closed; wrong to read here as "not approved yet, all fine".
+        logger.error("workflow plan approval: grant for %s did not persist", plan_id)
+        raise HTTPException(status_code=500, detail="approval did not persist")
+
+    logger.info("workflow plan approval: %s approved by %s", plan_id, recorded.approved_by)
+    return {
+        # Echoed VERBATIM. Returning a normalised form would teach a caller that some other
+        # spelling is equivalent, which is exactly the equivalence approval_store forbids.
+        "plan_id": plan_id,
+        "approved": True,
+        "changed": True,
+        "approved_at": recorded.approved_at,
+        "approved_by": recorded.approved_by,
+    }
+
+
+@app.get("/workflows/runs/{run_id}/plan")
+async def get_workflow_run_plan_endpoint(
+    run_id: str,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Dict:
+    """Report a run's plan identifier and whether it is approved (issue #583 FR-8).
+
+    READ-ONLY, and a NEW route rather than an extension of ``GET /workflows/runs/{run_id}``: adding
+    fields to a shipped response would change a surface every existing caller already parses, which
+    C-1 forbids.
+
+    This is what the read-only MCP tool consults, so an agent that meets an approval refusal can tell
+    the operator WHICH ``plan_id`` to approve. It cannot grant one — that is the CLI's, behind
+    ``cao:admin``.
+
+    ``plan_id`` is ``None`` for a YAML run (which never freezes a manifest) and for a script run whose
+    freeze failed. Both are reported as ``None`` rather than as "unapproved", because "this run has no
+    plan identifier" and "this plan is not approved" call for entirely different operator actions.
+    """
+    # Imported locally, matching the other run-row handlers in this module (see the resume endpoint).
+    from cli_agent_orchestrator.services import workflow_journal
+
+    row = await asyncio.to_thread(workflow_journal.get_run, run_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"unknown run '{run_id}'")
+
+    # Reuses the gate's extractor rather than parsing the manifest a second way: two extractors
+    # disagreeing about what a run's plan_id is would be worse than either being wrong alone.
+    plan_id = approval_gate.plan_id_from_manifest(row.manifest_json)
+    if plan_id is None:
+        return {"run_id": run_id, "tier": row.tier, "plan_id": None, "approved": None}
+
+    approval = await asyncio.to_thread(approval_store.get_approval, plan_id)
+    return {
+        "run_id": run_id,
+        "tier": row.tier,
+        "plan_id": plan_id,
+        "approved": approval is not None,
+        "approved_at": approval.approved_at if approval else None,
+        "approved_by": approval.approved_by if approval else None,
+    }
+
+
 @app.post("/workflows/runs")
 async def start_workflow_run_endpoint(
     body: WorkflowRunRequest,
@@ -4270,6 +4411,22 @@ async def submit_workflow_run_endpoint(
         spec_snapshot = json.dumps(
             {"source": spec.source, "path": spec.path, "content_hash": spec.content_hash}
         )
+        # Step 4b — approval gate (issue #583 Bolt 2, ``approval-gate``). Built ONCE here and handed
+        # to the INSERT below unchanged, so the manifest that is CHECKED is byte-identical to the one
+        # STORED. Gating BEFORE the INSERT means a refused start leaves no ``workflow_run`` row: every
+        # first run of a new plan is refused by design, so recording them would durably record runs
+        # that never happened. The blocking arm in ``script_runner`` gates identically at its Step 0b,
+        # because otherwise a run's approvability would depend on which route started it. No-ops
+        # entirely when enforcement is disabled, which is the default.
+        manifest_json = manifest_freeze.build_manifest_json(
+            source_hash=spec.content_hash, inputs=body.inputs
+        )
+        try:
+            approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)
+        except approval_gate.PlanApprovalRequiredError as e:
+            # 403, distinct from this endpoint's 409 (run_id collision) and 422 (lint / corrupt), so a
+            # caller can tell "needs approval" from "the run broke".
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
         # Step 5 — the script row is a single INSERT (no seed steps), already
         # atomic on its own connection. This is the one deliberate deviation from
         # the engines' best-effort write: awaited, and its failure aborts with 500.
@@ -4290,9 +4447,9 @@ async def submit_workflow_run_endpoint(
                 # BOTH script entry points must freeze or a run's approvability would depend on
                 # which route started it. ``build_manifest_json`` is total and returns None on
                 # failure, which writes NULL and fails CLOSED at the approval gate.
-                manifest_freeze.build_manifest_json(
-                    source_hash=spec.content_hash, inputs=body.inputs
-                ),
+                # ``approval-gate`` (Bolt 2 unit 7) built this value at Step 4b and has already gated
+                # on it; reusing it rather than rebuilding is what makes checked-equals-stored true.
+                manifest_json,
             )
         except sqlite3.IntegrityError:
             # TOCTOU (PR #525 review): step 0's uniqueness check and this insert are
@@ -5654,6 +5811,13 @@ async def resume_workflow_run_endpoint(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail=f"unknown run '{run_id}'"
             )
+        except approval_gate.PlanApprovalRequiredError as e:
+            # issue #583 Bolt 2, ``approval-gate``: 403, and it must be caught HERE rather than left
+            # to the arms below. ``PlanApprovalRequiredError`` is deliberately not a ``ValueError``
+            # precisely so the trailing 400 arm cannot claim it, and not a ``ResumeNotAllowedError``
+            # because 409 means "this run cannot be resumed" — a fact about the run — whereas this is
+            # a fact about the plan, and the operator's next action is completely different.
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
         except workflow_service.ResumeNotAllowedError as e:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
         except workflow_service.ResumeCorruptError as e:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -4645,6 +4645,8 @@ async def start_workflow_run_endpoint(
                 status_code=422,
                 detail={"findings": workflow_spec_service.render_findings(e.findings)},
             )
+        except approval_gate.PlanApprovalRequiredError as e:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
         except KeyError as e:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
         except ValueError as e:
@@ -4805,8 +4807,10 @@ async def submit_workflow_run_endpoint(
         # that never happened. The blocking arm in ``script_runner`` gates identically at its Step 0b,
         # because otherwise a run's approvability would depend on which route started it. No-ops
         # entirely when enforcement is disabled, which is the default.
-        manifest_json = manifest_freeze.build_manifest_json(
-            source_hash=spec.content_hash, inputs=body.inputs
+        manifest_json = await asyncio.to_thread(
+            manifest_freeze.build_manifest_json,
+            source_hash=spec.content_hash,
+            inputs=body.inputs,
         )
         try:
             approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -4423,7 +4423,7 @@ async def submit_workflow_run_endpoint(
         manifest_json = await asyncio.to_thread(
             manifest_freeze.build_manifest_json,
             source_hash=spec.content_hash,
-            inputs=body.inputs,
+            inputs=resolved,
         )
         try:
             approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -4258,6 +4258,8 @@ async def start_workflow_run_endpoint(
                 status_code=422,
                 detail={"findings": workflow_spec_service.render_findings(e.findings)},
             )
+        except approval_gate.PlanApprovalRequiredError as e:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
         except KeyError as e:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
         except ValueError as e:
@@ -4418,8 +4420,10 @@ async def submit_workflow_run_endpoint(
         # that never happened. The blocking arm in ``script_runner`` gates identically at its Step 0b,
         # because otherwise a run's approvability would depend on which route started it. No-ops
         # entirely when enforcement is disabled, which is the default.
-        manifest_json = manifest_freeze.build_manifest_json(
-            source_hash=spec.content_hash, inputs=body.inputs
+        manifest_json = await asyncio.to_thread(
+            manifest_freeze.build_manifest_json,
+            source_hash=spec.content_hash,
+            inputs=body.inputs,
         )
         try:
             approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -123,6 +123,7 @@ from cli_agent_orchestrator.security.auth import (
 )
 from cli_agent_orchestrator.services import (
     flow_service,
+    manifest_freeze,
     secret_gate,
     session_service,
     terminal_service,
@@ -4670,6 +4671,15 @@ async def submit_workflow_run_endpoint(
                 started_at,
                 "script",
                 "1",
+                # issue #583 Bolt 2, ``manifest-freeze``: the frozen manifest rides the SAME
+                # INSERT as the run row (ADR-583-4's no-two-writes lesson). This is the ASYNC
+                # script arm; the blocking arm freezes in ``script_runner`` the same way, and
+                # BOTH script entry points must freeze or a run's approvability would depend on
+                # which route started it. ``build_manifest_json`` is total and returns None on
+                # failure, which writes NULL and fails CLOSED at the approval gate.
+                manifest_freeze.build_manifest_json(
+                    source_hash=spec.content_hash, inputs=body.inputs
+                ),
             )
         except sqlite3.IntegrityError:
             # TOCTOU (PR #525 review): step 0's uniqueness check and this insert are

--- a/src/cli_agent_orchestrator/cli/commands/workflow.py
+++ b/src/cli_agent_orchestrator/cli/commands/workflow.py
@@ -172,6 +172,66 @@ def get_cmd(name, as_json):
         click.echo(f"  - {step['id']} ({step['provider']}/{step['agent']})")
 
 
+@workflow.command(name="approve")
+@click.argument("plan_id")
+@click.option(
+    "--json", "as_json", is_flag=True, default=False, help="Emit the approval record as JSON."
+)
+def approve_cmd(plan_id, as_json):
+    """Approve a PLAN_ID so runs of that plan may start (issue #583 FR-8).
+
+    A plan identifier is computed at RUN START from the workflow's execution-affecting fields, so a
+    NEW OR CHANGED PLAN IS REFUSED ONCE before it can be approved: run it, copy the plan_id from the
+    refusal, approve it here, run again. Approval enforcement is off by default — this command is
+    only consequential once ``workflow.require_approval`` is enabled.
+
+    Approving twice is harmless and changes nothing: the original approver and timestamp are kept and
+    reported back, so "already approved" is distinguishable from "just approved by me".
+
+    THERE IS NO WAY TO REVOKE AN APPROVAL, deliberately. An update path could point an existing
+    approval at a changed plan, which would let work nobody reviewed execute with a genuine approval
+    behind it.
+
+    The recorded approver is the local OS account. It is PROVENANCE, NOT IDENTITY — nothing verifies
+    it, and CAO runs as the invoking user.
+
+    Exit codes:
+      0  the plan is approved (whether this call approved it or found it already approved)
+      1  the request was rejected or the server could not be reached
+    """
+    try:
+        response = requests.post(
+            f"{API_BASE_URL}/workflows/plans/approve",
+            # plan_id rides the BODY, never the path: it contains a ':' and must reach the server
+            # verbatim, because a normalisation is how two distinct plans could share one approval.
+            json={"plan_id": plan_id},
+            timeout=MCP_REQUEST_TIMEOUT,
+        )
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(f"could not reach cao-server: {e}")
+
+    if response.status_code == 400:
+        raise click.ClickException(_extract_detail(response, "invalid request"))
+    if response.status_code == 403:
+        raise click.ClickException(
+            _extract_detail(response, "forbidden: approving a plan requires the cao:admin scope")
+        )
+    if response.status_code != 200:
+        raise click.ClickException(_extract_detail(response, f"status {response.status_code}"))
+
+    record = response.json()
+    if as_json:
+        click.echo(_json.dumps(record, indent=2))
+        return
+
+    if record.get("changed"):
+        click.echo(f"approved {record['plan_id']}")
+    else:
+        click.echo(f"{record['plan_id']} was already approved (no change)")
+    click.echo(f"  at: {record.get('approved_at')}")
+    click.echo(f"  by: {record.get('approved_by')}  (local account; provenance, not identity)")
+
+
 @workflow.command(name="delete")
 @click.argument("name")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -731,6 +731,28 @@ def _migrate_workflow_run() -> None:
     rows back-fill to ``tier='yaml'``, ``generation='1'``. ``generation`` is TEXT,
     not INTEGER, so it compares byte-identically against the env-var-transported
     string generation value (domain-entities B4 fix).
+
+    ``manifest-column`` (issue #583 Bolt 2, ADR-583-12) additively appends ONE
+    column, ``manifest_json``, through the same PRAGMA-gated idiom — the frozen
+    execution manifest envelope, carrying source hash, inputs, repository and
+    worktree baseline, provider, model, profile, permissions, limits, retry
+    policy, the resolved-memory record, and the ``plan_id`` derived from them.
+    ``DEFAULT NULL`` means "manifest absent", which every pre-Bolt-2 row is, so
+    such a row reads back observably identical to its pre-extension form
+    (INV-1/INV-2) and no back-fill is attempted — a manifest records how a run was
+    LAUNCHED, which is not recoverable for a run that already started.
+
+    Because this body's failure is silent (see the ``except`` below), the column's
+    existence is VERIFIED rather than assumed: ``test_workflow_run_columns`` in
+    ``test/clients/test_workflow_run_migration.py`` asserts it on a fresh database,
+    with its TEXT type and NULL default. A silent failure would otherwise surface
+    far from its cause, as every run losing its manifest — which the Bolt 2
+    approval gate reads as "never approved" and refuses. That direction is
+    fail-closed, but the diagnosis is still remote, hence the assertion.
+
+    This column is NOT indexed (ADR-583-12: re-approval compares a ``plan_id``
+    read out of the envelope and no query filters on it). Writing and reading it
+    belong to the ``manifest-freeze`` unit, not to this migrator.
     """
     import sqlite3
 
@@ -761,6 +783,9 @@ def _migrate_workflow_run() -> None:
                     "ALTER TABLE workflow_run ADD COLUMN generation TEXT NOT NULL DEFAULT '1'"
                 )
                 logger.info("Migration: added generation column to workflow_run")
+            if "manifest_json" not in columns:
+                conn.execute("ALTER TABLE workflow_run ADD COLUMN manifest_json TEXT DEFAULT NULL")
+                logger.info("Migration: added manifest_json column to workflow_run")
     except Exception as e:  # noqa: BLE001 — derived/recoverable; logged at debug (B4-RD-4)
         logger.debug(f"workflow_run migration skipped: {e}")
 
@@ -812,8 +837,22 @@ def _migrate_workflow_run_step() -> None:
     block, so the combined body now issues FOUR guarded ``ALTER`` statements, not
     one. The risk #583 minimised is materially larger than either change assumed
     alone. #583's mitigation (assert the column exists on a fresh database) is
-    therefore MORE load-bearing after this merge, and #504's three columns have no
-    equivalent assertion. Flagged rather than silently reconciled.
+    therefore MORE load-bearing after this merge. Flagged rather than silently
+    reconciled.
+
+    CORRECTION (2026-08-18, issue #583 Bolt 2, unit ``manifest-column``). The
+    sentence above previously ended by claiming that "#504's three columns have no
+    equivalent assertion". **That claim was false and has been removed.** All three
+    ARE asserted, in ``test/clients/test_workflow_run_migration.py``: ``terminal_id``,
+    ``reprompted`` and ``error_kind`` appear in ``test_workflow_run_step_columns``'s
+    exact ``set(cols) == {...}`` column set, and each carries a nullable check
+    (``[3] == 0``) plus a default check (``[4] == "NULL"``) in the same test. The
+    locations are named here so the denial cannot rot back: a reader who believed it
+    would add a duplicate assertion to close a gap that does not exist. What DOES
+    survive from the note above is the crowding itself — four guarded ``ALTER``
+    statements under one silent ``except`` is a real and growing risk, and adopting a
+    migration framework for it is recorded as a candidate decision (out of scope for
+    a single additive column).
     """
     import sqlite3
 

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -314,6 +314,9 @@ def init_db() -> None:
     # #504 also migrates, so registry order is immaterial — never reorder the
     # entries above.
     _migrate_memory_relationships()
+    # Appended LAST (issue #583 Bolt 2, ``approval-store``). Disjoint from every table above —
+    # its own new table, no shared columns — so registry order is immaterial here too.
+    _migrate_workflow_plan_approval()
 
 
 def _restrict_db_file_permissions() -> None:
@@ -537,6 +540,52 @@ def _migrate_memory_relationships() -> None:
             _backfill_legacy_related_keys(conn)
     except Exception as e:
         logger.debug(f"memory_relationships migration skipped: {e}")
+
+
+def _migrate_workflow_plan_approval() -> None:
+    """Create the durable ``workflow_plan_approval`` table if missing (issue #583 Bolt 2, ``approval-store``).
+
+    FR-8's re-approval mechanism: one row per APPROVED PLAN, keyed by the ``plan_id`` that
+    ``plan_identifier.compute`` derives from a run's execution-affecting fields. A changed plan produces a
+    different ``plan_id``, finds no row, and is refused until it is approved in its own right.
+
+    ``plan_id`` IS THE PRIMARY KEY, so one-approval-per-plan is enforced by the database rather than by code
+    remembering to check. Combined with ``INSERT OR IGNORE`` in ``services/approval_store.py``, that makes an
+    approval WRITE-ONCE: a repeated grant cannot overwrite the original ``approved_at`` / ``approved_by``, and
+    there is no update path at all. That absence is deliberate and is the unit's central control — an update
+    would let an existing approval be pointed at a changed plan, so the row would read as approved while the
+    work behind it had never been reviewed.
+
+    KEYED BY PLAN, NOT BY RUN, and deliberately carrying NO foreign key to ``workflow_run``: an approval's
+    lifetime is independent of any run, so deleting a run must not be able to revoke one.
+
+    Idempotent, zero-arg, self-connecting; failure logged at debug and never propagated (B4-BR-1 / B4-RD-4),
+    same precedent as every migrator above. Because that failure is SILENT, the table's existence is VERIFIED
+    rather than assumed: see ``test/services/test_approval_store.py`` for the ``PRAGMA table_info`` assertion on
+    a fresh database. A missing table makes every approval lookup answer False, which refuses every run —
+    fail-closed, but diagnosed far from its cause.
+
+    NOT registered in ``workflow_journal``'s ``_REQUIRED_RUN_COLUMNS`` / ``_REQUIRED_STEP_COLUMNS``. That
+    verification is scoped to the columns the JOURNAL's own SQL reads, and this table is read by neither, so
+    coupling the journal's connection cache to it would be wrong. The consequence is that this table gets no
+    runtime self-healing the way ``manifest_json`` does; ``approval_store._connect`` runs this migrator on every
+    connect instead, so a transient failure is retried on the next operation.
+    """
+    import sqlite3
+
+    from cli_agent_orchestrator.constants import DATABASE_FILE
+
+    try:
+        with sqlite3.connect(str(DATABASE_FILE)) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS workflow_plan_approval ("
+                "plan_id TEXT PRIMARY KEY, "
+                "approved_at TEXT NOT NULL, "
+                "approved_by TEXT NOT NULL"
+                ")"
+            )
+    except Exception as e:  # noqa: BLE001 — derived/recoverable; logged at debug (B4-RD-4)
+        logger.debug(f"workflow_plan_approval migration skipped: {e}")
 
 
 def _backfill_legacy_related_keys(conn: Any) -> None:

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -786,6 +786,25 @@ WORKFLOW_INPUTS_MAX_BYTES = 32768
 # eviction for this column.
 WORKFLOW_JOURNAL_RESULT_MAX_BYTES = 32768
 
+# Byte bound on the persisted execution manifest envelope (issue #583 Bolt 2, NFR-1 /
+# ADR-583-12). Applied to the compact-JSON encoding AFTER redaction (never before — a
+# secret straddling the bound would otherwise survive), on the UTF-8 byte length rather
+# than the character count, because the bound is a storage limit.
+#
+# 256 KiB MATCHES WORKFLOW_MAX_SPEC_BYTES RATHER THAN THE 32768 USED BY ITS TWO
+# NEIGHBOURS, AND THE ARITHMETIC IS THE REASON. The manifest CONTAINS the resolved
+# inputs map, which is separately allowed up to WORKFLOW_INPUTS_MAX_BYTES (32768). A
+# 32 KiB manifest bound would therefore be tighter than one of its own eleven fields:
+# any workflow using its full inputs allowance would truncate on EVERY run, and what
+# gets sacrificed is the frozen memory content — FR-9's entire payload. Truncation would
+# become the normal case, destroying the ``truncated`` flag's value as a signal.
+#
+# The cost is accepted deliberately: this is the loosest of the workflow bounds, in a
+# column with no eviction. Mitigating facts — it is one row per RUN rather than per step,
+# the flag makes truncation visible when it does fire, and this is a named constant that
+# is cheap to tighten if truncation is never observed in practice.
+WORKFLOW_MANIFEST_MAX_BYTES = 256 * 1024
+
 # Units (from units-generation) whose constructs are EXECUTABLE in the current
 # Bolt. Empty in Bolt 1: the run engine (N5) is not shipped, so every
 # non-sequential mode and every loop/conditional construct tags as reserved.

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -661,6 +661,25 @@ WORKFLOW_INPUTS_MAX_BYTES = 32768
 # eviction for this column.
 WORKFLOW_JOURNAL_RESULT_MAX_BYTES = 32768
 
+# Byte bound on the persisted execution manifest envelope (issue #583 Bolt 2, NFR-1 /
+# ADR-583-12). Applied to the compact-JSON encoding AFTER redaction (never before — a
+# secret straddling the bound would otherwise survive), on the UTF-8 byte length rather
+# than the character count, because the bound is a storage limit.
+#
+# 256 KiB MATCHES WORKFLOW_MAX_SPEC_BYTES RATHER THAN THE 32768 USED BY ITS TWO
+# NEIGHBOURS, AND THE ARITHMETIC IS THE REASON. The manifest CONTAINS the resolved
+# inputs map, which is separately allowed up to WORKFLOW_INPUTS_MAX_BYTES (32768). A
+# 32 KiB manifest bound would therefore be tighter than one of its own eleven fields:
+# any workflow using its full inputs allowance would truncate on EVERY run, and what
+# gets sacrificed is the frozen memory content — FR-9's entire payload. Truncation would
+# become the normal case, destroying the ``truncated`` flag's value as a signal.
+#
+# The cost is accepted deliberately: this is the loosest of the workflow bounds, in a
+# column with no eviction. Mitigating facts — it is one row per RUN rather than per step,
+# the flag makes truncation visible when it does fire, and this is a named constant that
+# is cheap to tighten if truncation is never observed in practice.
+WORKFLOW_MANIFEST_MAX_BYTES = 256 * 1024
+
 # Units (from units-generation) whose constructs are EXECUTABLE in the current
 # Bolt. Empty in Bolt 1: the run engine (N5) is not shipped, so every
 # non-sequential mode and every loop/conditional construct tags as reserved.

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -2641,6 +2641,59 @@ async def workflow_start(
 
 
 @mcp.tool()
+async def workflow_plan_approval(
+    run_id: str = Field(description="The run id to report on (from workflow_start / workflow_run)"),
+) -> Dict[str, Any]:
+    """Report a run's plan identifier and whether that plan is approved (issue #583 FR-8).
+
+    READ-ONLY. THERE IS DELIBERATELY NO TOOL THAT GRANTS AN APPROVAL, and that absence is the
+    control: an approval is a human decision about a plan, and a tool that let you approve the plan
+    you just wrote would make the approval gate decorative in exactly the case it was designed for.
+    Approving is ``cao workflow approve <plan_id>`` at a human's terminal, behind the ``cao:admin``
+    scope. Use this tool to tell the operator which ``plan_id`` to approve.
+
+    WHAT IS NOT IMPLEMENTED, stated because you may otherwise assume it: a plan identifier covers the
+    workflow's execution-affecting fields, so changing any of them yields a different ``plan_id`` that
+    needs its own approval. But **rejection of an update presenting a stale source hash is NOT yet
+    implemented** — do not rely on a stale-hash check having run. Six manifest fields (provider,
+    model, profile, permissions, limits, retry policy) are also **omitted rather than recorded**,
+    because script-tier steps are discovered by executing the Python and so have no run-level value at
+    freeze time; they are covered transitively by the source hash.
+
+    Approval enforcement is **off by default**. When it is off, an unapproved plan still runs, and
+    ``approved: false`` here is informational rather than a prediction that the run will be refused.
+
+    ``plan_id`` is ``null`` for a YAML run (which never freezes a manifest) and for a script run whose
+    freeze failed. That is reported distinctly from "not approved", because the two call for entirely
+    different actions.
+
+    Returns a structured envelope on EVERY path — never raises into the agent loop (EV-1).
+    """
+    try:
+        response = requests.get(
+            f"{API_BASE_URL}/workflows/runs/{run_id}/plan",
+            timeout=_mcp_timeout(),
+        )
+    except requests.RequestException as e:
+        return {"ok": False, "error": f"could not reach cao-server: {e}"}
+
+    if response.status_code != 200:
+        detail = _extract_error_detail(response, f"status {response.status_code}")
+        return {"ok": False, "error": detail}
+
+    data = response.json()
+    return {
+        "ok": True,
+        "run_id": data.get("run_id"),
+        "tier": data.get("tier"),
+        "plan_id": data.get("plan_id"),
+        "approved": data.get("approved"),
+        "approved_at": data.get("approved_at"),
+        "approved_by": data.get("approved_by"),
+    }
+
+
+@mcp.tool()
 async def workflow_status(
     run_id: str = Field(description="The run id to snapshot (from workflow_start / workflow_run)"),
 ) -> Dict[str, Any]:

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -609,8 +609,11 @@ async def run_agent_step(
     #
     # ``None`` — a non-workflow caller, a YAML run, a run with no manifest, or a persist that failed —
     # means "pass nothing", and ``send_input`` then behaves exactly as it always has.
-    frozen_memory = frozen_run_memory.frozen_memory_for(
-        (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"), terminal_id, prompt
+    frozen_memory = await asyncio.to_thread(
+        frozen_run_memory.frozen_memory_for,
+        (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"),
+        terminal_id,
+        prompt,
     )
     if frozen_memory is None:
         # The call is left BYTE-IDENTICAL on the no-frozen-block path, rather than passing an extra
@@ -620,7 +623,10 @@ async def run_agent_step(
         await asyncio.to_thread(terminal_service.send_input, terminal_id, prompt)
     else:
         await asyncio.to_thread(
-            terminal_service.send_input, terminal_id, prompt, frozen_memory=frozen_memory
+            terminal_service.send_input,
+            terminal_id,
+            prompt,
+            frozen_memory=frozen_memory,
         )
 
     # Wait for completion — IN-PROCESS poll of status_monitor (NOT the

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -31,7 +31,7 @@ from cli_agent_orchestrator.models.provider import ProviderType
 from cli_agent_orchestrator.models.terminal import AgentStepResult, TerminalStatus
 from cli_agent_orchestrator.plugins import PluginRegistry
 from cli_agent_orchestrator.providers.kiro_capabilities import KiroPhase0KASError
-from cli_agent_orchestrator.services import terminal_service
+from cli_agent_orchestrator.services import frozen_run_memory, terminal_service
 from cli_agent_orchestrator.services.status_monitor import status_monitor
 from cli_agent_orchestrator.services.step_fingerprint import StepCallFields, compute
 from cli_agent_orchestrator.services.terminal_service import OutputMode
@@ -598,7 +598,30 @@ async def run_agent_step(
     # key sends); run it off the event loop so a slow tmux call cannot freeze
     # the whole server for other requests (same hazard as issue #382, which was
     # only fixed for DELETE /sessions). Any failure raises and propagates.
-    await asyncio.to_thread(terminal_service.send_input, terminal_id, prompt)
+    # issue #583 Bolt 2, ``memory-resolve-once``: hand this run's FROZEN memory block to the terminal
+    # so a replayed run sees the memory the ORIGINAL run recorded rather than the store's state today
+    # (FR-9). The run id is read from ``env_vars`` rather than taken as a new parameter, because the
+    # engine already sets ``CAO_WORKFLOW_RUN_ID`` there for the worker's ``workflow_return`` routing.
+    #
+    # Resolution happens HERE and nowhere earlier, which is the requirement rather than an
+    # optimisation: a run that never creates a terminal must resolve nothing, because an unresolved
+    # block is sensitive text that would be stored for no reason (NFR-1).
+    #
+    # ``None`` — a non-workflow caller, a YAML run, a run with no manifest, or a persist that failed —
+    # means "pass nothing", and ``send_input`` then behaves exactly as it always has.
+    frozen_memory = frozen_run_memory.frozen_memory_for(
+        (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"), terminal_id, prompt
+    )
+    if frozen_memory is None:
+        # The call is left BYTE-IDENTICAL on the no-frozen-block path, rather than passing an extra
+        # `None`. Existing tests assert this exact two-argument shape, and keeping them passing
+        # unchanged is the strongest available evidence for C-1: a non-workflow step reaches
+        # ``send_input`` exactly as it did before this unit.
+        await asyncio.to_thread(terminal_service.send_input, terminal_id, prompt)
+    else:
+        await asyncio.to_thread(
+            terminal_service.send_input, terminal_id, prompt, frozen_memory=frozen_memory
+        )
 
     # Wait for completion — IN-PROCESS poll of status_monitor (NOT the
     # HTTP-polling wait_until_terminal_status, which would reintroduce the

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -31,7 +31,7 @@ from cli_agent_orchestrator.models.provider import ProviderType
 from cli_agent_orchestrator.models.terminal import AgentStepResult, TerminalStatus
 from cli_agent_orchestrator.plugins import PluginRegistry
 from cli_agent_orchestrator.providers.kiro_capabilities import KiroPhase0KASError
-from cli_agent_orchestrator.services import terminal_service
+from cli_agent_orchestrator.services import frozen_run_memory, terminal_service
 from cli_agent_orchestrator.services.status_monitor import status_monitor
 from cli_agent_orchestrator.services.step_fingerprint import StepCallFields, compute
 from cli_agent_orchestrator.services.terminal_service import OutputMode
@@ -703,7 +703,30 @@ async def run_agent_step(
     # key sends); run it off the event loop so a slow tmux call cannot freeze
     # the whole server for other requests (same hazard as issue #382, which was
     # only fixed for DELETE /sessions). Any failure raises and propagates.
-    await asyncio.to_thread(terminal_service.send_input, terminal_id, prompt)
+    # issue #583 Bolt 2, ``memory-resolve-once``: hand this run's FROZEN memory block to the terminal
+    # so a replayed run sees the memory the ORIGINAL run recorded rather than the store's state today
+    # (FR-9). The run id is read from ``env_vars`` rather than taken as a new parameter, because the
+    # engine already sets ``CAO_WORKFLOW_RUN_ID`` there for the worker's ``workflow_return`` routing.
+    #
+    # Resolution happens HERE and nowhere earlier, which is the requirement rather than an
+    # optimisation: a run that never creates a terminal must resolve nothing, because an unresolved
+    # block is sensitive text that would be stored for no reason (NFR-1).
+    #
+    # ``None`` — a non-workflow caller, a YAML run, a run with no manifest, or a persist that failed —
+    # means "pass nothing", and ``send_input`` then behaves exactly as it always has.
+    frozen_memory = frozen_run_memory.frozen_memory_for(
+        (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"), terminal_id, prompt
+    )
+    if frozen_memory is None:
+        # The call is left BYTE-IDENTICAL on the no-frozen-block path, rather than passing an extra
+        # `None`. Existing tests assert this exact two-argument shape, and keeping them passing
+        # unchanged is the strongest available evidence for C-1: a non-workflow step reaches
+        # ``send_input`` exactly as it did before this unit.
+        await asyncio.to_thread(terminal_service.send_input, terminal_id, prompt)
+    else:
+        await asyncio.to_thread(
+            terminal_service.send_input, terminal_id, prompt, frozen_memory=frozen_memory
+        )
 
     # Wait for completion — IN-PROCESS poll of status_monitor (NOT the
     # HTTP-polling wait_until_terminal_status, which would reintroduce the

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -714,8 +714,11 @@ async def run_agent_step(
     #
     # ``None`` — a non-workflow caller, a YAML run, a run with no manifest, or a persist that failed —
     # means "pass nothing", and ``send_input`` then behaves exactly as it always has.
-    frozen_memory = frozen_run_memory.frozen_memory_for(
-        (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"), terminal_id, prompt
+    frozen_memory = await asyncio.to_thread(
+        frozen_run_memory.frozen_memory_for,
+        (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"),
+        terminal_id,
+        prompt,
     )
     if frozen_memory is None:
         # The call is left BYTE-IDENTICAL on the no-frozen-block path, rather than passing an extra
@@ -725,7 +728,10 @@ async def run_agent_step(
         await asyncio.to_thread(terminal_service.send_input, terminal_id, prompt)
     else:
         await asyncio.to_thread(
-            terminal_service.send_input, terminal_id, prompt, frozen_memory=frozen_memory
+            terminal_service.send_input,
+            terminal_id,
+            prompt,
+            frozen_memory=frozen_memory,
         )
 
     # Wait for completion — IN-PROCESS poll of status_monitor (NOT the

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -607,8 +607,9 @@ async def run_agent_step(
     # optimisation: a run that never creates a terminal must resolve nothing, because an unresolved
     # block is sensitive text that would be stored for no reason (NFR-1).
     #
-    # ``None`` — a non-workflow caller, a YAML run, a run with no manifest, or a persist that failed —
-    # means "pass nothing", and ``send_input`` then behaves exactly as it always has.
+    # ``None`` means there is no workflow manifest to honour, so use the historical live-memory path.
+    # ``""`` is different: it means an existing manifest's memory fill could not persist and MUST be
+    # passed through explicitly, suppressing ``send_input``'s live-memory fallback.
     frozen_memory = await asyncio.to_thread(
         frozen_run_memory.frozen_memory_for,
         (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"),

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -712,8 +712,9 @@ async def run_agent_step(
     # optimisation: a run that never creates a terminal must resolve nothing, because an unresolved
     # block is sensitive text that would be stored for no reason (NFR-1).
     #
-    # ``None`` — a non-workflow caller, a YAML run, a run with no manifest, or a persist that failed —
-    # means "pass nothing", and ``send_input`` then behaves exactly as it always has.
+    # ``None`` means there is no workflow manifest to honour, so use the historical live-memory path.
+    # ``""`` is different: it means an existing manifest's memory fill could not persist and MUST be
+    # passed through explicitly, suppressing ``send_input``'s live-memory fallback.
     frozen_memory = await asyncio.to_thread(
         frozen_run_memory.frozen_memory_for,
         (env_vars or {}).get("CAO_WORKFLOW_RUN_ID"),

--- a/src/cli_agent_orchestrator/services/approval_gate.py
+++ b/src/cli_agent_orchestrator/services/approval_gate.py
@@ -1,0 +1,142 @@
+"""Refuse an unapproved script-tier run (issue #583 Bolt 2, unit ``approval-gate``).
+
+FR-8's enforcement half. ``approval_store`` can say whether a ``plan_id`` is approved and
+``manifest_freeze`` computes that ``plan_id`` at run start; this module is the first code in Bolt 2
+that can actually STOP a run, and both freeze call sites already carry the written promise that
+something will — "writes NULL and fails CLOSED at the approval gate".
+
+ENFORCEMENT IS OPT-IN AND DEFAULTS OFF, WHICH IS A SECURITY DECISION RATHER THAN A CONCESSION.
+``manifest_freeze.build_manifest_json`` is total: it returns ``None`` on any failure, which writes a
+NULL manifest, which refuses here. Each of those is individually right. Composed under an always-on
+gate they mean a TRANSIENT freeze failure refuses a run with nothing wrong with it. Fail-closed is
+the right posture for a control someone deliberately switched on and the wrong one to impose on every
+user of a feature that has no in-product way to grant approval until Bolt 3.
+
+THE GATE REPORTS; IT DOES NOT FORM AN OPINION ABOUT WHETHER AN APPROVAL EXISTS.
+``approval_store.is_approved`` is the sole authority, is already total, and already answers ``False``
+on a database error. A second opinion here would be the copy that drifts — and a drifted
+authorisation check is the kind that looks correct while permitting something.
+
+IT SITS BEFORE THE FIRST IRREVERSIBLE ACT ON BOTH PATHS, and the two placements are not symmetric
+because what they protect is not the same thing:
+
+* **start** — before the ``workflow_run`` INSERT. A refused start leaves NO row: a run row is a
+  record of a run, and every first run of every new plan is refused by design, so recording them
+  would durably record runs that never happened.
+* **resume** — as a fifth check in ``resume_script_run``'s admission ladder, AFTER its existing four
+  (absent / live / not-resumable / corrupt) and BEFORE the generation bump. The bump fences out any
+  still-live process for that run, so bumping and then refusing would kill a possibly-healthy run on
+  behalf of a resume that was itself rejected. Two losses from one refusal.
+
+YAML RUNS ARE OUTSIDE THIS GATE BY CONSTRUCTION, not by a check that could pass for the wrong reason:
+the tier is already recorded on every run (``insert_run``'s ``tier: str = "yaml"``, with script runs
+passing ``"script"`` explicitly), so C-1 is met structurally.
+
+THIS IS A SAME-USER LOCAL CONTROL, NOT A PRIVILEGE BOUNDARY. CAO runs as the invoking user and a
+workflow script runs as that same user, so a script could edit ``settings.json`` or write to
+``workflow_plan_approval`` directly. That is inherent to a local single-user tool. What the gate does
+provide is that a plan cannot execute UNNOTICED under an approval granted for a different plan, which
+is FR-8's property and is worth having on its own terms. Documenting it as stronger than it is would
+be the actual defect.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from cli_agent_orchestrator.services import approval_store
+from cli_agent_orchestrator.services.settings_service import is_workflow_approval_required
+
+logger = logging.getLogger(__name__)
+
+SCRIPT_TIER = "script"
+
+
+class PlanApprovalRequiredError(Exception):
+    """A script-tier run was refused because its ``plan_id`` has no approval.
+
+    DELIBERATELY NOT A ``ValueError``. The API's resume handler ends with ``except ValueError -> 400``,
+    so subclassing it would silently transport this as a bad request. It is also deliberately NOT
+    ``ResumeNotAllowedError`` (409): that means "this run cannot be resumed" — a fact about the run —
+    whereas this is a fact about the PLAN, and the operator's next action is entirely different
+    (approve a ``plan_id`` versus investigate a stuck run). ``unit-of-work.md`` names this seam: the
+    failure must be "distinguishable from an ordinary execution error so a caller can tell 'needs
+    approval' from 'the run broke'". Transported as 403.
+
+    ``plan_id`` is carried explicitly because it is the operator's ONLY handle on what to approve. It
+    is ``None`` only when the manifest was absent or unparseable, and the message says so.
+    """
+
+    def __init__(self, message: str, plan_id: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.plan_id = plan_id
+
+
+def plan_id_from_manifest(manifest_json: Optional[str]) -> Optional[str]:
+    """Extract ``plan_id`` from a frozen manifest, or ``None`` if it cannot be read.
+
+    Total by design: a malformed manifest is an expected condition here, not an error. Every way this
+    can answer ``None`` converges on a refusal at :func:`ensure_plan_approved`, so absence never
+    becomes permission.
+
+    NEVER RECOMPUTES the identifier. On resume, recomputation would re-read the script from disk, so a
+    source edit between start and resume would produce a different ``plan_id`` and refuse a run whose
+    approval is perfectly valid for what it actually froze. Rejecting a stale source hash is a
+    separate mechanism, deferred to Bolt 3. Using one extraction on both paths also means the start
+    and resume gates cannot disagree about what the identifier is.
+    """
+    if not manifest_json:
+        return None
+    try:
+        document = json.loads(manifest_json)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(document, dict):
+        return None
+    plan_id = document.get("plan_id")
+    return plan_id if isinstance(plan_id, str) and plan_id else None
+
+
+def ensure_plan_approved(*, tier: str, manifest_json: Optional[str]) -> None:
+    """Raise :class:`PlanApprovalRequiredError` unless this run may proceed.
+
+    Returns ``None`` on every permitted path. Called from three places — the async start arm, the
+    blocking start arm, and resume admission — as ONE function rather than three inline checks,
+    because three copies of an authorisation check is three chances for one to drift, and both start
+    arms must agree or a run's approvability would depend on which route started it.
+
+    Two independent gates on applicability, both kept on purpose. The tier check is structural and
+    the setting is operational; either alone would satisfy C-1's letter, but a future flip of the
+    default must not silently start gating YAML.
+    """
+    if tier != SCRIPT_TIER:
+        return
+    if not is_workflow_approval_required():
+        # The default. is_approved is not called, so the disabled path cannot fail a run.
+        return
+
+    plan_id = plan_id_from_manifest(manifest_json)
+    if plan_id is None:
+        # Fail closed, exactly as both freeze call sites already promise in writing. A freeze that
+        # failed wrote NULL, and NULL is indistinguishable from a YAML run at the column level — but
+        # not here, because the tier already told us this is a script run.
+        logger.warning(
+            "workflow approval gate: refusing a script run with no readable plan_id in its "
+            "frozen manifest (approval is required by settings)"
+        )
+        raise PlanApprovalRequiredError(
+            "This script-tier run has no readable plan identifier in its frozen execution "
+            "manifest, so it cannot be matched against an approval. Approval is required by "
+            "workflow.require_approval."
+        )
+
+    if not approval_store.is_approved(plan_id):
+        # A control that refuses without saying which plan cannot be operated. plan_id is an opaque
+        # digest, so logging it adds nothing sensitive.
+        logger.warning("workflow approval gate: refusing unapproved plan_id %s", plan_id)
+        raise PlanApprovalRequiredError(
+            f"Plan '{plan_id}' has not been approved. Approve this plan identifier and run again. "
+            "Note that a plan_id is computed at run start, so the first run of a new or changed "
+            "plan is refused by design.",
+            plan_id=plan_id,
+        )

--- a/src/cli_agent_orchestrator/services/approval_provenance.py
+++ b/src/cli_agent_orchestrator/services/approval_provenance.py
@@ -1,0 +1,67 @@
+"""Resolve who approved a plan, bounded (issue #583 Bolt 2, unit ``approval-operation``).
+
+This exists as its own module for one reason: it is the discharge of ``SR-2B1-7``, an obligation
+``approval-store`` carried unowned across two units — *"``approved_by``'s length and provenance are
+``approval-operation``'s to constrain"* — and an obligation that lives inside a request handler is an
+obligation nobody can find or test.
+
+IT IS A PROVENANCE NOTE AND NOT AN IDENTITY CLAIM, and every description of it must say so. CAO runs
+as the invoking user and nothing here verifies anything; ``approval-gate`` already recorded the bound
+(``SR-2B4-12``: a same-user local control, not a privilege boundary). What this value can honestly
+report is which local account ran the approve command. Documenting it as more than that would be the
+defect.
+
+IT IS BOUNDED BECAUSE IT IS INPUT, WHICH IS THE PART THAT LOOKS WRONG UNTIL YOU CHECK.
+``getpass.getuser()`` resolves from ``LOGNAME`` / ``USER`` / ``LNAME`` / ``USERNAME`` before falling
+back to the password database — environment variables, hence caller-influenced. Its air of being an
+ambient fact about the machine is exactly what would get it written to a durable row unchecked. Two
+concrete consequences if it were not bounded:
+
+* an arbitrarily long value grows a write-once row that can never be updated or deleted;
+* a value containing a newline splits one log line into two apparent events, and this unit logs
+  ``approved_by`` at ``info`` as the only record of when an approval intent was expressed.
+"""
+
+import getpass
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Comfortably longer than any real account name, short enough that a crafted value cannot grow the
+#: row. ``approval-store``'s column is unbounded TEXT, so the bound has to live here.
+APPROVED_BY_MAX_LENGTH = 64
+
+#: Used when the account cannot be resolved at all. Obviously generic on purpose — it must not be
+#: mistakable for a real username, because a reader comparing two rows should be able to tell
+#: "unknown" from "someone called unknown".
+UNRESOLVED_ACCOUNT = "unknown-local-account"
+
+
+def bound(value: str) -> str:
+    """Strip control characters and truncate to :data:`APPROVED_BY_MAX_LENGTH`.
+
+    Separate from :func:`local_account` so the bounding rule can be tested directly against hostile
+    values rather than only through whatever the test machine's environment happens to hold.
+    """
+    cleaned = "".join(ch for ch in value if ch.isprintable())
+    cleaned = cleaned.strip()
+    if not cleaned:
+        return UNRESOLVED_ACCOUNT
+    return cleaned[:APPROVED_BY_MAX_LENGTH]
+
+
+def local_account() -> str:
+    """The local OS account, bounded. NEVER raises.
+
+    A grant must not fail because a provenance note could not be written: the operator's intent is
+    the point, and this value is a note about it. Anything unresolvable becomes
+    :data:`UNRESOLVED_ACCOUNT`.
+    """
+    try:
+        raw = getpass.getuser()
+    except Exception as e:  # noqa: BLE001 — a note must never fail the operation it annotates
+        logger.warning("could not resolve the local account for an approval: %s", e)
+        return UNRESOLVED_ACCOUNT
+    if not isinstance(raw, str):
+        return UNRESOLVED_ACCOUNT
+    return bound(raw)

--- a/src/cli_agent_orchestrator/services/approval_store.py
+++ b/src/cli_agent_orchestrator/services/approval_store.py
@@ -1,0 +1,127 @@
+"""The durable plan-approval record (issue #583 Bolt 2, unit ``approval-store``).
+
+FR-8's re-approval mechanism, and nothing more. One row per approved plan, keyed by the ``plan_id`` that
+``plan_identifier.compute`` derives from a run's execution-affecting fields: a changed plan produces a
+different ``plan_id``, finds no row, and is refused until approved in its own right.
+
+THIS MODULE DECIDES NOTHING ABOUT EXECUTION. ``components.md`` is explicit that ``PlanApprovalBinding``
+"consumes the manifest; decides nothing about execution" — it answers "does an approval exist for this
+``plan_id``?" and stops. Whether that permits a run is ``approval-gate``'s call (unit 7). Two places deciding
+whether a run may proceed means the second one drifts, and a drifted authorisation check is the kind that looks
+correct while permitting something.
+
+THERE IS NO UPDATE, NO DELETE AND NO REPLACING UPSERT, AND THAT ABSENCE IS THE CENTRAL CONTROL. An update path
+would let a caller point an existing approval at a changed plan: the row would read as approved, its timestamp
+would look recent, and **work nobody reviewed would execute with a genuine approval behind it** — not a bypass
+of the gate, but a corruption of the thing the gate consults. ``grant`` therefore uses ``INSERT OR IGNORE``, so
+write-once is a property of the statement rather than of a caller remembering to look first.
+
+ABSENCE MEANS UNAPPROVED, AND THAT IS WHY EVERY FAULT HERE IS SAFE. A missing table, a silent migration
+failure, a database error — all converge on "no row found". Because absence answers False rather than raising or
+defaulting open, each of those becomes a REFUSED RUN rather than an authorisation bypass. Fail-closed, the same
+direction pass 2A established for an absent manifest.
+
+``plan_id`` IS OPAQUE: stored and compared verbatim, never parsed, never normalised. A normalisation is how two
+distinct plans could come to share one approval, and ``plan-v1:``'s versioned prefix exists precisely so a
+future scheme is DISTINGUISHABLE rather than silently comparable.
+
+ONE CONSEQUENCE AN OPERATOR WILL MEET, so it is written down. ``plan_id`` does not exist until
+``manifest-freeze`` computes it at run start, so a plan that has never been started cannot have been approved —
+**the first run of any new plan is refused by design.** The loop is: run refused, ``plan_id`` reported, approve,
+re-run. That friction is temporary rather than intrinsic: Bolt 3's authoring sequence presents the plan and
+takes approval BEFORE running. ``approval-gate``'s refusal message MUST carry the ``plan_id``, or the operator
+has nothing to act on.
+"""
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from cli_agent_orchestrator.clients.database import _migrate_workflow_plan_approval
+from cli_agent_orchestrator.constants import DATABASE_FILE
+
+
+@dataclass(frozen=True)
+class PlanApproval:
+    """One ``workflow_plan_approval`` row. Frozen: an approval is a record, not a mutable state."""
+
+    plan_id: str
+    approved_at: str
+    approved_by: str
+
+
+def _now() -> str:
+    """UTC ISO timestamp, matching ``workflow_run.started_at``'s convention so the two compare alike."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _connect() -> sqlite3.Connection:
+    """Open a connection, ensuring the table exists first.
+
+    THE MIGRATOR RUNS ON EVERY CONNECT, AND THAT IS NOT BELT-AND-BRACES. Relying on ``init_db`` alone is
+    verifiably insufficient: ``workflow_journal``'s own ``_MIGRATED_PATHS`` comment records that **five test
+    modules repoint ``DATABASE_FILE`` to a temporary path mid-process**, which is exactly why the journal does
+    not trust the lifespan either. Without this call the table would be absent precisely where this unit's tests
+    and ``approval-gate``'s run, and every lookup would answer "not approved" — refusing every run.
+
+    DELIBERATELY NOT MEMOISED, unlike the journal. It needed ``_MIGRATED_PATHS`` because it re-ran two migrators
+    plus DDL on EVERY journal call; this issues one idempotent ``CREATE TABLE IF NOT EXISTS`` before an
+    operation that happens once per run start. A cache would also require the column verification the journal
+    learned it needed — because a migrator that swallows failure "RETURNS NORMALLY when it fails" and so
+    establishes nothing — which is a lot of machinery for three columns. Revisit if this table ever lands on a
+    hot path.
+    """
+    _migrate_workflow_plan_approval()
+    return sqlite3.connect(str(DATABASE_FILE))
+
+
+def grant(plan_id: str, approved_by: str) -> None:
+    """Record an approval for ``plan_id``. Write-once: a repeated grant is a no-op.
+
+    ``INSERT OR IGNORE`` rather than a plain ``INSERT`` so a second grant for an already-approved plan neither
+    errors nor overwrites the original ``approved_at`` / ``approved_by``. Harmless to repeat, impossible to
+    rewrite.
+    """
+    with _connect() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO workflow_plan_approval (plan_id, approved_at, approved_by) "
+            "VALUES (?, ?, ?)",
+            (plan_id, _now(), approved_by),
+        )
+
+
+def is_approved(plan_id: str) -> bool:
+    """Does an approval exist for ``plan_id``? TOTAL — never raises, and absence answers ``False``.
+
+    The one question this module answers. It reports a fact; it does not decide whether a run may proceed.
+    """
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM workflow_plan_approval WHERE plan_id = ?", (plan_id,)
+            ).fetchone()
+        return row is not None
+    except sqlite3.Error:
+        # A database fault is not permission. Answering False keeps every failure mode fail-closed:
+        # the run is refused rather than admitted on the strength of an error.
+        return False
+
+
+def get_approval(plan_id: str) -> Optional[PlanApproval]:
+    """The approval record for ``plan_id``, or ``None``. TOTAL — never raises.
+
+    FOR DIAGNOSIS, NOT FOR DECIDING. "When, and by whom" is the first question a refused operator asks;
+    ``approval-gate`` should still route on :func:`is_approved`.
+    """
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT plan_id, approved_at, approved_by FROM workflow_plan_approval WHERE plan_id = ?",
+                (plan_id,),
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    return PlanApproval(plan_id=row[0], approved_at=row[1], approved_by=row[2])

--- a/src/cli_agent_orchestrator/services/execution_manifest.py
+++ b/src/cli_agent_orchestrator/services/execution_manifest.py
@@ -1,0 +1,296 @@
+"""Build, serialise and parse the frozen execution manifest (issue #583, unit ``manifest-envelope``).
+
+One bounded, secret-redacted record of HOW a run was launched, persisted as a single
+``workflow_run.manifest_json`` value (ADR-583-12). Every re-approval decision in Bolt 2 compares a
+``plan_id`` read out of this envelope, and FR-9's guarantee that a resumed run is insulated from
+later edits to durable memory rests on the memory record it carries.
+
+LEAF MODULE: imports ``secret_gate``, ``constants``, ``dataclasses``, ``hashlib``, ``json`` and
+``typing`` ONLY. No I/O, no state, no configuration, and NO LOGGING OF ANY KIND. Both are security
+requirements rather than style preferences, and both are PRESERVATION requirements — the
+pure-function shape already has them, and a later "improvement" is what would take them away:
+
+* Nothing is persisted or emitted here beyond the returned envelope. The inputs include ``inputs``
+  and ``permissions``, which is exactly where a credential shows up in practice (a token in a
+  workflow input, a key in a permission grant).
+* NO field value is echoed into a log line, a message, or an exception. The obvious diagnostic
+  instinct ("log the document so we can see what was frozen") moves a credential out of a bounded,
+  redacted column and into a log file, which is typically world-readable on the host and often
+  shipped off it. This module therefore has no logger and no ``print``, matching
+  ``secret_gate.py``'s, ``step_result.py``'s and ``step_fingerprint.py``'s posture.
+
+TWO ORDERINGS ARE PART OF THE CONTRACT, and reversing either is a silent regression:
+
+1. **REDACT BEFORE BOUNDING.** Inherited from ``step_result.build_envelope``, whose docstring calls
+   this "not an implementation preference". Were bounding first, the redactor would only ever see the
+   truncated prefix, so a secret STRADDLING the boundary would be persisted in the clear. The happy
+   path produces an identical-looking envelope either way, which is what makes this the one property
+   here that fails SILENTLY — hence a dedicated test.
+2. **HASH THE MEMORY CONTENT BEFORE REDACTING IT.** ``FrozenMemoryRecord.content_hash`` identifies
+   what was RESOLVED from CAO memory. Hashing post-redaction would make that identity depend on
+   ``secret_gate._SECRET_PATTERNS``, so any later change to the ruleset would silently alter every
+   historical hash and break FR-9's cross-resume comparison at the upgrade. A hash needs no
+   redaction, which is why this module can touch the raw content and remain safe.
+
+THE HASH/CONTENT ASYMMETRY IS DELIBERATE. ``content_hash`` covers the FULL resolved content;
+``content`` stores what FITS. When the bound bites they describe different byte strings, and
+``memory.truncated`` records it. That looks wrong until FR-9 is read precisely: its criterion is that
+altering CAO memory after a failure does not change what a resumed run SEES. **Determinism is the
+requirement; completeness is not.** A truncated block injected identically on every resume satisfies
+FR-9; re-resolving to recover the dropped bytes would violate it, because re-resolution is exactly
+what a post-failure memory edit changes.
+
+WHAT THIS MODULE DOES NOT DO. It does not store the envelope (``manifest-column`` owns the column),
+does not assemble the field values (``manifest-freeze`` owns run-start assembly), does not compute
+``plan_id`` (``plan-identifier`` owns the scheme — this module treats the value as OPAQUE and never
+parses it), and does not resolve memory (``memory-resolve-once`` owns that, and fills the record
+shape defined here).
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from typing import Any, Dict, Optional
+
+from cli_agent_orchestrator.constants import WORKFLOW_MANIFEST_MAX_BYTES
+from cli_agent_orchestrator.services.secret_gate import redact_json_leaves
+
+# Compact separators: the bound is on BYTES, so whitespace is storage spent for nothing.
+# Same form as ``step_result.serialise_envelope``.
+_JSON_SEPARATORS = (",", ":")
+
+
+@dataclass(frozen=True)
+class FrozenMemoryRecord:
+    """FR-9's contribution: the resolved memory block, frozen at run start.
+
+    ``content_hash`` covers the FULL resolved content (see the module docstring); ``content`` holds
+    what survived bounding. ``truncated`` is the flag that makes that asymmetry legible rather than
+    looking like corruption.
+    """
+
+    content: str
+    source: str
+    content_hash: str
+    truncated: bool
+
+
+@dataclass(frozen=True)
+class ExecutionManifestEnvelope:
+    """The value persisted into ``workflow_run.manifest_json``.
+
+    Frozen: FR-8's "frozen manifest" enforced structurally, so nothing downstream can mutate a
+    manifest after it is built. ``plan_id`` is carried OPAQUELY — this module never parses it.
+
+    SIX FIELDS ARE OPTIONAL, AND ``None`` MEANS OMITTED RATHER THAN NULL (issue #583 Bolt 2, unit
+    ``manifest-freeze``). ``provider``, ``model``, ``profile``, ``permissions``, ``limits`` and
+    ``retry_policy`` have NO run-level source in the script tier — each is a per-step argument to
+    ``step()``. :func:`_document` therefore DROPS them when they are ``None`` instead of serialising
+    ``null``, because a ``null`` asserts "this field exists and has no value" while the truth is that
+    the field has no run-level existence in that tier. Six nulls would collapse "not applicable here",
+    "not captured" and "genuinely absent" into one indistinguishable token.
+
+    ``notes`` carries the explanation INTO the envelope. The envelope is what an agent reads when
+    diagnosing a failed run (FR-12's concern), so a divergence from FR-8's field list explained only in
+    a design document is one the reader of the DATA would rediscover — and most likely misread as
+    missing data.
+    """
+
+    plan_id: str
+    source_hash: str
+    inputs: Any
+    repo_baseline: Any
+    provider: Optional[Any]
+    model: Optional[Any]
+    profile: Optional[Any]
+    permissions: Optional[Any]
+    limits: Optional[Any]
+    retry_policy: Optional[Any]
+    memory: FrozenMemoryRecord
+    truncated: bool
+    redacted: bool
+    notes: str = ""
+
+
+# The six fields a caller may legitimately omit, in FR-8's order. Named once so ``_document`` and
+# ``parse`` cannot disagree about which keys are optional.
+_OMITTABLE = ("provider", "model", "profile", "permissions", "limits", "retry_policy")
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _document(envelope: ExecutionManifestEnvelope) -> Dict[str, Any]:
+    """The wire shape. One place, so ``serialise`` and the bounding measurement cannot disagree.
+
+    An omittable field whose value is ``None`` is DROPPED rather than serialised as ``null`` — see the
+    envelope's docstring for why the distinction matters. Because the bounding measurement runs through
+    this same function, an omitted field costs nothing against the byte bound either.
+    """
+    document: Dict[str, Any] = {
+        "plan_id": envelope.plan_id,
+        "source_hash": envelope.source_hash,
+        "inputs": envelope.inputs,
+        "repo_baseline": envelope.repo_baseline,
+    }
+    for name in _OMITTABLE:
+        value = getattr(envelope, name)
+        if value is not None:
+            document[name] = value
+    document["memory"] = {
+        "content": envelope.memory.content,
+        "source": envelope.memory.source,
+        "content_hash": envelope.memory.content_hash,
+        "truncated": envelope.memory.truncated,
+    }
+    document["truncated"] = envelope.truncated
+    document["redacted"] = envelope.redacted
+    if envelope.notes:
+        document["notes"] = envelope.notes
+    return document
+
+
+def _encoded_length(envelope: ExecutionManifestEnvelope) -> int:
+    return len(json.dumps(_document(envelope), separators=_JSON_SEPARATORS).encode("utf-8"))
+
+
+def build(
+    *,
+    plan_id: str,
+    source_hash: str,
+    inputs: Any,
+    repo_baseline: Any,
+    provider: Optional[Any] = None,
+    model: Optional[Any] = None,
+    profile: Optional[Any] = None,
+    permissions: Optional[Any] = None,
+    limits: Optional[Any] = None,
+    retry_policy: Optional[Any] = None,
+    memory_content: str = "",
+    memory_source: str = "",
+    notes: str = "",
+) -> ExecutionManifestEnvelope:
+    """Produce a redacted, bounded, flagged envelope.
+
+    TOTAL: raises nothing on well-typed input (INV: bounding is lossy but never rejects). An
+    oversized document is truncated and flagged, never refused — a run must not fail because its
+    manifest was large.
+
+    Order, per the module docstring: hash the memory content, assemble, redact the whole tree, then
+    measure and bound. ``redacted`` is a bare bool and the matched pattern names are DISCARDED —
+    naming which pattern fired is itself a disclosure about the secret's shape.
+    """
+    # 1. Hash BEFORE redaction: the identity must not depend on the redaction ruleset.
+    memory_hash = _sha256(memory_content)
+
+    # 2. Assemble the pre-redaction document. ``inputs`` is arbitrary user-supplied JSON, which is
+    #    why redaction below has to walk the tree rather than touch a single field.
+    raw: Dict[str, Any] = {
+        "plan_id": plan_id,
+        "source_hash": source_hash,
+        "inputs": inputs,
+        "repo_baseline": repo_baseline,
+        "provider": provider,
+        "model": model,
+        "profile": profile,
+        "permissions": permissions,
+        "limits": limits,
+        "retry_policy": retry_policy,
+        "notes": notes,
+        "memory_content": memory_content,
+        "memory_source": memory_source,
+    }
+
+    # 3. Redact BEFORE bounding. ``redacted`` is derived by comparison rather than by collecting
+    #    pattern names, which keeps the names out of this function entirely.
+    cleaned = redact_json_leaves(raw)
+    redacted = cleaned != raw
+
+    envelope = ExecutionManifestEnvelope(
+        plan_id=cleaned["plan_id"],
+        source_hash=cleaned["source_hash"],
+        inputs=cleaned["inputs"],
+        repo_baseline=cleaned["repo_baseline"],
+        provider=cleaned["provider"],
+        model=cleaned["model"],
+        profile=cleaned["profile"],
+        permissions=cleaned["permissions"],
+        limits=cleaned["limits"],
+        retry_policy=cleaned["retry_policy"],
+        notes=cleaned["notes"],
+        memory=FrozenMemoryRecord(
+            content=cleaned["memory_content"],
+            source=cleaned["memory_source"],
+            content_hash=memory_hash,
+            truncated=False,
+        ),
+        truncated=False,
+        redacted=redacted,
+    )
+
+    # 4. Bound, INCLUSIVELY: a document of exactly the bound is NOT truncated.
+    overflow = _encoded_length(envelope) - WORKFLOW_MANIFEST_MAX_BYTES
+    if overflow <= 0:
+        return envelope
+
+    # The memory content is the field that gives: it is the only field with no natural small bound,
+    # and its hash was already taken over the FULL string, so bounding it loses bytes without losing
+    # identity. Trim by the overflow (plus a margin for the JSON escaping of what remains), then
+    # re-measure rather than trusting the arithmetic.
+    content = envelope.memory.content
+    keep = max(0, len(content.encode("utf-8")) - overflow)
+    while True:
+        trimmed = content.encode("utf-8")[:keep].decode("utf-8", errors="ignore")
+        candidate = replace(
+            envelope,
+            memory=replace(envelope.memory, content=trimmed, truncated=True),
+            truncated=True,
+        )
+        if _encoded_length(candidate) <= WORKFLOW_MANIFEST_MAX_BYTES or keep == 0:
+            return candidate
+        keep = max(0, keep - max(1, keep // 8))
+
+
+def serialise(envelope: ExecutionManifestEnvelope) -> str:
+    """Render an envelope to the string stored in ``workflow_run.manifest_json``."""
+    return json.dumps(_document(envelope), separators=_JSON_SEPARATORS)
+
+
+def parse(manifest_json: Optional[str]) -> Optional[ExecutionManifestEnvelope]:
+    """Reconstruct an envelope from a stored value. TOTAL — never raises.
+
+    ``None`` is the column's default and means "manifest absent". Empty or malformed input ALSO
+    answers ``None``, matching ``step_result.parse_envelope``'s posture: a corrupt manifest degrades
+    to "absent" rather than propagating a ``json`` exception into every read of the run row. Absent
+    is a state the Bolt 2 approval gate already handles fail-closed, so degrading is safe; raising
+    would turn one bad row into a failure on every read of it.
+    """
+    if not manifest_json:
+        return None
+    try:
+        document = json.loads(manifest_json)
+        memory = document["memory"]
+        return ExecutionManifestEnvelope(
+            plan_id=document["plan_id"],
+            source_hash=document["source_hash"],
+            inputs=document["inputs"],
+            repo_baseline=document["repo_baseline"],
+            provider=document.get("provider"),
+            model=document.get("model"),
+            profile=document.get("profile"),
+            permissions=document.get("permissions"),
+            limits=document.get("limits"),
+            retry_policy=document.get("retry_policy"),
+            memory=FrozenMemoryRecord(
+                content=memory["content"],
+                source=memory["source"],
+                content_hash=memory["content_hash"],
+                truncated=memory["truncated"],
+            ),
+            truncated=document["truncated"],
+            redacted=document["redacted"],
+            notes=document.get("notes", ""),
+        )
+    except Exception:  # noqa: BLE001 — totality is the contract; see the docstring
+        return None

--- a/src/cli_agent_orchestrator/services/execution_manifest.py
+++ b/src/cli_agent_orchestrator/services/execution_manifest.py
@@ -230,6 +230,17 @@ def build(
     )
 
     # 4. Bound, INCLUSIVELY: a document of exactly the bound is NOT truncated.
+    return _bound(envelope)
+
+
+def _bound(envelope: ExecutionManifestEnvelope) -> ExecutionManifestEnvelope:
+    """Trim the memory content until the encoded document fits, INCLUSIVELY.
+
+    Factored out of :func:`build` so :func:`with_memory` bounds by the same code rather than by a
+    second implementation of the same rule — the memory record is filled AFTER the freeze, and the
+    freeze measured a document that did not yet contain it, so filling it can exceed a bound that
+    previously passed.
+    """
     overflow = _encoded_length(envelope) - WORKFLOW_MANIFEST_MAX_BYTES
     if overflow <= 0:
         return envelope
@@ -250,6 +261,56 @@ def build(
         if _encoded_length(candidate) <= WORKFLOW_MANIFEST_MAX_BYTES or keep == 0:
             return candidate
         keep = max(0, keep - max(1, keep // 8))
+
+
+def with_memory(
+    envelope: ExecutionManifestEnvelope, *, content: str, source: str
+) -> ExecutionManifestEnvelope:
+    """Fill the memory record of an already-frozen envelope (issue #583 ``memory-resolve-once``).
+
+    The freeze writes this record EMPTY — memory resolves lazily, at the first point a run needs it,
+    and a run that creates no terminal must resolve nothing because an unused block is sensitive text
+    kept for no reason. So FR-9's payload cannot ride the freeze, and this is how it arrives.
+
+    EVERY OTHER FIELD IS RETURNED BYTE-IDENTICAL, AND THAT IS A CORRECTNESS REQUIREMENT RATHER THAN
+    TIDINESS. The other fields are the inputs ``plan_identifier.compute`` hashed into the ``plan_id``
+    that a human may already have approved. Rewriting one would change the identifier of a plan that
+    has already been approved and possibly already run, and ``approval_gate`` would then refuse a run
+    whose approval was perfectly valid. This is also why the envelope is NOT rebuilt by re-calling
+    :func:`build` with the parsed fields: those fields have already been redacted, so a rebuild would
+    redact them a second time and re-measure the whole document, moving bytes in exactly the fields
+    that must not move.
+
+    The module's ordering rules are preserved:
+
+    * the hash is taken over the FULL ``content``, BEFORE redaction, so ``content_hash`` identifies
+      what was RESOLVED from CAO memory rather than what survived the redaction ruleset of the day;
+    * redaction runs BEFORE bounding, so a secret straddling the boundary cannot be persisted in the
+      clear as the truncated prefix;
+    * bounding runs through the shared :func:`_bound`, because the freeze measured a document that did
+      not yet contain this record and filling it can push a previously-passing document over.
+
+    ``redacted`` is OR-ed rather than replaced: the flag records that something in this document was
+    redacted at some point, and a memory fill that redacts nothing must not clear a flag the freeze set.
+    """
+    memory_hash = _sha256(content)
+
+    # Only the memory pair is redacted here. The rest of the tree was redacted at freeze time and is
+    # deliberately not walked again — see the docstring on why re-processing it is the hazard.
+    raw: Dict[str, Any] = {"memory_content": content, "memory_source": source}
+    cleaned = redact_json_leaves(raw)
+
+    filled = replace(
+        envelope,
+        memory=FrozenMemoryRecord(
+            content=cleaned["memory_content"],
+            source=cleaned["memory_source"],
+            content_hash=memory_hash,
+            truncated=False,
+        ),
+        redacted=envelope.redacted or cleaned != raw,
+    )
+    return _bound(filled)
 
 
 def serialise(envelope: ExecutionManifestEnvelope) -> str:

--- a/src/cli_agent_orchestrator/services/frozen_run_memory.py
+++ b/src/cli_agent_orchestrator/services/frozen_run_memory.py
@@ -1,0 +1,154 @@
+"""Resolve CAO memory once per run and freeze it (issue #583 Bolt 2, unit ``memory-resolve-once``).
+
+FR-9's actual guarantee. Two units built the parts and left them inert: ``manifest-freeze`` wrote an
+empty ``FrozenMemoryRecord`` and named this unit as its filler, and ``terminal-frozen-memory`` added
+the optional pre-resolved parameter on the injection path with nothing to supply it. This module is
+what resolves, records, and supplies — so that altering CAO memory after a failure cannot change what
+a resumed run sees.
+
+THE ORDER IS PERSIST-THEN-USE, AND IT IS THE WHOLE CORRECTNESS ARGUMENT. The record is written into
+``manifest_json`` BEFORE the block is handed to a terminal. The two crash outcomes are not symmetric:
+
+* crash AFTER persisting — the manifest records memory that may never have been used. An over-record:
+  harmless, and detectable, because the run has a memory record and no terminal.
+* crash AFTER using and before persisting — the run SAW memory that nothing recorded. That is FR-9's
+  own Fail criterion, and it fails SILENTLY, because an empty memory record is indistinguishable from
+  a run that never created a terminal. Worse, a later replay reads that empty record and falls through
+  to LIVE memory, which is the exact drift the feature exists to prevent.
+
+Only one of the two breaks the requirement, so the ordering is forced rather than preferred. It is the
+same discipline the envelope already applies with redact-then-bound and hash-then-redact.
+
+A FAILED PERSIST INJECTS NOTHING. That is not a separate policy — handing over a block whose record did
+not persist IS the use-then-persist failure, reached by another route. The run proceeds with no memory:
+a visible, explicable difference rather than an unrecorded one.
+
+THE ONCE-PER-RUN FLAG IS THE RECORD'S PRESENCE, NOT ITS CONTENT. A run that legitimately resolved no
+memories records ``""``, and ``""`` is a RESOLVED result — ``terminal_service`` discriminates on
+``is None`` for exactly this reason. Were the flag "content is truthy", such a run would re-resolve at
+every terminal and again on every resume, each time reading the live store. The flag is durable
+(a column, not process state) because a resume can happen in a fresh process, and process-local
+bookkeeping would forget and re-resolve — reintroducing the requirement's Fail criterion through
+bookkeeping rather than logic.
+
+THE RUN IS INJECTED WITH WHAT WAS STORED, not with what was resolved. The stored copy is redacted and
+may be truncated, so it and the raw resolution are not always the same bytes — and only one of them can
+be injected. Injecting the stored copy makes the original run and every replay see BYTE-IDENTICAL
+context, which is FR-9 met strictly. Two consequences, both accepted deliberately:
+
+* a workflow-driven terminal's memory block is REDACTED, where a non-workflow terminal's is not. That
+  is a real behaviour difference, documented in ``docs/workflows.md``; it is also a security
+  improvement, since a secret sitting in curated memory stops reaching the agent's context here.
+* when the bound bites, the agent sees less memory than the live path would have given it, and
+  ``memory.truncated`` records that it happened.
+
+The alternative — full block on the first run, stored copy on a replay — diverges only on runs where
+redaction or truncation bit, which is to say on runs with a lot of memory, which is to say it would be
+found in production rather than in a test.
+
+WHAT THIS MODULE DOES NOT DO. It does not hash, redact, bound or truncate (``execution_manifest`` owns
+all four, and hashes BEFORE redacting so the hash identifies what was resolved). It does not decide
+whether memory reaches an agent at all — the operator's kill switch governs that, and
+``terminal_service`` honours it on the frozen path too. It does not resolve eagerly: a run that creates
+no terminal resolves nothing, because an unused block is sensitive text kept for no reason.
+"""
+
+import logging
+from typing import Optional
+
+from cli_agent_orchestrator.services import execution_manifest, workflow_journal
+
+logger = logging.getLogger(__name__)
+
+#: What ``source`` records for a block resolved through the ordinary curated path. A fixed token
+#: rather than free text, because it is compared across a resume and read by ``frozen-context-proof``.
+MEMORY_SOURCE_CURATED = "cao-memory:curated"
+
+
+def _resolve_live(terminal_id: str, task_description: str) -> str:
+    """Resolve memory the same way the live injection path does.
+
+    Deliberately the SAME call ``terminal_service.inject_memory_context`` makes, including the 200
+    character task-description slice: this unit changes WHEN memory is resolved, never WHAT
+    resolution means. A separate resolution path here would make a replayed run's context differ from
+    a live one for reasons unrelated to freezing.
+    """
+    from cli_agent_orchestrator.services.memory_service import MemoryService
+
+    return MemoryService().get_curated_memory_context(
+        terminal_id, task_description=task_description[:200]
+    )
+
+
+def frozen_memory_for(
+    run_id: Optional[str], terminal_id: str, task_description: str = ""
+) -> Optional[str]:
+    """The memory block this run's terminals must be given, or ``None`` for "resolve live".
+
+    ``None`` means the caller should pass nothing to ``send_input`` and let today's live path run —
+    which is the correct answer for a non-workflow terminal, for a YAML run, for a run with no
+    manifest, and for a run whose memory record could not be persisted.
+
+    TOTAL: never raises. A workflow step must not fail because a memory block could not be frozen;
+    the worst outcome here is a run that proceeds without memory, which is visible in the manifest.
+    """
+    if not run_id:
+        # Not a workflow terminal. Today's behaviour, untouched — C-1.
+        return None
+
+    try:
+        row = workflow_journal.get_run(run_id)
+    except Exception as e:  # noqa: BLE001 — a journal fault must not fail the step
+        logger.warning("frozen memory: could not read run '%s' (resolving live): %s", run_id, e)
+        return None
+
+    if row is None or row.manifest_json is None:
+        # A YAML run never freezes a manifest, and a script run whose freeze failed has none either.
+        # Both mean "there is nothing frozen to honour", which is not the same as "no memory".
+        return None
+
+    envelope = execution_manifest.parse(row.manifest_json)
+    if envelope is None:
+        logger.warning(
+            "frozen memory: run '%s' has an unreadable manifest (resolving live)", run_id
+        )
+        return None
+
+    if envelope.memory.source:
+        # ALREADY RESOLVED, and ``source`` is the flag for a reason worth stating, because the two
+        # obvious alternatives are both wrong:
+        #
+        #   * NOT the content's truthiness. A run that legitimately resolved no memories stores "",
+        #     and a truthiness flag would re-resolve it at every terminal and again on every resume,
+        #     each time reading the LIVE store — the drift FR-9 exists to prevent.
+        #   * NOT ``content_hash`` either, which looks like the natural "was anything recorded"
+        #     probe and is NEVER empty: the freeze calls ``build(memory_content="")``, and
+        #     ``sha256("")`` is a perfectly ordinary 64-character digest. Reading the hash would make
+        #     every run look already-resolved and nothing would ever resolve at all.
+        #
+        # ``source`` is empty at freeze time and a fixed non-empty token once filled, so it says
+        # exactly "this record has a provenance", which is what "resolved" means here. This is the
+        # branch a resume takes, and it is why a resume resolves nothing.
+        return envelope.memory.content
+
+    resolved = _resolve_live(terminal_id, task_description)
+
+    filled = execution_manifest.with_memory(
+        envelope, content=resolved, source=MEMORY_SOURCE_CURATED
+    )
+
+    try:
+        # PERSIST FIRST. If this raises, we must NOT return a block: see the module docstring.
+        workflow_journal.update_run_manifest(run_id, execution_manifest.serialise(filled))
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "frozen memory: could not record the resolved block for run '%s'; the run proceeds "
+            "with NO memory rather than using memory the manifest does not record: %s",
+            run_id,
+            e,
+        )
+        return None
+
+    # The STORED copy — redacted, possibly truncated — so this run and every replay of it see the
+    # same bytes. Not `resolved`, which is the raw resolution.
+    return filled.memory.content

--- a/src/cli_agent_orchestrator/services/frozen_run_memory.py
+++ b/src/cli_agent_orchestrator/services/frozen_run_memory.py
@@ -86,8 +86,9 @@ def frozen_memory_for(
     """The memory block this run's terminals must be given, or ``None`` for "resolve live".
 
     ``None`` means the caller should pass nothing to ``send_input`` and let today's live path run —
-    which is the correct answer for a non-workflow terminal, for a YAML run, for a run with no
-    manifest, and for a run whose memory record could not be persisted.
+    which is the correct answer for a non-workflow terminal, for a YAML run, or for a run with no
+    readable manifest. ``""`` means a manifest existed but its memory block could not be persisted;
+    the caller must supply that empty block to prevent the terminal's live-memory fallback.
 
     TOTAL: never raises. A workflow step must not fail because a memory block could not be frozen;
     the worst outcome here is a run that proceeds without memory, which is visible in the manifest.
@@ -114,41 +115,55 @@ def frozen_memory_for(
         )
         return None
 
-    if envelope.memory.source:
-        # ALREADY RESOLVED, and ``source`` is the flag for a reason worth stating, because the two
-        # obvious alternatives are both wrong:
-        #
-        #   * NOT the content's truthiness. A run that legitimately resolved no memories stores "",
-        #     and a truthiness flag would re-resolve it at every terminal and again on every resume,
-        #     each time reading the LIVE store — the drift FR-9 exists to prevent.
-        #   * NOT ``content_hash`` either, which looks like the natural "was anything recorded"
-        #     probe and is NEVER empty: the freeze calls ``build(memory_content="")``, and
-        #     ``sha256("")`` is a perfectly ordinary 64-character digest. Reading the hash would make
-        #     every run look already-resolved and nothing would ever resolve at all.
-        #
-        # ``source`` is empty at freeze time and a fixed non-empty token once filled, so it says
-        # exactly "this record has a provenance", which is what "resolved" means here. This is the
-        # branch a resume takes, and it is why a resume resolves nothing.
-        return envelope.memory.content
+    while True:
+        if envelope.memory.source:
+            # ``source`` is the durable resolved flag. Content may legitimately be "", and the
+            # hash is always populated even before the lazy fill, so neither can identify a fill.
+            return envelope.memory.content
 
-    resolved = _resolve_live(terminal_id, task_description)
-
-    filled = execution_manifest.with_memory(
-        envelope, content=resolved, source=MEMORY_SOURCE_CURATED
-    )
-
-    try:
-        # PERSIST FIRST. If this raises, we must NOT return a block: see the module docstring.
-        workflow_journal.update_run_manifest(run_id, execution_manifest.serialise(filled))
-    except Exception as e:  # noqa: BLE001
-        logger.warning(
-            "frozen memory: could not record the resolved block for run '%s'; the run proceeds "
-            "with NO memory rather than using memory the manifest does not record: %s",
-            run_id,
-            e,
+        resolved = _resolve_live(terminal_id, task_description)
+        filled = execution_manifest.with_memory(
+            envelope, content=resolved, source=MEMORY_SOURCE_CURATED
         )
-        return None
 
-    # The STORED copy — redacted, possibly truncated — so this run and every replay of it see the
-    # same bytes. Not `resolved`, which is the raw resolution.
-    return filled.memory.content
+        try:
+            persisted = workflow_journal.compare_and_set_run_manifest(
+                run_id, row.manifest_json, execution_manifest.serialise(filled)
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "frozen memory: could not record the resolved block for run '%s'; the run proceeds "
+                "with NO memory rather than using memory the manifest does not record: %s",
+                run_id,
+                e,
+            )
+            return ""
+
+        if persisted:
+            # The STORED copy — redacted, possibly truncated — so this run and every replay sees
+            # the same bytes. Not `resolved`, which is the raw resolution.
+            return filled.memory.content
+
+        try:
+            row = workflow_journal.get_run(run_id)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "frozen memory: could not reload run '%s' after a competing fill; "
+                "the run proceeds with NO memory: %s",
+                run_id,
+                e,
+            )
+            return ""
+
+        if row is None or row.manifest_json is None:
+            logger.warning(
+                "frozen memory: run '%s' disappeared after a competing fill; "
+                "the run proceeds with NO memory",
+                run_id,
+            )
+            return ""
+
+        envelope = execution_manifest.parse(row.manifest_json)
+        if envelope is None:
+            logger.warning("frozen memory: run '%s' has an unreadable manifest", run_id)
+            return ""

--- a/src/cli_agent_orchestrator/services/manifest_freeze.py
+++ b/src/cli_agent_orchestrator/services/manifest_freeze.py
@@ -1,0 +1,138 @@
+"""Assemble and freeze a script-tier run's execution manifest (issue #583, unit ``manifest-freeze``).
+
+Where pass 2A's three other units become one behaviour: this module derives a repository baseline, assembles
+the fields it can actually know, computes the ``plan_id``, and builds the bounded, redacted envelope. It
+re-implements none of that — ``execution_manifest`` owns the envelope, ``plan_identifier`` owns the
+identifier, ``git_baseline`` owns the baseline.
+
+IT RETURNS A VALUE AND WRITES NOTHING, AND THAT IS THE WHOLE DESIGN. The two script-tier callers already
+call ``workflow_journal.insert_run``; they pass this function's result to it, so the manifest and the run row
+land in ONE statement.
+
+Bolt 1 paid for this lesson. Its critical hazard was exactly the two-write shape: ``append_step`` +
+``update_step`` were two transactions for one logical settle, and a crash between them left a row with a
+settled state and a NULL output that the replay guard could not detect — returning a successful replay
+carrying no output. ADR-583-4's answer was a single-transaction settle. The equivalent window here would
+produce a run row whose ``manifest_json`` is NULL, INDISTINGUISHABLE from a YAML run and from a failed
+freeze, so nothing could tell a crashed freeze from a benign absence. Eliminating the interval eliminates the
+state.
+
+BEST-EFFORT AND TOTAL: every failure returns ``None`` after a ``warning``, and the run continues. This
+matches ``_journal_insert_run``'s stated posture ("journal write is best-effort; in-memory floor still serves
+live reads") and INV-4 — a journal concern must never reach into a running step. It is safe because the
+failure direction is FAIL-CLOSED: a ``None`` becomes a NULL manifest, which the Bolt 2 approval gate reads as
+"never approved" and REFUSES. The failure can never let an unapproved run execute; it can only refuse a run
+that should have been allowed.
+
+SIX OF FR-8'S NINE MANIFEST FIELDS ARE OMITTED, AND THE OMISSION IS THE HONEST READING. Verified against
+``WorkflowRunRequest`` (exactly ``name_or_path``, ``inputs``, ``run_id``) and ``ScriptSpec`` (``name``,
+``path``, ``source``, ``content_hash``, ``findings``, ``inputs``): provider, model, profile, permissions,
+limits and retry policy have NO run-level source in the script tier. Each is a per-step argument the Python
+passes to ``step()`` while executing — the same property that made ``plan_id`` run-level in the first place,
+because script-tier steps are DISCOVERED BY EXECUTING THE PYTHON.
+
+They are omitted rather than written as ``null`` because a ``null`` asserts "this field exists and has no
+value", while the truth is that the field has no run-level existence here. Six nulls would collapse "not
+applicable in this tier", "not captured" and "genuinely absent" into one indistinguishable token, and the
+repair a future reader would most plausibly attempt is inventing run-level execution defaults — a concept
+this tier does not have.
+
+FR-8'S PASS CRITERION STILL HOLDS, TRANSITIVELY: those six settings are chosen BY THE SOURCE, so changing any
+of them means editing the script, which changes ``content_hash``, which changes ``plan_id``. The source hash
+covers all six. That argument is not left as prose — ``test_manifest_freeze.py`` changes a step's provider in
+the script source and asserts the identifier changes.
+
+WHAT THIS MODULE DOES NOT DO. It does not write (the callers do, in one statement), does not bound or redact
+(``execution_manifest.build`` does), does not compute the identifier (``plan_identifier.compute`` does), does
+not resolve memory (``memory-resolve-once``, pass 2B, fills the record this leaves empty), and does not touch
+the YAML tier at all.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from cli_agent_orchestrator.services import execution_manifest, plan_identifier
+from cli_agent_orchestrator.utils.git_baseline import derive_baseline
+
+logger = logging.getLogger(__name__)
+
+OMITTED_FIELDS_NOTE = (
+    "provider, model, profile, permissions, limits and retry_policy are omitted: they have no "
+    "run-level source in the script tier (each is a per-step argument to step()). They are covered "
+    "transitively by source_hash, because the script's own source chooses them."
+)
+"""Recorded IN the envelope, not only in the design documents.
+
+The envelope is what an agent reads when diagnosing a failed run (FR-12's concern). A divergence from FR-8's
+field list explained only in a design artifact is a divergence the reader of the DATA will rediscover, and
+most likely misread as missing data.
+"""
+
+
+def build_manifest_json(
+    *,
+    source_hash: str,
+    inputs: Any,
+    cwd: Optional[str] = None,
+) -> Optional[str]:
+    """Freeze the manifest for a script-tier run and return the value to store, or ``None``.
+
+    Called ONCE per run, at run-row creation, before any step executes — ``plan_id`` must exist before
+    execution for an approval to be checked against it, so a manifest assembled later could only describe
+    what already ran.
+
+    TOTAL: raises nothing. Any failure logs a ``warning`` and returns ``None``, which the caller passes to
+    ``insert_run`` as a NULL manifest. The exception text is logged; NO FIELD VALUE IS, because ``inputs``
+    is exactly where a credential appears in practice.
+    """
+    try:
+        baseline: Dict[str, Any] = derive_baseline(cwd or os.getcwd())
+
+        # Six of FR-8's nine fields are None here because they have no run-level source in this tier
+        # (see the module docstring). ``plan_identifier`` renders a None scalar as a distinct
+        # not-supplied sentinel, so their absence is part of the identity rather than invisible to it.
+        fields = plan_identifier.PlanFields(
+            source_hash=source_hash,
+            inputs=inputs,
+            repo_baseline=baseline,
+            provider=None,
+            model=None,
+            profile=None,
+            permissions=None,
+            limits=None,
+            retry_policy=None,
+        )
+        plan_id = plan_identifier.compute(fields)
+
+        # ``build`` is the ONLY door: it owns bounding and redaction, so nothing here constructs JSON,
+        # truncates, or calls a redactor. Two paths producing manifests would let the newer one skip
+        # NFR-1's guarantees entirely.
+        envelope = execution_manifest.build(
+            plan_id=plan_id,
+            source_hash=source_hash,
+            inputs=inputs,
+            repo_baseline=baseline,
+            # The six are left None, which ``_document`` DROPS rather than serialising as null — the
+            # distinction between "no run-level existence in this tier" and "exists but empty".
+            provider=None,
+            model=None,
+            profile=None,
+            permissions=None,
+            limits=None,
+            retry_policy=None,
+            # The explanation travels IN the envelope, in its own field rather than smuggled into a
+            # field meant for a provider name.
+            notes=OMITTED_FIELDS_NOTE,
+            # Empty at freeze time: there is no resolved memory at run start. ``memory-resolve-once``
+            # (pass 2B) owns populating this, and a reader expecting FR-9's payload here would otherwise
+            # read the empty record as a defect.
+            memory_content="",
+            memory_source="",
+        )
+        return execution_manifest.serialise(envelope)
+    except (
+        Exception
+    ) as e:  # noqa: BLE001 — best-effort; the run must not fail because of the manifest
+        logger.warning("manifest freeze failed (run continues, manifest absent): %s", e)
+        return None

--- a/src/cli_agent_orchestrator/services/manifest_freeze.py
+++ b/src/cli_agent_orchestrator/services/manifest_freeze.py
@@ -88,6 +88,11 @@ def build_manifest_json(
     """
     try:
         baseline: Dict[str, Any] = derive_baseline(cwd or os.getcwd())
+        if not baseline.get("available"):
+            logger.warning(
+                "manifest freeze unavailable repository baseline (run continues, manifest absent)"
+            )
+            return None
 
         # Six of FR-8's nine fields are None here because they have no run-level source in this tier
         # (see the module docstring). ``plan_identifier`` renders a None scalar as a distinct

--- a/src/cli_agent_orchestrator/services/plan_identifier.py
+++ b/src/cli_agent_orchestrator/services/plan_identifier.py
@@ -1,0 +1,239 @@
+"""Compute and classify a run's execution ``plan_id`` (issue #583, unit ``plan-identifier``).
+
+One definition of "is this the same execution plan?", and a stored value whose provenance is readable
+from the value itself. FR-8's re-approval rule routes on this module's output: a wrong field list
+produces either a false match (a changed plan executing under a stale approval) or a permanent false
+mismatch (re-approval demanded on every run).
+
+RUN-LEVEL, AND DELIBERATELY NOT THE STEP FINGERPRINT'S FIELD SET. ``step_fingerprint.compute`` hashes
+ten PER-STEP components; this module hashes FR-8's nine RUN-LEVEL fields. The two sets overlap and do
+not coincide. The decisive reason they cannot be shared: script-tier steps are DISCOVERED BY EXECUTING
+THE PYTHON, so no step inventory exists at approval time — a ``plan_id`` covering per-step fields would
+need a list that cannot be produced when it is needed. A step's prompt still reaches this value
+transitively, because it lives in the workflow source whose hash is component 1.
+
+LEAF MODULE: imports ``hashlib``, ``json``, ``dataclasses`` and ``typing`` ONLY. No I/O, no state, no
+configuration, and NO LOGGING OF ANY KIND. Both are security requirements rather than style
+preferences, and both are PRESERVATION requirements — the pure-function shape already has them, and a
+later "improvement" is what would take them away:
+
+* NOTHING IS PERSISTED. ``compute`` takes fields, returns a digest, stores nothing. Its inputs include
+  ``inputs`` — arbitrary user-supplied JSON, which is exactly where a credential lands in practice (a
+  token passed as a workflow input, a key interpolated by a script). Storing the inputs would create a
+  SECOND durable home for that text with its own redaction obligation and its own eviction gap. A hash
+  needs no redaction, which is why this module can touch that text and remain the safest module in the
+  Bolt.
+* NO FIELD VALUE IS ECHOED into a log line, a message, or an exception. The previous point's whole
+  benefit is destroyed by one helpful log line: the obvious diagnostic instinct ("log the fields so we
+  can see what changed") moves a credential out of a hash and into a log file, which is typically
+  world-readable on the host and often shipped off it. This module therefore has no logger and no
+  ``print``, matching ``secret_gate.py``'s, ``step_result.py``'s and ``step_fingerprint.py``'s posture.
+
+``sha256`` IS AN IDENTITY FUNCTION HERE, NOT A SECURITY BOUNDARY. The unit claims collision resistance
+for identity and claims nothing about authentication: the value is stored in the same ``manifest_json``
+envelope it describes, so anyone able to write that column can simply write whatever value makes an
+approval match, without needing a collision. Integrity of the database file is the filesystem's job.
+
+WHAT THIS MODULE DOES NOT DO. It does not assemble the field values (``manifest-freeze``), does not
+carry or store the value (``manifest-envelope`` holds it opaquely inside the envelope;
+``manifest-column`` owns the column), does not record approvals (``approval-store``), and decides
+nothing about whether a run may proceed (``approval-gate``). It reports identity and provenance.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Literal, Optional
+
+PLAN_SCHEME_PREFIX = "plan-v1:"
+"""The scheme marker carried by every value ``compute`` emits.
+
+NAMED RATHER THAN INLINED because ``compute`` writes it and ``scheme_of`` reads it: two literals is the
+drift that would let one side stop recognising the other's output.
+
+``plan-v1:`` RATHER THAN ``v1:``, deliberately. A stored ``plan_id`` and a stored ``call_fingerprint``
+are both "short prefix + 64 lowercase hex", and ``step_fingerprint``'s stated reason for putting
+provenance IN the value was that a row read by any future consumer is self-describing without a schema
+lookup — which only pays off if the two namespaces cannot be confused. ``v1:`` is the single worst
+available choice: it is exactly what a LEGACY step fingerprint would have been called had the narrow
+three-field scheme carried a prefix, making it the one string most likely to be misread. The version is
+kept so a later change to the field set has a way to announce itself.
+"""
+
+_NOT_SUPPLIED = "\x01not-supplied"
+"""Substituted for a ``None`` scalar so ``None`` stays distinct from ``""`` (BR-2A3-3).
+
+"No profile" and "the empty profile" are different plans. The leading ``\\x01`` is defence in depth, not
+the argument: the guarantee is POSITIONAL, because length-prefixed framing makes every component's
+extent explicit, so a real field whose value happened to equal this string still occupies its own framed
+slot.
+"""
+
+# Separates a component's byte length from its bytes. The LENGTH PREFIX is what makes the encoding
+# injective, and it is the one place this scheme deliberately DIVERGES from ``v2``.
+#
+# ``step_fingerprint.compute`` joins its ten components with a single ``\x00`` and records the
+# consequence honestly: safe for ordinary field boundaries — ("a","b") cannot collide with ("ab","") —
+# but NOT injective when a component itself contains ``\x00``, and closing it "means length-prefixed
+# framing, which is a scheme change and therefore a ``v3:`` decision". ``v2`` already had rows on disk,
+# so it had to defer.
+#
+# THIS SCHEME HAS NO ROWS ON DISK AND TAKES THE DECISION NOW. The reachability also differs: a step's
+# fields are provider and agent names, while component 2 here is ARBITRARY USER-SUPPLIED JSON, so a
+# component containing the separator is something a workflow author can simply write. Inheriting a known
+# non-injectivity into a scheme with a free choice would be a defect adopted for cosmetic symmetry — and
+# a collision between two plans means one plan executing under the other's approval.
+_FRAME_SEP = ":"
+
+# Fixed precision for numeric leaves, so ``600`` and ``600.0`` are ONE identity. An int reaching a
+# float-typed field is entirely ordinary in Python, and rendering the value's repr would fork one plan's
+# identity into two for no execution difference at all. Inlined rather than placed in ``constants.py``
+# for the same reason as the separator: changing it changes every stored value, so it is part of the
+# hash contract, not a tunable someone may legitimately revise.
+_NUMBER_PRECISION = 6
+
+
+@dataclass(frozen=True)
+class PlanFields:
+    """FR-8's nine execution-affecting run-level fields.
+
+    THE FIELD ORDER IS PART OF THE HASH CONTRACT (BR-2A3-1). It is FR-8's own stated order, adopted
+    rather than invented because it is the order the requirement is written in and therefore the order a
+    reader will check the implementation against.
+
+    REORDERING THEM SILENTLY INVALIDATES EVERY STORED VALUE. A stored ``plan-v1:`` value would stay
+    ``plan-v1:`` while meaning something different, so ``scheme_of``'s classification cannot detect the
+    break and equality cannot detect it — the two populations become indistinguishable WITHIN one
+    scheme. Every existing approval would quietly stop matching and every run would demand re-approval
+    for no reason. That is the one failure mode this scheme's versioning has no answer for, which is why
+    a test pins the digest of a known field set.
+    """
+
+    source_hash: Optional[str]
+    inputs: Any
+    repo_baseline: Any
+    provider: Optional[str]
+    model: Optional[str]
+    profile: Optional[str]
+    permissions: Any
+    limits: Any
+    retry_policy: Any
+
+
+def _text(value: Optional[str]) -> str:
+    """Normalise an optional scalar, keeping ``None`` distinct from ``""`` (BR-2A3-3)."""
+    return _NOT_SUPPLIED if value is None else value
+
+
+def _number(value: Any) -> Any:
+    """Render a numeric leaf at fixed precision so ``600`` and ``600.0`` agree (BR-2A3-7).
+
+    Applied through :func:`_canonicalise` to the leaves of the structured fields. ``bool`` is checked
+    FIRST because ``bool`` is a subclass of ``int`` in Python, and normalising ``True`` to ``"1.000000"``
+    would erase the distinction between a flag and a count.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return f"{float(value):.{_NUMBER_PRECISION}f}"
+    return value
+
+
+def _canonicalise(node: Any) -> Any:
+    """Recursively normalise numeric leaves inside a structured field.
+
+    Dict key ORDER is handled by ``json.dumps(sort_keys=True)`` rather than here; this walk exists only
+    to give numbers one spelling at every depth.
+
+    NOTE ON BOOLEANS (BR-2A3-8). No top-level field is a boolean — the nine are one hash, four
+    structures and four strings — so this module writes no ``_flag`` helper, unlike
+    ``step_fingerprint``. Booleans reaching this walk are INSIDE a structure and are left untouched,
+    because ``json.dumps`` already renders them canonically as ``true`` / ``false``. Adding a helper for
+    a field kind that does not exist would be dead code asserting a normalisation nothing calls.
+    """
+    if isinstance(node, dict):
+        return {k: _canonicalise(v) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_canonicalise(v) for v in node]
+    return _number(node)
+
+
+def _structure(value: Any) -> str:
+    """Render a structured field canonically: dict keys SORTED, list order PRESERVED (BR-2A3-6).
+
+    The asymmetry is the point. Without ``sort_keys`` the same logical inputs supplied with keys in a
+    different order would produce a different ``plan_id`` and force a re-approval for a plan that
+    executes identically — a false positive FR-8 never asks for, and one that trains an operator to
+    approve without reading. List order is preserved because a reordered permissions list or retry
+    sequence may genuinely execute differently, so sorting would erase a real difference.
+
+    ``default=str`` keeps the function TOTAL over values ``json`` cannot natively encode, rather than
+    raising and taking a field value into the traceback with it.
+    """
+    return json.dumps(
+        _canonicalise(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def _frame(component: str) -> bytes:
+    """Emit one component as ``<byte-length><sep><bytes>``, making the encoding injective."""
+    encoded = component.encode("utf-8")
+    return f"{len(encoded)}{_FRAME_SEP}".encode("utf-8") + encoded
+
+
+def compute(fields: PlanFields) -> str:
+    """Hash the nine components into ``"plan-v1:<64 lowercase hex>"``.
+
+    NINE COMPONENTS IN A FIXED ORDER, AND THE TUPLE IS NEVER SHORTENED (BR-2A3-1/BR-2A3-2). A ``None``
+    scalar becomes :data:`_NOT_SUPPLIED` rather than being dropped, so two plans differing only in WHICH
+    field is absent cannot collide.
+
+    TOTAL on well-typed input: it raises nothing, which is also why no exception path can carry a field
+    value. A type violation surfaces as the ordinary ``TypeError`` rather than being silently normalised
+    — hashing it would hide the caller's bug behind a plausible digest.
+
+    THE OUTPUT IS FIXED-SIZE — 72 characters, no user bytes — so it can be neither an injection vector
+    nor a growth vector, which is why NFR-1's bounding and redaction are inapplicable here by
+    construction rather than deferred.
+    """
+    components = (
+        _text(fields.source_hash),
+        _structure(fields.inputs),
+        _structure(fields.repo_baseline),
+        _text(fields.provider),
+        _text(fields.model),
+        _text(fields.profile),
+        _structure(fields.permissions),
+        _structure(fields.limits),
+        _structure(fields.retry_policy),
+    )
+    framed = b"".join(_frame(component) for component in components)
+    return PLAN_SCHEME_PREFIX + hashlib.sha256(framed).hexdigest()
+
+
+def scheme_of(stored: Optional[str]) -> Literal["plan-v1", "unknown", "absent"]:
+    """Report what a stored value says about its own provenance. TOTAL — never raises.
+
+    THREE ANSWERS, NOT TWO, and the middle one is why the prefix exists. Equality alone conflates "the
+    plan changed" with "this value was computed under different rules and cannot be verified":
+    comparing a ``plan-v1:`` value against an unknown-scheme value ALWAYS fails, so a bare comparison
+    would report a changed plan for something nobody can assess. Those two situations need different
+    remedies — a changed plan needs re-approval, an unverifiable one needs a human ruling — and
+    conflating them pushes an operator toward approving something no one understood. ADR-583-5 records
+    the same distinction for legacy step fingerprints: unverifiable, not divergent.
+
+    ``unknown`` is UNREACHABLE IN BOLT 2 — there are no legacy ``plan_id`` rows. It is defined anyway so
+    that a future field-set change is not left discovering that its only available operation is an
+    equality test guaranteed to fail.
+
+    This function reports provenance and decides nothing. What an ``unknown`` value MEANS for a run is
+    ``approval-gate``'s call.
+    """
+    if not stored:
+        return "absent"
+    if stored.startswith(PLAN_SCHEME_PREFIX):
+        return "plan-v1"
+    return "unknown"

--- a/src/cli_agent_orchestrator/services/plan_identifier.py
+++ b/src/cli_agent_orchestrator/services/plan_identifier.py
@@ -126,16 +126,20 @@ def _text(value: Optional[str]) -> str:
 
 
 def _number(value: Any) -> Any:
-    """Render a numeric leaf at fixed precision so ``600`` and ``600.0`` agree (BR-2A3-7).
+    """Render numeric leaves exactly while keeping integral int/float spellings equivalent (BR-2A3-7).
 
     Applied through :func:`_canonicalise` to the leaves of the structured fields. ``bool`` is checked
-    FIRST because ``bool`` is a subclass of ``int`` in Python, and normalising ``True`` to ``"1.000000"``
+    FIRST because ``bool`` is a subclass of ``int`` in Python, and normalising ``True`` to ``"1"``
     would erase the distinction between a flag and a count.
     """
     if isinstance(value, bool):
         return value
-    if isinstance(value, (int, float)):
-        return f"{float(value):.{_NUMBER_PRECISION}f}"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if value.is_integer():
+            return str(int(value))
+        return f"{value:.{_NUMBER_PRECISION}f}"
     return value
 
 

--- a/src/cli_agent_orchestrator/services/script_runner.py
+++ b/src/cli_agent_orchestrator/services/script_runner.py
@@ -1166,8 +1166,10 @@ async def run_script_workflow(spec: Any, inputs: Dict[str, Any], run_id: str) ->
     # --- Step 0b: approval gate (issue #583 Bolt 2, ``approval-gate``) ---
     # Built ONCE here and handed to the INSERT below unchanged, so the manifest that is CHECKED is
     # byte-identical to the one STORED — and ADR-583-4's one-write discipline is preserved.
-    manifest_json = manifest_freeze.build_manifest_json(
-        source_hash=spec.content_hash, inputs=inputs
+    manifest_json = await asyncio.to_thread(
+        manifest_freeze.build_manifest_json,
+        source_hash=spec.content_hash,
+        inputs=inputs,
     )
     # Placed here, and not lower, for two reasons that are both about leaving nothing behind:
     #   * BEFORE the registry write and the journal INSERT, so a refused start leaves no live record

--- a/src/cli_agent_orchestrator/services/script_runner.py
+++ b/src/cli_agent_orchestrator/services/script_runner.py
@@ -51,7 +51,12 @@ from cli_agent_orchestrator.models.workflow_runtime import (
     StepState,
     WorkflowRunResult,
 )
-from cli_agent_orchestrator.services import manifest_freeze, terminal_service, workflow_journal
+from cli_agent_orchestrator.services import (
+    approval_gate,
+    manifest_freeze,
+    terminal_service,
+    workflow_journal,
+)
 from cli_agent_orchestrator.services.script_lint import lint_script
 from cli_agent_orchestrator.services.secret_gate import redact_json_leaves, redact_secrets
 from cli_agent_orchestrator.services.step_output_store import _validate_key_part, step_output_store
@@ -1158,6 +1163,23 @@ async def run_script_workflow(spec: Any, inputs: Dict[str, Any], run_id: str) ->
     if result.status == "fail":
         raise ScriptLintError(result.findings)  # ZERO code ran, no journal row yet
 
+    # --- Step 0b: approval gate (issue #583 Bolt 2, ``approval-gate``) ---
+    # Built ONCE here and handed to the INSERT below unchanged, so the manifest that is CHECKED is
+    # byte-identical to the one STORED — and ADR-583-4's one-write discipline is preserved.
+    manifest_json = manifest_freeze.build_manifest_json(
+        source_hash=spec.content_hash, inputs=inputs
+    )
+    # Placed here, and not lower, for two reasons that are both about leaving nothing behind:
+    #   * BEFORE the registry write and the journal INSERT, so a refused start leaves no live record
+    #     and no ``workflow_run`` row. Every first run of a new plan is refused by design, so
+    #     recording them would durably record runs that never happened.
+    #   * OUTSIDE the ``try`` around ``insert_run`` below, which swallows EVERY exception by design
+    #     ("journal insert is best-effort; live floor still serves"). A refusal raised inside it would
+    #     be logged and the run would continue — the gate would appear to work and would authorise
+    #     nothing.
+    # No-ops entirely when enforcement is disabled, which is the default.
+    approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)
+
     # --- Step 1: register the live record + journal the durable run row ---
     record = ScriptRunRecord(
         run_id=run_id,
@@ -1203,7 +1225,9 @@ async def run_script_workflow(spec: Any, inputs: Dict[str, Any], run_id: str) ->
             # window would produce a NULL manifest indistinguishable from a YAML run and from a
             # failed freeze. ``build_manifest_json`` is TOTAL and returns None on any failure, which
             # writes NULL and fails CLOSED at the approval gate.
-            manifest_freeze.build_manifest_json(source_hash=spec.content_hash, inputs=inputs),
+            # ``approval-gate`` (Bolt 2 unit 7) built this value at Step 0b and has already gated on
+            # it; reusing it rather than rebuilding is what makes checked-equals-stored true.
+            manifest_json,
         )
     except (
         Exception
@@ -1363,6 +1387,29 @@ async def resume_script_run(
                     f"run '{run_id}' step '{journal_step.step_id}' has unconsumed recovery consent; "
                     "supply a fresh decision for this step to resume"
                 )
+
+        # --- Gate 6: plan approval -> 403 (issue #583 Bolt 2, ``approval-gate``) ---
+        # LAST of the admission gates, and that position is the requirement rather than a preference.
+        #
+        # It was authored as gate 5 against Bolt 2's base and RENUMBERED to 6 when Bolt 2 rebased onto
+        # a merged Bolt 1: PR #628's review added the recovery-consent gate above, at the same place,
+        # after Bolt 2 had branched. Both gates survive and the ORDERING PRINCIPLE is what decided
+        # which goes first — consent is a fact about the RUN, like gates 1-4, while approval is a fact
+        # about the PLAN, so approval stays last among admission checks.
+        #
+        # It must come:
+        #   * AFTER gates 1-5, so "unknown run", "already live", "not resumable", "corrupt snapshot"
+        #     and "unconsumed consent" keep their own answers — a caller must be able to tell those
+        #     from "needs approval", and the concurrent-resume question is settled by the drive claim
+        #     above before this gate is ever asked.
+        #   * BEFORE ``apply_decisions`` below and BEFORE the generation bump further down. The bump
+        #     fences out any still-live process for this run, so bumping and then refusing would kill
+        #     a possibly-healthy run on behalf of a resume that was itself rejected — two losses from
+        #     one refusal. ``apply_decisions`` writes, and a refused resume must leave nothing behind.
+        # ``plan_id`` comes from the manifest ALREADY on the row and is never recomputed: recomputing
+        # would re-read the script from disk, so an edit between start and resume would refuse a run
+        # whose approval is perfectly valid for what it actually froze.
+        approval_gate.ensure_plan_approved(tier=row.tier, manifest_json=row.manifest_json)
 
         # --- The human's recovery decisions (issue #583, FR-7). NOT a gate: admission
         # is over, this resume holds the drive claim, and nothing has been spawned yet.

--- a/src/cli_agent_orchestrator/services/script_runner.py
+++ b/src/cli_agent_orchestrator/services/script_runner.py
@@ -51,9 +51,9 @@ from cli_agent_orchestrator.models.workflow_runtime import (
     StepState,
     WorkflowRunResult,
 )
-from cli_agent_orchestrator.services import terminal_service, workflow_journal
+from cli_agent_orchestrator.services import manifest_freeze, terminal_service, workflow_journal
 from cli_agent_orchestrator.services.script_lint import lint_script
-from cli_agent_orchestrator.services.secret_gate import redact_secrets
+from cli_agent_orchestrator.services.secret_gate import redact_json_leaves, redact_secrets
 from cli_agent_orchestrator.services.step_output_store import _validate_key_part, step_output_store
 from cli_agent_orchestrator.services.step_result import build_envelope, serialise_envelope
 from cli_agent_orchestrator.services.workflow_service import (
@@ -662,25 +662,6 @@ def _sanitise_error(error: Optional[str]) -> Optional[str]:
     return _ERROR_TRUNCATION_MARKER.format(dropped=dropped) + tail
 
 
-def _redact_json_leaves(node: Any) -> Any:
-    """Recursively ``redact_secrets`` every string inside a parsed JSON document (SR-4).
-
-    Dict KEYS are redacted alongside values. A credential is as capable of landing in
-    a key as in a value, and INV-5 admits no unredacted credential; the accepted cost
-    is that two keys differing only inside a redacted span collapse into one, which
-    loses a member but cannot produce an invalid document. Non-string scalars pass
-    through untouched — there is nothing in an ``int`` for a pattern to match.
-    """
-    if isinstance(node, str):
-        redacted, _fired = redact_secrets(node)
-        return redacted
-    if isinstance(node, dict):
-        return {_redact_json_leaves(k): _redact_json_leaves(v) for k, v in node.items()}
-    if isinstance(node, list):
-        return [_redact_json_leaves(v) for v in node]
-    return node
-
-
 def _output_placeholder(reason: str, byte_length: int) -> str:
     """A small, VALID JSON document standing in for an ``output_json`` that was dropped.
 
@@ -725,7 +706,7 @@ def _sanitise_output_json(output_json: Optional[str]) -> Optional[str]:
     except Exception:  # noqa: BLE001 — totality is the contract (SR-6); see the docstring
         return _output_placeholder("unparseable", raw_bytes)
     try:
-        serialised = json.dumps(_redact_json_leaves(document), separators=(",", ":"))
+        serialised = json.dumps(redact_json_leaves(document), separators=(",", ":"))
     except Exception:  # noqa: BLE001 — a value the walk cannot re-serialise (or a depth
         # limit) must still settle the step, so it degrades to the same placeholder.
         return _output_placeholder("unserialisable", raw_bytes)
@@ -1216,6 +1197,13 @@ async def run_script_workflow(spec: Any, inputs: Dict[str, Any], run_id: str) ->
             record.started_at,
             "script",
             "1",
+            # issue #583 Bolt 2, ``manifest-freeze``: the frozen manifest rides the SAME INSERT as
+            # the run row. ADR-583-4's lesson — Bolt 1's critical hazard was two writes for one
+            # logical settle, and a crash between them left a state nothing could detect. Here that
+            # window would produce a NULL manifest indistinguishable from a YAML run and from a
+            # failed freeze. ``build_manifest_json`` is TOTAL and returns None on any failure, which
+            # writes NULL and fails CLOSED at the approval gate.
+            manifest_freeze.build_manifest_json(source_hash=spec.content_hash, inputs=inputs),
         )
     except (
         Exception

--- a/src/cli_agent_orchestrator/services/secret_gate.py
+++ b/src/cli_agent_orchestrator/services/secret_gate.py
@@ -13,7 +13,7 @@ credential shapes.
 """
 
 import re
-from typing import List, Optional, Pattern, Tuple
+from typing import Any, List, Optional, Pattern, Tuple
 
 # Ordered (name, compiled_regex) pairs. First match wins, so ordering is
 # stable and reproducible across calls. No entropy scoring.
@@ -79,3 +79,40 @@ def redact_secrets(content: str) -> Tuple[str, List[str]]:
         if count:
             fired.append(name)
     return content, fired
+
+
+def redact_json_leaves(node: Any) -> Any:
+    """Recursively :func:`redact_secrets` every string inside a parsed JSON document.
+
+    Dict KEYS are redacted alongside values. A credential is as capable of landing in
+    a key as in a value, and no unredacted credential may be persisted; the accepted
+    cost is that two keys differing only inside a redacted span collapse into one,
+    which loses a member but cannot produce an invalid document. Non-string scalars
+    pass through untouched — there is nothing in an ``int`` for a pattern to match.
+
+    PROMOTED HERE from ``script_runner._redact_json_leaves`` by issue #583 Bolt 2, unit
+    ``manifest-envelope``, so that BOTH the step-output path and the execution-manifest
+    envelope share ONE definition. Two copies of this function would drift, and the
+    drift would be silent and security-relevant in the worst direction: one path would
+    keep persisting a credential class the other had already learned to catch.
+
+    THIS MODULE IS THE RIGHT HOME because it is a LEAF — it imports only ``re`` and
+    ``typing``. ``services/execution_manifest.py`` can therefore depend on it and remain
+    a leaf itself, which importing from ``script_runner`` (a heavyweight module) would
+    have prevented by inverting the layering that ``step_result.py`` and
+    ``step_fingerprint.py`` established.
+
+    OPERATE ON THE PARSED TREE, NEVER ON THE SERIALISED STRING. Redacting a JSON string
+    would replace text inside string literals and could span a quote or an escape
+    sequence, producing an unparseable document — written successfully and failing on
+    every read. Walking parsed values and re-serialising afterwards makes output
+    validity hold by construction.
+    """
+    if isinstance(node, str):
+        redacted, _fired = redact_secrets(node)
+        return redacted
+    if isinstance(node, dict):
+        return {redact_json_leaves(k): redact_json_leaves(v) for k, v in node.items()}
+    if isinstance(node, list):
+        return [redact_json_leaves(v) for v in node]
+    return node

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -431,6 +431,52 @@ def is_learning_enabled() -> bool:
         return False
 
 
+def is_workflow_approval_required() -> bool:
+    """Return True when an unapproved script-tier workflow run must be refused (issue #583 FR-8).
+
+    Default is **False**: enforcement is opt-in. A ``plan_id`` does not exist until run start, so a
+    plan that has never run cannot have been approved and its first run is refused by design. Making
+    that the default would break every existing script-tier caller one Bolt before the authoring
+    sequence that presents a plan and takes approval BEFORE running.
+
+    PRECEDENCE IS DELIBERATELY ASYMMETRIC, AND THIS IS NOT AN OVERSIGHT. Every sibling setting here
+    resolves ``CAO_* env var > settings.json > default`` — see :func:`is_memory_enabled`. This one
+    does NOT:
+
+        ``CAO_WORKFLOW_REQUIRE_APPROVAL`` may turn the gate **ON**.
+        Only ``settings.json`` can turn it **OFF**.
+
+    The reason is that this setting is a CONTROL, not a feature toggle. Under the house precedence,
+    anything able to set an environment variable could switch the approval gate off while the
+    operator's settings file still read as configured on — which would make the weakest
+    configuration mechanism in the system the one that decides whether runs are authorised. The
+    asymmetry is monotonic in the safe direction: nothing that merely influences an environment can
+    weaken the gate, while enabling it for a single test or trial stays a one-liner.
+
+    Read failure resolves to the default (disabled) with a warning, which is the ONE place this
+    mechanism is deliberately not fail-closed. Treating an unreadable settings file as "gate on"
+    would refuse every script run in the installation on the strength of a JSON typo. Resolving to
+    disabled makes the unreadable case behave like the unconfigured case, and the asymmetry above
+    bounds the residual: an operator who enabled the gate via the environment is unaffected by a
+    corrupt file.
+    """
+    env = os.environ.get("CAO_WORKFLOW_REQUIRE_APPROVAL")
+    if env is not None and env.strip().lower() in ("1", "true", "yes"):
+        # Enable-only: a falsy env value is NOT consulted, so it cannot override an enabling
+        # settings.json below. Returning early on truthy is what makes the precedence asymmetric.
+        return True
+    try:
+        workflow_settings = _load().get("workflow", {})
+        if not isinstance(workflow_settings, dict):
+            return False
+        return bool(workflow_settings.get("require_approval", False))
+    except Exception as e:
+        logger.warning(
+            "Failed to read workflow.require_approval, defaulting to False (gate disabled): %s", e
+        )
+        return False
+
+
 def is_instruction_promotion_enabled() -> bool:
     """Return True when learned-lesson promotion into profile files is enabled.
 

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -116,20 +116,59 @@ _memory_injected_lock = threading.Lock()
 _deferred_init_tasks: set = set()
 
 
-def inject_memory_context(first_message: str, terminal_id: str) -> str:
+def inject_memory_context(
+    first_message: str, terminal_id: str, frozen_memory: str | None = None
+) -> str:
     """Prepend <cao-memory> context block to the first user message.
 
     Tracks which terminals have already been injected so that only the very
     first user message after init receives the memory block.
 
-    Calls MemoryService.get_memory_context_for_terminal() which returns
-    a formatted <cao-memory>...</cao-memory> block (or empty string if
-    no memories exist). Stateless — no file mutation, no backup/restore.
+    Calls MemoryService.get_curated_memory_context(), which returns a formatted
+    <cao-memory>...</cao-memory> block (or empty string if no memories exist).
+    Stateless — no file mutation, no backup/restore.
+
+    ``frozen_memory`` is an OPTIONAL PRE-RESOLVED BLOCK (issue #583 FR-9). When it
+    is not None the block is injected verbatim and MemoryService is never
+    consulted, so a replayed workflow run sees the memory the ORIGINAL run
+    recorded rather than whatever the store holds today. When it is None this
+    function behaves exactly as it always has, which is what keeps every
+    non-workflow terminal in CAO unaffected — and this module deliberately knows
+    nothing about workflows: the parameter is named for its content, not its
+    origin.
     """
     with _memory_injected_lock:
         if terminal_id in _memory_injected_terminals:
             return first_message
         _memory_injected_terminals.add(terminal_id)
+
+    if frozen_memory is not None:
+        # "" is a SUPPLIED block, not an absent one: it means the original run
+        # resolved no memory, so prepend nothing — and, crucially, do NOT fall
+        # through to the live path. Deciding the arm on `is not None` while
+        # deciding the prepend on truthiness is deliberate; collapsing the two
+        # into one truthiness test is exactly how a run that legitimately froze
+        # an empty block would pick up memories written after it, which is the
+        # drift FR-9 exists to prevent.
+        if not frozen_memory:
+            return first_message
+        # The operator's kill switch binds this path too. Skipping MemoryService
+        # would otherwise skip its is_memory_enabled() check, and a workflow run
+        # would paste memory into the context of someone who turned memory off.
+        # The cost is that a replay under a disabled switch differs from the
+        # original run — acceptable because the manifest records that memory was
+        # frozen, so the difference is explainable, whereas a bypassed control
+        # would leave no trace at all. Imported lazily for the same
+        # settings -> memory circular-import reason memory_service documents.
+        from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+        if not is_memory_enabled():
+            return first_message
+        # No try/except here on purpose: string concatenation cannot fail on I/O,
+        # so the only thing a guard could swallow is a programming error — and
+        # swallowing it would silently downgrade a replay to live memory, which
+        # is a wrong answer wearing a right answer's clothes.
+        return frozen_memory + "\n\n" + first_message
 
     try:
         svc = MemoryService()
@@ -1514,6 +1553,7 @@ def send_input(
     registry: PluginRegistry | None = None,
     sender_id: str | None = None,
     orchestration_type: OrchestrationType | None = None,
+    frozen_memory: str | None = None,
 ) -> bool:
     """Send input to terminal via tmux paste buffer.
 
@@ -1521,6 +1561,12 @@ def send_input(
     of Enter keys sent after pasting is determined by the provider's
     ``paste_enter_count`` property (e.g., some TUIs need 2 Enters because
     bracketed paste triggers multi-line mode).
+
+    ``frozen_memory`` is forwarded UNCHANGED to :func:`inject_memory_context` and
+    is otherwise none of this function's business — not inspected, not validated,
+    not logged. It is last and defaulted so existing positional callers (notably
+    ``agent_step.run_agent_step``, which passes exactly two arguments) are
+    unaffected.
     """
     try:
         metadata = get_terminal_metadata(terminal_id)
@@ -1573,7 +1619,7 @@ def send_input(
         # plugins/webhooks see what the caller sent — not the
         # internal <cao-memory> block that we paste into the TUI.
         original_message = message
-        message = inject_memory_context(message, terminal_id)
+        message = inject_memory_context(message, terminal_id, frozen_memory)
 
         # Check how many Enter keys the provider needs after paste
         enter_count = provider.paste_enter_count if provider else 1

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -115,20 +115,59 @@ _memory_injected_lock = threading.Lock()
 _deferred_init_tasks: set = set()
 
 
-def inject_memory_context(first_message: str, terminal_id: str) -> str:
+def inject_memory_context(
+    first_message: str, terminal_id: str, frozen_memory: str | None = None
+) -> str:
     """Prepend <cao-memory> context block to the first user message.
 
     Tracks which terminals have already been injected so that only the very
     first user message after init receives the memory block.
 
-    Calls MemoryService.get_memory_context_for_terminal() which returns
-    a formatted <cao-memory>...</cao-memory> block (or empty string if
-    no memories exist). Stateless — no file mutation, no backup/restore.
+    Calls MemoryService.get_curated_memory_context(), which returns a formatted
+    <cao-memory>...</cao-memory> block (or empty string if no memories exist).
+    Stateless — no file mutation, no backup/restore.
+
+    ``frozen_memory`` is an OPTIONAL PRE-RESOLVED BLOCK (issue #583 FR-9). When it
+    is not None the block is injected verbatim and MemoryService is never
+    consulted, so a replayed workflow run sees the memory the ORIGINAL run
+    recorded rather than whatever the store holds today. When it is None this
+    function behaves exactly as it always has, which is what keeps every
+    non-workflow terminal in CAO unaffected — and this module deliberately knows
+    nothing about workflows: the parameter is named for its content, not its
+    origin.
     """
     with _memory_injected_lock:
         if terminal_id in _memory_injected_terminals:
             return first_message
         _memory_injected_terminals.add(terminal_id)
+
+    if frozen_memory is not None:
+        # "" is a SUPPLIED block, not an absent one: it means the original run
+        # resolved no memory, so prepend nothing — and, crucially, do NOT fall
+        # through to the live path. Deciding the arm on `is not None` while
+        # deciding the prepend on truthiness is deliberate; collapsing the two
+        # into one truthiness test is exactly how a run that legitimately froze
+        # an empty block would pick up memories written after it, which is the
+        # drift FR-9 exists to prevent.
+        if not frozen_memory:
+            return first_message
+        # The operator's kill switch binds this path too. Skipping MemoryService
+        # would otherwise skip its is_memory_enabled() check, and a workflow run
+        # would paste memory into the context of someone who turned memory off.
+        # The cost is that a replay under a disabled switch differs from the
+        # original run — acceptable because the manifest records that memory was
+        # frozen, so the difference is explainable, whereas a bypassed control
+        # would leave no trace at all. Imported lazily for the same
+        # settings -> memory circular-import reason memory_service documents.
+        from cli_agent_orchestrator.services.settings_service import is_memory_enabled
+
+        if not is_memory_enabled():
+            return first_message
+        # No try/except here on purpose: string concatenation cannot fail on I/O,
+        # so the only thing a guard could swallow is a programming error — and
+        # swallowing it would silently downgrade a replay to live memory, which
+        # is a wrong answer wearing a right answer's clothes.
+        return frozen_memory + "\n\n" + first_message
 
     try:
         svc = MemoryService()
@@ -1171,6 +1210,7 @@ def send_input(
     registry: PluginRegistry | None = None,
     sender_id: str | None = None,
     orchestration_type: OrchestrationType | None = None,
+    frozen_memory: str | None = None,
 ) -> bool:
     """Send input to terminal via tmux paste buffer.
 
@@ -1178,6 +1218,12 @@ def send_input(
     of Enter keys sent after pasting is determined by the provider's
     ``paste_enter_count`` property (e.g., some TUIs need 2 Enters because
     bracketed paste triggers multi-line mode).
+
+    ``frozen_memory`` is forwarded UNCHANGED to :func:`inject_memory_context` and
+    is otherwise none of this function's business — not inspected, not validated,
+    not logged. It is last and defaulted so existing positional callers (notably
+    ``agent_step.run_agent_step``, which passes exactly two arguments) are
+    unaffected.
     """
     try:
         metadata = get_terminal_metadata(terminal_id)
@@ -1230,7 +1276,7 @@ def send_input(
         # plugins/webhooks see what the caller sent — not the
         # internal <cao-memory> block that we paste into the TUI.
         original_message = message
-        message = inject_memory_context(message, terminal_id)
+        message = inject_memory_context(message, terminal_id, frozen_memory)
 
         # Check how many Enter keys the provider needs after paste
         enter_count = provider.paste_enter_count if provider else 1

--- a/src/cli_agent_orchestrator/services/workflow_journal.py
+++ b/src/cli_agent_orchestrator/services/workflow_journal.py
@@ -123,6 +123,12 @@ class RunRow:
     finished_at: Optional[str]
     tier: str = "yaml"
     generation: str = "1"
+    # issue #583 Bolt 2, ``approval-gate``: the frozen execution manifest, readable. ``manifest-column``
+    # added the column and ``manifest-freeze`` writes it, but until now NOTHING read it back — the
+    # resume approval gate is the first reader, so it owns the read path. Additive and defaulted, the
+    # same shape ``StepRow``'s docstring describes for U1's nullable fields: a row written before this
+    # (or by a YAML run, which never freezes) reads back observably identical to its previous shape.
+    manifest_json: Optional[str] = None
 
 
 @dataclass
@@ -841,7 +847,7 @@ def get_run(run_id: str) -> Optional[RunRow]:
     with _connect() as conn:
         row = conn.execute(
             "SELECT run_id, workflow_name, spec_snapshot, inputs_json, state, "
-            "current_step_id, started_at, finished_at, tier, generation "
+            "current_step_id, started_at, finished_at, tier, generation, manifest_json "
             "FROM workflow_run WHERE run_id = ?",
             (run_id,),
         ).fetchone()
@@ -858,6 +864,9 @@ def get_run(run_id: str) -> Optional[RunRow]:
         finished_at=row[7],
         tier=row[8],
         generation=row[9],
+        # issue #583 Bolt 2, ``approval-gate``: NULL for every YAML run and for any run whose freeze
+        # failed. Both read back as None, which the resume gate refuses when enforcement is on.
+        manifest_json=row[10],
     )
 
 

--- a/src/cli_agent_orchestrator/services/workflow_journal.py
+++ b/src/cli_agent_orchestrator/services/workflow_journal.py
@@ -476,6 +476,35 @@ def insert_run_with_steps(
         )
 
 
+def update_run_manifest(run_id: str, manifest_json: str) -> None:
+    """Replace ``workflow_run.manifest_json`` for ``run_id`` (issue #583 ``memory-resolve-once``).
+
+    THE ONLY SANCTIONED CALLER IS THE MEMORY FILL, and the narrowness is the point. The manifest is
+    written once at run start, in the same INSERT as the run row, precisely so there is no crash
+    window between two writes (ADR-583-4). Memory is the one field that cannot ride that write — it
+    resolves lazily, at the first point a run needs it, and a run that creates no terminal must
+    resolve nothing — so ``manifest-freeze`` leaves the memory record empty and this is the write
+    that fills it.
+
+    THE CALLER MUST PRESERVE EVERY OTHER FIELD BYTE-FOR-BYTE, and ``execution_manifest.with_memory``
+    is what guarantees it. The other fields are the inputs the ``plan_id`` was hashed from, and a
+    human may already have approved that identifier: rewrite one and the plan a run is executing
+    stops matching the approval that authorised it. A general "update the manifest" primitive would
+    be an invitation to do exactly that, which is why this function takes a whole document rather
+    than field arguments and says so here instead of accepting a field name.
+
+    Raises on failure rather than swallowing, because the caller must NOT hand a memory block to a
+    terminal whose record did not persist — a run that used memory the manifest does not record is
+    the one outcome FR-9 forbids, and it fails silently (an empty record is indistinguishable from a
+    run that never created a terminal).
+    """
+    with _connect() as conn:
+        conn.execute(
+            "UPDATE workflow_run SET manifest_json = ? WHERE run_id = ?",
+            (manifest_json, run_id),
+        )
+
+
 def insert_steps(run_id: str, steps: Sequence[Tuple[str, str]], updated_at: str) -> None:
     """INSERT one ``workflow_run_step`` row per ``(step_id, state)`` (E2).
 

--- a/src/cli_agent_orchestrator/services/workflow_journal.py
+++ b/src/cli_agent_orchestrator/services/workflow_journal.py
@@ -77,6 +77,18 @@ _REQUIRED_RUN_COLUMNS = frozenset(
         "finished_at",
         "tier",
         "generation",
+        # manifest-column (issue #583 Bolt 2, ADR-583-12). Registering the column here is
+        # NOT bookkeeping — it is what gives the silent-migration risk a RUNTIME mitigation.
+        # ``_migrate_workflow_run`` swallows its own failures at debug level, so a failed
+        # ALTER leaves the column absent with no signal. With the column in this set,
+        # ``_journal_schema_is_present`` answers False for such a database, ``_connect``
+        # declines to cache the schema, and the migrators therefore keep running on later
+        # connections instead of being skipped — the path self-heals. Omitting it would make
+        # the new column drop silently out of verification, which is exactly the drift the
+        # equality assertion in
+        # ``test_workflow_journal_connection_posture.py::test_the_required_column_sets_match_what_the_migrators_produce``
+        # exists to catch.
+        "manifest_json",
     }
 )
 _REQUIRED_STEP_COLUMNS = frozenset(
@@ -358,6 +370,7 @@ def insert_run(
     started_at: str,
     tier: str = "yaml",
     generation: str = "1",
+    manifest_json: Optional[str] = None,
 ) -> None:
     """INSERT the ``workflow_run`` row at ``start_run`` (lifecycle table, E1).
 
@@ -378,8 +391,8 @@ def insert_run(
         conn.execute(
             "INSERT INTO workflow_run "
             "(run_id, workflow_name, spec_snapshot, inputs_json, state, "
-            " current_step_id, started_at, finished_at, tier, generation) "
-            "VALUES (?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?)",
+            " current_step_id, started_at, finished_at, tier, generation, manifest_json) "
+            "VALUES (?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?)",
             (
                 run_id,
                 workflow_name,
@@ -389,6 +402,7 @@ def insert_run(
                 started_at,
                 tier,
                 generation,
+                manifest_json,
             ),
         )
 
@@ -404,6 +418,7 @@ def insert_run_with_steps(
     updated_at: str,
     tier: str = "yaml",
     generation: str = "1",
+    manifest_json: Optional[str] = None,
 ) -> None:
     """Atomically INSERT the run row AND seed its step rows in ONE transaction (U2, TR-1).
 
@@ -433,8 +448,8 @@ def insert_run_with_steps(
         conn.execute(
             "INSERT INTO workflow_run "
             "(run_id, workflow_name, spec_snapshot, inputs_json, state, "
-            " current_step_id, started_at, finished_at, tier, generation) "
-            "VALUES (?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?)",
+            " current_step_id, started_at, finished_at, tier, generation, manifest_json) "
+            "VALUES (?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?)",
             (
                 run_id,
                 workflow_name,
@@ -444,6 +459,7 @@ def insert_run_with_steps(
                 started_at,
                 tier,
                 generation,
+                manifest_json,
             ),
         )
         conn.executemany(

--- a/src/cli_agent_orchestrator/services/workflow_journal.py
+++ b/src/cli_agent_orchestrator/services/workflow_journal.py
@@ -476,35 +476,6 @@ def insert_run_with_steps(
         )
 
 
-def update_run_manifest(run_id: str, manifest_json: str) -> None:
-    """Replace ``workflow_run.manifest_json`` for ``run_id`` (issue #583 ``memory-resolve-once``).
-
-    THE ONLY SANCTIONED CALLER IS THE MEMORY FILL, and the narrowness is the point. The manifest is
-    written once at run start, in the same INSERT as the run row, precisely so there is no crash
-    window between two writes (ADR-583-4). Memory is the one field that cannot ride that write — it
-    resolves lazily, at the first point a run needs it, and a run that creates no terminal must
-    resolve nothing — so ``manifest-freeze`` leaves the memory record empty and this is the write
-    that fills it.
-
-    THE CALLER MUST PRESERVE EVERY OTHER FIELD BYTE-FOR-BYTE, and ``execution_manifest.with_memory``
-    is what guarantees it. The other fields are the inputs the ``plan_id`` was hashed from, and a
-    human may already have approved that identifier: rewrite one and the plan a run is executing
-    stops matching the approval that authorised it. A general "update the manifest" primitive would
-    be an invitation to do exactly that, which is why this function takes a whole document rather
-    than field arguments and says so here instead of accepting a field name.
-
-    Raises on failure rather than swallowing, because the caller must NOT hand a memory block to a
-    terminal whose record did not persist — a run that used memory the manifest does not record is
-    the one outcome FR-9 forbids, and it fails silently (an empty record is indistinguishable from a
-    run that never created a terminal).
-    """
-    with _connect() as conn:
-        conn.execute(
-            "UPDATE workflow_run SET manifest_json = ? WHERE run_id = ?",
-            (manifest_json, run_id),
-        )
-
-
 def compare_and_set_run_manifest(
     run_id: str, expected_manifest_json: str, manifest_json: str
 ) -> bool:

--- a/src/cli_agent_orchestrator/services/workflow_journal.py
+++ b/src/cli_agent_orchestrator/services/workflow_journal.py
@@ -505,6 +505,23 @@ def update_run_manifest(run_id: str, manifest_json: str) -> None:
         )
 
 
+def compare_and_set_run_manifest(
+    run_id: str, expected_manifest_json: str, manifest_json: str
+) -> bool:
+    """Replace a run manifest only when it still equals the contender's snapshot.
+
+    The memory filler is the sole concurrent manifest writer. A false return is
+    a normal lost race, distinct from a SQLite exception, which callers must
+    surface as a failed persistence rather than overwrite the winner.
+    """
+    with _connect() as conn:
+        cursor = conn.execute(
+            "UPDATE workflow_run SET manifest_json = ? " "WHERE run_id = ? AND manifest_json = ?",
+            (manifest_json, run_id, expected_manifest_json),
+        )
+        return cursor.rowcount == 1
+
+
 def insert_steps(run_id: str, steps: Sequence[Tuple[str, str]], updated_at: str) -> None:
     """INSERT one ``workflow_run_step`` row per ``(step_id, state)`` (E2).
 

--- a/src/cli_agent_orchestrator/utils/git_baseline.py
+++ b/src/cli_agent_orchestrator/utils/git_baseline.py
@@ -10,7 +10,7 @@ be the reason a run cannot start, so every failure — not a repository, ``git``
 unreadable directory, a hung process — is reported as a RECORDED ABSENCE rather than an exception. Absence is
 a representable state, not an error.
 
-COMMIT AND DIRTY FLAG ONLY, AND THE OMISSIONS ARE DELIBERATE. No branch name, and above all NO PATH: a path
+COMMIT AND WORKTREE STATE ONLY, AND THE OMISSIONS ARE DELIBERATE. No branch name, and above all NO PATH: a path
 is environment-specific, so including it would make the ``plan_id`` derived from this baseline differ between
 two machines running an identical plan — a spurious re-approval on every machine change, which is the same
 false positive that sorting dict keys in ``plan_identifier`` exists to prevent. Normalise away what does not
@@ -25,7 +25,9 @@ overlooked. **IF A THIRD CALLER EVER NEEDS A NEVER-RAISES GIT WRAPPER, CONSOLIDA
 decided on.
 """
 
+import hashlib
 import logging
+import os
 import subprocess
 from typing import Any, Dict, Optional
 
@@ -36,7 +38,9 @@ logger = logging.getLogger(__name__)
 _GIT_TIMEOUT_SECONDS = 10
 
 
-def _run_git(args: list[str], cwd: str) -> Optional[subprocess.CompletedProcess]:
+def _run_git(
+    args: list[str], cwd: str, *, text: bool = True
+) -> Optional[subprocess.CompletedProcess[Any]]:
     """Run ``git <args>`` in ``cwd``, returning ``None`` when it could not run or did not succeed.
 
     LIST-ARGV, NEVER A SHELL STRING, and no value is interpolated into the arguments — every element is an
@@ -53,7 +57,7 @@ def _run_git(args: list[str], cwd: str) -> Optional[subprocess.CompletedProcess]
             ["git", *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=text,
             timeout=_GIT_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired) as e:
@@ -68,11 +72,45 @@ def _run_git(args: list[str], cwd: str) -> Optional[subprocess.CompletedProcess]
     return completed
 
 
+def _worktree_state(cwd: str) -> Dict[str, str]:
+    """Capture tracked and untracked changes without recording an absolute worktree path."""
+    tracked = _run_git(["diff", "--binary", "--no-ext-diff", "HEAD", "--"], cwd, text=False)
+    untracked = _run_git(["ls-files", "--others", "--exclude-standard", "-z"], cwd, text=False)
+    if tracked is None or untracked is None:
+        return {"status": "unavailable"}
+
+    tracked_bytes = tracked.stdout
+    untracked_paths = [path for path in untracked.stdout.split(b"\0") if path]
+    if not tracked_bytes and not untracked_paths:
+        return {"status": "clean"}
+
+    digest = hashlib.sha256()
+    digest.update(len(tracked_bytes).to_bytes(8, "big"))
+    digest.update(tracked_bytes)
+    try:
+        for relative_path in sorted(untracked_paths):
+            # ``git ls-files`` yields repository-relative paths. Refuse an unexpected path rather than
+            # hashing outside the worktree if a repository changes beneath this snapshot operation.
+            if relative_path.startswith(b"/") or b".." in relative_path.split(b"/"):
+                return {"status": "unavailable"}
+            contents_path = os.path.join(os.fsencode(cwd), relative_path)
+            with open(contents_path, "rb") as untracked_file:
+                contents = untracked_file.read()
+            digest.update(len(relative_path).to_bytes(8, "big"))
+            digest.update(relative_path)
+            digest.update(len(contents).to_bytes(8, "big"))
+            digest.update(contents)
+    except OSError:
+        return {"status": "unavailable"}
+
+    return {"status": "dirty", "digest": f"sha256:{digest.hexdigest()}"}
+
+
 def derive_baseline(cwd: str) -> Dict[str, Any]:
     """The repository baseline for a run starting in ``cwd``. Never raises.
 
     Returns ``{"available": False}`` when no baseline could be read, and
-    ``{"available": True, "commit": <sha>, "dirty": <bool>}`` when one could.
+    ``{"available": True, "commit": <sha>, "worktree_state": <state>}`` when one could.
 
     ``available`` IS AN EXPLICIT FIELD rather than an absent key or a ``None`` commit, because the manifest
     is a durable record read later by an agent diagnosing a failed run: "we could not determine the
@@ -87,12 +125,4 @@ def derive_baseline(cwd: str) -> Dict[str, Any]:
     if not commit:
         return {"available": False}
 
-    # A repository with no commits yet, or any other state where the porcelain read fails, still yields a
-    # usable commit-less answer rather than discarding the commit we already have.
-    status = _run_git(["status", "--porcelain"], cwd)
-    dirty = bool(status.stdout.strip()) if status is not None else None
-
-    baseline: Dict[str, Any] = {"available": True, "commit": commit}
-    if dirty is not None:
-        baseline["dirty"] = dirty
-    return baseline
+    return {"available": True, "commit": commit, "worktree_state": _worktree_state(cwd)}

--- a/src/cli_agent_orchestrator/utils/git_baseline.py
+++ b/src/cli_agent_orchestrator/utils/git_baseline.py
@@ -1,0 +1,98 @@
+"""Derive a run's repository baseline (issue #583 Bolt 2, unit ``manifest-freeze``).
+
+The one thing about a script-tier plan that the workflow source hash CANNOT capture. Everything else the
+manifest records about how a run will execute is in the script itself; the surrounding repository is not.
+Two runs of an identical script against different commits are genuinely different plans, and a resume onto a
+different commit is exactly the drift FR-12 wants diagnosable.
+
+TOTAL BY CONSTRUCTION: nothing here raises, and nothing blocks indefinitely. Deriving a baseline must never
+be the reason a run cannot start, so every failure — not a repository, ``git`` missing from ``PATH``, an
+unreadable directory, a hung process — is reported as a RECORDED ABSENCE rather than an exception. Absence is
+a representable state, not an error.
+
+COMMIT AND DIRTY FLAG ONLY, AND THE OMISSIONS ARE DELIBERATE. No branch name, and above all NO PATH: a path
+is environment-specific, so including it would make the ``plan_id`` derived from this baseline differ between
+two machines running an identical plan — a spurious re-approval on every machine change, which is the same
+false positive that sorting dict keys in ``plan_identifier`` exists to prevent. Normalise away what does not
+affect execution.
+
+ON THE DUPLICATION WITH ``worktree_service._run_git``. That function already has this module's exact
+never-raises contract, and it is private to a service whose purpose (worktree management) is unrelated to
+freezing a manifest. Promoting it would have been the THIRD Bolt-1-file promotion in a single Construction
+pass, so a second wrapper is accepted here for testability and layering rather than because the sibling was
+overlooked. **IF A THIRD CALLER EVER NEEDS A NEVER-RAISES GIT WRAPPER, CONSOLIDATE INTO A SHARED
+``utils/git.py`` RATHER THAN ADDING A FOURTH.** Two is a bounded, documented cost; three is a pattern nobody
+decided on.
+"""
+
+import logging
+import subprocess
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Bounded so a hung git process cannot delay run start. Generous relative to the work — two local
+# invocations that read refs — because the point is to fail eventually, not quickly.
+_GIT_TIMEOUT_SECONDS = 10
+
+
+def _run_git(args: list[str], cwd: str) -> Optional[subprocess.CompletedProcess]:
+    """Run ``git <args>`` in ``cwd``, returning ``None`` when it could not run or did not succeed.
+
+    LIST-ARGV, NEVER A SHELL STRING, and no value is interpolated into the arguments — every element is an
+    authored literal and the only variable is the working directory. Command injection is closed by
+    construction rather than by escaping.
+
+    An ``OSError`` (``git`` absent, ``cwd`` unreadable) and a ``TimeoutExpired`` (hung process) are reported
+    the SAME way a nonzero exit code is: ``None``. The caller has one branch to write, which is what makes
+    this module's "never raises" contract hold rather than being a docstring claim that an exotic
+    environment quietly breaks.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        # Debug, not warning: a workspace outside git is entirely ordinary and this is not a fault.
+        logger.debug("git_baseline: %s failed (baseline recorded absent): %s", args, e)
+        return None
+    if completed.returncode != 0:
+        logger.debug(
+            "git_baseline: %s exited %d (baseline recorded absent)", args, completed.returncode
+        )
+        return None
+    return completed
+
+
+def derive_baseline(cwd: str) -> Dict[str, Any]:
+    """The repository baseline for a run starting in ``cwd``. Never raises.
+
+    Returns ``{"available": False}`` when no baseline could be read, and
+    ``{"available": True, "commit": <sha>, "dirty": <bool>}`` when one could.
+
+    ``available`` IS AN EXPLICIT FIELD rather than an absent key or a ``None`` commit, because the manifest
+    is a durable record read later by an agent diagnosing a failed run: "we could not determine the
+    repository state" and "the repository state is empty" call for different conclusions, and a reader should
+    not have to infer which one a missing key meant.
+    """
+    head = _run_git(["rev-parse", "HEAD"], cwd)
+    if head is None:
+        return {"available": False}
+
+    commit = head.stdout.strip()
+    if not commit:
+        return {"available": False}
+
+    # A repository with no commits yet, or any other state where the porcelain read fails, still yields a
+    # usable commit-less answer rather than discarding the commit we already have.
+    status = _run_git(["status", "--porcelain"], cwd)
+    dirty = bool(status.stdout.strip()) if status is not None else None
+
+    baseline: Dict[str, Any] = {"available": True, "commit": commit}
+    if dirty is not None:
+        baseline["dirty"] = dirty
+    return baseline

--- a/src/cli_agent_orchestrator/utils/git_baseline.py
+++ b/src/cli_agent_orchestrator/utils/git_baseline.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 # invocations that read refs — because the point is to fail eventually, not quickly.
 _GIT_TIMEOUT_SECONDS = 10
 _HASH_CHUNK_BYTES = 64 * 1024
+_UNTRACKED_HASH_BUDGET_BYTES = 64 * 1024 * 1024  # 64 MiB
 
 _TRACKED_DIFF_ARGS = [
     "-c",
@@ -114,7 +115,12 @@ def _run_git(
 
 
 def _worktree_state(cwd: str) -> Dict[str, str]:
-    """Capture tracked and untracked changes without recording an absolute worktree path."""
+    """Capture tracked and untracked changes without recording an absolute worktree path.
+
+    Hash at most ``_UNTRACKED_HASH_BUDGET_BYTES`` of untracked regular-file content. Exhausting
+    that aggregate limit, or observing a path race, records the state as unavailable rather than
+    producing an identity from a partial snapshot.
+    """
     tracked = _run_git(_TRACKED_DIFF_ARGS, cwd, text=False)
     untracked = _run_git(["ls-files", "--others", "--exclude-standard", "-z"], cwd, text=False)
     if tracked is None or untracked is None:
@@ -128,6 +134,7 @@ def _worktree_state(cwd: str) -> Dict[str, str]:
     digest = hashlib.sha256()
     digest.update(len(tracked_bytes).to_bytes(8, "big"))
     digest.update(tracked_bytes)
+    hashed_untracked_bytes = 0
     try:
         for relative_path in sorted(untracked_paths):
             # ``git ls-files`` yields repository-relative paths. Refuse an unexpected path rather than
@@ -155,7 +162,8 @@ def _worktree_state(cwd: str) -> Dict[str, str]:
 
             digest.update(len(relative_path).to_bytes(8, "big"))
             digest.update(relative_path)
-            entry_mode = os.lstat(contents_path).st_mode
+            entry_stat = os.lstat(contents_path)
+            entry_mode = entry_stat.st_mode
             if stat.S_ISLNK(entry_mode):
                 link_payload = os.readlink(contents_path)
                 digest.update(b"S")
@@ -170,13 +178,55 @@ def _worktree_state(cwd: str) -> Dict[str, str]:
                 return {"status": "unavailable"}
 
             digest.update(b"F")
-            content_length = 0
-            with open(contents_path, "rb") as untracked_file:
-                content_length = os.fstat(untracked_file.fileno()).st_size
-                digest.update(content_length.to_bytes(8, "big"))
-                while chunk := untracked_file.read(_HASH_CHUNK_BYTES):
-                    digest.update(chunk)
-                    content_length -= len(chunk)
+            nonblocking_flag = getattr(os, "O_NONBLOCK", None)
+            nofollow_flag = getattr(os, "O_NOFOLLOW", None)
+            if nonblocking_flag is None or nofollow_flag is None:
+                logger.debug(
+                    "git_baseline: required descriptor flags are unavailable "
+                    "(baseline recorded absent): %r",
+                    relative_path,
+                )
+                return {"status": "unavailable"}
+
+            descriptor = -1
+            try:
+                descriptor = os.open(contents_path, os.O_RDONLY | nonblocking_flag | nofollow_flag)
+                opened_stat = os.fstat(descriptor)
+                if (
+                    not stat.S_ISREG(opened_stat.st_mode)
+                    or opened_stat.st_dev != entry_stat.st_dev
+                    or opened_stat.st_ino != entry_stat.st_ino
+                ):
+                    logger.debug(
+                        "git_baseline: untracked entry changed before descriptor open "
+                        "(baseline recorded absent): %r",
+                        relative_path,
+                    )
+                    return {"status": "unavailable"}
+
+                content_length = opened_stat.st_size
+                if content_length + hashed_untracked_bytes > _UNTRACKED_HASH_BUDGET_BYTES:
+                    logger.debug(
+                        "git_baseline: untracked hash budget exhausted (baseline recorded absent): %r",
+                        relative_path,
+                    )
+                    return {"status": "unavailable"}
+                hashed_untracked_bytes += content_length
+
+                with os.fdopen(descriptor, "rb") as untracked_file:
+                    descriptor = -1
+                    digest.update(content_length.to_bytes(8, "big"))
+                    while content_length:
+                        chunk = untracked_file.read(min(_HASH_CHUNK_BYTES, content_length))
+                        if not chunk:
+                            break
+                        digest.update(chunk)
+                        content_length -= len(chunk)
+                    if os.fstat(untracked_file.fileno()).st_size != opened_stat.st_size:
+                        content_length = -1
+            finally:
+                if descriptor != -1:
+                    os.close(descriptor)
             if content_length != 0:
                 logger.debug(
                     "git_baseline: untracked file changed while reading "
@@ -194,8 +244,11 @@ def _worktree_state(cwd: str) -> Dict[str, str]:
 def derive_baseline(cwd: str) -> Dict[str, Any]:
     """The repository baseline for a run starting in ``cwd``. Never raises.
 
-    Returns ``{"available": False}`` when no baseline could be read, and
+    Returns ``{"available": False}`` when no verifiable baseline could be read, and
     ``{"available": True, "commit": <sha>, "worktree_state": <state>}`` when one could.
+
+    A successfully read commit may accompany ``available: False`` when the worktree snapshot itself
+    was unavailable. The commit alone is not a complete baseline and cannot identify an approvable plan.
 
     ``available`` IS AN EXPLICIT FIELD rather than an absent key or a ``None`` commit, because the manifest
     is a durable record read later by an agent diagnosing a failed run: "we could not determine the
@@ -210,4 +263,7 @@ def derive_baseline(cwd: str) -> Dict[str, Any]:
     if not commit:
         return {"available": False}
 
-    return {"available": True, "commit": commit, "worktree_state": _worktree_state(cwd)}
+    worktree_state = _worktree_state(cwd)
+    if worktree_state["status"] == "unavailable":
+        return {"available": False, "commit": commit, "worktree_state": worktree_state}
+    return {"available": True, "commit": commit, "worktree_state": worktree_state}

--- a/src/cli_agent_orchestrator/utils/git_baseline.py
+++ b/src/cli_agent_orchestrator/utils/git_baseline.py
@@ -28,6 +28,7 @@ decided on.
 import hashlib
 import logging
 import os
+import stat
 import subprocess
 from typing import Any, Dict, Optional
 
@@ -36,6 +37,46 @@ logger = logging.getLogger(__name__)
 # Bounded so a hung git process cannot delay run start. Generous relative to the work — two local
 # invocations that read refs — because the point is to fail eventually, not quickly.
 _GIT_TIMEOUT_SECONDS = 10
+_HASH_CHUNK_BYTES = 64 * 1024
+
+_TRACKED_DIFF_ARGS = [
+    "-c",
+    "core.abbrev=40",
+    "-c",
+    "core.quotePath=true",
+    "-c",
+    "core.autocrlf=false",
+    "-c",
+    "color.ui=false",
+    "-c",
+    "color.diff=false",
+    "-c",
+    "diff.renames=false",
+    "-c",
+    "diff.algorithm=myers",
+    "-c",
+    "diff.indentHeuristic=false",
+    "-c",
+    "diff.context=3",
+    "-c",
+    "diff.interHunkContext=0",
+    "-c",
+    "diff.submodule=short",
+    "diff",
+    "--binary",
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-color",
+    "--no-prefix",
+    "--no-renames",
+    "--diff-algorithm=myers",
+    "--no-indent-heuristic",
+    "--unified=3",
+    "--inter-hunk-context=0",
+    "--ignore-submodules=none",
+    "HEAD",
+    "--",
+]
 
 
 def _run_git(
@@ -74,7 +115,7 @@ def _run_git(
 
 def _worktree_state(cwd: str) -> Dict[str, str]:
     """Capture tracked and untracked changes without recording an absolute worktree path."""
-    tracked = _run_git(["diff", "--binary", "--no-ext-diff", "HEAD", "--"], cwd, text=False)
+    tracked = _run_git(_TRACKED_DIFF_ARGS, cwd, text=False)
     untracked = _run_git(["ls-files", "--others", "--exclude-standard", "-z"], cwd, text=False)
     if tracked is None or untracked is None:
         return {"status": "unavailable"}
@@ -92,15 +133,59 @@ def _worktree_state(cwd: str) -> Dict[str, str]:
             # ``git ls-files`` yields repository-relative paths. Refuse an unexpected path rather than
             # hashing outside the worktree if a repository changes beneath this snapshot operation.
             if relative_path.startswith(b"/") or b".." in relative_path.split(b"/"):
+                logger.debug(
+                    "git_baseline: invalid untracked path (baseline recorded absent): %r",
+                    relative_path,
+                )
                 return {"status": "unavailable"}
-            contents_path = os.path.join(os.fsencode(cwd), relative_path)
-            with open(contents_path, "rb") as untracked_file:
-                contents = untracked_file.read()
+
+            contents_path = os.fsencode(cwd)
+            path_components = relative_path.split(b"/")
+            for index, component in enumerate(path_components):
+                contents_path = os.path.join(contents_path, component)
+                if stat.S_ISLNK(os.lstat(contents_path).st_mode):
+                    if index != len(path_components) - 1:
+                        logger.debug(
+                            "git_baseline: untracked path has a symlinked parent "
+                            "(baseline recorded absent): %r",
+                            relative_path,
+                        )
+                        return {"status": "unavailable"}
+                    break
+
             digest.update(len(relative_path).to_bytes(8, "big"))
             digest.update(relative_path)
-            digest.update(len(contents).to_bytes(8, "big"))
-            digest.update(contents)
-    except OSError:
+            entry_mode = os.lstat(contents_path).st_mode
+            if stat.S_ISLNK(entry_mode):
+                link_payload = os.readlink(contents_path)
+                digest.update(b"S")
+                digest.update(len(link_payload).to_bytes(8, "big"))
+                digest.update(link_payload)
+                continue
+            if not stat.S_ISREG(entry_mode):
+                logger.debug(
+                    "git_baseline: invalid untracked entry (baseline recorded absent): %r",
+                    relative_path,
+                )
+                return {"status": "unavailable"}
+
+            digest.update(b"F")
+            content_length = 0
+            with open(contents_path, "rb") as untracked_file:
+                content_length = os.fstat(untracked_file.fileno()).st_size
+                digest.update(content_length.to_bytes(8, "big"))
+                while chunk := untracked_file.read(_HASH_CHUNK_BYTES):
+                    digest.update(chunk)
+                    content_length -= len(chunk)
+            if content_length != 0:
+                logger.debug(
+                    "git_baseline: untracked file changed while reading "
+                    "(baseline recorded absent): %r",
+                    relative_path,
+                )
+                return {"status": "unavailable"}
+    except OSError as e:
+        logger.debug("git_baseline: untracked entry unavailable (baseline recorded absent): %s", e)
         return {"status": "unavailable"}
 
     return {"status": "dirty", "digest": f"sha256:{digest.hexdigest()}"}

--- a/test/api/test_workflow_runs.py
+++ b/test/api/test_workflow_runs.py
@@ -8,6 +8,10 @@ unknown run/spec, 400 invalid inputs, 409 cancel-of-finished, 501 reserved mode,
 
 from __future__ import annotations
 
+import asyncio
+import threading
+from types import SimpleNamespace
+
 import pytest
 
 from cli_agent_orchestrator.models.workflow import (
@@ -281,6 +285,94 @@ def test_script_run_resolved_inputs_passed_to_runner(client, script_run_env):
     assert script_run_env["spy"]["called"] is True
     # ``note`` is optional with no default -> omitted; ``topic`` kept.
     assert script_run_env["spy"]["inputs"] == {"topic": "birds"}
+
+
+def test_blocking_script_start_returns_approval_refusal(client, monkeypatch):
+    """A script approval refusal is actionable rather than an internal error."""
+    from cli_agent_orchestrator.models.workflow import ScriptSpec
+    from cli_agent_orchestrator.services import approval_gate, script_runner
+
+    spec = ScriptSpec(
+        name="scr",
+        path="/tmp/scr.py",
+        source="def main():\n    pass\n",
+        content_hash="deadbeef",
+    )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.workflow_spec_service.get_workflow",
+        lambda name_or_path, scan_dir=None: spec,
+    )
+
+    async def _refuse(spec_arg, inputs, run_id):
+        raise approval_gate.PlanApprovalRequiredError(
+            "Plan 'plan-v1:blocked' has not been approved.",
+            plan_id="plan-v1:blocked",
+        )
+
+    monkeypatch.setattr(script_runner, "run_script_workflow", _refuse)
+
+    response = client.post(
+        "/workflows/runs",
+        json={"name_or_path": "scr", "inputs": {}, "run_id": "approval-refusal"},
+    )
+
+    assert response.status_code == 403
+    assert "plan-v1:blocked" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_blocking_script_manifest_freeze_is_offloaded_from_event_loop(monkeypatch):
+    """The blocking script start leaves the event loop schedulable while freezing."""
+    from cli_agent_orchestrator.models.workflow import ScriptSpec
+    from cli_agent_orchestrator.services import manifest_freeze, script_runner
+
+    probe_started = threading.Event()
+    same_loop_sentinel = threading.Event()
+    release_probe = threading.Event()
+    observed = {}
+    event_loop_thread_id = threading.get_ident()
+
+    def blocking_manifest(*, source_hash, inputs):
+        observed["manifest_thread_id"] = threading.get_ident()
+        probe_started.set()
+        observed["sentinel_ran_while_blocked"] = same_loop_sentinel.wait(timeout=1)
+        assert release_probe.wait(timeout=1)
+        return '{"plan_id":"plan-v1:offloaded"}'
+
+    async def advance_same_loop() -> None:
+        while not probe_started.is_set():
+            await asyncio.sleep(0)
+        same_loop_sentinel.set()
+
+    async def _drive(record, path, env):
+        return _result()
+
+    spec = ScriptSpec(
+        name="scr",
+        path="/tmp/scr.py",
+        source="def main():\n    pass\n",
+        content_hash="deadbeef",
+    )
+    monkeypatch.setattr(manifest_freeze, "build_manifest_json", blocking_manifest)
+    monkeypatch.setattr(
+        script_runner, "lint_script", lambda source, path: SimpleNamespace(status="pass")
+    )
+    monkeypatch.setattr(script_runner.approval_gate, "ensure_plan_approved", lambda **kwargs: None)
+    monkeypatch.setattr(script_runner.workflow_journal, "insert_run", lambda *args: None)
+    monkeypatch.setattr(script_runner, "_drive_process", _drive)
+
+    run_task = asyncio.create_task(script_runner.run_script_workflow(spec, {}, "manifest-blocking"))
+    sentinel_task = asyncio.create_task(advance_same_loop())
+    while not probe_started.is_set():
+        await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release_probe.set()
+
+    await run_task
+    await sentinel_task
+
+    assert observed["manifest_thread_id"] != event_loop_thread_id
+    assert observed["sentinel_ran_while_blocked"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -773,6 +865,68 @@ def test_submit_script_tier_202_and_drives(client, async_script_env):
             break
     assert final == "completed"
     assert async_script_env["prepared"]["called"] is True
+
+
+@pytest.mark.asyncio
+async def test_submit_script_manifest_freeze_is_offloaded_from_event_loop(monkeypatch):
+    """The submit script start leaves the event loop schedulable while freezing."""
+    from cli_agent_orchestrator.api import main as api_main
+    from cli_agent_orchestrator.models.workflow import ScriptSpec
+    from cli_agent_orchestrator.services import (
+        manifest_freeze,
+        script_runner,
+        workflow_spec_service,
+    )
+
+    probe_started = threading.Event()
+    same_loop_sentinel = threading.Event()
+    release_probe = threading.Event()
+    observed = {}
+    event_loop_thread_id = threading.get_ident()
+
+    def blocking_manifest(*, source_hash, inputs):
+        observed["manifest_thread_id"] = threading.get_ident()
+        probe_started.set()
+        observed["sentinel_ran_while_blocked"] = same_loop_sentinel.wait(timeout=1)
+        assert release_probe.wait(timeout=1)
+        return '{"plan_id":"plan-v1:offloaded"}'
+
+    async def advance_same_loop() -> None:
+        while not probe_started.is_set():
+            await asyncio.sleep(0)
+        same_loop_sentinel.set()
+
+    spec = ScriptSpec(
+        name="scr",
+        path="/tmp/scr.py",
+        source="def main():\n    pass\n",
+        content_hash="deadbeef",
+    )
+    monkeypatch.setattr(workflow_spec_service, "get_workflow", lambda name_or_path: spec)
+    monkeypatch.setattr(workflow_service, "_validate_inputs", lambda spec, inputs: inputs)
+    monkeypatch.setattr(workflow_service, "_now", lambda: "2026-01-01T00:00:00Z")
+    monkeypatch.setattr(manifest_freeze, "build_manifest_json", blocking_manifest)
+    monkeypatch.setattr(
+        script_runner, "lint_script", lambda source, path: SimpleNamespace(status="pass")
+    )
+    monkeypatch.setattr(api_main.approval_gate, "ensure_plan_approved", lambda **kwargs: None)
+    monkeypatch.setattr(workflow_journal, "insert_run", lambda *args: None)
+    monkeypatch.setattr(api_main, "_schedule_background_drive", lambda *args: None)
+
+    body = api_main.WorkflowRunRequest(name_or_path="scr", inputs={}, run_id="manifest-submit")
+    submit_task = asyncio.create_task(api_main.submit_workflow_run_endpoint(body, []))
+    sentinel_task = asyncio.create_task(advance_same_loop())
+    while not probe_started.is_set():
+        await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release_probe.set()
+
+    response = await submit_task
+    await sentinel_task
+
+    assert response["state"] == "running"
+    assert observed["manifest_thread_id"] != event_loop_thread_id
+    assert observed["sentinel_ran_while_blocked"] is True
 
 
 def test_submit_script_lint_fail_422_no_row(client, async_script_env):

--- a/test/api/test_workflow_runs.py
+++ b/test/api/test_workflow_runs.py
@@ -9,6 +9,7 @@ unknown run/spec, 400 invalid inputs, 409 cancel-of-finished, 501 reserved mode,
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 from types import SimpleNamespace
 
@@ -865,6 +866,45 @@ def test_submit_script_tier_202_and_drives(client, async_script_env):
             break
     assert final == "completed"
     assert async_script_env["prepared"]["called"] is True
+
+
+def test_submit_script_manifest_freezes_resolved_inputs(client, async_script_env, monkeypatch):
+    """The async script manifest, journal, and drive share resolved inputs."""
+    from cli_agent_orchestrator.api import main as api_main
+    from cli_agent_orchestrator.models.workflow import InputDecl
+    from cli_agent_orchestrator.services import manifest_freeze, workflow_spec_service
+
+    resolved_inputs = {"topic": "default topic"}
+    spec = async_script_env["spec"].model_copy(
+        update={"inputs": {"topic": InputDecl(type="string", default="default topic")}}
+    )
+    captured = {}
+
+    monkeypatch.setattr(
+        workflow_spec_service, "get_workflow", lambda name_or_path, scan_dir=None: spec
+    )
+
+    def _capture_manifest(*, source_hash, inputs):
+        captured["manifest_inputs"] = inputs
+        return '{"plan_id":"plan-v1:resolved-inputs"}'
+
+    def _capture_schedule(record, spec_arg, run_id, tier, inputs):
+        captured["scheduled_inputs"] = inputs
+
+    monkeypatch.setattr(manifest_freeze, "build_manifest_json", _capture_manifest)
+    monkeypatch.setattr(api_main, "_schedule_background_drive", _capture_schedule)
+
+    response = client.post(
+        "/workflows/runs:submit",
+        json={"name_or_path": "scr", "inputs": {}, "run_id": "async-resolved-inputs"},
+    )
+
+    assert response.status_code == 202
+    assert captured["manifest_inputs"] == resolved_inputs
+    assert (
+        json.loads(workflow_journal.get_run("async-resolved-inputs").inputs_json) == resolved_inputs
+    )
+    assert captured["scheduled_inputs"] == resolved_inputs
 
 
 @pytest.mark.asyncio

--- a/test/clients/test_workflow_run_migration.py
+++ b/test/clients/test_workflow_run_migration.py
@@ -69,6 +69,7 @@ def test_workflow_run_columns(patched_db):
         "finished_at",
         "tier",
         "generation",
+        "manifest_json",
     }
     # run_id is the primary key; the nullable columns are current_step_id/finished_at.
     assert cols["run_id"][5] == 1
@@ -79,6 +80,19 @@ def test_workflow_run_columns(patched_db):
     # U3 additive columns (E1): tier/generation default to the YAML-preserving values.
     assert cols["tier"][4] == "'yaml'"
     assert cols["generation"][4] == "'1'"
+    # manifest-column additive column (issue #583 Bolt 2, ADR-583-12): one TEXT column
+    # defaulting to NULL, so every pre-Bolt-2 row reads as "manifest absent".
+    #
+    # THIS ASSERTION IS THE UNIT'S WHOLE MITIGATION FOR THE SILENT-MIGRATION RISK, not a
+    # routine column check. ``_migrate_workflow_run``'s body is wrapped in
+    # ``except Exception`` -> ``logger.debug``, so a failed ALTER leaves the column absent
+    # with no visible signal; the symptom then appears at the Bolt 2 approval gate, which
+    # reads an absent manifest as "never approved" and refuses the run — arbitrarily far
+    # from the cause. Asserting on a FRESH database is what turns that from assumed into
+    # verified. Do not delete it as redundant with the column-set assertion above: the set
+    # proves presence, these two prove the shape a reader depends on.
+    assert cols["manifest_json"][2] == "TEXT"
+    assert cols["manifest_json"][4] == "NULL"
 
 
 def test_workflow_run_no_loop_columns(patched_db):
@@ -275,6 +289,12 @@ def test_workflow_run_indexes_do_not_change_columns(patched_db):
         "finished_at",
         "tier",
         "generation",
+        # manifest-column (issue #583 Bolt 2): this set is MIRRORED from
+        # test_workflow_run_columns, so an additive column has to be added in both places.
+        # There is a third mirror in production code —
+        # workflow_journal._REQUIRED_RUN_COLUMNS — guarded by its own equality assertion in
+        # test_workflow_journal_connection_posture.py. Three places, one column set.
+        "manifest_json",
     }
 
 

--- a/test/services/test_agent_step.py
+++ b/test/services/test_agent_step.py
@@ -70,6 +70,29 @@ def _patch_terminal_layer(
 
 
 class TestHappyPath:
+    def test_an_empty_frozen_block_is_passed_to_suppress_live_memory(self):
+        create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer()
+        with (
+            create,
+            send as m_send,
+            delete,
+            get_output,
+            exit_cli,
+            wait,
+            status,
+            patch(f"{_MODULE}.frozen_run_memory.frozen_memory_for", return_value=""),
+        ):
+            asyncio.run(
+                run_agent_step(
+                    "kiro_cli",
+                    "dev",
+                    "x",
+                    env_vars={"CAO_WORKFLOW_RUN_ID": "run-frozen"},
+                )
+            )
+
+        m_send.assert_called_once_with("abc12345", "x", frozen_memory="")
+
     def test_frozen_memory_resolution_is_offloaded_from_the_event_loop(self):
         """A polling frozen-memory resolver must leave the server loop schedulable."""
         block = "<cao-memory>frozen</cao-memory>"

--- a/test/services/test_agent_step.py
+++ b/test/services/test_agent_step.py
@@ -7,6 +7,7 @@ success.
 """
 
 import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,7 +15,10 @@ import pytest
 from cli_agent_orchestrator.models.kiro_engine import KiroEngine
 from cli_agent_orchestrator.models.terminal import AgentStepResult, TerminalStatus
 from cli_agent_orchestrator.providers.kiro_capabilities import KiroPhase0KASError
-from cli_agent_orchestrator.services.agent_step import StepExecutionError, run_agent_step
+from cli_agent_orchestrator.services.agent_step import (
+    StepExecutionError,
+    run_agent_step,
+)
 from cli_agent_orchestrator.services.terminal_service import OutputMode
 
 _MODULE = "cli_agent_orchestrator.services.agent_step"
@@ -66,6 +70,67 @@ def _patch_terminal_layer(
 
 
 class TestHappyPath:
+    def test_frozen_memory_resolution_is_offloaded_from_the_event_loop(self):
+        """A polling frozen-memory resolver must leave the server loop schedulable."""
+        block = "<cao-memory>frozen</cao-memory>"
+        resolution_started = threading.Event()
+        resolution_finished = threading.Event()
+        release_resolution = threading.Event()
+        resolver_thread_ids = []
+
+        async def _run():
+            event_loop_thread_id = threading.get_ident()
+            sentinel_ran = asyncio.Event()
+
+            def _resolve(run_id, terminal_id, prompt):
+                resolver_thread_ids.append(threading.get_ident())
+                resolution_started.set()
+                release_resolution.wait(timeout=1)
+                resolution_finished.set()
+                return block
+
+            async def _sentinel():
+                sentinel_ran.set()
+
+            create, send, delete, get_output, exit_cli, get_wd, wait, status = (
+                _patch_terminal_layer()
+            )
+            with (
+                create,
+                send as m_send,
+                delete,
+                get_output,
+                exit_cli,
+                wait,
+                status,
+                patch(
+                    f"{_MODULE}.frozen_run_memory.frozen_memory_for",
+                    side_effect=_resolve,
+                ),
+            ):
+                step = asyncio.create_task(
+                    run_agent_step(
+                        "kiro_cli",
+                        "dev",
+                        "x",
+                        env_vars={"CAO_WORKFLOW_RUN_ID": "run-frozen"},
+                    )
+                )
+                await asyncio.to_thread(resolution_started.wait)
+                asyncio.create_task(_sentinel())
+                await asyncio.sleep(0)
+                assert sentinel_ran.is_set()
+                assert not resolution_finished.is_set()
+                release_resolution.set()
+                await step
+
+            m_send.assert_called_once_with("abc12345", "x", frozen_memory=block)
+            return event_loop_thread_id
+
+        event_loop_thread_id = asyncio.run(_run())
+        assert len(resolver_thread_ids) == 1
+        assert resolver_thread_ids[0] != event_loop_thread_id
+
     def test_create_per_call_runs_full_sequence_and_tears_down(self):
         create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer()
         with (
@@ -93,7 +158,15 @@ class TestHappyPath:
 
     def test_teardown_false_skips_delete(self):
         create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer()
-        with create, send, delete as m_delete, get_output, exit_cli as m_exit, wait, status:
+        with (
+            create,
+            send,
+            delete as m_delete,
+            get_output,
+            exit_cli as m_exit,
+            wait,
+            status,
+        ):
             asyncio.run(run_agent_step("kiro_cli", "dev", "x", teardown=False))
         m_delete.assert_not_called()
         m_exit.assert_not_called()
@@ -298,7 +371,16 @@ class TestHappyPath:
         """caller_id (#284 callback routing) and inherited allowed_tools must
         reach create_terminal for handoff workers."""
         create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer()
-        with create as m_create, send, delete, get_output, exit_cli, get_wd, wait, status:
+        with (
+            create as m_create,
+            send,
+            delete,
+            get_output,
+            exit_cli,
+            get_wd,
+            wait,
+            status,
+        ):
             asyncio.run(
                 run_agent_step(
                     "kiro_cli",

--- a/test/services/test_approval_gate.py
+++ b/test/services/test_approval_gate.py
@@ -1,0 +1,258 @@
+"""Tests for the plan-approval gate (issue #583 Bolt 2, unit ``approval-gate``).
+
+Three carry the unit's load:
+
+* ``test_enforcement_is_off_by_default_so_an_unapproved_script_run_proceeds`` — C-1. If this fails, every
+  existing script-tier caller breaks, because a ``plan_id`` does not exist until run start and the first run
+  of any new plan is therefore refused.
+* ``test_a_yaml_run_is_never_gated_even_with_enforcement_on`` — C-1's harder half. YAML runs never freeze a
+  manifest, so a gate that keyed off "manifest present" instead of the tier would refuse all of them.
+* ``test_the_env_var_cannot_turn_the_gate_off`` — the asymmetric precedence. Written as an assertion about
+  PRECEDENCE rather than about a value, because an implementation that followed the house
+  ``env > file`` rule by habit would pass every other test in this file.
+"""
+
+import json
+
+import pytest
+
+from cli_agent_orchestrator.services import approval_gate, approval_store, settings_service
+from cli_agent_orchestrator.services.approval_gate import (
+    PlanApprovalRequiredError,
+    ensure_plan_approved,
+    plan_id_from_manifest,
+)
+
+PLAN = "plan-v1:abc123"
+MANIFEST = json.dumps({"plan_id": PLAN, "source_hash": "sha256:deadbeef"})
+
+
+@pytest.fixture()
+def enforcement_on(monkeypatch):
+    monkeypatch.setattr(approval_gate, "is_workflow_approval_required", lambda: True)
+
+
+@pytest.fixture()
+def approved(monkeypatch):
+    """Approve exactly ``PLAN`` and nothing else, without touching a database."""
+    monkeypatch.setattr(approval_store, "is_approved", lambda plan_id: plan_id == PLAN)
+
+
+@pytest.fixture()
+def nothing_approved(monkeypatch):
+    monkeypatch.setattr(approval_store, "is_approved", lambda plan_id: False)
+
+
+# ---------------------------------------------------------------------------
+# The three load-bearing properties
+# ---------------------------------------------------------------------------
+
+
+def test_enforcement_is_off_by_default_so_an_unapproved_script_run_proceeds(monkeypatch):
+    """C-1 and the default. ``is_approved`` must not even be consulted."""
+    consulted = []
+    monkeypatch.setattr(approval_store, "is_approved", lambda p: consulted.append(p) or False)
+    monkeypatch.setattr(approval_gate, "is_workflow_approval_required", lambda: False)
+
+    ensure_plan_approved(tier="script", manifest_json=MANIFEST)  # must not raise
+
+    assert consulted == [], "the disabled path must not consult the approval store at all"
+
+
+def test_a_yaml_run_is_never_gated_even_with_enforcement_on(enforcement_on, nothing_approved):
+    """A YAML run never freezes a manifest, so a manifest-keyed gate would refuse every one of them."""
+    ensure_plan_approved(tier="yaml", manifest_json=None)  # must not raise
+
+
+def test_the_env_var_cannot_turn_the_gate_off(monkeypatch, tmp_path):
+    """ASYMMETRIC PRECEDENCE: env may enable, only settings.json may disable.
+
+    Asserted as a statement about precedence, not about a value: an implementation that followed the
+    house ``env > file > default`` rule would pass every other test here and fail only this one.
+    """
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({"workflow": {"require_approval": True}}))
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", settings_file)
+
+    for disabling_value in ("0", "false", "no", ""):
+        monkeypatch.setenv("CAO_WORKFLOW_REQUIRE_APPROVAL", disabling_value)
+        assert settings_service.is_workflow_approval_required() is True, (
+            f"env value {disabling_value!r} must NOT be able to disable the gate — a control the "
+            "environment can switch off is not a control"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Enforcement on
+# ---------------------------------------------------------------------------
+
+
+def test_an_unapproved_plan_is_refused_and_the_refusal_carries_the_plan_id(
+    enforcement_on, nothing_approved
+):
+    """Without the plan_id an operator meeting a first-run refusal has nothing to act on."""
+    with pytest.raises(PlanApprovalRequiredError) as excinfo:
+        ensure_plan_approved(tier="script", manifest_json=MANIFEST)
+
+    assert excinfo.value.plan_id == PLAN
+    assert PLAN in str(excinfo.value)
+
+
+def test_an_approved_plan_proceeds(enforcement_on, approved):
+    ensure_plan_approved(tier="script", manifest_json=MANIFEST)  # must not raise
+
+
+def test_an_approval_for_a_different_plan_does_not_admit_this_one(enforcement_on, approved):
+    """The whole re-approval mechanism: a changed plan is a different plan_id."""
+    other = json.dumps({"plan_id": "plan-v1:something-else"})
+    with pytest.raises(PlanApprovalRequiredError):
+        ensure_plan_approved(tier="script", manifest_json=other)
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        None,
+        "",
+        "not json at all",
+        "[]",
+        '"a string"',
+        "{}",
+        json.dumps({"plan_id": None}),
+        json.dumps({"plan_id": ""}),
+    ],
+)
+def test_an_unreadable_manifest_refuses(enforcement_on, approved, manifest):
+    """FAIL CLOSED — the promise both freeze call sites already make in writing.
+
+    A freeze that failed writes NULL, and every shape of unreadable manifest must converge here
+    rather than on permission.
+    """
+    with pytest.raises(PlanApprovalRequiredError) as excinfo:
+        ensure_plan_approved(tier="script", manifest_json=manifest)
+    assert excinfo.value.plan_id is None
+
+
+def test_a_database_error_refuses_rather_than_permits(enforcement_on, monkeypatch):
+    """``approval_store.is_approved`` already answers False on sqlite3.Error; the gate must honour it."""
+    monkeypatch.setattr(approval_store, "is_approved", lambda p: False)
+    with pytest.raises(PlanApprovalRequiredError):
+        ensure_plan_approved(tier="script", manifest_json=MANIFEST)
+
+
+# ---------------------------------------------------------------------------
+# The refusal type
+# ---------------------------------------------------------------------------
+
+
+def test_the_refusal_is_not_a_valueerror():
+    """The API resume handler ends with ``except ValueError -> 400``.
+
+    Subclassing ValueError would transport a security refusal as a bad request, and a caller reading
+    400 would go looking for a malformed argument instead of approving a plan.
+    """
+    assert not issubclass(PlanApprovalRequiredError, ValueError)
+
+
+def test_the_refusal_is_distinct_from_the_resume_ladders_other_outcomes():
+    from cli_agent_orchestrator.services import workflow_service
+
+    assert not issubclass(PlanApprovalRequiredError, workflow_service.ResumeNotAllowedError)
+    assert not issubclass(PlanApprovalRequiredError, workflow_service.ResumeCorruptError)
+    assert not issubclass(PlanApprovalRequiredError, KeyError)
+
+
+# ---------------------------------------------------------------------------
+# plan_id extraction — total, and never recomputed
+# ---------------------------------------------------------------------------
+
+
+def test_plan_id_is_read_from_the_manifest_verbatim():
+    assert plan_id_from_manifest(MANIFEST) == PLAN
+
+
+def test_plan_id_extraction_is_total():
+    """Every malformed shape answers None rather than raising — absence never becomes permission."""
+    for bad in (None, "", "{", "null", "3", "[]", '{"plan_id": 7}', '{"other": "x"}'):
+        assert plan_id_from_manifest(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# The setting
+# ---------------------------------------------------------------------------
+
+
+def test_the_env_var_can_turn_the_gate_on(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", tmp_path / "absent.json")
+    for enabling_value in ("1", "true", "yes", "TRUE", " 1 "):
+        monkeypatch.setenv("CAO_WORKFLOW_REQUIRE_APPROVAL", enabling_value)
+        assert settings_service.is_workflow_approval_required() is True
+
+
+def test_the_setting_defaults_to_disabled(monkeypatch, tmp_path):
+    monkeypatch.delenv("CAO_WORKFLOW_REQUIRE_APPROVAL", raising=False)
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", tmp_path / "absent.json")
+    assert settings_service.is_workflow_approval_required() is False
+
+
+def test_settings_json_can_enable_and_disable(monkeypatch, tmp_path):
+    monkeypatch.delenv("CAO_WORKFLOW_REQUIRE_APPROVAL", raising=False)
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", settings_file)
+
+    settings_file.write_text(json.dumps({"workflow": {"require_approval": True}}))
+    assert settings_service.is_workflow_approval_required() is True
+
+    settings_file.write_text(json.dumps({"workflow": {"require_approval": False}}))
+    assert settings_service.is_workflow_approval_required() is False
+
+
+def test_an_unreadable_setting_resolves_to_disabled(monkeypatch, tmp_path):
+    """The ONE place this mechanism is deliberately not fail-closed.
+
+    Resolving an unparseable settings file to "gate on" would refuse every script run in the
+    installation on the strength of a JSON typo. The asymmetry above bounds the residual: an operator
+    who enabled the gate via the environment is unaffected by a corrupt file.
+    """
+    monkeypatch.delenv("CAO_WORKFLOW_REQUIRE_APPROVAL", raising=False)
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{not valid json")
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", settings_file)
+
+    assert settings_service.is_workflow_approval_required() is False
+
+
+def test_a_non_dict_workflow_section_resolves_to_disabled(monkeypatch, tmp_path):
+    monkeypatch.delenv("CAO_WORKFLOW_REQUIRE_APPROVAL", raising=False)
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({"workflow": "not a dict"}))
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", settings_file)
+
+    assert settings_service.is_workflow_approval_required() is False
+
+
+# ---------------------------------------------------------------------------
+# The read path this unit had to add
+# ---------------------------------------------------------------------------
+
+
+def test_the_run_row_exposes_manifest_json():
+    """``manifest-column`` added the column and ``manifest-freeze`` writes it, but nothing read it back.
+
+    The resume gate is the first reader, so this unit added the field and the SELECT. Without it,
+    ``row.manifest_json`` is an AttributeError at resume admission — a crash, not a refusal.
+    """
+    from cli_agent_orchestrator.services.workflow_journal import RunRow
+
+    assert "manifest_json" in RunRow.__dataclass_fields__
+    row = RunRow(
+        run_id="r",
+        workflow_name="w",
+        spec_snapshot="{}",
+        inputs_json="{}",
+        state="RUNNING",
+        current_step_id=None,
+        started_at="t",
+        finished_at=None,
+    )
+    assert row.manifest_json is None, "defaulted, so a pre-existing row reads back unchanged"

--- a/test/services/test_approval_gate.py
+++ b/test/services/test_approval_gate.py
@@ -183,6 +183,7 @@ def test_plan_id_extraction_is_total():
 
 
 def test_the_env_var_can_turn_the_gate_on(monkeypatch, tmp_path):
+    """The environment belongs to the CAO server process that resolves this setting."""
     monkeypatch.setattr(settings_service, "SETTINGS_FILE", tmp_path / "absent.json")
     for enabling_value in ("1", "true", "yes", "TRUE", " 1 "):
         monkeypatch.setenv("CAO_WORKFLOW_REQUIRE_APPROVAL", enabling_value)

--- a/test/services/test_approval_gate_integration.py
+++ b/test/services/test_approval_gate_integration.py
@@ -1,0 +1,206 @@
+"""The four integration properties `approval-gate` could not assert about itself (issue #583 Bolt 2).
+
+``approval-gate``'s unit tests cover 8 of the 12 behaviours its NFR pass pinned. The remaining four are
+about what the gate's refusal does to the SYSTEM, and a unit test of the gate in isolation cannot see
+any of them:
+
+1. a refused start leaves NO ``workflow_run`` row — asserted against the journal, not inferred;
+2. a refused resume does NOT bump the generation — the gate's correctness is an ORDERING inside
+   ``resume_script_run``, and the NFR pass called this "the one most likely to regress silently under a
+   later refactor of the admission ladder";
+3. the refusal reaches a caller as **403**, distinct from the ladder's 404 / 409 / 422;
+4. the two start arms produce the SAME verdict on the same inputs — otherwise a run's approvability
+   would depend on which route started it.
+
+Number 2 is the one that carries the most weight. Bumping the generation FENCES OUT any still-live
+process for that run, so bumping and then refusing would kill a possibly-healthy run on behalf of a
+resume that was itself rejected — two losses from one refusal. Nothing about that is visible from the
+gate function; it is a property of where the call sits.
+"""
+
+import json
+
+import pytest
+
+from cli_agent_orchestrator.services import (
+    approval_gate,
+    approval_store,
+    execution_manifest,
+    settings_service,
+    workflow_journal,
+)
+
+PLAN_ID = "plan-v1:integration"
+
+
+@pytest.fixture(autouse=True)
+def enforcement_on(tmp_path, monkeypatch):
+    """A temp database, and approval enforcement switched on through the REAL setting."""
+    from cli_agent_orchestrator import constants
+    from cli_agent_orchestrator.clients import database as database_client
+
+    path = tmp_path / "cao.db"
+    monkeypatch.setattr(constants, "DATABASE_FILE", path)
+    monkeypatch.setattr(database_client, "DATABASE_FILE", path, raising=False)
+    monkeypatch.setattr(workflow_journal, "DATABASE_FILE", path, raising=False)
+    monkeypatch.setattr(approval_store, "DATABASE_FILE", path, raising=False)
+    database_client.init_db()
+
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({"workflow": {"require_approval": True}}))
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", settings_file)
+    monkeypatch.delenv("CAO_WORKFLOW_REQUIRE_APPROVAL", raising=False)
+    return path
+
+
+def _manifest() -> str:
+    return execution_manifest.serialise(
+        execution_manifest.build(
+            plan_id=PLAN_ID, source_hash="sha256:abc", inputs={}, repo_baseline={}
+        )
+    )
+
+
+def _insert_failed_script_run(run_id: str) -> None:
+    """A FAILED script run with a frozen manifest — the shape a resume is offered."""
+    workflow_journal.insert_run(
+        run_id,
+        "wf",
+        json.dumps({"source": "print(1)", "path": None, "content_hash": "sha256:abc"}),
+        "{}",
+        "failed",  # RunState.FAILED's VALUE — the enum is lower-case
+        "2026-08-19T00:00:00+00:00",
+        "script",
+        "1",
+        _manifest(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. A refused start writes no run row
+# ---------------------------------------------------------------------------
+
+
+def test_a_refused_start_leaves_no_workflow_run_row():
+    """Asserted against the journal rather than inferred from the raise.
+
+    Every first run of every new plan is refused by design, so if a refusal wrote a row the table would
+    durably record runs that never happened — which is why the gate sits before the INSERT.
+    """
+    with pytest.raises(approval_gate.PlanApprovalRequiredError):
+        approval_gate.ensure_plan_approved(tier="script", manifest_json=_manifest())
+
+    assert workflow_journal.get_run("any-run") is None
+    assert workflow_journal.list_runs() == [] or all(
+        row.run_id != "any-run" for row in workflow_journal.list_runs()
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. A refused resume does not bump the generation  ← the load-bearing one
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_refused_resume_does_not_bump_the_generation():
+    """THE ORDERING PROPERTY. The gate is admission gate 5, BEFORE the bump.
+
+    A bump fences out any still-live process for the run. Bumping and then refusing would kill a
+    possibly-healthy run on behalf of a resume that was itself rejected. This test is the only thing
+    that would notice the gate being moved after the bump by a later refactor.
+    """
+    from cli_agent_orchestrator.services import script_runner
+
+    _insert_failed_script_run("run-refused-resume")
+    before = workflow_journal.get_run("run-refused-resume").generation
+
+    with pytest.raises(approval_gate.PlanApprovalRequiredError) as excinfo:
+        await script_runner.resume_script_run("run-refused-resume")
+
+    assert excinfo.value.plan_id == PLAN_ID
+    after = workflow_journal.get_run("run-refused-resume").generation
+    assert after == before, (
+        "a refused resume must NOT bump the generation — the bump fences out a live process, so "
+        "bumping then refusing loses the run AND the resume"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_approved_resume_is_admitted_past_the_gate():
+    """The converse, so the test above cannot pass by the gate refusing everything."""
+    from cli_agent_orchestrator.services import script_runner
+
+    _insert_failed_script_run("run-approved-resume")
+    approval_store.grant(PLAN_ID, "test-account")
+
+    # What happens AFTER the gate is not this test's business — it may succeed, or fail on tmux or a
+    # missing provider. The only forbidden outcome is the gate's own refusal. Asserted this way rather
+    # than with pytest.raises, because assuming it must fail later made the test depend on the
+    # environment instead of on the property.
+    try:
+        await script_runner.resume_script_run("run-approved-resume")
+    except approval_gate.PlanApprovalRequiredError:  # pragma: no cover - the failure this forbids
+        pytest.fail("an approved plan must be admitted past gate 5")
+    except Exception:  # noqa: BLE001 - any later failure is out of scope for this property
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 3. The refusal reaches a caller as 403
+# ---------------------------------------------------------------------------
+
+
+def test_the_resume_endpoint_answers_403_and_not_400_or_409():
+    """``PlanApprovalRequiredError`` is not a ``ValueError``, so the trailing 400 arm cannot claim it.
+
+    403 also has to be distinct from the ladder's 409: "needs approval" is a fact about the PLAN and
+    "cannot be resumed" is a fact about the RUN, and the operator's next action differs completely.
+    """
+    from fastapi.testclient import TestClient
+
+    from cli_agent_orchestrator.api.main import app
+
+    _insert_failed_script_run("run-403")
+    client = TestClient(app, base_url="http://localhost")
+
+    response = client.post("/workflows/runs/run-403/resume")
+
+    assert response.status_code == 403, (
+        f"expected 403, got {response.status_code}: a security refusal transported as 400 sends the "
+        "caller looking for a malformed argument instead of approving a plan"
+    )
+    assert PLAN_ID in json.dumps(response.json()), "the refusal must carry the plan_id"
+
+
+# ---------------------------------------------------------------------------
+# 4. Both start arms agree
+# ---------------------------------------------------------------------------
+
+
+def test_both_start_arms_reach_the_same_verdict_on_the_same_inputs():
+    """Otherwise a run's approvability depends on which route started it.
+
+    Asserted as the property the two arms share: they call ONE gate function with the same arguments.
+    Both call sites are checked in source, and the gate's verdict is exercised directly — which is what
+    makes "identical" mean something rather than being two separately-drifting copies.
+    """
+    import inspect
+
+    from cli_agent_orchestrator.api import main as api_main
+    from cli_agent_orchestrator.services import script_runner
+
+    async_arm = inspect.getsource(api_main)
+    blocking_arm = inspect.getsource(script_runner)
+
+    for source, name in ((async_arm, "api/main.py"), (blocking_arm, "script_runner.py")):
+        assert 'ensure_plan_approved(tier="script", manifest_json=manifest_json)' in source, (
+            f"{name} must gate through the shared ensure_plan_approved with the frozen manifest; "
+            "two inline checks are two chances for one to drift"
+        )
+
+    manifest = _manifest()
+    with pytest.raises(approval_gate.PlanApprovalRequiredError):
+        approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest)
+
+    approval_store.grant(PLAN_ID, "test-account")
+    approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest)  # must not raise

--- a/test/services/test_approval_gate_integration.py
+++ b/test/services/test_approval_gate_integration.py
@@ -81,7 +81,7 @@ def _insert_failed_script_run(run_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_a_refused_start_leaves_no_workflow_run_row():
+def test_unapproved_plan_is_refused_before_any_run_row_is_written():
     """Asserted against the journal rather than inferred from the raise.
 
     Every first run of every new plan is refused by design, so if a refusal wrote a row the table would

--- a/test/services/test_approval_operation.py
+++ b/test/services/test_approval_operation.py
@@ -1,0 +1,250 @@
+"""Tests for granting an approval (issue #583 Bolt 2, unit ``approval-operation``).
+
+Three carry the unit's load:
+
+* ``test_a_repeat_grant_reports_the_original_approver_and_timestamp`` — this unit's worst failure mode is a
+  command that APPEARS to work. ``grant`` is ``INSERT OR IGNORE``, so a plain "success" would leave an operator
+  unable to tell "I just approved this" from "someone approved it last week and my grant did nothing".
+* ``test_the_approve_endpoint_requires_the_admin_scope`` — removing the MCP grant tool is not sufficient on its
+  own, because the MCP boundary reaches the backplane over HTTP. If this endpoint accepted ``cao:write`` a
+  write-scoped agent token could grant directly. Asserted against the dependency so "aligning" it with the
+  sibling ``WRITE, ADMIN`` endpoints fails here rather than silently widening the grant.
+* ``test_no_mcp_tool_can_grant_an_approval`` — an absence, and absences do not fail on their own.
+"""
+
+import json
+
+import pytest
+
+from cli_agent_orchestrator.services import approval_provenance
+
+# ---------------------------------------------------------------------------
+# approved_by — the bounding that discharges SR-2B1-7
+# ---------------------------------------------------------------------------
+
+
+def test_a_long_account_name_is_truncated():
+    """The column is unbounded TEXT and the row can never be updated or deleted."""
+    bounded = approval_provenance.bound("a" * 500)
+    assert len(bounded) == approval_provenance.APPROVED_BY_MAX_LENGTH
+
+
+def test_control_characters_are_stripped():
+    """A newline in ``USER`` would split one log line into two apparent events.
+
+    This unit logs ``approved_by`` at info as the only record of when an approval intent was
+    expressed, so a value that can forge a second log entry is a real problem rather than a tidy one.
+    """
+    bounded = approval_provenance.bound("stan\nGRANTED: plan-v1:evil by root")
+    assert "\n" not in bounded
+    assert "\r" not in bounded
+
+
+def test_an_empty_or_whitespace_account_becomes_the_placeholder():
+    for empty in ("", "   ", "\n\t"):
+        assert approval_provenance.bound(empty) == approval_provenance.UNRESOLVED_ACCOUNT
+
+
+def test_local_account_never_raises(monkeypatch):
+    """A grant must not fail because a provenance NOTE could not be written."""
+
+    def _boom():
+        raise OSError("no passwd entry, no environment")
+
+    monkeypatch.setattr(approval_provenance.getpass, "getuser", _boom)
+    assert approval_provenance.local_account() == approval_provenance.UNRESOLVED_ACCOUNT
+
+
+def test_local_account_bounds_a_hostile_environment_value(monkeypatch):
+    """``getpass.getuser`` reads LOGNAME/USER/LNAME/USERNAME — environment, therefore INPUT.
+
+    Its air of being an ambient fact about the machine is exactly what would get it written unchecked.
+    """
+    monkeypatch.setattr(approval_provenance.getpass, "getuser", lambda: "x" * 200 + "\n")
+    resolved = approval_provenance.local_account()
+    assert len(resolved) == approval_provenance.APPROVED_BY_MAX_LENGTH
+    assert "\n" not in resolved
+
+
+def test_the_placeholder_is_not_mistakable_for_a_username():
+    """A reader comparing rows must be able to tell "unknown" from "someone called unknown"."""
+    assert "-" in approval_provenance.UNRESOLVED_ACCOUNT
+    assert approval_provenance.UNRESOLVED_ACCOUNT != "unknown"
+
+
+# ---------------------------------------------------------------------------
+# The endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """A TestClient against a temporary database, with the approval table migrated."""
+    from fastapi.testclient import TestClient
+
+    from cli_agent_orchestrator import constants
+    from cli_agent_orchestrator.clients import database as database_client
+    from cli_agent_orchestrator.services import approval_store
+
+    path = tmp_path / "cao.db"
+    monkeypatch.setattr(constants, "DATABASE_FILE", path)
+    monkeypatch.setattr(database_client, "DATABASE_FILE", path, raising=False)
+    monkeypatch.setattr(approval_store, "DATABASE_FILE", path, raising=False)
+
+    from cli_agent_orchestrator.api.main import app
+
+    # base_url="http://localhost" because a host-header middleware rejects TestClient's default
+    # "testserver" with a bare 400 "Invalid host header" — the same shape every test/api/ client uses.
+    return TestClient(app, base_url="http://localhost")
+
+
+def test_granting_an_unapproved_plan_approves_it(client):
+    response = client.post("/workflows/plans/approve", json={"plan_id": "plan-v1:aaa"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["approved"] is True
+    assert body["changed"] is True
+    assert body["plan_id"] == "plan-v1:aaa"
+    assert body["approved_at"]
+    assert body["approved_by"]
+
+
+def test_a_repeat_grant_reports_the_original_approver_and_timestamp(client, monkeypatch):
+    """WRITE-ONCE, made legible. A fresh timestamp here would be a lie about when it was approved."""
+    monkeypatch.setattr(approval_provenance, "local_account", lambda: "first-account")
+    first = client.post("/workflows/plans/approve", json={"plan_id": "plan-v1:bbb"}).json()
+
+    monkeypatch.setattr(approval_provenance, "local_account", lambda: "second-account")
+    second = client.post("/workflows/plans/approve", json={"plan_id": "plan-v1:bbb"}).json()
+
+    assert second["approved"] is True
+    assert second["changed"] is False, "a repeat grant must report that it changed nothing"
+    assert second["approved_by"] == "first-account", "the original approver must survive"
+    assert second["approved_at"] == first["approved_at"], "the original timestamp must survive"
+
+
+def test_the_plan_id_is_stored_and_echoed_verbatim(client):
+    """A normalisation is how two distinct plans could come to share one approval."""
+    for value in ("plan-v1:abc", "v2:legacy-looking", "no-scheme", "MiXeD-v1:CaSe"):
+        body = client.post("/workflows/plans/approve", json={"plan_id": value}).json()
+        assert body["plan_id"] == value
+
+        from cli_agent_orchestrator.services import approval_store
+
+        record = approval_store.get_approval(value)
+        assert record is not None and record.plan_id == value
+
+
+def test_an_empty_plan_id_is_rejected_and_writes_nothing(client):
+    from cli_agent_orchestrator.services import approval_store
+
+    for empty in ("", "   "):
+        response = client.post("/workflows/plans/approve", json={"plan_id": empty})
+        assert response.status_code == 400
+        assert approval_store.is_approved(empty) is False
+
+
+def test_a_caller_supplied_approved_by_is_ignored(client):
+    """Accepting it would be the appearance of accountability with none of the substance."""
+    body = client.post(
+        "/workflows/plans/approve",
+        json={"plan_id": "plan-v1:ccc", "approved_by": "someone-else-entirely"},
+    ).json()
+    assert body["approved_by"] != "someone-else-entirely"
+
+
+# ---------------------------------------------------------------------------
+# The scope — the control that makes the MCP decision real
+# ---------------------------------------------------------------------------
+
+
+def test_the_approve_endpoint_requires_the_admin_scope():
+    """Asserted on the ROUTE's dependencies, not on behaviour.
+
+    ``require_any_scope`` is default-off, so a behavioural test would pass against ANY scope choice in
+    a default install. The property that matters is which scopes the route declares.
+    """
+    import inspect
+
+    from cli_agent_orchestrator.api.main import approve_workflow_plan_endpoint
+    from cli_agent_orchestrator.security.auth import SCOPE_ADMIN, SCOPE_READ, SCOPE_WRITE
+
+    source = inspect.getsource(approve_workflow_plan_endpoint)
+    assert "require_any_scope(SCOPE_ADMIN)" in source, (
+        "approving must require cao:admin ONLY. Widening it to the sibling WRITE, ADMIN pattern "
+        "would let a write-scoped agent token grant approvals directly over HTTP, which is exactly "
+        "what removing the MCP grant tool was meant to prevent."
+    )
+    assert SCOPE_ADMIN == "cao:admin"
+    assert SCOPE_WRITE != SCOPE_ADMIN and SCOPE_READ != SCOPE_ADMIN
+
+
+def test_no_mcp_tool_can_grant_an_approval():
+    """The absence IS the control, so it needs a test — absences do not fail on their own."""
+    from cli_agent_orchestrator.mcp_server import server
+
+    tool_names = {name for name in dir(server) if not name.startswith("_")}
+    for forbidden in (
+        "workflow_approve",
+        "workflow_approve_plan",
+        "approve_plan",
+        "workflow_grant_approval",
+        "grant_plan_approval",
+    ):
+        assert forbidden not in tool_names, (
+            f"{forbidden} must not exist: an agent that can approve the plan it just wrote makes "
+            "the approval gate decorative in exactly the case it was designed for"
+        )
+
+
+def test_the_mcp_report_description_names_the_stale_hash_gap():
+    """The description is MACHINE-READ metadata an agent uses to decide what to call.
+
+    A description implying stale-hash rejection would cause an agent to rely on a check that never
+    runs. Two of Bolt 1C's five false surfaces were prioritised for exactly this reason.
+    """
+    from cli_agent_orchestrator.mcp_server.server import workflow_plan_approval
+
+    doc = workflow_plan_approval.__doc__ or ""
+    assert "stale" in doc.lower() and "not" in doc.lower()
+    assert "NO TOOL THAT GRANTS" in doc.upper() or "no tool that grants" in doc.lower()
+    assert "off by default" in doc.lower(), "enforcement's default must not be left to be guessed"
+
+
+# ---------------------------------------------------------------------------
+# The read endpoint the MCP tool consults
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_report_distinguishes_no_plan_id_from_unapproved(client):
+    """ "This run has no plan identifier" and "this plan is not approved" need different actions."""
+    from cli_agent_orchestrator.clients import database as database_client
+    from cli_agent_orchestrator.services import workflow_journal
+
+    database_client.init_db()
+    workflow_journal.insert_run(
+        "run-yaml", "wf", "{}", "{}", "RUNNING", "2026-08-19T00:00:00+00:00"
+    )
+    workflow_journal.insert_run(
+        "run-script",
+        "wf",
+        "{}",
+        "{}",
+        "RUNNING",
+        "2026-08-19T00:00:00+00:00",
+        "script",
+        "1",
+        json.dumps({"plan_id": "plan-v1:reported"}),
+    )
+
+    yaml_report = client.get("/workflows/runs/run-yaml/plan").json()
+    assert yaml_report["plan_id"] is None
+    assert yaml_report["approved"] is None, "None, not False — there is no plan to approve"
+
+    script_report = client.get("/workflows/runs/run-script/plan").json()
+    assert script_report["plan_id"] == "plan-v1:reported"
+    assert script_report["approved"] is False, "a real plan_id with no approval is False, not None"
+
+
+def test_the_plan_report_404s_on_an_unknown_run(client):
+    assert client.get("/workflows/runs/no-such-run/plan").status_code == 404

--- a/test/services/test_approval_store.py
+++ b/test/services/test_approval_store.py
@@ -1,0 +1,168 @@
+"""Tests for the durable plan-approval record (issue #583 Bolt 2, unit ``approval-store``).
+
+Two carry the unit's load:
+
+* ``test_a_repeated_grant_does_not_rewrite_the_original`` — write-once. If this fails, an existing approval can
+  be pointed at a changed plan: the row reads as approved, the timestamp looks recent, and work nobody reviewed
+  executes with a genuine approval behind it.
+* ``test_an_unknown_plan_is_not_approved`` — absence means unapproved. Every fault in this unit (missing table,
+  silent migration failure, database error) converges on "no row found", so if absence were ever permissive each
+  one would become an authorisation bypass rather than a refused run.
+"""
+
+import importlib
+import sqlite3
+
+import pytest
+
+from cli_agent_orchestrator import constants
+from cli_agent_orchestrator.clients import database as database_client
+from cli_agent_orchestrator.services import approval_store
+
+
+@pytest.fixture()
+def db_path(tmp_path, monkeypatch):
+    """Repoint ``DATABASE_FILE`` at a temporary database, WITHOUT running ``init_db``.
+
+    This is the condition that made migrator-on-connect necessary rather than optional: the journal's own
+    ``_MIGRATED_PATHS`` comment records that five test modules do exactly this, so a unit relying on the FastAPI
+    lifespan would find no table here.
+    """
+    path = tmp_path / "cao.db"
+    monkeypatch.setattr(constants, "DATABASE_FILE", path)
+    monkeypatch.setattr(database_client, "DATABASE_FILE", path, raising=False)
+    importlib.reload(approval_store)
+    monkeypatch.setattr(approval_store, "DATABASE_FILE", path, raising=False)
+    return path
+
+
+def _columns(path):
+    with sqlite3.connect(str(path)) as conn:
+        return {row[1]: row for row in conn.execute("PRAGMA table_info(workflow_plan_approval)")}
+
+
+# ---------------------------------------------------------------------------
+# The two load-bearing properties
+# ---------------------------------------------------------------------------
+
+
+def test_a_repeated_grant_does_not_rewrite_the_original(db_path):
+    """WRITE-ONCE. ``INSERT OR IGNORE`` makes it a property of the statement, not of a caller's check."""
+    approval_store.grant("plan-v1:abc", "stan")
+    first = approval_store.get_approval("plan-v1:abc")
+    assert first is not None
+
+    approval_store.grant("plan-v1:abc", "someone-else")
+    second = approval_store.get_approval("plan-v1:abc")
+
+    assert second is not None
+    assert second.approved_by == "stan", "a second grant must not change the approver"
+    assert second.approved_at == first.approved_at, "a second grant must not change the timestamp"
+
+
+def test_an_unknown_plan_is_not_approved(db_path):
+    """Absence answers False and raises nothing — so every fault mode is fail-closed."""
+    assert approval_store.is_approved("plan-v1:never-granted") is False
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_the_table_exists_on_a_fresh_database_with_its_three_columns(db_path):
+    """The unit's whole mitigation for a SILENT migration failure.
+
+    ``_migrate_workflow_plan_approval`` swallows failure at debug level, so its return says nothing about the
+    schema. A missing table makes every lookup answer False, refusing every run — diagnosed far from its cause.
+    """
+    approval_store.is_approved("anything")  # forces a connect, which runs the migrator
+
+    cols = _columns(db_path)
+    assert set(cols) == {"plan_id", "approved_at", "approved_by"}
+    assert (
+        cols["plan_id"][5] == 1
+    ), "plan_id must be the PRIMARY KEY — one approval per plan, enforced by the DB"
+    assert cols["approved_at"][3] == 1, "approved_at is NOT NULL"
+    assert cols["approved_by"][3] == 1, "approved_by is NOT NULL"
+
+
+def test_the_migration_is_idempotent(db_path):
+    database_client._migrate_workflow_plan_approval()
+    database_client._migrate_workflow_plan_approval()
+    assert set(_columns(db_path)) == {"plan_id", "approved_at", "approved_by"}
+
+
+def test_it_works_against_a_repointed_database_without_init_db(db_path):
+    """The condition that made migrator-on-connect necessary. ``init_db`` is never called in this module."""
+    assert not db_path.exists() or "workflow_plan_approval" not in str(_columns(db_path))
+    approval_store.grant("plan-v1:fresh", "stan")
+    assert approval_store.is_approved("plan-v1:fresh") is True
+
+
+# ---------------------------------------------------------------------------
+# Behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_grant_then_is_approved(db_path):
+    assert approval_store.is_approved("plan-v1:x") is False
+    approval_store.grant("plan-v1:x", "stan")
+    assert approval_store.is_approved("plan-v1:x") is True
+
+
+def test_one_grant_does_not_approve_a_different_plan(db_path):
+    """The whole re-approval mechanism: a changed plan is a different plan_id and finds no row."""
+    approval_store.grant("plan-v1:aaa", "stan")
+    assert approval_store.is_approved("plan-v1:bbb") is False
+
+
+def test_plan_id_is_stored_verbatim_and_never_normalised(db_path):
+    """A normalisation is how two distinct plans could come to share one approval."""
+    for value in ("plan-v1:abc", "v2:legacy-looking", "no-scheme-at-all", "  spaced  "):
+        approval_store.grant(value, "stan")
+        record = approval_store.get_approval(value)
+        assert record is not None
+        assert record.plan_id == value
+
+
+def test_get_approval_returns_the_record_and_none_when_absent(db_path):
+    assert approval_store.get_approval("plan-v1:missing") is None
+    approval_store.grant("plan-v1:present", "stan")
+    record = approval_store.get_approval("plan-v1:present")
+    assert record is not None
+    assert record.approved_by == "stan"
+    assert record.approved_at.endswith(
+        "+00:00"
+    ), "timestamps are UTC ISO, matching workflow_run.started_at"
+
+
+# ---------------------------------------------------------------------------
+# The surface, whose ABSENCES are the control
+# ---------------------------------------------------------------------------
+
+
+def test_the_module_offers_no_update_delete_or_replacing_upsert():
+    """The absence IS the security control — an update path could transfer an approval to a changed plan.
+
+    Asserted on the public surface rather than by behaviour, because the property is the absence of a
+    capability. Same shape as pass 2A's leaf-module posture tests.
+    """
+    public = {n for n in dir(approval_store) if not n.startswith("_")}
+    for forbidden in (
+        "update",
+        "delete",
+        "revoke",
+        "upsert",
+        "replace",
+        "set_approval",
+        "update_approval",
+    ):
+        assert forbidden not in public, f"{forbidden} must not exist on this module"
+
+    source = open(approval_store.__file__, encoding="utf-8").read()
+    code = "".join(source.replace('"""', "\x00").split("\x00")[::2])
+    assert "UPDATE workflow_plan_approval" not in code
+    assert "DELETE FROM workflow_plan_approval" not in code
+    assert "INSERT OR REPLACE" not in code
+    assert "ON CONFLICT" not in code, "an upsert that replaces would defeat write-once"

--- a/test/services/test_execution_manifest.py
+++ b/test/services/test_execution_manifest.py
@@ -1,0 +1,199 @@
+"""Tests for the execution manifest envelope (issue #583 Bolt 2, unit ``manifest-envelope``).
+
+The properties asserted here are the unit's requirements, not a coverage exercise. One of them —
+``test_a_secret_straddling_the_bound_is_still_redacted`` — is the only property in the unit that
+fails SILENTLY, and it is the reason redact-before-bound is a contract rather than a preference.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+from cli_agent_orchestrator.constants import WORKFLOW_MANIFEST_MAX_BYTES
+from cli_agent_orchestrator.services import execution_manifest as em
+
+# A literal that ``secret_gate._SECRET_PATTERNS`` matches. Kept in one place so a ruleset change
+# breaks these tests loudly in one spot rather than subtly in eight.
+SECRET = "AKIAIOSFODNN7EXAMPLE"  # matches the ``aws_access_key`` pattern; 20 chars, fixed length
+
+
+def _build(**overrides):
+    """A minimal valid envelope; overrides supply whatever the test is actually about."""
+    fields = dict(
+        plan_id="v1:0" * 4,
+        source_hash="deadbeef",
+        inputs={},
+        repo_baseline={},
+        provider="mock_cli",
+        model="m",
+        profile="developer",
+        permissions={},
+        limits={},
+        retry_policy={},
+        memory_content="",
+        memory_source="cao-memory",
+    )
+    fields.update(overrides)
+    return em.build(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def test_a_secret_straddling_the_bound_is_still_redacted():
+    """THE ONE THAT FAILS SILENTLY. Redact-before-bound, asserted at the boundary itself.
+
+    Were the order reversed, the redactor would only ever see the truncated prefix, so a secret
+    beginning before the bound and ending after it would be persisted in the clear. The happy path
+    produces an identical-looking envelope either way, so no other test in this file would notice.
+    """
+    # Find where truncation actually lands, rather than guessing an offset: build once with pure
+    # filler and read back how much content survived. The bound applies to the whole JSON document,
+    # so the cut point is not simply the constant.
+    oversized = WORKFLOW_MANIFEST_MAX_BYTES + 10_000
+    probe = _build(memory_content="x" * oversized)
+    assert probe.truncated is True, "the probe payload must exceed the bound"
+    cut = len(probe.memory.content)
+
+    # Now place the secret so it STRADDLES that cut point: half before it, half after.
+    half = len(SECRET) // 2
+    content = ("x" * (cut - half)) + SECRET + ("y" * 10_000)
+    envelope = _build(memory_content=content)
+
+    assert envelope.truncated is True, "expected the bound to bite for this payload"
+    stored = em.serialise(envelope)
+    assert SECRET not in stored
+    # And not a fragment either: the leading half must not survive at the boundary, which is
+    # exactly what bound-then-redact would leave behind.
+    assert SECRET[:half] not in stored
+    assert envelope.redacted is True
+
+
+def test_a_secret_nested_three_levels_deep_is_redacted():
+    envelope = _build(inputs={"a": {"b": {"c": SECRET}}})
+    assert SECRET not in em.serialise(envelope)
+    assert envelope.redacted is True
+
+
+def test_a_secret_used_as_a_dict_key_is_redacted():
+    """Keys are redacted alongside values: a credential lands in a key as readily as in a value."""
+    envelope = _build(permissions={SECRET: "granted"})
+    assert SECRET not in em.serialise(envelope)
+    assert envelope.redacted is True
+
+
+def test_redacted_is_false_when_nothing_matches():
+    envelope = _build(inputs={"harmless": "value"}, memory_content="nothing secret here")
+    assert envelope.redacted is False
+
+
+def test_no_pattern_name_appears_anywhere_in_the_envelope():
+    """``redacted`` is a bare bool: naming which pattern fired discloses the secret's shape.
+
+    The redaction MARKER is expected in the stored text; what must not appear is any structured
+    record of which patterns fired, so the envelope carries a bool and nothing else.
+    """
+    envelope = _build(inputs={"tok": SECRET})
+    assert envelope.redacted is True
+    assert isinstance(envelope.redacted, bool)
+    # No field of the envelope is a list/collection of fired pattern names.
+    document = json.loads(em.serialise(envelope))
+    assert "fired" not in document
+    assert "patterns" not in document
+
+
+# ---------------------------------------------------------------------------
+# Bounding
+# ---------------------------------------------------------------------------
+
+
+def test_the_bound_is_inclusive():
+    """Exactly the bound is NOT truncated; one byte more is. Matches ``step_result``'s boundary."""
+    small = _build(memory_content="a" * 100)
+    assert small.truncated is False
+
+    over = _build(memory_content="a" * (WORKFLOW_MANIFEST_MAX_BYTES + 1))
+    assert over.truncated is True
+    assert len(em.serialise(over).encode("utf-8")) <= WORKFLOW_MANIFEST_MAX_BYTES
+
+
+def test_build_never_raises_on_an_oversized_document():
+    """Bounding is lossy but TOTAL: a run must not fail because its manifest was large."""
+    envelope = _build(memory_content="z" * (WORKFLOW_MANIFEST_MAX_BYTES * 3))
+    assert envelope.truncated is True
+    assert envelope.memory.truncated is True
+
+
+# ---------------------------------------------------------------------------
+# The hash/content asymmetry (FR-9)
+# ---------------------------------------------------------------------------
+
+
+def test_content_hash_covers_the_full_content_not_the_stored_copy():
+    """FR-9's identity survives truncation, which is what makes a cross-resume comparison possible."""
+    full = "m" * (WORKFLOW_MANIFEST_MAX_BYTES + 10_000)
+    envelope = _build(memory_content=full)
+
+    assert envelope.memory.truncated is True
+    assert len(envelope.memory.content) < len(full), "the stored copy should be shorter"
+    assert envelope.memory.content_hash == hashlib.sha256(full.encode("utf-8")).hexdigest()
+
+
+def test_the_hash_does_not_depend_on_the_redaction_ruleset():
+    """Hash BEFORE redaction, so a later ``_SECRET_PATTERNS`` change cannot rewrite history.
+
+    Asserted against the raw input's own digest: if hashing ever moved after redaction, a content
+    string containing a secret would hash to the redacted form instead and this would fail.
+    """
+    content = f"before {SECRET} after"
+    envelope = _build(memory_content=content)
+
+    assert envelope.memory.content_hash == hashlib.sha256(content.encode("utf-8")).hexdigest()
+    # And the STORED copy is redacted even though the hash is not.
+    assert SECRET not in envelope.memory.content
+
+
+# ---------------------------------------------------------------------------
+# Serialise / parse
+# ---------------------------------------------------------------------------
+
+
+def test_parse_is_total():
+    """Absent, empty and malformed all answer None rather than raising."""
+    assert em.parse(None) is None
+    assert em.parse("") is None
+    assert em.parse("{not json") is None
+    assert em.parse('{"plan_id": "only-this-field"}') is None
+
+
+def test_round_trip():
+    envelope = _build(inputs={"k": [1, 2, {"n": None}]}, memory_content="frozen block")
+    assert em.parse(em.serialise(envelope)) == envelope
+
+
+def test_plan_id_is_carried_opaquely():
+    """This unit never parses ``plan_id``: any string round-trips unchanged."""
+    for value in ("v1:abc", "v2:def", "not-a-scheme-at-all", ""):
+        assert _build(plan_id=value).plan_id == value
+
+
+# ---------------------------------------------------------------------------
+# Module posture (preservation, per the module docstring)
+# ---------------------------------------------------------------------------
+
+
+def test_the_module_has_no_logger_and_no_print():
+    """SR: one helpful log line would move a credential out of a redacted column into a log file.
+
+    Source inspection rather than behaviour, because the property is the ABSENCE of a capability —
+    the same shape Bolt 1 used for its leaf-module posture tests.
+    """
+    source = Path(em.__file__).read_text(encoding="utf-8")
+    # Strip the docstrings: they discuss logging deliberately, and that prose is the point.
+    without_docstrings = source.replace('"""', "\x00").split("\x00")
+    code = "".join(without_docstrings[::2])
+    assert "logging" not in code
+    assert "logger" not in code
+    assert "print(" not in code

--- a/test/services/test_frozen_context_proof.py
+++ b/test/services/test_frozen_context_proof.py
@@ -1,0 +1,300 @@
+"""FR-9's Pass criterion, as one scenario (issue #583 Bolt 2, unit ``frozen-context-proof``).
+
+FR-9 says: *altering CAO memory after a failure does not change what a resumed run sees; the resolved
+memory content, source and hash used by the run are recorded.* That is a claim about a SEQUENCE — a run
+resolves memory, fails, the memory is edited, the run resumes — and every other test in this Bolt
+verifies one link of it. Each of them can pass while the sequence is broken: a resume that reads the
+record correctly but a later terminal that re-resolves satisfies "the resume reads the record" and
+still violates the requirement.
+
+``unit-of-work.md`` made this its own unit for a reason drawn from the previous Bolt: the upgrade-window
+test had to be bolted onto Bolt 1B's Definition of Done at ``delivery-planning`` because
+``units-generation`` had assigned it to no unit, "despite it being the top-ranked risk". An end-to-end
+scenario owned by nobody does not get written.
+
+WHAT THIS PROVES, AND WHAT IT DOES NOT. Every link in the chain here is the real shipped code: the real
+journal on a temporary database, the real manifest envelope, the real ``frozen_run_memory``, the real
+``inject_memory_context``. Two boundaries are stubbed — the provider process, and what memory resolution
+returns.
+
+So this does NOT prove that tmux delivers the bytes, that a real provider starts, or that a real process
+death preserves the record. It proves the FROZEN-CONTEXT guarantee. That limit is written here rather
+than left implicit, because a module named as an end-to-end proof invites a reader to believe it covers
+more than it does — and this issue's Bolt 1C spent a whole unit removing five surfaces that claimed
+more than they delivered.
+
+IT LIVES UNDER ``test/services/`` DELIBERATELY. CI runs
+``pytest test/ --ignore=test/providers/test_kiro_cli_integration.py --ignore=test/e2e -m "not e2e"``, so
+a maximally faithful version of this scenario placed under ``test/e2e`` would never execute, and FR-9's
+Pass criterion would be verified only when someone remembered to run it by hand. A proof that does not
+run is not a proof — the "owned by nobody" failure wearing a different hat.
+"""
+
+import hashlib
+import json
+
+import pytest
+
+from cli_agent_orchestrator.services import (
+    approval_gate,
+    approval_store,
+    execution_manifest,
+    frozen_run_memory,
+    settings_service,
+    terminal_service,
+    workflow_journal,
+)
+
+RUN_ID = "run-frozen-proof"
+
+#: The block the ORIGINAL run resolves and the manifest records.
+BLOCK_ORIGINAL = "<cao-memory>ORIGINAL-BLOCK-FROZEN-AT-FIRST-TERMINAL</cao-memory>"
+
+#: What resolution would return AFTER the edit. The resumed run must NEVER see this.
+#: Deliberately unmistakable in a failure message: the whole diagnosis of this test is "which block
+#: arrived?", so the two must not look alike.
+BLOCK_AFTER_EDIT = "<cao-memory>EDITED-AFTER-THE-FAILURE-MUST-NOT-APPEAR</cao-memory>"
+
+#: The CANONICAL published AWS example key, not an invented secret-shaped string. An invented one
+#: matches none of ``secret_gate._SECRET_PATTERNS``, so a redaction assertion built on it passes while
+#: demonstrating nothing — a mistake made earlier in this same Bolt and caught only because a different
+#: assertion in the same test disagreed.
+EXAMPLE_SECRET = "AKIAIOSFODNN7EXAMPLE"
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    """A temp database, and the injection guard cleared.
+
+    Both are explicit rather than assumed. ``_memory_injected_terminals`` is MODULE-LEVEL state and this
+    scenario injects more than once; ``DATABASE_FILE`` is repointed on every module that reads it,
+    because the journal's own ``_MIGRATED_PATHS`` comment records that five test modules repoint it
+    mid-process. The suite also runs with random ordering, so nothing here may depend on another test
+    having left a clean process behind.
+    """
+    from cli_agent_orchestrator import constants
+    from cli_agent_orchestrator.clients import database as database_client
+
+    path = tmp_path / "cao.db"
+    monkeypatch.setattr(constants, "DATABASE_FILE", path)
+    monkeypatch.setattr(database_client, "DATABASE_FILE", path, raising=False)
+    monkeypatch.setattr(workflow_journal, "DATABASE_FILE", path, raising=False)
+    monkeypatch.setattr(approval_store, "DATABASE_FILE", path, raising=False)
+    database_client.init_db()
+
+    with terminal_service._memory_injected_lock:
+        terminal_service._memory_injected_terminals.clear()
+    yield
+    with terminal_service._memory_injected_lock:
+        terminal_service._memory_injected_terminals.clear()
+
+
+def _freeze_a_run(run_id: str = RUN_ID) -> None:
+    """Create a script run whose manifest is frozen with an EMPTY memory record.
+
+    Built with the REAL ``execution_manifest.build`` and ``workflow_journal.insert_run`` rather than a
+    hand-written JSON literal: a literal would let this test survive a change to the envelope's shape,
+    and a test that survives a change to the thing it proves is worse than no test, because it reports
+    success about a structure that no longer exists.
+    """
+    envelope = execution_manifest.build(
+        plan_id="plan-v1:frozen-proof",
+        source_hash="sha256:abc123",
+        inputs={"target": "docs"},
+        repo_baseline={"commit": "deadbeef", "dirty": False},
+    )
+    workflow_journal.insert_run(
+        run_id,
+        "frozen-proof-workflow",
+        json.dumps({"source": "print(1)", "path": None, "content_hash": "sha256:abc123"}),
+        json.dumps({"target": "docs"}),
+        "RUNNING",
+        "2026-08-19T00:00:00+00:00",
+        "script",
+        "1",
+        execution_manifest.serialise(envelope),
+    )
+
+
+# ===========================================================================
+# THE SCENARIO — one test, because FR-9's criterion is the SEQUENCE
+# ===========================================================================
+
+
+def test_editing_memory_after_a_failure_does_not_change_what_the_resumed_run_sees(monkeypatch):
+    """FR-9's Pass criterion, start to finish.
+
+    Split into per-phase tests, each phase could pass while the whole broke. The phases below are steps
+    inside one test, each carrying its own assertions so a failure names the step rather than the final
+    comparison.
+    """
+    _freeze_a_run()
+
+    resolutions = []
+
+    def _resolve(terminal_id, task_description):
+        resolutions.append(terminal_id)
+        return BLOCK_ORIGINAL
+
+    monkeypatch.setattr(frozen_run_memory, "_resolve_live", _resolve)
+
+    # ---- PHASE 1: the original run resolves, records, and injects -------------------------------
+    first_block = frozen_run_memory.frozen_memory_for(RUN_ID, "term-original", "do the task")
+    assert first_block == BLOCK_ORIGINAL
+    assert len(resolutions) == 1, "the first terminal must resolve exactly once"
+
+    recorded = execution_manifest.parse(workflow_journal.get_run(RUN_ID).manifest_json)
+    assert recorded is not None
+    assert recorded.memory.content == BLOCK_ORIGINAL
+    assert recorded.memory.source == frozen_run_memory.MEMORY_SOURCE_CURATED
+    original_hash = recorded.memory.content_hash
+    assert original_hash == hashlib.sha256(BLOCK_ORIGINAL.encode("utf-8")).hexdigest()
+
+    injected_first = terminal_service.inject_memory_context(
+        "do the task", "term-original", frozen_memory=first_block
+    )
+    assert BLOCK_ORIGINAL in injected_first, "the original run's agent must see the frozen block"
+
+    # ---- PHASE 2: the run fails ----------------------------------------------------------------
+    # Nothing to do, and that is the point of persist-before-use: the record was durable BEFORE the
+    # block was ever handed over, so a failure at any moment after phase 1 leaves the record intact.
+
+    # ---- PHASE 3: CAO memory is edited ---------------------------------------------------------
+    def _resolve_after_edit(terminal_id, task_description):
+        resolutions.append(terminal_id)
+        return BLOCK_AFTER_EDIT
+
+    monkeypatch.setattr(frozen_run_memory, "_resolve_live", _resolve_after_edit)
+
+    # THE ANTI-VACUITY GUARD. Without this the entire test passes whenever the simulated edit fails to
+    # take effect — a stub that silently kept returning the original block would produce a green test
+    # that proves nothing at all. This is the single most likely way this test could rot.
+    assert (
+        frozen_run_memory._resolve_live("probe", "probe") == BLOCK_AFTER_EDIT
+    ), "the edit must be real: a LIVE resolution has to return the new content"
+    resolutions.pop()  # the probe is not a run resolution
+
+    # ---- PHASE 4: the run resumes --------------------------------------------------------------
+    resumed_block = frozen_run_memory.frozen_memory_for(RUN_ID, "term-resumed", "do the task")
+
+    assert resumed_block == BLOCK_ORIGINAL, (
+        "the resumed run must see the block frozen at the ORIGINAL run — this is FR-9's Pass "
+        "criterion, and receiving BLOCK_AFTER_EDIT here is its Fail criterion"
+    )
+    assert BLOCK_AFTER_EDIT not in (resumed_block or "")
+    assert len(resolutions) == 1, (
+        "a resume must resolve NOTHING. A second entry here means the run re-read the live store, "
+        "which is exactly what a post-failure memory edit changes"
+    )
+
+    injected_resumed = terminal_service.inject_memory_context(
+        "do the task", "term-resumed", frozen_memory=resumed_block
+    )
+    assert BLOCK_ORIGINAL in injected_resumed
+    assert BLOCK_AFTER_EDIT not in injected_resumed
+
+    # ---- PHASE 5: the record is unchanged ------------------------------------------------------
+    after = execution_manifest.parse(workflow_journal.get_run(RUN_ID).manifest_json)
+    assert after is not None
+    assert after.memory.content_hash == original_hash, (
+        "FR-9's second half: the RECORDED hash must be unchanged. Content equality alone would miss "
+        "a resume that re-recorded the same bytes with a fresh hash"
+    )
+    assert after.memory.content == BLOCK_ORIGINAL
+    assert after.memory.source == frozen_run_memory.MEMORY_SOURCE_CURATED
+
+
+# ===========================================================================
+# The two consequences of "the run sees what was STORED"
+# ===========================================================================
+
+
+def test_the_agent_sees_the_redacted_copy_not_the_raw_resolution(monkeypatch):
+    """The decision that the run sees the STORED copy lives in ONE line of ``frozen_run_memory``.
+
+    Returning ``resolved`` instead of ``filled.memory.content`` is a one-word change that passes every
+    unit test in this Bolt, and its consequence is that the original run and its replays see different
+    bytes whenever redaction bit. NO other test spans resolve -> store -> inject, so nothing else can
+    notice that word changing.
+    """
+    _freeze_a_run()
+    block_with_secret = f"<cao-memory>token={EXAMPLE_SECRET}</cao-memory>"
+    monkeypatch.setattr(frozen_run_memory, "_resolve_live", lambda tid, task: block_with_secret)
+
+    frozen = frozen_run_memory.frozen_memory_for(RUN_ID, "term-1", "task")
+    injected = terminal_service.inject_memory_context("task", "term-1", frozen_memory=frozen)
+
+    assert EXAMPLE_SECRET not in injected, (
+        "the agent must receive the REDACTED stored copy. Seeing the raw key here means the raw "
+        "resolution was injected instead of what the manifest recorded"
+    )
+    assert "<cao-memory>" in injected, "the block itself must still arrive"
+
+    recorded = execution_manifest.parse(workflow_journal.get_run(RUN_ID).manifest_json)
+    assert recorded is not None and EXAMPLE_SECRET not in recorded.memory.content
+    assert (
+        recorded.memory.content_hash
+        == hashlib.sha256(block_with_secret.encode("utf-8")).hexdigest()
+    ), "the hash covers the FULL resolved content, taken before redaction"
+
+
+def test_an_oversized_block_is_injected_truncated_and_says_so(monkeypatch):
+    """The other half of "what was stored": when the bound bites, the agent sees less."""
+    from cli_agent_orchestrator.constants import WORKFLOW_MANIFEST_MAX_BYTES
+
+    _freeze_a_run()
+    huge = "<cao-memory>" + ("m" * WORKFLOW_MANIFEST_MAX_BYTES) + "</cao-memory>"
+    monkeypatch.setattr(frozen_run_memory, "_resolve_live", lambda tid, task: huge)
+
+    frozen = frozen_run_memory.frozen_memory_for(RUN_ID, "term-1", "task")
+
+    assert frozen is not None
+    assert len(frozen) < len(huge), "the injected block is the truncated stored copy"
+    recorded = execution_manifest.parse(workflow_journal.get_run(RUN_ID).manifest_json)
+    assert recorded is not None
+    assert recorded.memory.truncated is True, "truncation must be RECORDED, not silent"
+    assert recorded.memory.content_hash == hashlib.sha256(huge.encode("utf-8")).hexdigest()
+
+    stored_size = len(workflow_journal.get_run(RUN_ID).manifest_json.encode("utf-8"))
+    assert stored_size <= WORKFLOW_MANIFEST_MAX_BYTES
+
+
+# ===========================================================================
+# The recorded dependency on approval-gate, proven rather than assumed
+# ===========================================================================
+
+
+def test_the_gate_dependency_is_real_when_enforcement_is_on(tmp_path, monkeypatch):
+    """``unit-of-work.md`` made this unit depend on ``approval-gate``.
+
+    Enforcement defaults OFF, so that dependency is satisfied by construction and would be invisible.
+    This turns it on — through the REAL setting and the REAL store, not a stubbed predicate, because a
+    stubbed setting only proves the stub.
+    """
+    _freeze_a_run()
+    manifest_json = workflow_journal.get_run(RUN_ID).manifest_json
+
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({"workflow": {"require_approval": True}}))
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", settings_file)
+    monkeypatch.delenv("CAO_WORKFLOW_REQUIRE_APPROVAL", raising=False)
+
+    with pytest.raises(approval_gate.PlanApprovalRequiredError) as excinfo:
+        approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)
+    assert excinfo.value.plan_id == "plan-v1:frozen-proof"
+
+    approval_store.grant("plan-v1:frozen-proof", "test-account")
+    approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)  # must not raise
+
+
+def test_enforcement_off_is_the_default_so_the_scenario_above_needs_no_approval(
+    monkeypatch, tmp_path
+):
+    """Why the main scenario does not grant an approval: with the default, nothing is gated."""
+    monkeypatch.delenv("CAO_WORKFLOW_REQUIRE_APPROVAL", raising=False)
+    monkeypatch.setattr(settings_service, "SETTINGS_FILE", tmp_path / "absent.json")
+    _freeze_a_run()
+
+    approval_gate.ensure_plan_approved(
+        tier="script", manifest_json=workflow_journal.get_run(RUN_ID).manifest_json
+    )

--- a/test/services/test_frozen_run_memory.py
+++ b/test/services/test_frozen_run_memory.py
@@ -15,6 +15,8 @@ Four carry the unit's load:
 """
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -82,13 +84,13 @@ def test_the_record_is_persisted_before_the_block_is_returned(
     """ORDERING. A crash after using and before persisting loses the FR-9 evidence, silently."""
     events = []
 
-    real_update = workflow_journal.update_run_manifest
+    real_compare_and_set = workflow_journal.compare_and_set_run_manifest
 
-    def _tracked(run_id, manifest_json):
+    def _tracked(run_id, expected_manifest_json, manifest_json):
         events.append("persisted")
-        return real_update(run_id, manifest_json)
+        return real_compare_and_set(run_id, expected_manifest_json, manifest_json)
 
-    monkeypatch.setattr(workflow_journal, "update_run_manifest", _tracked)
+    monkeypatch.setattr(workflow_journal, "compare_and_set_run_manifest", _tracked)
 
     block = frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "do the task")
     events.append("returned")
@@ -100,15 +102,15 @@ def test_the_record_is_persisted_before_the_block_is_returned(
     assert block is not None
 
 
-def test_a_failed_persist_returns_no_block(journalled_run, resolves, monkeypatch):
+def test_a_failed_persist_returns_an_explicit_empty_block(journalled_run, resolves, monkeypatch):
     """No block rather than an unrecorded one. The run proceeds with NO memory, visibly."""
 
-    def _boom(run_id, manifest_json):
+    def _boom(run_id, expected_manifest_json, manifest_json):
         raise RuntimeError("disk full")
 
-    monkeypatch.setattr(workflow_journal, "update_run_manifest", _boom)
+    monkeypatch.setattr(workflow_journal, "compare_and_set_run_manifest", _boom)
 
-    assert frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task") is None
+    assert frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task") == ""
 
 
 def test_a_run_that_resolved_no_memory_does_not_re_resolve(journalled_run, monkeypatch):
@@ -177,6 +179,49 @@ def test_a_second_terminal_reuses_the_record(journalled_run, resolves):
 
     assert first == second
     assert len(resolves) == 1, "resolution happens once per RUN, not once per terminal"
+
+
+def test_concurrent_first_fills_return_the_persisted_winner(journalled_run, monkeypatch):
+    """A CAS loss reloads the winner instead of overwriting it with this terminal's block."""
+    both_resolvers_started = threading.Barrier(2)
+
+    def _resolve(terminal_id, task_description):
+        both_resolvers_started.wait(timeout=2)
+        return f"<cao-memory>{terminal_id}</cao-memory>"
+
+    monkeypatch.setattr(frozen_run_memory, "_resolve_live", _resolve)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(
+            frozen_run_memory.frozen_memory_for, journalled_run, "term-first", "task"
+        )
+        second_future = executor.submit(
+            frozen_run_memory.frozen_memory_for, journalled_run, "term-second", "task"
+        )
+        first = first_future.result(timeout=5)
+        second = second_future.result(timeout=5)
+
+    stored = execution_manifest.parse(workflow_journal.get_run(journalled_run).manifest_json)
+    assert stored is not None
+    assert first == second == stored.memory.content
+    assert stored.memory.source == frozen_run_memory.MEMORY_SOURCE_CURATED
+
+
+def test_an_unreadable_manifest_after_cas_loss_suppresses_live_memory(
+    journalled_run, resolves, monkeypatch
+):
+    real_parse = execution_manifest.parse
+    parse_calls = 0
+
+    def _parse_then_fail(manifest_json):
+        nonlocal parse_calls
+        parse_calls += 1
+        return real_parse(manifest_json) if parse_calls == 1 else None
+
+    monkeypatch.setattr(workflow_journal, "compare_and_set_run_manifest", lambda *_args: False)
+    monkeypatch.setattr(execution_manifest, "parse", _parse_then_fail)
+
+    assert frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task") == ""
 
 
 def test_a_resume_reads_the_record_and_never_resolves(journalled_run, resolves):

--- a/test/services/test_frozen_run_memory.py
+++ b/test/services/test_frozen_run_memory.py
@@ -262,7 +262,12 @@ def test_an_unknown_run_resolves_nothing(journalled_run, resolves):
 
 
 def test_an_unreadable_manifest_resolves_nothing(journalled_run, resolves):
-    workflow_journal.update_run_manifest(journalled_run, "{not json")
+    row = workflow_journal.get_run(journalled_run)
+    assert row is not None and row.manifest_json is not None
+    assert workflow_journal.compare_and_set_run_manifest(
+        journalled_run, row.manifest_json, "{not json"
+    )
+    assert not hasattr(workflow_journal, "update_run_manifest")
     assert frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task") is None
     assert resolves == []
 

--- a/test/services/test_frozen_run_memory.py
+++ b/test/services/test_frozen_run_memory.py
@@ -1,0 +1,303 @@
+"""Tests for resolve-once-and-freeze (issue #583 Bolt 2, unit ``memory-resolve-once``).
+
+Four carry the unit's load:
+
+* ``test_the_record_is_persisted_before_the_block_is_returned`` — the ordering IS the correctness
+  argument, and the happy path looks identical either way, so only an ordering assertion can see it.
+* ``test_a_failed_persist_returns_no_block`` — using memory the manifest does not record is the one
+  outcome FR-9 forbids, and it fails silently: an empty record is indistinguishable from a run that
+  never created a terminal.
+* ``test_a_run_that_resolved_no_memory_does_not_re_resolve`` — the once-per-run flag must be the
+  record's PRESENCE, not its content's truthiness. Under a truthiness flag this run re-resolves at
+  every terminal and again on every resume, each time reading the LIVE store.
+* ``test_filling_the_record_does_not_change_the_plan_id`` — memory is not one of ``PlanFields``' nine
+  fields. If it ever becomes one, every approval on the machine silently stops matching.
+"""
+
+import json
+
+import pytest
+
+from cli_agent_orchestrator.services import (
+    execution_manifest,
+    frozen_run_memory,
+    plan_identifier,
+    workflow_journal,
+)
+
+
+@pytest.fixture()
+def journalled_run(tmp_path, monkeypatch):
+    """A script run with a frozen manifest whose memory record is EMPTY, as the freeze leaves it."""
+    from cli_agent_orchestrator import constants
+    from cli_agent_orchestrator.clients import database as database_client
+
+    path = tmp_path / "cao.db"
+    monkeypatch.setattr(constants, "DATABASE_FILE", path)
+    monkeypatch.setattr(database_client, "DATABASE_FILE", path, raising=False)
+    monkeypatch.setattr(workflow_journal, "DATABASE_FILE", path, raising=False)
+    database_client.init_db()
+
+    envelope = execution_manifest.build(
+        plan_id="plan-v1:abc",
+        source_hash="sha256:deadbeef",
+        inputs={"k": "v"},
+        repo_baseline={"commit": "abc123"},
+    )
+    workflow_journal.insert_run(
+        "run-1",
+        "wf",
+        "{}",
+        "{}",
+        "RUNNING",
+        "2026-08-19T00:00:00+00:00",
+        "script",
+        "1",
+        execution_manifest.serialise(envelope),
+    )
+    return "run-1"
+
+
+@pytest.fixture()
+def resolves(monkeypatch):
+    """Stub live resolution and count how many times it is consulted."""
+    calls = []
+
+    def _resolve(terminal_id, task_description):
+        calls.append((terminal_id, task_description))
+        return "<cao-memory>LIVE BLOCK</cao-memory>"
+
+    monkeypatch.setattr(frozen_run_memory, "_resolve_live", _resolve)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# The four load-bearing properties
+# ---------------------------------------------------------------------------
+
+
+def test_the_record_is_persisted_before_the_block_is_returned(
+    journalled_run, resolves, monkeypatch
+):
+    """ORDERING. A crash after using and before persisting loses the FR-9 evidence, silently."""
+    events = []
+
+    real_update = workflow_journal.update_run_manifest
+
+    def _tracked(run_id, manifest_json):
+        events.append("persisted")
+        return real_update(run_id, manifest_json)
+
+    monkeypatch.setattr(workflow_journal, "update_run_manifest", _tracked)
+
+    block = frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "do the task")
+    events.append("returned")
+
+    assert events == ["persisted", "returned"], (
+        "the record must be written BEFORE the block is handed back — a crash in the other order "
+        "leaves a run that saw memory nothing recorded, which is FR-9's Fail criterion"
+    )
+    assert block is not None
+
+
+def test_a_failed_persist_returns_no_block(journalled_run, resolves, monkeypatch):
+    """No block rather than an unrecorded one. The run proceeds with NO memory, visibly."""
+
+    def _boom(run_id, manifest_json):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(workflow_journal, "update_run_manifest", _boom)
+
+    assert frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task") is None
+
+
+def test_a_run_that_resolved_no_memory_does_not_re_resolve(journalled_run, monkeypatch):
+    """`""` IS a resolved result. The flag is the record's presence, never the content's truthiness."""
+    calls = []
+    monkeypatch.setattr(
+        frozen_run_memory,
+        "_resolve_live",
+        lambda tid, task: calls.append(tid) or "",
+    )
+
+    first = frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task")
+    second = frozen_run_memory.frozen_memory_for(journalled_run, "term-2", "task")
+
+    assert first == ""
+    assert second == "", "an empty resolved block must be honoured, not re-resolved"
+    assert len(calls) == 1, (
+        "under a truthiness flag this run would re-resolve at every terminal and on every resume, "
+        "each time reading the LIVE store — the drift FR-9 exists to prevent"
+    )
+
+
+def test_filling_the_record_does_not_change_the_plan_id(journalled_run, resolves):
+    """Memory is absent from PlanFields. If it ever isn't, every approval silently stops matching."""
+    before = execution_manifest.parse(workflow_journal.get_run(journalled_run).manifest_json)
+    frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task")
+    after = execution_manifest.parse(workflow_journal.get_run(journalled_run).manifest_json)
+
+    assert before is not None and after is not None
+    assert after.plan_id == before.plan_id
+
+    fields = plan_identifier.PlanFields(
+        source_hash=after.source_hash,
+        inputs=after.inputs,
+        repo_baseline=after.repo_baseline,
+        provider=None,
+        model=None,
+        profile=None,
+        permissions=None,
+        limits=None,
+        retry_policy=None,
+    )
+    assert "memory" not in plan_identifier.PlanFields.__dataclass_fields__
+    assert plan_identifier.compute(fields).startswith("plan-v1:")
+
+
+# ---------------------------------------------------------------------------
+# Resolve once
+# ---------------------------------------------------------------------------
+
+
+def test_the_first_terminal_resolves_and_records(journalled_run, resolves):
+    block = frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "do the task")
+
+    assert block == "<cao-memory>LIVE BLOCK</cao-memory>"
+    stored = execution_manifest.parse(workflow_journal.get_run(journalled_run).manifest_json)
+    assert stored is not None
+    assert stored.memory.content == block
+    assert stored.memory.source == frozen_run_memory.MEMORY_SOURCE_CURATED
+    assert stored.memory.content_hash
+
+
+def test_a_second_terminal_reuses_the_record(journalled_run, resolves):
+    first = frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task")
+    second = frozen_run_memory.frozen_memory_for(journalled_run, "term-2", "different task")
+
+    assert first == second
+    assert len(resolves) == 1, "resolution happens once per RUN, not once per terminal"
+
+
+def test_a_resume_reads_the_record_and_never_resolves(journalled_run, resolves):
+    """The resume path in miniature: the record exists, so nothing is resolved."""
+    frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task")
+    resolves.clear()
+
+    replayed = frozen_run_memory.frozen_memory_for(journalled_run, "term-fresh", "task")
+
+    assert replayed == "<cao-memory>LIVE BLOCK</cao-memory>"
+    assert resolves == [], "a resume must never re-resolve — that is FR-9's whole point"
+
+
+# ---------------------------------------------------------------------------
+# When there is nothing frozen to honour
+# ---------------------------------------------------------------------------
+
+
+def test_no_run_id_resolves_nothing(resolves):
+    """A non-workflow terminal. C-1: today's live path, untouched."""
+    assert frozen_run_memory.frozen_memory_for(None, "term-1", "task") is None
+    assert frozen_run_memory.frozen_memory_for("", "term-1", "task") is None
+    assert resolves == []
+
+
+def test_a_run_with_no_manifest_resolves_nothing(journalled_run, resolves):
+    """A YAML run never freezes a manifest; "nothing frozen" is not "no memory"."""
+    workflow_journal.insert_run(
+        "run-yaml", "wf", "{}", "{}", "RUNNING", "2026-08-19T00:00:00+00:00"
+    )
+    assert frozen_run_memory.frozen_memory_for("run-yaml", "term-1", "task") is None
+    assert resolves == []
+
+
+def test_an_unknown_run_resolves_nothing(journalled_run, resolves):
+    assert frozen_run_memory.frozen_memory_for("no-such-run", "term-1", "task") is None
+    assert resolves == []
+
+
+def test_an_unreadable_manifest_resolves_nothing(journalled_run, resolves):
+    workflow_journal.update_run_manifest(journalled_run, "{not json")
+    assert frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task") is None
+    assert resolves == []
+
+
+# ---------------------------------------------------------------------------
+# with_memory — the fill that must not disturb plan_id's inputs
+# ---------------------------------------------------------------------------
+
+
+def test_with_memory_leaves_every_other_field_byte_identical():
+    """The other fields are what plan_id was hashed from."""
+    envelope = execution_manifest.build(
+        plan_id="plan-v1:xyz",
+        source_hash="sha256:cafe",
+        inputs={"deep": {"nested": [1, 2, 3]}},
+        repo_baseline={"commit": "abc", "dirty": True},
+        notes="a note",
+    )
+    filled = execution_manifest.with_memory(envelope, content="block", source="src")
+
+    before = json.loads(execution_manifest.serialise(envelope))
+    after = json.loads(execution_manifest.serialise(filled))
+    before.pop("memory")
+    after.pop("memory")
+    assert after == before, "filling memory must not move a single other field"
+
+
+def test_with_memory_hashes_the_full_content_before_redacting():
+    """``content_hash`` identifies what was RESOLVED, not what survived the ruleset of the day."""
+    import hashlib
+
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    envelope = execution_manifest.build(
+        plan_id="plan-v1:x", source_hash="s", inputs={}, repo_baseline={}
+    )
+    filled = execution_manifest.with_memory(envelope, content=secret, source="src")
+
+    assert filled.memory.content_hash == hashlib.sha256(secret.encode("utf-8")).hexdigest()
+    assert filled.memory.content != secret, "the stored copy must be redacted"
+    assert filled.redacted is True
+
+
+def test_with_memory_does_not_clear_a_redaction_flag_the_freeze_set():
+    """``redacted`` records that something was redacted at some point; a clean fill must not reset it."""
+    envelope = execution_manifest.build(
+        plan_id="plan-v1:x",
+        source_hash="s",
+        inputs={"token": "AKIAIOSFODNN7EXAMPLE"},
+        repo_baseline={},
+    )
+    assert envelope.redacted is True
+    filled = execution_manifest.with_memory(envelope, content="nothing secret", source="src")
+    assert filled.redacted is True
+
+
+def test_with_memory_bounds_an_oversized_block_and_flags_it():
+    """The freeze measured a document with NO memory, so filling it can exceed a bound that passed."""
+    from cli_agent_orchestrator.constants import WORKFLOW_MANIFEST_MAX_BYTES
+
+    envelope = execution_manifest.build(
+        plan_id="plan-v1:x", source_hash="s", inputs={}, repo_baseline={}
+    )
+    huge = "m" * (WORKFLOW_MANIFEST_MAX_BYTES * 2)
+    filled = execution_manifest.with_memory(envelope, content=huge, source="src")
+
+    assert filled.memory.truncated is True
+    assert filled.truncated is True
+    assert len(execution_manifest.serialise(filled).encode("utf-8")) <= WORKFLOW_MANIFEST_MAX_BYTES
+    assert len(filled.memory.content) < len(huge)
+
+
+# ---------------------------------------------------------------------------
+# NFR-1
+# ---------------------------------------------------------------------------
+
+
+def test_the_block_content_is_never_logged(journalled_run, resolves, caplog):
+    import logging
+
+    with caplog.at_level(logging.DEBUG):
+        frozen_run_memory.frozen_memory_for(journalled_run, "term-1", "task")
+
+    assert "LIVE BLOCK" not in caplog.text, "memory text must not reach a second sink"

--- a/test/services/test_manifest_freeze.py
+++ b/test/services/test_manifest_freeze.py
@@ -16,7 +16,12 @@ import json
 
 import pytest
 
-from cli_agent_orchestrator.services import execution_manifest, manifest_freeze
+from cli_agent_orchestrator.services import (
+    approval_gate,
+    approval_store,
+    execution_manifest,
+    manifest_freeze,
+)
 
 SECRET = "AKIAIOSFODNN7EXAMPLE"  # matches secret_gate's ``aws_access_key`` pattern
 
@@ -135,20 +140,91 @@ def test_the_plan_id_does_not_depend_on_the_working_directory(monkeypatch, tmp_p
 
 
 def test_a_missing_baseline_still_freezes():
-    """Outside a git repository the manifest is still written; absence is representable."""
-    document = _frozen(cwd="/nonexistent/path/for/test")
-    assert document["repo_baseline"] == {"available": False}
-    assert document["plan_id"].startswith("plan-v1:")
-
-
-def test_the_baseline_is_part_of_the_identity():
-    """Two runs of an identical script against different commits are different plans."""
-    a = _frozen(cwd="/nonexistent/path/a")["plan_id"]
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(
-            manifest_freeze,
-            "derive_baseline",
-            lambda _cwd: {"available": True, "commit": "deadbeef", "dirty": False},
+    """An unavailable baseline has no identifier that could be approved or replayed."""
+    assert (
+        manifest_freeze.build_manifest_json(
+            source_hash="abc123", inputs={"k": "v"}, cwd="/nonexistent/path/for/test"
         )
-        b = _frozen()["plan_id"]
+        is None
+    )
+
+
+def test_an_unavailable_worktree_snapshot_has_no_approvable_plan_id(monkeypatch):
+    monkeypatch.setattr(
+        manifest_freeze,
+        "derive_baseline",
+        lambda _cwd: {
+            "available": False,
+            "commit": "deadbeef",
+            "worktree_state": {"status": "unavailable"},
+        },
+    )
+
+    assert manifest_freeze.build_manifest_json(source_hash="abc123", inputs={"k": "v"}) is None
+
+
+def test_an_unavailable_snapshot_reaches_the_gate_without_a_plan_id(monkeypatch):
+    available = {
+        "available": True,
+        "commit": "deadbeef",
+        "worktree_state": {"status": "dirty", "digest": "sha256:first"},
+    }
+    unavailable = {
+        "available": False,
+        "commit": "deadbeef",
+        "worktree_state": {"status": "unavailable"},
+    }
+    baselines = iter((available, unavailable))
+    monkeypatch.setattr(manifest_freeze, "derive_baseline", lambda _cwd: next(baselines))
+    monkeypatch.setattr(approval_gate, "is_workflow_approval_required", lambda: True)
+
+    approved_manifest = manifest_freeze.build_manifest_json(source_hash="abc123", inputs={"k": "v"})
+    assert approved_manifest is not None
+    approved_plan_id = json.loads(approved_manifest)["plan_id"]
+    monkeypatch.setattr(approval_store, "is_approved", lambda plan_id: plan_id == approved_plan_id)
+    approval_gate.ensure_plan_approved(tier="script", manifest_json=approved_manifest)
+
+    unavailable_manifest = manifest_freeze.build_manifest_json(
+        source_hash="abc123", inputs={"k": "v"}
+    )
+    with pytest.raises(approval_gate.PlanApprovalRequiredError) as excinfo:
+        approval_gate.ensure_plan_approved(tier="script", manifest_json=unavailable_manifest)
+
+    assert excinfo.value.plan_id is None
+
+
+def test_an_available_baseline_is_part_of_the_identity_and_unavailable_baselines_are_not(
+    monkeypatch,
+):
+    """Two available commits are distinct plans; an unavailable snapshot has no plan."""
+    monkeypatch.setattr(
+        manifest_freeze,
+        "derive_baseline",
+        lambda _cwd: {
+            "available": True,
+            "commit": "first",
+            "worktree_state": {"status": "clean"},
+        },
+    )
+    a = _frozen()["plan_id"]
+    monkeypatch.setattr(
+        manifest_freeze,
+        "derive_baseline",
+        lambda _cwd: {
+            "available": True,
+            "commit": "second",
+            "worktree_state": {"status": "clean"},
+        },
+    )
+    b = _frozen()["plan_id"]
     assert a != b
+    monkeypatch.setattr(
+        manifest_freeze,
+        "derive_baseline",
+        lambda _cwd: {
+            "available": False,
+            "commit": "second",
+            "worktree_state": {"status": "unavailable"},
+        },
+    )
+    assert manifest_freeze.build_manifest_json(source_hash="abc123", inputs={"k": "v"}) is None

--- a/test/services/test_manifest_freeze.py
+++ b/test/services/test_manifest_freeze.py
@@ -1,0 +1,154 @@
+"""Tests for freezing a script-tier run's execution manifest (issue #583 Bolt 2, ``manifest-freeze``).
+
+Two of these carry the unit's load:
+
+* ``test_a_secret_in_inputs_does_not_reach_the_manifest`` is the concrete reason
+  ``execution_manifest.build`` is the only door. ``inputs`` is arbitrary user JSON and the most likely
+  place a credential appears in a workflow run.
+* ``test_changing_the_source_hash_changes_the_plan_id`` converts this unit's transitive-coverage
+  ARGUMENT into a PROPERTY. Six of FR-8's nine manifest fields are omitted because they have no
+  run-level source in this tier; the omission is only safe because the script's own source chooses
+  them, so a source change must move the identifier. If this test fails, the omission is unsafe and a
+  changed provider could execute under a stale approval.
+"""
+
+import json
+
+import pytest
+
+from cli_agent_orchestrator.services import execution_manifest, manifest_freeze
+
+SECRET = "AKIAIOSFODNN7EXAMPLE"  # matches secret_gate's ``aws_access_key`` pattern
+
+OMITTED = ("provider", "model", "profile", "permissions", "limits", "retry_policy")
+
+
+def _frozen(**overrides) -> dict:
+    kwargs = {"source_hash": "abc123", "inputs": {"k": "v"}}
+    kwargs.update(overrides)
+    value = manifest_freeze.build_manifest_json(**kwargs)
+    assert value is not None
+    return json.loads(value)
+
+
+# ---------------------------------------------------------------------------
+# The two load-bearing properties
+# ---------------------------------------------------------------------------
+
+
+def test_a_secret_in_inputs_does_not_reach_the_manifest():
+    """Everything reaching the column passes through ``build``'s tree redaction."""
+    value = manifest_freeze.build_manifest_json(source_hash="h", inputs={"tok": SECRET})
+    assert value is not None
+    assert SECRET not in value
+    assert json.loads(value)["redacted"] is True
+
+
+def test_changing_the_source_hash_changes_the_plan_id():
+    """The transitive-coverage property. See the module docstring.
+
+    The six omitted fields are chosen by the script's own source, so a source change must move the
+    identifier. This is what makes omitting them safe rather than merely convenient.
+    """
+    a = _frozen(source_hash="hash-of-script-v1")["plan_id"]
+    b = _frozen(source_hash="hash-of-script-v2")["plan_id"]
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# What is recorded, and what is not
+# ---------------------------------------------------------------------------
+
+
+def test_the_six_absent_fields_are_omitted_not_null():
+    """A null would assert "exists but empty"; these fields have no run-level existence in this tier."""
+    document = _frozen()
+    for name in OMITTED:
+        assert name not in document, f"{name} should be omitted, not present as null"
+
+
+def test_the_note_explaining_the_omission_travels_in_the_envelope():
+    """The envelope is what an agent reads when diagnosing a failed run, so the reason lives there."""
+    document = _frozen()
+    assert "notes" in document
+    for name in OMITTED:
+        assert name in document["notes"]
+    assert "source_hash" in document["notes"]
+
+
+def test_the_three_recorded_fields_are_present():
+    document = _frozen()
+    assert document["source_hash"] == "abc123"
+    assert document["inputs"] == {"k": "v"}
+    assert "repo_baseline" in document
+    assert document["plan_id"].startswith("plan-v1:")
+
+
+def test_the_memory_record_is_empty_at_freeze_time():
+    """There is no resolved memory at run start; ``memory-resolve-once`` (pass 2B) fills it."""
+    memory = _frozen()["memory"]
+    assert memory["content"] == ""
+    assert memory["truncated"] is False
+
+
+def test_the_frozen_value_round_trips_through_parse():
+    value = manifest_freeze.build_manifest_json(source_hash="h", inputs={"a": [1, 2]})
+    assert value is not None
+    assert execution_manifest.parse(value) is not None
+
+
+# ---------------------------------------------------------------------------
+# Totality and identity stability
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_and_logs_rather_than_raising(monkeypatch, caplog):
+    """Best-effort: the run must not fail because its manifest could not be assembled.
+
+    A ``None`` writes NULL, which the approval gate reads as "never approved" and REFUSES — so the
+    failure direction is fail-closed, never an unapproved run that executes.
+    """
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("assembly exploded")
+
+    monkeypatch.setattr(manifest_freeze.plan_identifier, "compute", _boom)
+    with caplog.at_level("WARNING"):
+        assert manifest_freeze.build_manifest_json(source_hash="h", inputs={}) is None
+    assert any("manifest freeze failed" in r.message for r in caplog.records)
+
+
+def test_the_plan_id_does_not_depend_on_the_working_directory(monkeypatch, tmp_path):
+    """Path-independence: two machines running an identical plan must agree.
+
+    The baseline deliberately excludes the worktree path for exactly this reason, so a differing cwd
+    with the same repository state cannot move the identifier.
+    """
+    monkeypatch.setattr(
+        manifest_freeze,
+        "derive_baseline",
+        lambda _cwd: {"available": True, "commit": "c", "dirty": False},
+    )
+    a = _frozen(cwd=str(tmp_path))["plan_id"]
+    b = _frozen(cwd="/some/other/path")["plan_id"]
+    assert a == b
+
+
+def test_a_missing_baseline_still_freezes():
+    """Outside a git repository the manifest is still written; absence is representable."""
+    document = _frozen(cwd="/nonexistent/path/for/test")
+    assert document["repo_baseline"] == {"available": False}
+    assert document["plan_id"].startswith("plan-v1:")
+
+
+def test_the_baseline_is_part_of_the_identity():
+    """Two runs of an identical script against different commits are different plans."""
+    a = _frozen(cwd="/nonexistent/path/a")["plan_id"]
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            manifest_freeze,
+            "derive_baseline",
+            lambda _cwd: {"available": True, "commit": "deadbeef", "dirty": False},
+        )
+        b = _frozen()["plan_id"]
+    assert a != b

--- a/test/services/test_plan_identifier.py
+++ b/test/services/test_plan_identifier.py
@@ -45,7 +45,7 @@ def test_the_digest_of_a_known_field_set_is_pinned():
     just been invalidated. Update the literal ONLY together with a scheme-version bump.
     """
     assert compute(_fields()) == (
-        "plan-v1:8bcf384e8c5ba8faeb3c1aa1fd5ff5bc63bf523c5d8893d1978797e5c97b716a"
+        "plan-v1:0743b0b78d9c2a75c770a6aad22caa4681d5e4705d155e0ab98482bb2cf728d0"
     )
 
 
@@ -115,6 +115,14 @@ def test_absence_in_different_positions_is_distinct():
 def test_integer_and_float_spellings_agree():
     """``600`` and ``600.0`` are one identity: an int in a float-typed field is ordinary in Python."""
     assert compute(_fields(limits={"timeout": 600})) == compute(_fields(limits={"timeout": 600.0}))
+
+
+def test_distinct_large_integers_have_distinct_plan_ids():
+    assert compute(_fields(inputs={"n": 2**53})) != compute(_fields(inputs={"n": 2**53 + 1}))
+
+
+def test_an_oversized_integer_can_be_hashed():
+    assert compute(_fields(inputs={"n": 10**400})).startswith("plan-v1:")
 
 
 def test_booleans_are_not_normalised_into_numbers():

--- a/test/services/test_plan_identifier.py
+++ b/test/services/test_plan_identifier.py
@@ -1,0 +1,191 @@
+"""Tests for the run-level plan identifier (issue #583 Bolt 2, unit ``plan-identifier``).
+
+The properties here are the unit's contract. Two of them are load-bearing beyond ordinary coverage:
+
+* ``test_the_digest_of_a_known_field_set_is_pinned`` is what makes a reordered component list fail
+  LOUDLY. Reordering silently changes every stored value while the ``plan-v1:`` prefix stays
+  ``plan-v1:``, so neither classification nor equality can detect it — every existing approval would
+  quietly stop matching. Without a pinned digest nothing in the suite would notice.
+* ``test_changing_each_field_in_turn_changes_the_value`` asserts FR-8's Pass criterion field by field
+  rather than assuming it. A field silently omitted from the hash is invisible to every other test.
+"""
+
+import dataclasses
+from pathlib import Path
+
+from cli_agent_orchestrator.services import plan_identifier as pi
+from cli_agent_orchestrator.services.plan_identifier import PlanFields, compute, scheme_of
+
+
+def _fields(**overrides) -> PlanFields:
+    base = PlanFields(
+        source_hash="h",
+        inputs={"a": 1, "b": 2},
+        repo_baseline={},
+        provider="mock_cli",
+        model="m",
+        profile="dev",
+        permissions={},
+        limits={},
+        retry_policy={},
+    )
+    return dataclasses.replace(base, **overrides) if overrides else base
+
+
+# ---------------------------------------------------------------------------
+# The contract
+# ---------------------------------------------------------------------------
+
+
+def test_the_digest_of_a_known_field_set_is_pinned():
+    """THE GUARD AGAINST A SILENT REORDERING. See the module docstring.
+
+    If this fails after a change to the component order, the framing, the prefix, or any normaliser,
+    that is the test doing its job — every stored ``plan_id`` and therefore every recorded approval has
+    just been invalidated. Update the literal ONLY together with a scheme-version bump.
+    """
+    assert compute(_fields()) == (
+        "plan-v1:8bcf384e8c5ba8faeb3c1aa1fd5ff5bc63bf523c5d8893d1978797e5c97b716a"
+    )
+
+
+def test_changing_each_field_in_turn_changes_the_value():
+    """FR-8's Pass criterion, asserted field by field rather than assumed.
+
+    A field left out of the hash would be invisible to every other test in this file: the plan would
+    change, the identifier would not, and a changed plan would execute under a stale approval.
+    """
+    baseline = compute(_fields())
+    altered = {
+        "source_hash": "different",
+        "inputs": {"a": 1, "b": 3},
+        "repo_baseline": {"sha": "x"},
+        "provider": "claude_code",
+        "model": "other",
+        "profile": "reviewer",
+        "permissions": {"write": True},
+        "limits": {"steps": 5},
+        "retry_policy": {"retries": 2},
+    }
+    assert set(altered) == {f.name for f in dataclasses.fields(PlanFields)}, (
+        "every one of the nine fields must be exercised; this guard catches a field added to "
+        "PlanFields without being added here"
+    )
+    for name, value in altered.items():
+        assert compute(_fields(**{name: value})) != baseline, f"{name} does not affect plan_id"
+
+
+def test_the_output_shape_is_fixed_regardless_of_input_size():
+    """72 characters, no user bytes: neither an injection nor a growth vector."""
+    for inputs in ({}, {"k": "v"}, {"big": "x" * 100_000}):
+        value = compute(_fields(inputs=inputs))
+        assert value.startswith("plan-v1:")
+        assert len(value) == 72
+        hex_part = value[len("plan-v1:") :]
+        assert len(hex_part) == 64
+        assert hex_part == hex_part.lower()
+        assert all(c in "0123456789abcdef" for c in hex_part)
+
+
+# ---------------------------------------------------------------------------
+# Canonical form
+# ---------------------------------------------------------------------------
+
+
+def test_dict_key_order_does_not_change_the_value():
+    """A reordered map executes identically, so it must not force a re-approval."""
+    assert compute(_fields(inputs={"a": 1, "b": 2})) == compute(_fields(inputs={"b": 2, "a": 1}))
+
+
+def test_list_order_does_change_the_value():
+    """A reordered permissions list or retry sequence may genuinely execute differently."""
+    assert compute(_fields(inputs=[1, 2])) != compute(_fields(inputs=[2, 1]))
+
+
+def test_none_and_empty_string_are_distinct():
+    """ "No profile" and "the empty profile" are different plans."""
+    assert compute(_fields(profile=None)) != compute(_fields(profile=""))
+
+
+def test_absence_in_different_positions_is_distinct():
+    """The tuple is never shortened, so two plans cannot collide by which field is missing."""
+    assert compute(_fields(provider=None)) != compute(_fields(model=None))
+
+
+def test_integer_and_float_spellings_agree():
+    """``600`` and ``600.0`` are one identity: an int in a float-typed field is ordinary in Python."""
+    assert compute(_fields(limits={"timeout": 600})) == compute(_fields(limits={"timeout": 600.0}))
+
+
+def test_booleans_are_not_normalised_into_numbers():
+    """``bool`` subclasses ``int``; normalising ``True`` to a number would erase flag-versus-count."""
+    assert compute(_fields(permissions={"write": True})) != compute(
+        _fields(permissions={"write": 1})
+    )
+
+
+def test_framing_is_injective_where_a_naive_join_would_collide():
+    """Length-prefixed framing closes the limit ``step_fingerprint`` deferred to a ``v3:`` decision.
+
+    Under a naive single-separator join these two field sets render identically: the boundary between
+    two adjacent components becomes indistinguishable from the separator inside one of them. A collision
+    here means one plan executing under another plan's approval.
+    """
+    sep = pi._FRAME_SEP
+    a = _fields(provider=f"x{sep}y", model="z")
+    b = _fields(provider="x", model=f"y{sep}z")
+    assert compute(a) != compute(b)
+
+
+# ---------------------------------------------------------------------------
+# Provenance
+# ---------------------------------------------------------------------------
+
+
+def test_scheme_of_reports_three_states():
+    assert scheme_of(compute(_fields())) == "plan-v1"
+    assert scheme_of("v2:" + "a" * 64) == "unknown"
+    assert scheme_of(None) == "absent"
+    assert scheme_of("") == "absent"
+
+
+def test_scheme_of_never_raises():
+    for value in (None, "", "plan-v1:", "garbage", "\x00", "plan-v2:abc", "a" * 10_000):
+        assert scheme_of(value) in {"plan-v1", "unknown", "absent"}
+
+
+def test_absent_is_distinguishable_from_unknown():
+    """The distinction is the point: re-approval versus a human ruling are different remedies."""
+    assert scheme_of(None) != scheme_of("v2:abc")
+
+
+# ---------------------------------------------------------------------------
+# Module posture (preservation)
+# ---------------------------------------------------------------------------
+
+
+def test_the_module_has_no_logger_and_no_print():
+    """One helpful log line would move a credential out of a hash and into a world-readable file."""
+    source = Path(pi.__file__).read_text(encoding="utf-8")
+    # Strip docstrings: they discuss logging deliberately, and that prose is the point.
+    code = "".join(source.replace('"""', "\x00").split("\x00")[::2])
+    assert "logging" not in code
+    assert "logger" not in code
+    assert "print(" not in code
+
+
+def test_the_module_imports_only_the_four_permitted_names():
+    """Leaf purity: ``hashlib``, ``json``, ``dataclasses``, ``typing`` and nothing else."""
+    source = Path(pi.__file__).read_text(encoding="utf-8")
+    # Strip docstrings BEFORE scanning: prose wraps onto lines beginning "from ..." and would be
+    # mistaken for an import. (Found by this test failing on its own first run.)
+    code = "".join(source.replace('"""', "\x00").split("\x00")[::2])
+    imports = [line.strip() for line in code.splitlines() if line.startswith(("import ", "from "))]
+    assert imports == [
+        "import hashlib",
+        "import json",
+        "from dataclasses import dataclass",
+        "from typing import Any, Literal, Optional",
+    ]
+    # No import from elsewhere in this codebase: the module must stay a leaf.
+    assert "cli_agent_orchestrator" not in "".join(imports)

--- a/test/services/test_terminal_frozen_memory.py
+++ b/test/services/test_terminal_frozen_memory.py
@@ -1,0 +1,187 @@
+"""Tests for the optional pre-resolved memory block (issue #583 Bolt 2, unit ``terminal-frozen-memory``).
+
+Two carry the unit's load:
+
+* ``test_an_empty_frozen_block_prepends_nothing_and_never_consults_memoryservice`` — the ``is None`` vs
+  truthiness distinction. An empty block is a SUPPLIED block meaning "the original run resolved no memory". Under
+  a single truthiness test it would fall through to the live path and pick up memories written after the original
+  run — the exact drift FR-9 exists to prevent, arriving through the one case nobody thinks to test.
+* ``test_the_kill_switch_binds_the_frozen_path_too`` — skipping ``MemoryService`` also skips its
+  ``is_memory_enabled()`` check, so without this a workflow run would paste memory into the context of an
+  operator who turned memory off. A control bypass, not a determinism bug.
+
+ONE TRAP THESE TESTS AVOID. The first-message guard (``_memory_injected_terminals``) also suppresses a
+``MemoryService`` call on message two, so "MemoryService was not constructed" is NOT by itself evidence that the
+frozen arm ran. Every assertion of that shape below is made on a FIRST message to a FRESH terminal id.
+"""
+
+import inspect
+
+import pytest
+
+from cli_agent_orchestrator.services import terminal_service
+from cli_agent_orchestrator.services.terminal_service import inject_memory_context
+
+
+@pytest.fixture(autouse=True)
+def fresh_injection_state():
+    """Every test starts from a terminal that has never been injected."""
+    with terminal_service._memory_injected_lock:
+        terminal_service._memory_injected_terminals.clear()
+    yield
+    with terminal_service._memory_injected_lock:
+        terminal_service._memory_injected_terminals.clear()
+
+
+@pytest.fixture()
+def spy(monkeypatch):
+    """Record whether ``MemoryService`` was constructed, and with what the curator was asked."""
+    calls = {"constructed": 0, "task_description": None, "terminal_id": None}
+
+    class _Spy:
+        def __init__(self):
+            calls["constructed"] += 1
+
+        def get_curated_memory_context(self, terminal_id, task_description=None):
+            calls["terminal_id"] = terminal_id
+            calls["task_description"] = task_description
+            return "<cao-memory>LIVE</cao-memory>"
+
+    monkeypatch.setattr(terminal_service, "MemoryService", _Spy)
+    return calls
+
+
+@pytest.fixture()
+def memory_disabled(monkeypatch):
+    """Turn the operator's kill switch off at the module the frozen arm imports from."""
+    from cli_agent_orchestrator.services import settings_service
+
+    monkeypatch.setattr(settings_service, "is_memory_enabled", lambda: False)
+
+
+# ---------------------------------------------------------------------------
+# The two load-bearing properties
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_frozen_block_prepends_nothing_and_never_consults_memoryservice(spy):
+    """`is None` decides the ARM; truthiness only decides the PREPEND. Collapsing them is the bug."""
+    result = inject_memory_context("do the thing", "term-empty", frozen_memory="")
+
+    assert result == "do the thing", "an empty frozen block must prepend nothing"
+    assert spy["constructed"] == 0, (
+        "an empty frozen block is a SUPPLIED block — it must NOT fall through to live memory, "
+        "or a run that legitimately froze no memory would pick up memories written after it"
+    )
+
+
+def test_the_kill_switch_binds_the_frozen_path_too(spy, memory_disabled):
+    """Skipping MemoryService skips its is_memory_enabled() check. That must not become a bypass."""
+    result = inject_memory_context(
+        "do the thing", "term-disabled", frozen_memory="<cao-memory>FROZEN</cao-memory>"
+    )
+
+    assert result == "do the thing", (
+        "with memory disabled, a frozen block must not be injected — a workflow run must not "
+        "re-enable memory for an operator who turned it off"
+    )
+    assert spy["constructed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The frozen path
+# ---------------------------------------------------------------------------
+
+
+def test_a_frozen_block_is_injected_verbatim_with_the_live_separator(spy):
+    block = "<cao-memory>FROZEN</cao-memory>"
+    result = inject_memory_context("do the thing", "term-verbatim", frozen_memory=block)
+
+    assert result == block + "\n\n" + "do the thing"
+    assert "LIVE" not in result
+
+
+def test_a_supplied_block_does_not_construct_memoryservice_on_a_first_message(spy):
+    """Asserted on a FIRST message to a FRESH id, so the first-message guard cannot be the cause."""
+    inject_memory_context("do the thing", "term-fresh", frozen_memory="<cao-memory>F</cao-memory>")
+    assert spy["constructed"] == 0, "the frozen arm must not consult the live store"
+
+
+def test_the_first_message_guard_still_fires_once_per_terminal_on_the_frozen_path(spy):
+    block = "<cao-memory>FROZEN</cao-memory>"
+    first = inject_memory_context("one", "term-guard", frozen_memory=block)
+    second = inject_memory_context("two", "term-guard", frozen_memory=block)
+
+    assert first.startswith(block)
+    assert second == "two", "a frozen block must be injected at most once per terminal"
+
+
+# ---------------------------------------------------------------------------
+# The default path — C-1
+# ---------------------------------------------------------------------------
+
+
+def test_an_absent_block_uses_the_live_path_unchanged(spy):
+    long_message = "x" * 500
+    result = inject_memory_context(long_message, "term-live")
+
+    assert result == "<cao-memory>LIVE</cao-memory>" + "\n\n" + long_message
+    assert spy["constructed"] == 1
+    assert spy["terminal_id"] == "term-live"
+    assert spy["task_description"] == long_message[:200], "the 200-char slice must be unchanged"
+
+
+def test_the_live_path_is_unaffected_when_memory_is_disabled(spy, memory_disabled):
+    """With no frozen block the switch is MemoryService's business, exactly as before this unit."""
+    result = inject_memory_context("do the thing", "term-live-off")
+
+    assert result == "<cao-memory>LIVE</cao-memory>" + "\n\n" + "do the thing"
+    assert spy["constructed"] == 1, (
+        "the frozen arm's switch check must sit inside that arm — the live path must reach "
+        "MemoryService and let it apply its own check"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The signatures
+# ---------------------------------------------------------------------------
+
+
+def test_both_signatures_take_the_block_last_and_defaulted():
+    """``agent_step.run_agent_step`` calls send_input positionally with two arguments."""
+    for func in (inject_memory_context, terminal_service.send_input):
+        params = list(inspect.signature(func).parameters.values())
+        assert params[-1].name == "frozen_memory", f"{func.__name__}: block must come last"
+        assert params[-1].default is None, f"{func.__name__}: block must default to None"
+
+
+def test_send_input_forwards_the_block_unchanged(monkeypatch):
+    """send_input is a conduit: it must not inspect, validate or alter the block."""
+    seen = {}
+
+    def _capture(message, terminal_id, frozen_memory=None):
+        seen["message"] = message
+        seen["terminal_id"] = terminal_id
+        seen["frozen_memory"] = frozen_memory
+        raise RuntimeError("stop here — forwarding is all this test needs to observe")
+
+    monkeypatch.setattr(terminal_service, "inject_memory_context", _capture)
+    monkeypatch.setattr(
+        terminal_service,
+        "get_terminal_metadata",
+        lambda _tid: {"session_name": "s", "window": "0", "provider": "claude_code"},
+    )
+    # No provider, so the status/blocked guards above the injection point are skipped.
+    monkeypatch.setattr(
+        terminal_service.provider_manager, "get_provider", lambda _tid: None, raising=False
+    )
+
+    block = "<cao-memory>FROZEN</cao-memory>"
+    # send_input logs and RE-RAISES (terminal_service.py:1353-1355), so the sentinel
+    # surfaces here. It stops execution immediately after forwarding — which is all this
+    # test needs to observe, and it avoids mocking the tmux paste path that follows.
+    with pytest.raises(RuntimeError, match="stop here"):
+        terminal_service.send_input("term-fwd", "hello", frozen_memory=block)
+
+    assert seen["frozen_memory"] == block, "the block must arrive unchanged"
+    assert seen["message"] == "hello"

--- a/test/telemetry/test_orchestration_instrumentation.py
+++ b/test/telemetry/test_orchestration_instrumentation.py
@@ -53,7 +53,7 @@ provider_stub.paste_submit_delay = 0.3
 
 terminal_service.get_terminal_metadata = lambda tid: {"tmux_session": "cao-s", "tmux_window": "w"}
 terminal_service.provider_manager.get_provider = lambda tid: provider_stub
-terminal_service.inject_memory_context = lambda msg, tid: msg
+terminal_service.inject_memory_context = lambda msg, tid, frozen=None: msg
 terminal_service.update_last_active = lambda tid: None
 terminal_service.status_monitor = MagicMock()
 terminal_service.get_backend = lambda: MagicMock()

--- a/test/utils/test_git_baseline.py
+++ b/test/utils/test_git_baseline.py
@@ -10,7 +10,7 @@ import subprocess
 from cli_agent_orchestrator.utils import git_baseline
 
 
-def test_returns_commit_and_dirty_inside_a_repository(tmp_path):
+def _initialise_repository(tmp_path):
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True)
@@ -18,14 +18,71 @@ def test_returns_commit_and_dirty_inside_a_repository(tmp_path):
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
 
+
+def test_returns_commit_and_worktree_state_inside_a_repository(tmp_path):
+    _initialise_repository(tmp_path)
+
     baseline = git_baseline.derive_baseline(str(tmp_path))
 
     assert baseline["available"] is True
     assert len(baseline["commit"]) == 40
-    assert baseline["dirty"] is False
+    assert baseline["worktree_state"] == {"status": "clean"}
+
+
+def test_dirty_worktree_state_depends_on_the_uncommitted_contents(tmp_path):
+    _initialise_repository(tmp_path)
 
     (tmp_path / "f.txt").write_text("two", encoding="utf-8")
-    assert git_baseline.derive_baseline(str(tmp_path))["dirty"] is True
+    baseline_a = git_baseline.derive_baseline(str(tmp_path))
+
+    (tmp_path / "f.txt").write_text("three", encoding="utf-8")
+    baseline_b = git_baseline.derive_baseline(str(tmp_path))
+
+    assert baseline_a["commit"] == baseline_b["commit"]
+    assert baseline_a["worktree_state"] != baseline_b["worktree_state"]
+
+
+def test_staged_changes_and_deletions_are_dirty_worktree_states(tmp_path):
+    _initialise_repository(tmp_path)
+    clean = git_baseline.derive_baseline(str(tmp_path))
+
+    (tmp_path / "f.txt").write_text("staged", encoding="utf-8")
+    subprocess.run(["git", "add", "f.txt"], cwd=tmp_path, check=True)
+    staged = git_baseline.derive_baseline(str(tmp_path))
+
+    subprocess.run(["git", "reset", "--hard", "HEAD"], cwd=tmp_path, check=True)
+    (tmp_path / "f.txt").unlink()
+    deleted = git_baseline.derive_baseline(str(tmp_path))
+
+    assert staged["worktree_state"] != clean["worktree_state"]
+    assert deleted["worktree_state"] != clean["worktree_state"]
+
+
+def test_untracked_file_contents_affect_worktree_state(tmp_path):
+    _initialise_repository(tmp_path)
+    (tmp_path / "untracked.txt").write_text("one", encoding="utf-8")
+    baseline_a = git_baseline.derive_baseline(str(tmp_path))
+
+    (tmp_path / "untracked.txt").write_text("two", encoding="utf-8")
+    baseline_b = git_baseline.derive_baseline(str(tmp_path))
+
+    assert baseline_a["worktree_state"] != baseline_b["worktree_state"]
+
+
+def test_records_an_unavailable_worktree_state_explicitly(monkeypatch, tmp_path):
+    _initialise_repository(tmp_path)
+    actual_run_git = git_baseline._run_git
+
+    def _unavailable_after_head(args, cwd, **kwargs):
+        if args[:2] == ["diff", "--binary"]:
+            return None
+        return actual_run_git(args, cwd, **kwargs)
+
+    monkeypatch.setattr(git_baseline, "_run_git", _unavailable_after_head)
+
+    baseline = git_baseline.derive_baseline(str(tmp_path))
+
+    assert baseline["worktree_state"] == {"status": "unavailable"}
 
 
 def test_records_absence_outside_a_repository(tmp_path):
@@ -59,19 +116,14 @@ def test_records_absence_on_unreadable_directory():
 
 
 def test_captures_no_branch_and_no_path(tmp_path):
-    """Only commit and dirty. A path is environment-specific and would make plan_id machine-dependent.
+    """Only commit and worktree state. A path is environment-specific and would make plan_id machine-dependent.
 
     Including a branch or path would mean two machines running an identical plan derived different
     ``plan_id`` values, forcing a spurious re-approval on every machine change.
     """
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True)
-    (tmp_path / "f.txt").write_text("x", encoding="utf-8")
-    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
-    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+    _initialise_repository(tmp_path)
 
     baseline = git_baseline.derive_baseline(str(tmp_path))
 
-    assert set(baseline) == {"available", "commit", "dirty"}
+    assert set(baseline) == {"available", "commit", "worktree_state"}
     assert str(tmp_path) not in str(baseline)

--- a/test/utils/test_git_baseline.py
+++ b/test/utils/test_git_baseline.py
@@ -1,0 +1,77 @@
+"""Tests for the run's repository baseline derivation (issue #583 Bolt 2, unit ``manifest-freeze``).
+
+The contract under test is TOTALITY. Deriving a baseline must never be the reason a run cannot start, so
+every failure mode — not a repository, ``git`` absent, unreadable directory, hung process — has to answer a
+recorded absence rather than raise or block. Four of the six tests here exist for that alone.
+"""
+
+import subprocess
+
+from cli_agent_orchestrator.utils import git_baseline
+
+
+def test_returns_commit_and_dirty_inside_a_repository(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True)
+    (tmp_path / "f.txt").write_text("one", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+
+    baseline = git_baseline.derive_baseline(str(tmp_path))
+
+    assert baseline["available"] is True
+    assert len(baseline["commit"]) == 40
+    assert baseline["dirty"] is False
+
+    (tmp_path / "f.txt").write_text("two", encoding="utf-8")
+    assert git_baseline.derive_baseline(str(tmp_path))["dirty"] is True
+
+
+def test_records_absence_outside_a_repository(tmp_path):
+    """A workspace outside git is entirely ordinary, not a fault."""
+    assert git_baseline.derive_baseline(str(tmp_path)) == {"available": False}
+
+
+def test_records_absence_when_git_is_missing(monkeypatch, tmp_path):
+    """``git`` absent from PATH raises ``FileNotFoundError`` (an ``OSError``); it must not escape."""
+
+    def _boom(*_args, **_kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert git_baseline.derive_baseline(str(tmp_path)) == {"available": False}
+
+
+def test_records_absence_on_timeout(monkeypatch, tmp_path):
+    """A hung git must not block run start."""
+
+    def _hang(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", _hang)
+    assert git_baseline.derive_baseline(str(tmp_path)) == {"available": False}
+
+
+def test_records_absence_on_unreadable_directory():
+    """A nonexistent cwd surfaces as ``OSError`` from ``subprocess.run``; also an absence."""
+    assert git_baseline.derive_baseline("/nonexistent/path/for/test") == {"available": False}
+
+
+def test_captures_no_branch_and_no_path(tmp_path):
+    """Only commit and dirty. A path is environment-specific and would make plan_id machine-dependent.
+
+    Including a branch or path would mean two machines running an identical plan derived different
+    ``plan_id`` values, forcing a spurious re-approval on every machine change.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, check=True)
+    (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+
+    baseline = git_baseline.derive_baseline(str(tmp_path))
+
+    assert set(baseline) == {"available", "commit", "dirty"}
+    assert str(tmp_path) not in str(baseline)

--- a/test/utils/test_git_baseline.py
+++ b/test/utils/test_git_baseline.py
@@ -5,6 +5,8 @@ every failure mode — not a repository, ``git`` absent, unreadable directory, h
 recorded absence rather than raise or block. Four of the six tests here exist for that alone.
 """
 
+import builtins
+import os
 import subprocess
 
 from cli_agent_orchestrator.utils import git_baseline
@@ -69,12 +71,115 @@ def test_untracked_file_contents_affect_worktree_state(tmp_path):
     assert baseline_a["worktree_state"] != baseline_b["worktree_state"]
 
 
+def test_untracked_file_is_hashed_in_bounded_chunks(monkeypatch, tmp_path):
+    _initialise_repository(tmp_path)
+    hash_chunk_bytes = 64 * 1024
+    contents = b"x" * (hash_chunk_bytes * 2 + 1)
+    untracked_path = tmp_path / "untracked.bin"
+    untracked_path.write_bytes(contents)
+    read_sizes = []
+    actual_open = builtins.open
+
+    class _TrackingFile:
+        def __init__(self, file):
+            self._file = file
+
+        def read(self, size=-1):
+            read_sizes.append(size)
+            return self._file.read(size)
+
+        def __getattr__(self, name):
+            return getattr(self._file, name)
+
+        def __enter__(self):
+            self._file.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._file.__exit__(*args)
+
+    def _track_untracked_open(path, *args, **kwargs):
+        opened = actual_open(path, *args, **kwargs)
+        if os.fsencode(path) == os.fsencode(untracked_path):
+            return _TrackingFile(opened)
+        return opened
+
+    monkeypatch.setattr(builtins, "open", _track_untracked_open)
+
+    baseline = git_baseline.derive_baseline(str(tmp_path))
+
+    assert baseline["worktree_state"]["status"] == "dirty"
+    assert read_sizes
+    assert -1 not in read_sizes
+    assert all(read_size == hash_chunk_bytes for read_size in read_sizes)
+
+
+def test_untracked_file_symlink_hashes_link_payload_without_dereferencing(tmp_path):
+    _initialise_repository(tmp_path)
+    external = tmp_path.parent / "external.txt"
+    external.write_text("one", encoding="utf-8")
+    link = tmp_path / "untracked-link"
+    link.symlink_to(external)
+
+    before = git_baseline.derive_baseline(str(tmp_path))
+    external.write_text("two", encoding="utf-8")
+    after_external_target_change = git_baseline.derive_baseline(str(tmp_path))
+
+    replacement = tmp_path.parent / "replacement.txt"
+    replacement.write_text("two", encoding="utf-8")
+    link.unlink()
+    link.symlink_to(replacement)
+    after_link_retarget = git_baseline.derive_baseline(str(tmp_path))
+
+    assert before["worktree_state"] == after_external_target_change["worktree_state"]
+    assert before["worktree_state"] != after_link_retarget["worktree_state"]
+
+
+def test_untracked_directory_symlink_does_not_collapse_dirty_state(tmp_path):
+    _initialise_repository(tmp_path)
+    external_directory = tmp_path.parent / "external-directory"
+    external_directory.mkdir()
+    (tmp_path / "untracked-directory").symlink_to(external_directory, target_is_directory=True)
+    (tmp_path / "dirty.txt").write_text("one", encoding="utf-8")
+
+    first = git_baseline.derive_baseline(str(tmp_path))
+    (tmp_path / "dirty.txt").write_text("two", encoding="utf-8")
+    second = git_baseline.derive_baseline(str(tmp_path))
+
+    assert first["worktree_state"]["status"] == "dirty"
+    assert first["worktree_state"] != second["worktree_state"]
+
+
+def test_worktree_state_ignores_local_diff_presentation_settings(tmp_path):
+    _initialise_repository(tmp_path)
+    (tmp_path / "f.txt").write_text("two\nthree\nfour\n", encoding="utf-8")
+
+    baseline_without_settings = git_baseline.derive_baseline(str(tmp_path))
+    for key, value in (
+        ("diff.context", "0"),
+        ("diff.interHunkContext", "99"),
+        ("diff.algorithm", "histogram"),
+        ("diff.indentHeuristic", "true"),
+        ("diff.noprefix", "true"),
+        ("diff.mnemonicPrefix", "true"),
+        ("diff.renames", "true"),
+        ("diff.submodule", "log"),
+        ("core.quotePath", "false"),
+        ("core.autocrlf", "true"),
+        ("color.diff", "always"),
+    ):
+        subprocess.run(["git", "config", key, value], cwd=tmp_path, check=True)
+    baseline_with_settings = git_baseline.derive_baseline(str(tmp_path))
+
+    assert baseline_with_settings["worktree_state"] == baseline_without_settings["worktree_state"]
+
+
 def test_records_an_unavailable_worktree_state_explicitly(monkeypatch, tmp_path):
     _initialise_repository(tmp_path)
     actual_run_git = git_baseline._run_git
 
     def _unavailable_after_head(args, cwd, **kwargs):
-        if args[:2] == ["diff", "--binary"]:
+        if "diff" in args:
             return None
         return actual_run_git(args, cwd, **kwargs)
 

--- a/test/utils/test_git_baseline.py
+++ b/test/utils/test_git_baseline.py
@@ -5,9 +5,9 @@ every failure mode — not a repository, ``git`` absent, unreadable directory, h
 recorded absence rather than raise or block. Four of the six tests here exist for that alone.
 """
 
-import builtins
 import os
 import subprocess
+import threading
 
 from cli_agent_orchestrator.utils import git_baseline
 
@@ -78,7 +78,7 @@ def test_untracked_file_is_hashed_in_bounded_chunks(monkeypatch, tmp_path):
     untracked_path = tmp_path / "untracked.bin"
     untracked_path.write_bytes(contents)
     read_sizes = []
-    actual_open = builtins.open
+    actual_fdopen = os.fdopen
 
     class _TrackingFile:
         def __init__(self, file):
@@ -98,20 +98,63 @@ def test_untracked_file_is_hashed_in_bounded_chunks(monkeypatch, tmp_path):
         def __exit__(self, *args):
             return self._file.__exit__(*args)
 
-    def _track_untracked_open(path, *args, **kwargs):
-        opened = actual_open(path, *args, **kwargs)
-        if os.fsencode(path) == os.fsencode(untracked_path):
-            return _TrackingFile(opened)
-        return opened
+    def _track_untracked_fdopen(descriptor, *args, **kwargs):
+        return _TrackingFile(actual_fdopen(descriptor, *args, **kwargs))
 
-    monkeypatch.setattr(builtins, "open", _track_untracked_open)
+    monkeypatch.setattr(os, "fdopen", _track_untracked_fdopen)
 
     baseline = git_baseline.derive_baseline(str(tmp_path))
 
     assert baseline["worktree_state"]["status"] == "dirty"
     assert read_sizes
     assert -1 not in read_sizes
-    assert all(read_size == hash_chunk_bytes for read_size in read_sizes)
+    assert all(0 < read_size <= hash_chunk_bytes for read_size in read_sizes)
+
+
+def test_untracked_file_replaced_by_fifo_before_open_returns_unavailable_without_blocking(
+    monkeypatch, tmp_path
+):
+    _initialise_repository(tmp_path)
+    untracked_path = tmp_path / "untracked"
+    untracked_path.write_bytes(b"contents")
+    actual_lstat = os.lstat
+    target_lstat_calls = 0
+
+    def _replace_after_entry_validation(path, *args, **kwargs):
+        nonlocal target_lstat_calls
+        result = actual_lstat(path, *args, **kwargs)
+        if os.fsencode(path) == os.fsencode(untracked_path):
+            target_lstat_calls += 1
+            if target_lstat_calls == 2:
+                untracked_path.unlink()
+                os.mkfifo(untracked_path)
+        return result
+
+    monkeypatch.setattr(os, "lstat", _replace_after_entry_validation)
+    result = []
+    completed = threading.Event()
+
+    def _derive():
+        result.append(git_baseline.derive_baseline(str(tmp_path)))
+        completed.set()
+
+    worker = threading.Thread(target=_derive, daemon=True)
+    worker.start()
+    try:
+        assert completed.wait(1), "opening the replacement FIFO must not block baseline derivation"
+    finally:
+        if worker.is_alive():
+            writer = os.open(untracked_path, os.O_WRONLY | os.O_NONBLOCK)
+            os.close(writer)
+        worker.join(timeout=1)
+
+    assert result == [
+        {
+            "available": False,
+            "commit": result[0]["commit"],
+            "worktree_state": {"status": "unavailable"},
+        }
+    ]
 
 
 def test_untracked_file_symlink_hashes_link_payload_without_dereferencing(tmp_path):
@@ -176,17 +219,35 @@ def test_worktree_state_ignores_local_diff_presentation_settings(tmp_path):
 
 def test_records_an_unavailable_worktree_state_explicitly(monkeypatch, tmp_path):
     _initialise_repository(tmp_path)
-    actual_run_git = git_baseline._run_git
+    actual_run = subprocess.run
 
-    def _unavailable_after_head(args, cwd, **kwargs):
+    def _timeout_worktree_snapshot(args, *args_rest, **kwargs):
         if "diff" in args:
-            return None
-        return actual_run_git(args, cwd, **kwargs)
+            raise subprocess.TimeoutExpired(cmd=args, timeout=1)
+        return actual_run(args, *args_rest, **kwargs)
 
-    monkeypatch.setattr(git_baseline, "_run_git", _unavailable_after_head)
+    monkeypatch.setattr(subprocess, "run", _timeout_worktree_snapshot)
 
     baseline = git_baseline.derive_baseline(str(tmp_path))
 
+    assert baseline == {
+        "available": False,
+        "commit": baseline["commit"],
+        "worktree_state": {"status": "unavailable"},
+    }
+
+
+def test_untracked_hash_budget_exhaustion_records_an_unavailable_baseline(tmp_path):
+    _initialise_repository(tmp_path)
+    untracked_path = tmp_path / "untracked.bin"
+    untracked_path.touch()
+    # Without this fallback, pre-fix code fails with AttributeError instead of exercising behaviour.
+    budget = getattr(git_baseline, "_UNTRACKED_HASH_BUDGET_BYTES", 64 * 1024 * 1024)
+    os.truncate(untracked_path, budget + 1)
+
+    baseline = git_baseline.derive_baseline(str(tmp_path))
+
+    assert baseline["available"] is False
     assert baseline["worktree_state"] == {"status": "unavailable"}
 
 

--- a/tui/src/catalog.rs
+++ b/tui/src/catalog.rs
@@ -1,6 +1,6 @@
 //! The static run-policy table: what the TUI offers, and how (issue #321).
 //!
-//! One row per leaf command of the CAO Click tree — **69 of them** — each classified `InApp`,
+//! One row per leaf command of the CAO Click tree — **70 of them** — each classified `InApp`,
 //! `Handoff`, or `Hidden`. Three infallible lookups read that table and nothing else.
 //!
 //! # No I/O, and that is the security property (SR-1)
@@ -64,7 +64,7 @@ use std::vec::Vec;
 
 /// The number of leaf commands in the CAO Click tree.
 ///
-/// **69 as of this branch.** Two separate merges from `main` each brought four new leaf commands
+/// **70 as of this branch.** Two separate merges from `main` each brought four new leaf commands
 /// that this table did not know about, and both were caught by
 /// `test/test_command_catalog_matches_click.py` rather than by review — the second one in CI,
 /// because CI tests the PR MERGED against `main` while a local run only sees the branch. That is
@@ -86,7 +86,7 @@ use std::vec::Vec;
 /// must not offer itself — giving **33 IN-APP / 5 HANDOFF / 23 HIDE = 61**. Recorded here
 /// because a reader comparing the design's 60 against this 61 would otherwise suspect drift.
 /// (#321)
-const COMMAND_COUNT: usize = 69;
+const COMMAND_COUNT: usize = 70;
 
 /// What the TUI does with a command.
 ///
@@ -244,6 +244,7 @@ pub(crate) const DISPLAY_ORDER: [CommandId; COMMAND_COUNT] = [
     CommandId::SkillsList,
     CommandId::SkillsRemove,
     CommandId::TerminalRestore,
+    CommandId::WorkflowApprove,
     CommandId::WorkflowCancel,
     CommandId::WorkflowDelete,
     CommandId::WorkflowEvents,
@@ -403,6 +404,8 @@ pub enum CommandId {
     TerminalRestore,
 
     // `cao workflow *`
+    /// `cao workflow approve`
+    WorkflowApprove,
     /// `cao workflow cancel`
     WorkflowCancel,
     /// `cao workflow delete`
@@ -1047,6 +1050,20 @@ fn entry(id: CommandId) -> Command {
             // HIDE: human ruled out; recovery-by-terminal-ID tooling, not a launcher action
         },
 
+        CommandId::WorkflowApprove => Command {
+            id: CommandId::WorkflowApprove,
+            parent: Some("workflow"),
+            leaf_name: "approve",
+            summary: "Approve a plan identifier so runs of that plan may start.",
+            // Hidden per the mandated default: an unclassified command defaults to HIDE so an
+            // unvetted command cannot surface half-working. Not reviewed for in-app use, and there
+            // is a reason not to rush that review — approving a plan is a deliberate human
+            // authorisation act, and surfacing it as a one-click pane entry is exactly the shape
+            // that would make it casual. (#583 Bolt 2, approval-operation)
+            policy: Policy::Hidden,
+            params: &[Param { name: "plan_id", required: true, kind: ParamKind::Text }],
+            handoff_reason: None,
+        },
         CommandId::WorkflowCancel => Command {
             id: CommandId::WorkflowCancel,
             parent: Some("workflow"),
@@ -1262,7 +1279,7 @@ mod tests {
         counts
     }
 
-    /// Test 1 — **the policy distribution is 24 IN-APP / 18 HANDOFF / 27 HIDE, totalling 69.**
+    /// Test 1 — **the policy distribution is 24 IN-APP / 18 HANDOFF / 28 HIDE, totalling 70.**
     ///
     /// Every number here is a **hard-coded literal**, and that is the entire design of the test.
     /// Deriving any of them from the table — `assert_eq!(in_app, TABLE.iter().filter(..).count())`
@@ -1299,16 +1316,16 @@ mod tests {
     /// consistent and every test green, because nothing compared the table against the CLI. That
     /// is what `test/test_command_catalog_matches_click.py` now does. (Review on PR #547.)
     #[test]
-    fn the_policy_distribution_is_twentyfour_eighteen_twentyseven() {
+    fn the_policy_distribution_is_twentyfour_eighteen_twentyeight() {
         let (in_app, handoff, hidden) = distribution();
 
         assert_eq!(in_app, 24, "expected 24 IN-APP commands, found {in_app}");
         assert_eq!(handoff, 18, "expected 18 HANDOFF commands, found {handoff}");
-        assert_eq!(hidden, 27, "expected 27 HIDE commands, found {hidden}");
+        assert_eq!(hidden, 28, "expected 28 HIDE commands, found {hidden}");
         assert_eq!(
             in_app + handoff + hidden,
-            69,
-            "the three policy counts must account for all 69 leaf commands of the Click tree"
+            70,
+            "the three policy counts must account for all 70 leaf commands of the Click tree"
         );
 
         // The three counts summing to 69 does not prove 69 *distinct* commands were counted: a
@@ -1318,8 +1335,8 @@ mod tests {
         let distinct: BTreeSet<CommandId> = DISPLAY_ORDER.iter().copied().collect();
         assert_eq!(
             distinct.len(),
-            69,
-            "DISPLAY_ORDER must list 69 DISTINCT commands; a duplicate would let one command go \
+            70,
+            "DISPLAY_ORDER must list 70 DISTINCT commands; a duplicate would let one command go \
              uncounted while the totals still summed correctly"
         );
     }
@@ -1443,6 +1460,7 @@ mod tests {
                     CommandId::SkillsList => CommandId::SkillsList,
                     CommandId::SkillsRemove => CommandId::SkillsRemove,
                     CommandId::TerminalRestore => CommandId::TerminalRestore,
+                    CommandId::WorkflowApprove => CommandId::WorkflowApprove,
                     CommandId::WorkflowCancel => CommandId::WorkflowCancel,
                     CommandId::WorkflowDelete => CommandId::WorkflowDelete,
                     CommandId::WorkflowEvents => CommandId::WorkflowEvents,
@@ -1517,6 +1535,7 @@ mod tests {
                 CommandId::SkillsList,
                 CommandId::SkillsRemove,
                 CommandId::TerminalRestore,
+                CommandId::WorkflowApprove,
                 CommandId::WorkflowCancel,
                 CommandId::WorkflowDelete,
                 CommandId::WorkflowEvents,

--- a/tui/src/server.rs
+++ b/tui/src/server.rs
@@ -685,6 +685,12 @@ fn route(id: CommandId) -> Option<Route> {
         // unbounded for this client's purposes.
         CommandId::WorkflowResume => None,
         CommandId::WorkflowRun => None,
+        // `cao workflow approve` is classified HIDE, so the TUI never routes it — and this arm
+        // exists only because the match is exhaustive on purpose. It is deliberately `None` rather
+        // than a real binding: routing a command the TUI does not offer would build a reachable
+        // path to a human authorisation act that nothing in the interface has reviewed.
+        // (#583 Bolt 2, approval-operation)
+        CommandId::WorkflowApprove => None,
     }
 }
 


### PR DESCRIPTION
Bolt 2 of issue #583. Delivers **FR-8** (frozen execution manifest, plan identifier, re-approval) and
**FR-9** (run context separated from durable memory, and frozen). Ten units across two passes; rebased
onto `main` now that Bolt 1 (#628) has merged, so this diff carries **only** Bolt 2.

## What it does

**FR-8.** A script-tier run freezes a bounded, secret-redacted execution manifest at run start — in the
*same* INSERT as the run row — and derives a `plan_id` from its execution-affecting fields. An
unapproved plan is refused before anything irreversible happens. `cao workflow approve <plan_id>` grants,
write-once, behind the `cao:admin` scope. A read-only MCP tool reports a run's plan and approval state.

**FR-9.** Memory resolves **once** per run, at its first terminal, and is recorded into the manifest
**before** the block reaches an agent. Every later terminal of that run — and every resume, however long
afterwards — is given that recorded copy. Editing CAO memory after a failure cannot change what a resumed
run sees.

## Four declared divergences

None is a defect; all four are deliberate and recorded, and a reviewer should not have to discover them.

1. **Six of FR-8's nine manifest fields are omitted, not nulled** — provider, model, profile, permissions,
   limits, retry policy. Script-tier steps are discovered by *executing* the Python, so these have no
   run-level value at freeze time. They are covered transitively by the source hash (changing any means
   editing the script), and the envelope carries a `notes` field explaining the omission to whoever reads
   the *data*. A test pins it.
2. **Stale source-hash rejection is not implemented.** FR-8's other half belongs to the spec write path
   Bolt 3 builds. **FR-8 is therefore not complete with this PR.** The MCP tool's description says so
   explicitly, because that description is machine-read metadata an agent uses to choose a call.
3. **Approval enforcement defaults OFF** (`workflow.require_approval`, or `CAO_WORKFLOW_REQUIRE_APPROVAL=1`).
   This is a security decision rather than a concession: `build_manifest_json` is total and returns `None`
   on failure, which writes NULL, which fails closed — so an always-on gate would turn a *transient* freeze
   failure into a refused healthy run. A `plan_id` also does not exist until run start, so the first run of
   any new plan is refused by design; Bolt 3's authoring sequence is what makes enforcement usable by taking
   approval *before* running.
4. **The MCP tool is read-only.** The unit spec said "the CLI command **and the MCP tool** that grant an
   approval". An MCP grant tool would let an agent approve the plan it just wrote, which is what FR-8 exists
   to prevent. Raised as a question rather than resolved silently; the narrowing was chosen deliberately.

## Two conventions this PR breaks on purpose

**`CAO_WORKFLOW_REQUIRE_APPROVAL` may turn the gate ON but never OFF** — only `settings.json` can disable it.
Every sibling setting resolves `env > file > default`; this one is asymmetric, because a control that any
environment variable can switch off is not a control. Documented at the resolving function.

**The approve endpoint requires `SCOPE_ADMIN` only**, not the `SCOPE_WRITE, SCOPE_ADMIN` every sibling
workflow endpoint accepts. Please do not "align" it: the MCP boundary reaches the backplane over HTTP
(`test_http_only_boundary.py` enforces that), so a `cao:write` grant path would let an agent grant directly
and make divergence 4 cosmetic. Honest caveat: `require_any_scope` is default-off, so this is inert in a
default install — but so is `WRITE, ADMIN`; the two differ only where auth is enabled, which is the case the
distinction was asked for.

## Scope, honestly bounded

This is a **same-user local control, not a privilege boundary.** CAO runs as the invoking user and a workflow
script runs as that same user, so a determined local script can edit `settings.json` or the approval table
directly. What the gate provides is that a changed plan cannot execute *unnoticed* under an approval granted
for a different plan. `approved_by` is the local OS account: **provenance, not identity** — nothing verifies
it, and it is bounded to 64 characters with control characters stripped, because `getpass.getuser()` resolves
from environment variables and is therefore input despite looking like ambient fact.

## Verification

| Check | Result |
|---|---|
| CI's own invocation on this branch | **20 failed, 7,987 passed**, 30 skipped |
| `origin/main` alone, same invocation, fresh worktree | **20 failed, 7,856 passed**, 30 skipped |
| Regression attribution | **`diff` of the FAILED identities: IDENTICAL** |
| Pass delta | **+131 — exactly this Bolt's new tests** |
| `cargo test` (TUI) | 143 + 3 + 4 + 11 passed, 0 failed |
| `black` / `isort` / markdown links | clean |
| `mypy` on every changed module | clean |

Every one of the ten units was verified the same way as it landed: **by diffing failure identities against a
recorded baseline, never by comparing counts.** That mattered twice — once when nine added passes and one
broken test summed to +8 and the arithmetic admitted two readings.

**Heads-up on `main`, unrelated to this PR.** `main` currently has a failing test that neither #628 nor #630
causes alone: `test_run_step_extraction_failure_status.py::test_extraction_failure_settles_script_step_failed`
expects 500 and gets 409. It reproduces on a clean `origin/main` worktree and is included in the 20 above on
both sides. Worth an issue.

## Three properties were teeth-tested

A test that passes proves nothing about its own sensitivity. For three properties the defect was planted, the
test confirmed red, then the source restored and verified with `git diff`:

- gate moved to **after** the generation bump → the ordering test fails
- resume's already-resolved short-circuit removed → the FR-9 scenario fails, naming the re-resolution
- **raw** resolution injected instead of the stored copy → the redaction and truncation tests fail

The third is a one-word change that passes every unit test in the Bolt. Before `test_frozen_context_proof.py`,
nothing in the codebase would have noticed it.

## One user-visible behaviour change

**On a workflow-driven terminal the injected memory block is the frozen, redacted copy**, truncated if the
manifest's size bound bites. A terminal you start yourself still receives the live, unredacted block. The
frozen copy is what makes a replay byte-identical to the original run — and a secret sitting in curated memory
stops reaching the agent's context on this path. Documented in `docs/workflows.md`.

## Rebase note

Resolving the rebase surfaced one semantic conflict worth naming: **both #628's review and this branch added a
"Gate 5"** to `resume_script_run` at the same place. #628's recovery-consent gate arrived after this branch
had forked. Both survive; the approval gate is renumbered **Gate 6** and stays last among admission checks,
because consent is a fact about the *run* (like gates 1-4) while approval is a fact about the *plan*. Both
still sit before `apply_decisions` and before the generation bump, which is the binding constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
