### PR TITLE
fix(api): make the same-origin check scheme-aware

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -1353,7 +1353,9 @@ class OriginCheckMiddleware:
                 for name, value in scope.get("headers", [])
             }
             origin = headers.get("origin")
-            if origin and not is_http_origin_allowed(origin, headers.get("host")):
+            if origin and not is_http_origin_allowed(
+                origin, headers.get("host"), scope.get("scheme")
+            ):
                 logger.warning(
                     "Rejected cross-origin %s request: disallowed Origin %r",
                     scope["method"],
@@ -6079,7 +6081,9 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
     # WebSocket scope first (CAO_ALLOWED_HOSTS="*" opts out of that; see
     # is_ws_origin_allowed).
     origin = websocket.headers.get("origin")
-    if not is_ws_origin_allowed(origin, websocket.headers.get("host")):
+    if not is_ws_origin_allowed(
+        origin, websocket.headers.get("host"), websocket.scope.get("scheme")
+    ):
         logger.warning(
             "Rejected WebSocket attach for terminal %r: disallowed Origin %r",
             terminal_id,

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -459,8 +459,19 @@ WS_ALLOWED_CLIENTS = [
 WS_ALLOWED_ORIGINS = _split_env_list("CAO_WS_ALLOWED_ORIGINS")
 
 
-def _origin_authority(origin: str) -> "str | None":
-    """Return the ``host[:port]`` authority of an http/https ``Origin``.
+# ASGI reports ``ws``/``wss`` on a WebSocket scope, while a browser always
+# serializes the ``Origin`` header with the matching ``http``/``https`` scheme.
+# Fold the WebSocket forms onto the origin forms before comparing the two.
+_REQUEST_SCHEME_AS_ORIGIN_SCHEME = {
+    "http": "http",
+    "https": "https",
+    "ws": "http",
+    "wss": "https",
+}
+
+
+def _origin_scheme_and_authority(origin: str) -> "tuple[str, str] | None":
+    """Return ``(scheme, host[:port])`` for a plain http/https ``Origin``.
 
     ``None`` for anything that is not a plain http/https origin — an opaque
     ``"null"`` origin, a ``file://``/``data:`` scheme, or a malformed value —
@@ -479,10 +490,50 @@ def _origin_authority(origin: str) -> "str | None":
     # ``netloc`` may carry userinfo (user:pass@host); the authority a browser
     # actually reports in ``Origin`` never does, but strip it defensively so a
     # crafted value can't smuggle the trusted host into the userinfo segment.
-    return parts.netloc.rsplit("@", 1)[-1]
+    return parts.scheme, parts.netloc.rsplit("@", 1)[-1]
 
 
-def is_ws_origin_allowed(origin: "str | None", host: "str | None" = None) -> bool:
+def _origin_authority(origin: str) -> "str | None":
+    """Return the ``host[:port]`` authority of an http/https ``Origin``."""
+    parsed = _origin_scheme_and_authority(origin)
+    return None if parsed is None else parsed[1]
+
+
+def _is_same_origin(origin: str, host: str, scheme: "str | None") -> bool:
+    """Whether ``origin`` is same-origin with the request ``host``/``scheme``.
+
+    RFC 6454 defines an origin as the (scheme, host, port) triple, so the
+    authority match alone is not sufficient: ``http://h`` and ``https://h`` are
+    different origins.
+
+    The scheme comparison is deliberately one-directional. An ``http`` Origin on
+    an ``https`` request is rejected, which is unambiguous. An ``https`` Origin
+    on a request the server sees as plain ``http`` is still accepted, because
+    that is exactly the shape an HTTPS-terminating proxy produces when its
+    address is not in ``TRUSTED_FORWARDER_IPS``: uvicorn then ignores
+    ``X-Forwarded-Proto`` and reports ``scheme="http"`` for a request the browser
+    genuinely made over TLS. Rejecting that direction would break working
+    reverse-proxy and Codespaces deployments without closing a real hole, since
+    forging it means already controlling the victim's own origin over TLS.
+
+    ``scheme=None`` skips the comparison entirely, preserving the behaviour
+    callers had before the scheme was threaded through.
+    """
+    parsed = _origin_scheme_and_authority(origin)
+    if parsed is None:
+        return False
+    origin_scheme, authority = parsed
+    if authority != host:
+        return False
+    if scheme is None:
+        return True
+    request_scheme = _REQUEST_SCHEME_AS_ORIGIN_SCHEME.get(scheme.lower())
+    return not (request_scheme == "https" and origin_scheme == "http")
+
+
+def is_ws_origin_allowed(
+    origin: "str | None", host: "str | None" = None, scheme: "str | None" = None
+) -> bool:
     """Whether a WebSocket handshake ``Origin`` header may open a PTY socket.
 
     Rules, tightest-safe first:
@@ -513,6 +564,10 @@ def is_ws_origin_allowed(origin: "str | None", host: "str | None" = None) -> boo
       this branch too — the same explicit-opt-out tradeoff as
       ``CAO_WS_ALLOWED_CLIENTS="*"``. Keep ``ALLOWED_HOSTS`` scoped to the real
       serving hostname(s) rather than ``*`` whenever possible.
+
+      When ``scheme`` is supplied (the ASGI ``scope["scheme"]``, i.e. ``ws`` or
+      ``wss``), the match also requires the schemes to agree. See
+      ``_is_same_origin``.
     * Otherwise the ``Origin`` must appear in the explicit allowlists: the same
       ``CORS_ORIGINS`` list the HTTP API enforces plus any
       ``CAO_WS_ALLOWED_ORIGINS`` entries. Exact-string match mirrors how the
@@ -531,17 +586,17 @@ def is_ws_origin_allowed(origin: "str | None", host: "str | None" = None) -> boo
         return True
     if "*" in WS_ALLOWED_ORIGINS:
         return True
-    if host:
-        authority = _origin_authority(origin)
-        if authority is not None and authority == host:
-            return True
+    if host and _is_same_origin(origin, host, scheme):
+        return True
     # Membership only — an operator's ``CAO_CORS_ORIGINS="*"`` lands as the
     # literal string "*" in this list and matches ONLY a literal "*" Origin
     # (which no browser sends), so it never widens PTY trust. See docstring.
     return origin in CORS_ORIGINS or origin in WS_ALLOWED_ORIGINS
 
 
-def is_http_origin_allowed(origin: "str | None", host: "str | None" = None) -> bool:
+def is_http_origin_allowed(
+    origin: "str | None", host: "str | None" = None, scheme: "str | None" = None
+) -> bool:
     """Whether a state-changing HTTP request ``Origin`` header is trusted.
 
     CSRF / CWE-352 guard for the default-unauthenticated HTTP surface, mirroring
@@ -569,6 +624,11 @@ def is_http_origin_allowed(origin: "str | None", host: "str | None" = None) -> b
       which keeps the match DNS-rebinding-safe in the default loopback config.
       ``CAO_ALLOWED_HOSTS="*"`` opts out of that protection, matching the WS
       guard's documented tradeoff.
+
+      When ``scheme`` is supplied (the ASGI ``scope["scheme"]``), the match also
+      requires the schemes to agree, so an ``https`` request no longer accepts a
+      plain-``http`` Origin as same-origin. See ``_is_same_origin`` for why the
+      comparison is one-directional.
     * Otherwise the ``Origin`` must be in ``CORS_ORIGINS``. Exact-string match
       mirrors how the browser serializes ``Origin`` and how ``CORSMiddleware``
       compares it, so anything the CORS layer already trusts for reads is
@@ -578,10 +638,8 @@ def is_http_origin_allowed(origin: "str | None", host: "str | None" = None) -> b
         return True
     if "*" in CORS_ORIGINS:
         return True
-    if host:
-        authority = _origin_authority(origin)
-        if authority is not None and authority == host:
-            return True
+    if host and _is_same_origin(origin, host, scheme):
+        return True
     return origin in CORS_ORIGINS
 
 

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -427,6 +427,120 @@ class TestOriginAuthorityMalformedInput:
             assert constants.is_http_origin_allowed("http://[", "localhost:9889") is False
 
 
+class TestSchemeAwareSameOrigin:
+    """Regression for #653 item 2: the same-origin branch compared authority
+    (``host[:port]``) only, so a request that arrived over HTTPS accepted a
+    plain-``http`` Origin as same-origin. Under RFC 6454 an origin is the
+    (scheme, host, port) triple, so ``http://h`` and ``https://h`` are
+    different origins and the downgrade should not match.
+
+    The check is deliberately one-directional. It rejects an ``http`` Origin on
+    an ``https`` request, which is unambiguous. It does NOT reject an ``https``
+    Origin on a request that merely *looks* plain-http to the server, because
+    that is the shape produced by an HTTPS-terminating proxy whose address is
+    not in ``TRUSTED_FORWARDER_IPS`` — uvicorn then ignores
+    ``X-Forwarded-Proto`` and reports ``scheme='http'`` for a request the
+    browser genuinely made over TLS. Rejecting that direction would break
+    working reverse-proxy and Codespaces deployments without closing a real
+    hole, since forging it requires already controlling the victim's own
+    origin over TLS.
+    """
+
+    def test_https_request_rejects_http_origin(self):
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            assert (
+                constants.is_http_origin_allowed(
+                    "http://localhost:8765", "localhost:8765", scheme="https"
+                )
+                is False
+            )
+
+    def test_https_request_accepts_https_origin(self):
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            assert (
+                constants.is_http_origin_allowed(
+                    "https://localhost:8765", "localhost:8765", scheme="https"
+                )
+                is True
+            )
+
+    def test_http_request_accepts_http_origin(self):
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            assert (
+                constants.is_http_origin_allowed(
+                    "http://localhost:8765", "localhost:8765", scheme="http"
+                )
+                is True
+            )
+
+    def test_untrusted_proxy_shape_still_allowed(self):
+        """``scheme='http'`` + an ``https`` Origin is the untrusted-proxy shape;
+        allowed deliberately so TLS-terminating deployments keep working."""
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            assert (
+                constants.is_http_origin_allowed(
+                    "https://localhost:8765", "localhost:8765", scheme="http"
+                )
+                is True
+            )
+
+    def test_omitting_scheme_preserves_previous_behaviour(self):
+        """Callers that do not pass a scheme keep the pre-#653 semantics."""
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            assert (
+                constants.is_http_origin_allowed("http://localhost:8765", "localhost:8765") is True
+            )
+
+    def test_explicit_allowlist_entry_is_not_scheme_gated(self):
+        """The scheme check guards the same-origin branch only; an operator who
+        lists an origin explicitly still gets it, as before."""
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", ["http://localhost:8765"]):
+            assert (
+                constants.is_http_origin_allowed(
+                    "http://localhost:8765", "localhost:8765", scheme="https"
+                )
+                is True
+            )
+
+    def test_ws_handshake_rejects_http_origin_over_wss(self):
+        """The WS scope reports ``wss``/``ws``, which map onto the ``https``/
+        ``http`` origin schemes the browser serializes."""
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            with patch.object(constants, "WS_ALLOWED_ORIGINS", []):
+                assert (
+                    constants.is_ws_origin_allowed(
+                        "http://localhost:8765", "localhost:8765", scheme="wss"
+                    )
+                    is False
+                )
+
+    def test_ws_handshake_accepts_https_origin_over_wss(self):
+        from cli_agent_orchestrator import constants
+
+        with patch.object(constants, "CORS_ORIGINS", []):
+            with patch.object(constants, "WS_ALLOWED_ORIGINS", []):
+                assert (
+                    constants.is_ws_origin_allowed(
+                        "https://localhost:8765", "localhost:8765", scheme="wss"
+                    )
+                    is True
+                )
+
+
 class TestPipeLivenessCheckIntervalClamp:
     """Regression for the round-3 Copilot review on #397: PIPE_LIVENESS_CHECK_INTERVAL_S
     feeds ``threading.Event.wait(timeout)`` in the watchdog's poll loop


### PR DESCRIPTION
### Bug

RFC 6454 defines an origin as the (scheme, host, port) triple, but the same-origin branch in both guards compared authority (`host[:port]`) only:

```python
if host:
    authority = _origin_authority(origin)
    if authority is not None and authority == host:
        return True
```

So a request that arrived over HTTPS accepted a plain-`http` Origin as same-origin. `http://localhost:8765` and `https://localhost:8765` are different origins, but both `is_http_origin_allowed` and `is_ws_origin_allowed` treated them as one. Neither had any way to see the request scheme, so the answer was identical whichever way the request came in.

Not exploitable in the default plain-HTTP loopback config. It matters behind an HTTPS-terminating reverse proxy that forwards `Host`.

### Fix

Thread the ASGI `scope["scheme"]` into both guards and compare it against the Origin's own scheme. `_origin_authority` is refactored into `_origin_scheme_and_authority` so the scheme survives parsing, and the shared same-origin logic moves into `_is_same_origin`. `_origin_authority` stays as a thin wrapper, so its existing callers and tests are untouched.

**The scheme comparison is one-directional, and that is the part worth reviewing.** An `http` Origin on an `https` request is rejected. An `https` Origin on a request the server sees as plain `http` is still accepted, because that is exactly what an HTTPS-terminating proxy produces when its address is not in `TRUSTED_FORWARDER_IPS`: `proxy_headers=True` is always on, but `forwarded_allow_ips` defaults to loopback, so uvicorn ignores `X-Forwarded-Proto` and reports `scheme="http"` for a request the browser genuinely made over TLS. Rejecting that direction would 403 working reverse-proxy and Codespaces deployments without closing a real hole, since forging it requires already controlling the victim's own origin over TLS.

If you would rather have the strict both-directions check, it is a one-line change to `_is_same_origin` and I am happy to switch it. I went conservative because this guard sits on every state-changing request.

WebSocket scopes report `ws`/`wss` while browsers serialize Origin as `http`/`https`, so those are folded onto the origin forms before comparing.

Passing no scheme keeps the previous behaviour, so nothing outside the two request paths changes.

### Verified

Behaviour across all four combinations, `CORS_ORIGINS` empty, before and after:

| request scheme | Origin | before | after |
| --- | --- | --- | --- |
| https | `http://localhost:8765` | allowed | **blocked** |
| https | `https://localhost:8765` | allowed | allowed |
| http | `http://localhost:8765` | allowed | allowed |
| http | `https://localhost:8765` | allowed | allowed |

One behaviour change, in the direction the issue describes.

New `TestSchemeAwareSameOrigin` in `test/test_constants.py`, 8 tests covering those four cases plus the no-scheme backward-compatible path, an explicit-allowlist entry (not scheme-gated, since the check guards the same-origin branch only), and the two WS `wss` cases. All 8 fail before the fix and pass after.

```
$ uv run pytest test/test_constants.py -k "SchemeAware or Origin" -q
37 passed, 38 deselected
```

`black --check`, `isort --check-only`, and `mypy` clean on all three touched files.

**One thing I could not verify.** I could not exercise `OriginCheckMiddleware` end to end on this machine: `api/main.py` imports `fcntl`, `pty`, and `termios` at module scope, so it will not import on Windows, and stubbing that chain deep enough to load the module would not have produced a result worth trusting. The two call sites are one line each and are in the diff, but the middleware and WS handler paths themselves are covered only by the existing suite on a POSIX runner, not by anything I ran. Worth a look during review.

Fixes item 2 of #653, which can close with this. Item 1 landed in #656.
