### PR TITLE
fix(codex): recognize 0.149 idle composer

### DIFF
--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 # Regex patterns for Codex output analysis
 ANSI_CODE_PATTERN = r"\x1b\[[0-9;]*m"
-IDLE_PROMPT_PATTERN = r"(?:❯|›|codex>)"
+IDLE_PROMPT_PATTERN = r"(?:❯|›|»|codex>)"
 # Number of lines from the bottom of capture to check for the idle prompt.
 # With --no-alt-screen, codex output is inline (scrollback contains history),
 # so we can't anchor to \Z. Instead, check the last few lines where the prompt
@@ -49,15 +49,16 @@ ASSISTANT_PREFIX_PATTERN = r"^(?:(?:assistant|codex|agent)\s*:|[^\S\n]*•)"
 # paren) is required so legitimate model bullets like "• Called attention
 # to the bug" don't get filtered as tool calls.
 MCP_TOOL_CALL_PATTERN = r"^[^\S\n]*•\s+Called\s+[\w-]+\.[\w-]+\("
-# Match user input: "You ..." (label style) or "› text" (Codex interactive prompt).
-# The "›[^\S\n]*\S" alternative requires a non-whitespace character on the same line
-# to distinguish user input ("› what is your role?") from the empty idle prompt ("› ").
+# Match user input: "You ..." (label style), "› text" (older Codex interactive
+# prompt), or "» text" (Codex 0.149+ interactive prompt). The prompt alternative
+# requires a non-whitespace character on the same line to distinguish user input
+# from an empty idle prompt.
 # [^\S\n] matches horizontal whitespace only (spaces/tabs), preventing the pattern
 # from crossing newline boundaries into subsequent lines.
-USER_PREFIX_PATTERN = r"^(?:You\b|›[^\S\n]*\S)"
+USER_PREFIX_PATTERN = r"^(?:You\b|[›»][^\S\n]*\S)"
 # Strict idle prompt pattern for extraction: matches empty prompt lines only.
 # Distinguishes "› " (idle) from "› user message" (user input with text).
-IDLE_PROMPT_STRICT_PATTERN = r"^\s*(?:❯|›|codex>)\s*$"
+IDLE_PROMPT_STRICT_PATTERN = r"^\s*(?:❯|›|»|codex>)\s*$"
 
 PROCESSING_PATTERN = r"\b(thinking|working|running|executing|processing|analyzing)\b"
 WAITING_PROMPT_PATTERN = r"^(?:Approve|Allow)\b.*\b(?:y/n|yes/no|yes|no)\b"
@@ -283,7 +284,8 @@ STARTUP_IDLE_PLACEHOLDER_PATTERN = (
     r"Write tests for @filename|"
     r"Improve documentation in @filename|"
     r"Run /review on my current changes|"
-    r"Use /skills to list available skills"
+    r"Use /skills to list available skills|"
+    r"Ask Codex to do anything"
     r")\s*$"
 )
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2139,6 +2139,42 @@ class TestCodexProviderTrustPrompt:
 
         assert _has_startup_idle_composer(output) is True
 
+    def test_v0149_idle_composer_placeholder(self):
+        """Codex 0.149's new glyph/copy is a ready composer, not a timeout."""
+        output = (
+            "OpenAI Codex (v0.149.0)\n"
+            "» Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol ultra · /private/tmp/cao-smoke\n"
+        )
+
+        assert _has_startup_idle_composer(output) is True
+
+    @pytest.mark.asyncio
+    @patch(
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 20.0],
+    )
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_handle_trust_prompt_returns_on_v0149_idle_composer(
+        self, mock_backend, mock_error, mock_sleep, _mock_time
+    ):
+        mock_backend.return_value.get_history.return_value = (
+            "OpenAI Codex (v0.149.0)\n"
+            "» Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol ultra · /private/tmp/cao-smoke\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(timeout=20.0)
+
+        mock_backend.return_value.get_history.assert_called_once()
+        mock_sleep.assert_not_awaited()
+        mock_error.assert_not_called()
+        mock_backend.return_value.send_keys.assert_not_called()
+        mock_backend.return_value.send_special_key.assert_not_called()
+
     @pytest.mark.asyncio
     @patch(
         "cli_agent_orchestrator.providers.codex.time.time",


### PR DESCRIPTION
## Summary
- recognize the Codex 0.149+ idle composer glyph\n- recognize the new "Ask Codex to do anything" startup placeholder\n- keep user-input and strict-idle extraction aligned with the new glyph\n- cover both composer detection and trust-prompt early return\n\n## Problem\n\nCodex 0.149 changed its ready composer from the older glyph/copy to:\n\n    » Ask Codex to do anything\n\nCAO did not recognize that state, waited through the startup timeout, and rolled back terminal creation even though Codex was ready.\n\n## Validation\n\n- 263 provider tests passed, 3 skipped\n- focused Codex provider tests: 11 passed\n- Black check passed\n- live CAO smoke completed with Codex 0.149.0 and displayed gpt-5.6-sol ultra\n