### PR TITLE
feat(launch): resume a prior Claude Code conversation in the supervisor

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -342,6 +342,27 @@ class CreateSessionBody(CreateTerminalBody):
         return _check_metadata_size(v)
 
 
+RESUME_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{7,63}$")
+
+
+def _validate_resume_session_id(value: str) -> None:
+    """Validate a ``resume_session_id`` at the request boundary.
+
+    The id is interpolated into the provider's shell command
+    (``claude --resume <sid>``), so the charset is restricted to the shape
+    Claude Code actually emits (UUID-like) — no whitespace, quoting, or
+    shell metacharacters.
+
+    Raises:
+        ValueError: ``value`` does not match RESUME_SESSION_ID_RE.
+    """
+    if not RESUME_SESSION_ID_RE.match(value):
+        raise ValueError(
+            "invalid resume_session_id: expected 8-64 chars of [A-Za-z0-9._-] "
+            "starting with an alphanumeric"
+        )
+
+
 def _validate_model_id(value: str) -> None:
     """Validate a ``model`` override at the request boundary (PR #501 review).
 
@@ -2843,6 +2864,7 @@ async def create_session(
     memory_manager: Optional[str] = None,
     engine: Optional[KiroEngine] = None,
     model: Optional[str] = None,
+    resume_session_id: Optional[str] = None,
     body: Optional[CreateSessionBody] = None,
     _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
 ) -> Terminal:
@@ -2899,6 +2921,8 @@ async def create_session(
             validate_tmux_name(effective, "session_name")
         if model is not None:
             _validate_model_id(model)
+        if resume_session_id is not None:
+            _validate_resume_session_id(resume_session_id)
         if initial_message == "":
             raise ValueError("initial_message must not be empty")
         if body and body.initial_message_orchestration_type:
@@ -2928,6 +2952,7 @@ async def create_session(
             initial_message=initial_message,
             initial_message_orchestration_type=initial_message_orchestration_type,
             model=model,
+            resume_session_id=resume_session_id,
             group=body.group if body else None,
             metadata=body.metadata if body else None,
         )

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -342,7 +342,7 @@ class CreateSessionBody(CreateTerminalBody):
         return _check_metadata_size(v)
 
 
-RESUME_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{7,63}$")
+RESUME_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{7,63}\Z")
 
 
 def _validate_resume_session_id(value: str) -> None:

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -153,6 +153,14 @@ def _parse_env_pairs(pairs):
     "the URL. Blocked prefixes (CLAUDE/CODEX_/__MISE_) and >=2048-byte values "
     "are rejected. See issue #248.",
 )
+@click.option(
+    "--resume-session-id",
+    "resume_session_id",
+    default=None,
+    metavar="SESSION_ID",
+    help="Resume a prior Claude Code conversation in the launched supervisor "
+    "(claude --resume <id>). claude_code provider only.",
+)
 def launch(
     message,
     agents,
@@ -167,6 +175,7 @@ def launch(
     working_directory,
     memory,
     env_pairs,
+    resume_session_id,
 ):
     """Launch cao session with specified agent profile."""
     try:
@@ -296,6 +305,8 @@ def launch(
             params["allowed_tools"] = ",".join(resolved_allowed_tools)
         if memory:
             params["memory_manager"] = "true"
+        if resume_session_id:
+            params["resume_session_id"] = resume_session_id
 
         # Forwarded env vars travel in the JSON body so values (which may
         # contain secrets) don't end up in cao-server's HTTP access log.

--- a/src/cli_agent_orchestrator/providers/claude_code.py
+++ b/src/cli_agent_orchestrator/providers/claude_code.py
@@ -253,11 +253,17 @@ class ClaudeCodeProvider(BaseProvider):
         allowed_tools: Optional[list] = None,
         skill_prompt: Optional[str] = None,
         model: Optional[str] = None,
+        resume_session_id: Optional[str] = None,
     ):
         """Initialize provider state."""
         super().__init__(terminal_id, session_name, window_name, allowed_tools, skill_prompt)
         self._initialized = False
         self._agent_profile = agent_profile
+        # When set, the launched claude process resumes this Claude Code
+        # session id (--resume <sid>) instead of starting a fresh
+        # conversation. Used to re-open a supervisor conversation inside a
+        # new CAO session (durable-orchestra recovery).
+        self._resume_session_id = resume_session_id
         # Explicit per-call override for profile.model (see launch()'s own
         # --model resolution below) -- e.g. a handoff/assign caller pinning a
         # specific model for one worker without needing a dedicated profile.
@@ -367,6 +373,12 @@ class ClaudeCodeProvider(BaseProvider):
             command_parts = ["claude"]
         else:
             command_parts = ["claude", "--dangerously-skip-permissions"]
+
+        # Resume a prior Claude Code conversation. Applied for every profile
+        # branch below -- resume is orthogonal to profile decomposition; the
+        # session id was validated at the API boundary.
+        if self._resume_session_id:
+            command_parts.extend(["--resume", self._resume_session_id])
 
         # Route based on profile state
         native = getattr(profile, "native_agent", None) if profile else None

--- a/src/cli_agent_orchestrator/providers/manager.py
+++ b/src/cli_agent_orchestrator/providers/manager.py
@@ -42,10 +42,16 @@ class ProviderManager:
         skill_prompt: Optional[str] = None,
         model: Optional[str] = None,
         engine: Optional[KiroEngine] = None,
+        resume_session_id: Optional[str] = None,
     ) -> BaseProvider:
         """Create and store provider instance."""
         try:
             provider: BaseProvider
+            if resume_session_id and provider_type != ProviderType.CLAUDE_CODE.value:
+                raise ValueError(
+                    "resume_session_id is only supported by the claude_code provider "
+                    f"(got provider '{provider_type}')"
+                )
             if provider_type == ProviderType.KIRO_CLI.value:
                 if not agent_profile:
                     raise ValueError("Kiro CLI provider requires agent_profile parameter")
@@ -70,6 +76,7 @@ class ProviderManager:
                     allowed_tools,
                     skill_prompt=skill_prompt,
                     model=model,
+                    resume_session_id=resume_session_id,
                 )
             elif provider_type == ProviderType.CODEX.value:
                 provider = CodexProvider(

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -54,6 +54,7 @@ async def create_session(
     initial_message: str | None = None,
     initial_message_orchestration_type: OrchestrationType | None = None,
     model: str | None = None,
+    resume_session_id: str | None = None,
     group: Optional[List[str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
 ) -> Terminal:
@@ -99,6 +100,7 @@ async def create_session(
         initial_message=initial_message,
         initial_message_orchestration_type=initial_message_orchestration_type,
         model=model,
+        resume_session_id=resume_session_id,
         group=group,
         metadata=metadata,
     )

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -203,6 +203,7 @@ async def create_terminal(
     engine: Optional[KiroEngine | str] = None,
     kiro_capability_probe: Optional[Callable[[KiroEngine, set[str]], KiroCapabilities]] = None,
     model: Optional[str] = None,
+    resume_session_id: Optional[str] = None,
     use_worktree: bool = False,
     group: Optional[List[str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
@@ -509,6 +510,7 @@ async def create_terminal(
             skill_prompt=skill_prompt,
             model=model or (profile.model if profile else None),
             engine=resolved_engine,
+            resume_session_id=resume_session_id,
         )
 
         # Deferred-init path: return fast so callers (e.g. MCP assign) do not

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -262,6 +262,46 @@ class TestGetSkillContent:
 # ── Sessions CRUD ────────────────────────────────────────────────────
 
 
+class TestValidateResumeSessionId:
+    """Focused tests on the resume_session_id validation boundary.
+
+    This validator guards a string that is later interpolated into the
+    provider shell command (``claude --resume <sid>``); these tests pin the
+    accepted charset so a future regex edit cannot silently widen what
+    reaches the shell command.
+    """
+
+    def test_valid_ids_pass(self):
+        from cli_agent_orchestrator.api.main import _validate_resume_session_id
+
+        for value in [
+            "abcdefgh",  # 8 chars: minimum length
+            "01234567-89ab-cdef-0123-456789abcdef",  # UUID shape
+            "A1.b2_c3-d4",
+            "a" * 64,  # maximum length
+        ]:
+            _validate_resume_session_id(value)  # must not raise
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "abc defg",  # embedded space
+            "abcdefg;",  # shell separator
+            "$(whoami)x",  # command substitution
+            "abcdefg",  # 7 chars: too short
+            "a" * 65,  # 65 chars: too long
+            ".abcdefgh",  # leading dot
+            "abcdefgh\n",  # trailing newline (regex must anchor with \\Z)
+            "",  # empty
+        ],
+    )
+    def test_invalid_ids_raise(self, value):
+        from cli_agent_orchestrator.api.main import _validate_resume_session_id
+
+        with pytest.raises(ValueError):
+            _validate_resume_session_id(value)
+
+
 class TestCreateSession:
     """Tests for POST /sessions endpoint — success and error cases."""
 
@@ -304,6 +344,7 @@ class TestCreateSession:
             initial_message=None,
             initial_message_orchestration_type=None,
             model=None,
+            resume_session_id=None,
             group=None,
             metadata=None,
         )

--- a/test/providers/test_claude_code_unit.py
+++ b/test/providers/test_claude_code_unit.py
@@ -1416,6 +1416,26 @@ class TestClaudeCodeProviderMisc:
         assert "claude --dangerously-skip-permissions" in command
         assert "--permission-mode" not in command
 
+    def test_build_claude_command_with_resume_session_id(self):
+        """resume_session_id maps to `claude --resume <sid>` (durable-orchestra
+        recovery: re-open a prior supervisor conversation in a new CAO session)."""
+        provider = ClaudeCodeProvider(
+            "test123",
+            "test-session",
+            "window-0",
+            resume_session_id="11d55034-bb41-46ca-8686-59a9dbff16b5",
+        )
+        command = provider._build_claude_command()
+
+        assert "--resume 11d55034-bb41-46ca-8686-59a9dbff16b5" in command
+
+    def test_build_claude_command_no_resume_by_default(self):
+        """Without resume_session_id the command must not carry --resume."""
+        provider = ClaudeCodeProvider("test123", "test-session", "window-0")
+        command = provider._build_claude_command()
+
+        assert "--resume" not in command
+
     @patch("cli_agent_orchestrator.providers.claude_code.load_agent_profile")
     def test_build_claude_command_with_system_prompt(self, mock_load):
         """Test building Claude command with system prompt."""

--- a/test/providers/test_provider_manager_unit.py
+++ b/test/providers/test_provider_manager_unit.py
@@ -461,3 +461,35 @@ def test_create_provider_omp_stores_mapping():
 
     assert isinstance(provider, OmpProvider)
     assert manager.get_provider("t1") is provider
+
+
+def test_create_provider_resume_session_id_reaches_claude_code():
+    from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
+
+    manager = ProviderManager()
+    provider = manager.create_provider(
+        ProviderType.CLAUDE_CODE.value,
+        terminal_id="t-resume",
+        tmux_session="s1",
+        tmux_window="w1",
+        agent_profile=None,
+        resume_session_id="11d55034-bb41-46ca-8686-59a9dbff16b5",
+    )
+
+    assert isinstance(provider, ClaudeCodeProvider)
+    assert provider._resume_session_id == "11d55034-bb41-46ca-8686-59a9dbff16b5"
+
+
+def test_create_provider_resume_session_id_rejected_for_other_providers():
+    """resume_session_id is claude_code-only; other providers must fail closed
+    instead of silently starting a fresh conversation."""
+    manager = ProviderManager()
+    with pytest.raises(Exception, match="resume_session_id is only supported"):
+        manager.create_provider(
+            ProviderType.CODEX.value,
+            terminal_id="t-bad",
+            tmux_session="s1",
+            tmux_window="w1",
+            agent_profile=None,
+            resume_session_id="11d55034-bb41-46ca-8686-59a9dbff16b5",
+        )


### PR DESCRIPTION
- feat(launch): resume a prior Claude Code conversation in the supervisor

Adds an optional resume_session_id to the launch path (CLI
--resume-session-id -> POST /sessions -> session/terminal services ->
claude_code provider appends --resume <sid>). Validated at the API
boundary (UUID-like charset — the value is interpolated into the
provider's shell command) and rejected for non-claude_code providers
(fail closed rather than silently starting a fresh conversation).

Motivation: durable orchestras. CAO today always starts a fresh
conversation; when the host terminal dies or cao-server is upgraded, the
supervisor's Claude Code session (~/.claude/projects/<slug>/<sid>.jsonl)
survives but there was no way to re-open it INSIDE a CAO session with
handoff/assign tooling restored. With this, an external launcher can
rebuild the orchestra around the surviving conversation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EhSVUS48UVb7vvAvK5m6ho


Closes #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
