### PR TITLE
fix(api): make _origin_authority total against a malformed Origin

### DIFF
--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -466,7 +466,14 @@ def _origin_authority(origin: str) -> "str | None":
     ``"null"`` origin, a ``file://``/``data:`` scheme, or a malformed value —
     so those never satisfy the same-origin match below.
     """
-    parts = urlsplit(origin)
+    try:
+        parts = urlsplit(origin)
+    except ValueError:
+        # A malformed bracketed host (e.g. ``http://[``) makes ``urlsplit``
+        # raise instead of returning an unparsed result. Both callers sit on
+        # request paths that must fail closed with a 403, not propagate a 500
+        # from an unguarded parse error.
+        return None
     if parts.scheme not in ("http", "https") or not parts.netloc:
         return None
     # ``netloc`` may carry userinfo (user:pass@host); the authority a browser

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -400,6 +400,33 @@ class TestIsWsOriginAllowed:
                 )
 
 
+class TestOriginAuthorityMalformedInput:
+    """Regression for #653: ``_origin_authority`` fed a malformed bracketed
+    Origin (e.g. ``http://[``) must not raise. ``urlsplit`` propagates
+    ``ValueError: Invalid IPv6 URL`` for such input, and both callers sit on
+    request paths (HTTP middleware, WS handshake) that must fail closed with
+    a 403, not a 500 from an unguarded exception.
+    """
+
+    def test_malformed_bracketed_origin_returns_none(self):
+        from cli_agent_orchestrator.constants import _origin_authority
+
+        assert _origin_authority("http://[") is None
+
+    def test_malformed_origin_is_rejected_not_raised_by_ws_guard(self):
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            with patch.object(constants, "WS_ALLOWED_ORIGINS", []):
+                assert constants.is_ws_origin_allowed("http://[", "localhost:9889") is False
+
+    def test_malformed_origin_is_rejected_not_raised_by_http_guard(self):
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            assert constants.is_http_origin_allowed("http://[", "localhost:9889") is False
+
+
 class TestPipeLivenessCheckIntervalClamp:
     """Regression for the round-3 Copilot review on #397: PIPE_LIVENESS_CHECK_INTERVAL_S
     feeds ``threading.Event.wait(timeout)`` in the watchdog's poll loop


### PR DESCRIPTION
### Bug

`_origin_authority` (`constants.py:462`) calls `urlsplit` unguarded. A malformed bracketed Origin makes `urlsplit` raise instead of returning a parse result:

```
POST /flows
Origin: http://[
-> 500 (ValueError: Invalid IPv6 URL)
```

`_origin_authority` backs both `is_http_origin_allowed` (CSRF guard, #605) and `is_ws_origin_allowed` (WebSocket hijacking guard), so the same input raises identically on the WS handshake path. Both guards already return `None`/reject for every other unparseable Origin (opaque `"null"`, non-http scheme, empty netloc). This is the one input shape that skips that handling and reaches the caller as an unhandled exception instead of a 403.

### Fix

Wrap the `urlsplit` call and return `None` on `ValueError`, same as the existing non-http-scheme and empty-netloc branches. Two lines, no other behavior changes.

### Verified

New tests in `test/test_constants.py::TestOriginAuthorityMalformedInput`: `http://[` returns `None` from `_origin_authority` directly, and is rejected (not raised) by both `is_ws_origin_allowed` and `is_http_origin_allowed`. All three fail with the original `ValueError` before the fix and pass after.

```
$ uv run pytest test/test_constants.py -k "TestOriginAuthorityMalformedInput or TestIsWsOriginAllowed" -v
...
14 passed
```

`black --check`, `isort --check-only`, and `mypy` clean on both touched files.

Filed from #653 item 1 (origin-guard follow-ups from the #605 review). Item 2 (scheme-aware same-origin comparison) is a separate, larger change and isn't part of this PR.
