### PR TITLE
fix(kimi): Kimi Code CLI compatibility (agent-file, trust dialog, project mcp.json, bullets)

### DIFF
--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -325,9 +325,7 @@ class KimiCliProvider(BaseProvider):
                 result = subprocess.run(
                     ["kimi", "--help"], capture_output=True, text=True, timeout=10
                 )
-                cls._markdown_agent_file_cache = "Markdown file" in (
-                    result.stdout + result.stderr
-                )
+                cls._markdown_agent_file_cache = "Markdown file" in (result.stdout + result.stderr)
             except (OSError, subprocess.SubprocessError):
                 cls._markdown_agent_file_cache = False
         return cls._markdown_agent_file_cache
@@ -405,9 +403,7 @@ class KimiCliProvider(BaseProvider):
                         raw_name = getattr(profile, "name", None) or "cao-agent"
                         name = re.sub(r"[^a-z0-9]+", "-", str(raw_name).lower()).strip("-")
                         name = name or "cao-agent"
-                        description = (
-                            getattr(profile, "description", None) or "CAO-managed agent"
-                        )
+                        description = getattr(profile, "description", None) or "CAO-managed agent"
                         header = (
                             "---\n"
                             f"name: {json.dumps(name)}\n"
@@ -633,9 +629,7 @@ class KimiCliProvider(BaseProvider):
                 if not trust_answered and re.search(TRUST_PROMPT_PATTERN, clean_output):
                     from cli_agent_orchestrator.services.status_monitor import status_monitor
 
-                    logger.info(
-                        "Kimi Code workspace-trust dialog detected, trusting CAO temp dir"
-                    )
+                    logger.info("Kimi Code workspace-trust dialog detected, trusting CAO temp dir")
                     status_monitor.notify_input_sent(self.terminal_id)
                     # Menu cursor defaults to "Don't trust"; Up selects
                     # "Trust this folder", Enter confirms (validated manually

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -109,6 +109,18 @@ WELCOME_BANNER_PATTERN = r"Welcome to Kimi Code CLI!"
 # (persisted, so it does not recur until the next release).
 UPGRADE_PROMPT_PATTERN = r"Skip reminders for version|Upgrade now"
 
+# Kimi Code (MoonshotAI/kimi-code) workspace-trust dialog. When --mcp-config is
+# passed in a folder not previously trusted, kimi-code blocks BEFORE the REPL
+# asking whether to trust the workspace ("Project-level MCP servers are
+# disabled until you explicitly choose Trust"). CAO launches every instance in
+# a fresh per-instance temp dir, so with MCP servers configured the dialog
+# fires on EVERY launch and init times out unless answered. Answering "Trust
+# this folder" here is sound: the folder is CAO's own temp dir containing only
+# CAO-written files (agent.md / system.md), and the MCP config being enabled
+# is the one the operator's own profile declared. Approved by the operator
+# (Carlos, 2026-08-24) for the WaP fork.
+TRUST_PROMPT_PATTERN = r"Trust this folder"
+
 # User input box boundaries (pre-v1.20.0). Kimi displayed user messages in a bordered box:
 #   ╭──────────────────────────────╮
 #   │ user message text             │
@@ -585,6 +597,7 @@ class KimiCliProvider(BaseProvider):
         last_prompt_time = time.monotonic()
         any_prompt_handled = False
         upgrade_dismissed = False
+        trust_answered = False
         while True:
             now = time.monotonic()
             if now >= outer_deadline:
@@ -597,6 +610,36 @@ class KimiCliProvider(BaseProvider):
             )
             if output:
                 clean_output = re.sub(ANSI_CODE_PATTERN, "", output)
+                # Answer the kimi-code workspace-trust dialog once (same
+                # linger-in-buffer consideration as the upgrade dialog below).
+                # See TRUST_PROMPT_PATTERN for why answering it is sound here.
+                if not trust_answered and re.search(TRUST_PROMPT_PATTERN, clean_output):
+                    from cli_agent_orchestrator.services.status_monitor import status_monitor
+
+                    logger.info(
+                        "Kimi Code workspace-trust dialog detected, trusting CAO temp dir"
+                    )
+                    status_monitor.notify_input_sent(self.terminal_id)
+                    # Menu cursor defaults to "Don't trust"; Up selects
+                    # "Trust this folder", Enter confirms (validated manually
+                    # against kimi-code 0.38 in tmux).
+                    await asyncio.to_thread(
+                        get_backend().send_special_key,
+                        self.session_name,
+                        self.window_name,
+                        "Up",
+                    )
+                    await asyncio.to_thread(
+                        get_backend().send_special_key,
+                        self.session_name,
+                        self.window_name,
+                        "Enter",
+                    )
+                    trust_answered = True
+                    any_prompt_handled = True
+                    last_prompt_time = time.monotonic()  # reset idle timer
+                    await asyncio.sleep(1.0)
+                    continue
                 # Answer the upgrade dialog once; its text lingers in the buffer
                 # after dismissal, so the flag stops a re-answer on later polls.
                 if not upgrade_dismissed and re.search(UPGRADE_PROMPT_PATTERN, clean_output):

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -465,7 +465,21 @@ class KimiCliProvider(BaseProvider):
                             env["CAO_TERMINAL_ID"] = self.terminal_id
                             mcp_config[server_name]["env"] = env
 
-                    command_parts.extend(["--mcp-config", json.dumps(mcp_config)])
+                    if self._agent_file_uses_markdown():
+                        # Kimi Code CLI has no --mcp-config flag; it reads
+                        # project-local MCP from <cwd>/.kimi-code/mcp.json
+                        # ({"mcpServers": {...}}). The provider already cd's
+                        # into its per-instance temp dir, so the file is
+                        # scoped to this terminal only. Enabling these
+                        # project-level servers is what triggers the
+                        # workspace-trust dialog answered in
+                        # _handle_startup_dialog.
+                        kimi_code_dir = os.path.join(self._temp_dir, ".kimi-code")
+                        os.makedirs(kimi_code_dir, exist_ok=True)
+                        with open(os.path.join(kimi_code_dir, "mcp.json"), "w") as f:
+                            json.dump({"mcpServers": mcp_config}, f, indent=2)
+                    else:
+                        command_parts.extend(["--mcp-config", json.dumps(mcp_config)])
 
             except Exception as e:
                 raise ProviderError(

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -7,7 +7,8 @@ Key characteristics:
 - Command: ``kimi`` (installed via ``brew install kimi-cli`` or ``uv tool install kimi-cli``)
 - Idle prompt: ``💫`` (thinking mode, default) or ``✨`` (optionally prefixed with ``username@dirname``)
 - Processing: No idle prompt visible at bottom while the response is streaming
-- Response format: Bullet points prefixed with ``•`` (U+2022)
+- Response format: Bullet points prefixed with ``•`` (U+2022); Kimi Code
+  0.38+ renders response bullets as ``●`` (U+25CF) instead
 - Thinking output: Gray italic ``•`` bullets (ANSI color 38;5;244 + italic)
 - User input: Displayed in a bordered box using box-drawing characters (╭│╰)
 - Auto-approve: ``--yolo`` flag bypasses all tool action confirmations
@@ -140,7 +141,7 @@ PROMPT_WITH_INPUT_PATTERN = r"(?:\w+@[\w.-]+)?[✨💫][^\S\n]+\S"
 # To distinguish them in extraction, check ANSI styling in raw output:
 # - Thinking: gray italic (\x1b[38;5;244m• ... \x1b[3m\x1b[38;5;244m)
 # - Response: plain ``•`` without ANSI color prefix
-RESPONSE_BULLET_PATTERN = r"^•\s"
+RESPONSE_BULLET_PATTERN = r"^[•●]\s"
 
 # Thinking bullet detection in raw (ANSI-preserved) output.
 # Thinking lines use gray color (38;5;244) before the bullet character.
@@ -189,11 +190,13 @@ def _is_live_turn_spinner_line(line: str) -> bool:
     )
 
 
-# A response/thinking bullet ("• …") at line start. Its presence means a turn
+# A response/thinking bullet ("• …", or "● …" on Kimi Code 0.38+ — the
+# status bar's "agent (<model> ●)" is mid-line, so the line-start anchor
+# cannot false-match it) at line start. Its presence means a turn
 # has produced output — used to latch "input received" on the new TUI (the
 # welcome banner / update nag contain no "•", so this won't false-trigger at
 # init).
-ANY_BULLET_PATTERN = r"(?m)^\s*•"
+ANY_BULLET_PATTERN = r"(?m)^\s*[•●]"
 
 # Generic error patterns for detecting failure states in terminal output.
 ERROR_PATTERN = (
@@ -230,7 +233,7 @@ class KimiCliProvider(BaseProvider):
     _KIMI_PROMPT_RE = re.compile(r"(?:\w{1,32}@[\w.\-]{1,64})?[✨💫][^\S\n]{1,4}\S")
     # Response/thinking markers used to bound a user message line. Matches
     # the same ``• `` bullet the IDLE/PROCESSING path uses.
-    _KIMI_RESPONSE_MARKER_RE = re.compile(r"^•\s")
+    _KIMI_RESPONSE_MARKER_RE = re.compile(r"^[•●]\s")
 
     def __init__(
         self,
@@ -837,7 +840,7 @@ class KimiCliProvider(BaseProvider):
                 default=-1,
             )
             last_bullet = max(
-                (i for i, line in enumerate(lines) if re.match(r"\s*•", line)),
+                (i for i, line in enumerate(lines) if re.match(r"\s*[•●]", line)),
                 default=-1,
             )
             spinner_in_tail = last_spinner >= 0 and last_spinner >= len(lines) - 15
@@ -981,7 +984,7 @@ class KimiCliProvider(BaseProvider):
         if any(
             re.search(r"connecting to mcp servers|\(connecting\)", ln, re.IGNORECASE)
             for ln in rows
-            if not re.match(r"\s*•", ln)
+            if not re.match(r"\s*[•●]", ln)
         ):
             return TerminalStatus.PROCESSING
 

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -11,7 +11,10 @@ Key characteristics:
 - Thinking output: Gray italic ``•`` bullets (ANSI color 38;5;244 + italic)
 - User input: Displayed in a bordered box using box-drawing characters (╭│╰)
 - Auto-approve: ``--yolo`` flag bypasses all tool action confirmations
-- Agent profiles: ``--agent-file FILE`` (YAML format, extends built-in 'default' agent)
+- Agent profiles: ``--agent-file FILE``. Legacy kimi-cli expects a YAML file
+  (extends built-in 'default' agent via ``system_prompt_path``); Kimi Code CLI
+  (MoonshotAI/kimi-code) expects a Markdown file with YAML frontmatter. The
+  installed variant is auto-detected from ``kimi --help``.
 - MCP config: ``--mcp-config TEXT`` (JSON configuration, repeatable flag)
 - Exit commands: ``/exit``, ``exit``, ``quit``, or Ctrl-D
 - Status bar: ``HH:MM [yolo] agent (model, thinking) ctrl-x: toggle mode context: X.X%``
@@ -33,6 +36,7 @@ import re
 import shlex
 import shutil
 import stat
+import subprocess
 import tempfile
 import threading
 import time
@@ -200,6 +204,10 @@ class KimiCliProvider(BaseProvider):
     # the config file causes race conditions and file corruption.
     _mcp_timeout_configured = False
 
+    # Class-level cache for the --agent-file format probe (one subprocess call
+    # per process, shared by concurrent provider instances).
+    _markdown_agent_file_cache: Optional[bool] = None
+
     # Class-level prompt regex shared between status detection
     # and ``extract_session_context``. Bounded quantifiers
     # (no unbounded ``*`` / ``+`` — defeats ReDoS on pathological pane bytes).
@@ -284,6 +292,31 @@ class KimiCliProvider(BaseProvider):
         except Exception:
             return None
 
+    @classmethod
+    def _agent_file_uses_markdown(cls) -> bool:
+        """Return True when the installed ``kimi`` binary is Kimi Code CLI.
+
+        Kimi Code CLI (MoonshotAI/kimi-code, successor of the wound-down
+        kimi-cli) expects ``--agent-file`` to be a Markdown agent definition
+        (YAML frontmatter + body as system prompt) and rejects the legacy YAML
+        format with "Missing frontmatter". Legacy kimi-cli expects the YAML
+        ``system_prompt_path`` format. Probed once per process from
+        ``kimi --help``: kimi-code's help describes ``--agent-file`` as loading
+        "from a Markdown file". Falls back to the legacy YAML format when the
+        probe fails, preserving pre-existing behavior.
+        """
+        if cls._markdown_agent_file_cache is None:
+            try:
+                result = subprocess.run(
+                    ["kimi", "--help"], capture_output=True, text=True, timeout=10
+                )
+                cls._markdown_agent_file_cache = "Markdown file" in (
+                    result.stdout + result.stderr
+                )
+            except (OSError, subprocess.SubprocessError):
+                cls._markdown_agent_file_cache = False
+        return cls._markdown_agent_file_cache
+
     def _build_kimi_command(self) -> str:
         """Build Kimi CLI command with agent profile and MCP config if provided.
 
@@ -345,23 +378,48 @@ class KimiCliProvider(BaseProvider):
                     system_prompt = SECURITY_PROMPT + tool_constraint + system_prompt
 
                 if system_prompt:
-                    # Write the system prompt as a markdown file
-                    prompt_file = os.path.join(self._temp_dir, "system.md")
-                    with open(prompt_file, "w") as f:
-                        f.write(system_prompt)
+                    if self._agent_file_uses_markdown():
+                        # Kimi Code CLI: --agent-file is a Markdown agent
+                        # definition — YAML frontmatter (name/description)
+                        # with the body as the system prompt. json.dumps
+                        # yields valid YAML scalars, so no PyYAML dependency
+                        # is needed for quoting.
+                        # kimi-code validates the frontmatter name as
+                        # kebab-case (e.g. "code-reviewer"); CAO profile
+                        # names are snake_case, so normalize.
+                        raw_name = getattr(profile, "name", None) or "cao-agent"
+                        name = re.sub(r"[^a-z0-9]+", "-", str(raw_name).lower()).strip("-")
+                        name = name or "cao-agent"
+                        description = (
+                            getattr(profile, "description", None) or "CAO-managed agent"
+                        )
+                        header = (
+                            "---\n"
+                            f"name: {json.dumps(name)}\n"
+                            f"description: {json.dumps(description)}\n"
+                            "---\n\n"
+                        )
+                        agent_file = os.path.join(self._temp_dir, "agent.md")
+                        with open(agent_file, "w") as f:
+                            f.write(header + system_prompt)
+                    else:
+                        # Legacy kimi-cli: YAML agent file that extends the
+                        # default agent and points to a separate markdown
+                        # system prompt. Plain strings avoid a PyYAML
+                        # dependency.
+                        prompt_file = os.path.join(self._temp_dir, "system.md")
+                        with open(prompt_file, "w") as f:
+                            f.write(system_prompt)
 
-                    # Create the agent YAML that extends the default agent
-                    # and points to our custom system prompt file.
-                    # Written as plain string to avoid adding PyYAML dependency.
-                    agent_yaml = (
-                        "version: 1\n"
-                        "agent:\n"
-                        "  extend: default\n"
-                        "  system_prompt_path: ./system.md\n"
-                    )
-                    agent_file = os.path.join(self._temp_dir, "agent.yaml")
-                    with open(agent_file, "w") as f:
-                        f.write(agent_yaml)
+                        agent_yaml = (
+                            "version: 1\n"
+                            "agent:\n"
+                            "  extend: default\n"
+                            "  system_prompt_path: ./system.md\n"
+                        )
+                        agent_file = os.path.join(self._temp_dir, "agent.yaml")
+                        with open(agent_file, "w") as f:
+                            f.write(agent_yaml)
 
                     command_parts.extend(["--agent-file", agent_file])
 

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -224,6 +224,38 @@ class TestKimiCliProviderInitialization:
 
         provider.cleanup()
 
+    def test_get_status_new_tui_black_circle_bullet_completes(self):
+        """Kimi Code 0.38+ renders response bullets as ● (U+25CF), not •.
+
+        Without accepting ●, _has_received_input never latches on the new
+        TUI, the terminal reads IDLE forever after answering, and handoff
+        completion/extraction never fires (observed live: worker replied
+        '● SMOKE-OK' and stayed idle).
+        """
+        provider = KimiCliProvider("t-tui", "sess", "win")
+        screen = (
+            " ● SMOKE-OK\n"
+            " ╭──────────╮\n"
+            " │ >        │\n"
+            " ╰──────────╯\n"
+            " yolo  agent (kimi-k2.5 ●)  /tmp/x\n"
+            "                        context: 12% (29.5k/256k)\n"
+        )
+        assert provider.get_status(screen) == TerminalStatus.COMPLETED
+
+    def test_get_status_new_tui_status_bar_circle_alone_is_idle(self):
+        """The status bar's own ● ('agent (<model> ●)') is mid-line and must
+        NOT latch input — a freshly booted terminal stays IDLE."""
+        provider = KimiCliProvider("t-tui2", "sess", "win")
+        screen = (
+            " ╭──────────╮\n"
+            " │ >        │\n"
+            " ╰──────────╯\n"
+            " yolo  agent (kimi-k2.5 ●)  /tmp/x\n"
+            "                        context: 0% (0/256k)\n"
+        )
+        assert provider.get_status(screen) == TerminalStatus.IDLE
+
     def test_agent_file_probe_detects_kimi_code_help(self):
         """The probe keys off kimi-code's '--agent-file ... Markdown file' help text."""
         KimiCliProvider._markdown_agent_file_cache = None

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -95,14 +95,15 @@ class TestKimiCliProviderInitialization:
             await provider.initialize()
 
     @pytest.mark.asyncio
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
     async def test_initialize_with_agent_profile(
-        self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status
+        self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status, _mock_md
     ):
-        """Test initialization with agent profile creates temp files."""
+        """Test initialization with agent profile creates temp files (legacy kimi-cli)."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
         mock_profile = MagicMock()
@@ -121,9 +122,85 @@ class TestKimiCliProviderInitialization:
         command = call_args[0][2]
         assert "--agent-file" in command
         assert "--yolo" in command
+        # Legacy format: YAML agent file + separate system.md
+        assert "agent.yaml" in command
+        assert os.path.exists(os.path.join(provider._temp_dir, "system.md"))
 
         # Cleanup temp files
         provider.cleanup()
+
+    @pytest.mark.asyncio
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=True)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
+    async def test_initialize_with_agent_profile_kimi_code_markdown(
+        self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status, _mock_md
+    ):
+        """Kimi Code CLI expects --agent-file as Markdown with YAML frontmatter.
+
+        The legacy YAML format is rejected by kimi-code with
+        'Missing frontmatter', so the provider must emit
+        frontmatter + system prompt body instead.
+        """
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_profile = MagicMock()
+        mock_profile.name = "dev_worker"
+        mock_profile.description = "Implements scoped code changes"
+        mock_profile.model = None
+        mock_profile.system_prompt = "You are a helpful assistant"
+        mock_profile.mcpServers = None
+        mock_profile.provider_init_timeout = None
+        mock_load.return_value = mock_profile
+
+        provider = KimiCliProvider("term-1", "session-1", "window-1", agent_profile="developer")
+        result = await provider.initialize()
+        assert result is True
+
+        call_args = mock_tmux.return_value.send_keys.call_args
+        command = call_args[0][2]
+        assert "--agent-file" in command
+        assert "agent.md" in command
+        assert "agent.yaml" not in command
+
+        agent_file = os.path.join(provider._temp_dir, "agent.md")
+        with open(agent_file) as f:
+            content = f.read()
+        assert content.startswith("---\n")
+        assert '"dev-worker"' in content
+        # snake_case CAO profile names must be normalized to kebab-case
+        # (kimi-code rejects e.g. "smoke_kimi": 'expected kebab-case').
+        assert '"Implements scoped code changes"' in content
+        assert content.rstrip().endswith("You are a helpful assistant")
+
+        # Cleanup temp files
+        provider.cleanup()
+
+    def test_agent_file_probe_detects_kimi_code_help(self):
+        """The probe keys off kimi-code's '--agent-file ... Markdown file' help text."""
+        KimiCliProvider._markdown_agent_file_cache = None
+        try:
+            fake = MagicMock()
+            fake.stdout = (
+                "--agent-file <path>  Load an agent definition from a Markdown file"
+            )
+            fake.stderr = ""
+            with patch(
+                "cli_agent_orchestrator.providers.kimi_cli.subprocess.run",
+                return_value=fake,
+            ):
+                assert KimiCliProvider._agent_file_uses_markdown() is True
+
+            KimiCliProvider._markdown_agent_file_cache = None
+            with patch(
+                "cli_agent_orchestrator.providers.kimi_cli.subprocess.run",
+                side_effect=OSError("kimi not found"),
+            ):
+                assert KimiCliProvider._agent_file_uses_markdown() is False
+        finally:
+            KimiCliProvider._markdown_agent_file_cache = None
 
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
     def test_initialize_with_invalid_profile(self, mock_load):
@@ -558,8 +635,9 @@ class TestKimiCliProviderBuildCommand:
         assert provider._temp_dir is not None
         provider.cleanup()
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_with_system_prompt(self, mock_load):
+    def test_build_command_with_system_prompt(self, mock_load, _mock_md):
         """Test command with agent profile containing system prompt."""
         mock_profile = MagicMock()
         mock_profile.model = None
@@ -626,8 +704,9 @@ class TestKimiCliProviderBuildCommand:
         assert "/venv/bin/cao-mcp-server" in command
         provider.cleanup()
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_creates_agent_yaml(self, mock_load):
+    def test_build_command_creates_agent_yaml(self, mock_load, _mock_md):
         """Test that agent YAML and system prompt files are created correctly."""
         mock_profile = MagicMock()
         mock_profile.model = None
@@ -804,8 +883,9 @@ class TestKimiCliProviderBuildCommand:
         # Second instance should NOT have modified config (flag was already set)
         assert "tool_call_timeout_ms = 60000" in config_file.read_text()
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_no_timeout_without_mcp(self, mock_load, tmp_path):
+    def test_build_command_no_timeout_without_mcp(self, mock_load, _mock_md, tmp_path):
         """Test that MCP tool timeout is NOT modified when no MCP servers are configured."""
         mock_profile = MagicMock()
         mock_profile.model = None

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -261,9 +261,7 @@ class TestKimiCliProviderInitialization:
         KimiCliProvider._markdown_agent_file_cache = None
         try:
             fake = MagicMock()
-            fake.stdout = (
-                "--agent-file <path>  Load an agent definition from a Markdown file"
-            )
+            fake.stdout = "--agent-file <path>  Load an agent definition from a Markdown file"
             fake.stderr = ""
             with patch(
                 "cli_agent_orchestrator.providers.kimi_cli.subprocess.run",

--- a/test/providers/test_kimi_cli_unit.py
+++ b/test/providers/test_kimi_cli_unit.py
@@ -178,6 +178,52 @@ class TestKimiCliProviderInitialization:
         # Cleanup temp files
         provider.cleanup()
 
+    @pytest.mark.asyncio
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=True)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
+    async def test_initialize_with_mcp_servers_kimi_code_writes_project_file(
+        self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status, _mock_md
+    ):
+        """Kimi Code CLI has no --mcp-config flag: MCP servers go to the
+        per-instance temp dir as .kimi-code/mcp.json ({"mcpServers": ...}),
+        with CAO_TERMINAL_ID injected into each server's env."""
+        mock_wait_shell.return_value = True
+        mock_wait_status.return_value = True
+        mock_profile = MagicMock()
+        mock_profile.name = "dev_worker"
+        mock_profile.description = "desc"
+        mock_profile.model = None
+        mock_profile.system_prompt = "You are a helpful assistant"
+        mock_profile.mcpServers = {
+            "cao-mcp-server": {"command": "npx", "args": ["-y", "cao-mcp-server"]}
+        }
+        mock_profile.provider_init_timeout = None
+        mock_load.return_value = mock_profile
+
+        provider = KimiCliProvider("term-1", "session-1", "window-1", agent_profile="developer")
+        with patch(
+            "cli_agent_orchestrator.providers.kimi_cli.Path.home",
+            return_value=Path(tempfile.mkdtemp()),
+        ):
+            result = await provider.initialize()
+        assert result is True
+
+        command = mock_tmux.return_value.send_keys.call_args[0][2]
+        assert "--mcp-config" not in command
+
+        import json as _json
+
+        mcp_path = os.path.join(provider._temp_dir, ".kimi-code", "mcp.json")
+        with open(mcp_path) as f:
+            data = _json.load(f)
+        server = data["mcpServers"]["cao-mcp-server"]
+        assert server["env"]["CAO_TERMINAL_ID"] == "term-1"
+
+        provider.cleanup()
+
     def test_agent_file_probe_detects_kimi_code_help(self):
         """The probe keys off kimi-code's '--agent-file ... Markdown file' help text."""
         KimiCliProvider._markdown_agent_file_cache = None
@@ -212,14 +258,15 @@ class TestKimiCliProviderInitialization:
             provider._build_kimi_command()
 
     @pytest.mark.asyncio
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_until_status")
     @patch("cli_agent_orchestrator.providers.kimi_cli.wait_for_shell")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
     async def test_initialize_with_mcp_servers(
-        self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status
+        self, mock_load, mock_tmux, mock_wait_shell, mock_wait_status, _mock_md
     ):
-        """Test initialization with MCP servers in profile adds --mcp-config and modifies config.toml."""
+        """Test initialization with MCP servers in profile adds --mcp-config and modifies config.toml (legacy kimi-cli)."""
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
         mock_profile = MagicMock()
@@ -657,8 +704,9 @@ class TestKimiCliProviderBuildCommand:
         # Cleanup
         provider.cleanup()
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_with_mcp_config(self, mock_load, tmp_path):
+    def test_build_command_with_mcp_config(self, mock_load, _mock_md, tmp_path):
         """Test command with MCP server configuration including CAO_TERMINAL_ID injection."""
         mock_profile = MagicMock()
         mock_profile.model = None
@@ -679,8 +727,9 @@ class TestKimiCliProviderBuildCommand:
         # No --config flag (modifies config.toml directly to avoid breaking OAuth)
         assert "--config" not in command
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_resolves_bundled_mcp_command(self, mock_load, tmp_path):
+    def test_build_command_resolves_bundled_mcp_command(self, mock_load, _mock_md, tmp_path):
         """The bare cao-mcp-server command is resolved to a PATH-independent
         invocation in the emitted --mcp-config JSON (wiring guard: a refactor
         that drops the resolve_mcp_server_config call must fail this test)."""
@@ -735,8 +784,9 @@ class TestKimiCliProviderBuildCommand:
         # Cleanup
         provider.cleanup()
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_with_pydantic_mcp_config(self, mock_load):
+    def test_build_command_with_pydantic_mcp_config(self, mock_load, _mock_md):
         """Test command with MCP servers as Pydantic model objects."""
         mock_server = MagicMock()
         mock_server.model_dump.return_value = {"command": "node", "args": ["server.js"]}
@@ -757,8 +807,9 @@ class TestKimiCliProviderBuildCommand:
         # CAO_TERMINAL_ID should be injected into MCP server env
         assert "CAO_TERMINAL_ID" in command
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_mcp_preserves_existing_env(self, mock_load):
+    def test_build_command_mcp_preserves_existing_env(self, mock_load, _mock_md):
         """Test that CAO_TERMINAL_ID injection preserves existing env vars."""
         mock_profile = MagicMock()
         mock_profile.model = None
@@ -785,8 +836,9 @@ class TestKimiCliProviderBuildCommand:
         assert config["test-server"]["env"]["MY_VAR"] == "my_value"
         assert config["test-server"]["env"]["CAO_TERMINAL_ID"] == "abc123"
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_build_command_mcp_does_not_override_existing_terminal_id(self, mock_load):
+    def test_build_command_mcp_does_not_override_existing_terminal_id(self, mock_load, _mock_md):
         """Test that existing CAO_TERMINAL_ID in env is not overwritten."""
         mock_profile = MagicMock()
         mock_profile.model = None
@@ -909,8 +961,9 @@ class TestKimiCliProviderBuildCommand:
         assert "tool_call_timeout_ms = 60000" in config_file.read_text()
         provider.cleanup()
 
+    @patch.object(KimiCliProvider, "_agent_file_uses_markdown", return_value=False)
     @patch("cli_agent_orchestrator.providers.kimi_cli.load_agent_profile")
-    def test_mcp_timeout_config_missing(self, mock_load, tmp_path):
+    def test_mcp_timeout_config_missing(self, mock_load, _mock_md, tmp_path):
         """Test graceful handling when ~/.kimi/config.toml doesn't exist."""
         mock_profile = MagicMock()
         mock_profile.model = None

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -8,7 +8,7 @@ total runtime is hard-capped by ``provider_init_timeout``.
 Covers: ClaudeCodeProvider, KimiCliProvider, AntigravityCliProvider.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -289,6 +289,46 @@ class TestKimiCliIdleGap:
         # 's' sent to skip reminders at t=18 — the reset kept the loop alive to
         # cleanly detect readiness at t=35, past the old 20s window.
         mock_backend.send_keys.assert_called_once_with("sess", "win", "s", enter_count=0)
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)
+    @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.time")
+    @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
+    async def test_kimi_code_trust_dialog_answered(
+        self, mock_get_backend, mock_time, mock_sleep
+    ):
+        """kimi-code's workspace-trust dialog is answered once (Up + Enter).
+
+        With --mcp-config in a fresh CAO temp dir, kimi-code blocks before the
+        REPL on "Trust this folder" (cursor on "Don't trust"). The handler
+        selects the trust option; the reset idle timer keeps the loop alive to
+        detect readiness afterwards.
+        """
+        mock_backend = MagicMock()
+        mock_get_backend.return_value = mock_backend
+        mock_time.monotonic.side_effect = [
+            0.0,  # outer_deadline = 60
+            0.0,  # last_prompt_time = 0
+            5.0,  # iter1: trust dialog -> handled
+            5.0,  # last_prompt_time reset to 5
+            12.0,  # iter2: gap=7<20, ready -> return
+        ]
+        mock_backend.get_history.side_effect = [
+            "Project-level MCP servers are disabled until you explicitly choose Trust.\n"
+            "   Trust this folder\n \u276f Don't trust\n   Exit Kimi Code.",
+            "Welcome to Kimi!\n\U0001f4ab",
+        ]
+
+        p = self._make()
+        with patch.object(p, "get_status", return_value=TerminalStatus.IDLE):
+            await p._handle_startup_dialog()
+
+        assert mock_backend.send_special_key.call_args_list == [
+            call("sess", "win", "Up"),
+            call("sess", "win", "Enter"),
+        ]
+        mock_backend.send_keys.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_server_settings", _settings)

--- a/test/providers/test_startup_prompt_idle_gap.py
+++ b/test/providers/test_startup_prompt_idle_gap.py
@@ -295,9 +295,7 @@ class TestKimiCliIdleGap:
     @patch("cli_agent_orchestrator.providers.kimi_cli.asyncio.sleep")
     @patch("cli_agent_orchestrator.providers.kimi_cli.time")
     @patch("cli_agent_orchestrator.providers.kimi_cli.get_backend")
-    async def test_kimi_code_trust_dialog_answered(
-        self, mock_get_backend, mock_time, mock_sleep
-    ):
+    async def test_kimi_code_trust_dialog_answered(self, mock_get_backend, mock_time, mock_sleep):
         """kimi-code's workspace-trust dialog is answered once (Up + Enter).
 
         With --mcp-config in a fresh CAO temp dir, kimi-code blocks before the


### PR DESCRIPTION
- fix(kimi): recognize Kimi Code 0.38's ● response bullets in status/extraction

Kimi Code 0.38 renders response/thinking bullets as ● (U+25CF); every
detection and extraction pattern only accepted • (U+2022), so on the new
TUI _has_received_input never latched, a worker that had already answered
read IDLE forever, and handoff completion/extraction never fired
(observed live: worker printed '● SMOKE-OK' and the caller never got the
result). Widen the line-start bullet patterns to [•●] — the status bar's
own ● ('agent (<model> ●)') is mid-line, so the anchor cannot
false-match it; covered by a regression test for both directions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EhSVUS48UVb7vvAvK5m6ho

- fix(kimi): write project-local mcp.json for Kimi Code (no --mcp-config flag)

Kimi Code CLI removed the --mcp-config flag entirely (kimi-cli accepted
inline JSON); it reads project-local MCP servers from
<cwd>/.kimi-code/mcp.json ({"mcpServers": {...}}). In markdown mode the
provider now writes that file into its per-instance temp dir — scoped to
this terminal only — instead of passing the flag. Enabling project-level
servers is exactly what raises the workspace-trust dialog handled by the
previous commit. CAO_TERMINAL_ID env injection per server is unchanged.

Known gap left as-is: _ensure_mcp_timeout patches kimi-cli's
~/.kimi/config.toml, a no-op for kimi-code; matters only for long
handoffs FROM a kimi supervisor, not for worker usage.

Existing MCP build-command tests are pinned to the legacy format so they
stay deterministic regardless of the locally installed variant; a new
test covers the kimi-code file path (mcpServers wrapper + terminal env).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EhSVUS48UVb7vvAvK5m6ho

- fix(kimi): auto-answer Kimi Code workspace-trust dialog at startup

With --mcp-config in a folder not previously trusted, Kimi Code blocks
before the REPL on a workspace-trust menu ('Project-level MCP servers are
disabled until you explicitly choose Trust'), so init times out. CAO
launches every instance in a fresh temp dir, making the dialog fire on
every launch with MCP servers configured.

Answer it once per init (Up + Enter selects 'Trust this folder'; the menu
cursor defaults to 'Don't trust'), mirroring the existing upgrade-dialog
handler. Trusting is sound here: the workspace is CAO's own per-instance
temp dir containing only CAO-written files, and the MCP servers being
enabled are the ones the operator's profile declared.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EhSVUS48UVb7vvAvK5m6ho

- fix(kimi): support Kimi Code CLI Markdown --agent-file format

Kimi CLI (MoonshotAI/kimi-cli) is wound down upstream; its successor Kimi
Code CLI (MoonshotAI/kimi-code) installs the same `kimi` binary but expects
--agent-file to be a Markdown agent definition (YAML frontmatter + body as
system prompt). The legacy YAML format the provider generates is rejected
with 'Missing frontmatter ...', so any profile with a system prompt fails
to launch under kimi-code.

Probe `kimi --help` once per process (kimi-code describes --agent-file as
loading 'from a Markdown file') and emit the matching format. Falls back to
the legacy YAML format when the probe fails, preserving behavior for
existing kimi-cli installs. Existing tests are pinned to the legacy format
so they stay deterministic regardless of which variant is installed on the
host; new tests cover the Markdown format and the probe itself.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EhSVUS48UVb7vvAvK5m6ho


Closes the four Kimi Code CLI incompatibilities described per-commit above. Verified end-to-end against kimi-code 0.38.0 (brew): a profile with system prompt + cao-mcp-server boots unattended and handoff results flow back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
