### PR TITLE
refactor(api): drop the _origin_authority wrapper, document when the scheme guard applies

### DIFF
--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -507,12 +507,6 @@ def _origin_scheme_and_authority(origin: str) -> "tuple[str, str] | None":
     return parts.scheme, parts.netloc.rsplit("@", 1)[-1]
 
 
-def _origin_authority(origin: str) -> "str | None":
-    """Return the ``host[:port]`` authority of an http/https ``Origin``."""
-    parsed = _origin_scheme_and_authority(origin)
-    return None if parsed is None else parsed[1]
-
-
 def _is_same_origin(origin: str, host: str, scheme: "str | None") -> bool:
     """Whether ``origin`` is same-origin with the request ``host``/``scheme``.
 
@@ -529,6 +523,14 @@ def _is_same_origin(origin: str, host: str, scheme: "str | None") -> bool:
     genuinely made over TLS. Rejecting that direction would break working
     reverse-proxy and Codespaces deployments without closing a real hole, since
     forging it means already controlling the victim's own origin over TLS.
+
+    That leniency has a corollary worth stating: the comparison only does
+    anything where ``scheme`` is trustworthy, meaning uvicorn terminates TLS
+    itself or the proxy is listed in ``TRUSTED_FORWARDER_IPS``. Behind an
+    untrusted proxy ``scheme`` is ``"http"`` on a request the browser made over
+    TLS, and the check is then inert in both directions: the ``http`` Origin is
+    accepted as well. Operators who want it enforced should set
+    ``CAO_FORWARDED_ALLOW_IPS`` to the proxy address.
 
     ``scheme=None`` skips the comparison entirely, preserving the behaviour
     callers had before the scheme was threaded through.

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -401,17 +401,17 @@ class TestIsWsOriginAllowed:
 
 
 class TestOriginAuthorityMalformedInput:
-    """Regression for #653: ``_origin_authority`` fed a malformed bracketed
-    Origin (e.g. ``http://[``) must not raise. ``urlsplit`` propagates
+    """Regression for #653: origin parsing fed a malformed bracketed Origin
+    (e.g. ``http://[``) must not raise. ``urlsplit`` propagates
     ``ValueError: Invalid IPv6 URL`` for such input, and both callers sit on
     request paths (HTTP middleware, WS handshake) that must fail closed with
     a 403, not a 500 from an unguarded exception.
     """
 
     def test_malformed_bracketed_origin_returns_none(self):
-        from cli_agent_orchestrator.constants import _origin_authority
+        from cli_agent_orchestrator.constants import _origin_scheme_and_authority
 
-        assert _origin_authority("http://[") is None
+        assert _origin_scheme_and_authority("http://[") is None
 
     def test_malformed_origin_is_rejected_not_raised_by_ws_guard(self):
         from cli_agent_orchestrator import constants


### PR DESCRIPTION
Both non-blocking nits from the #658 review, as one PR since they are the same few lines. Thanks for the go-ahead.

### The wrapper

`_origin_authority` lost its last production caller in #658, when both guards moved onto `_is_same_origin`. It survived only so the #656 regression test stayed untouched in that diff, which kept the review smaller at the time and buys nothing now the change is on `main`.

Retargeted the test at `_origin_scheme_and_authority` and deleted the wrapper. The assertion is the same shape and covers the same parse path:

```python
assert _origin_scheme_and_authority("http://[") is None
```

`grep -rn "_origin_authority" --include=*.py src/ test/` now returns nothing, and the class docstring no longer names a function that does not exist.

### The docstring

Took your text nearly as drafted. The docstring argued why the comparison is lenient in one direction but left the corollary implied: the check does something only where `scope["scheme"]` is trustworthy, and behind a proxy outside `TRUSTED_FORWARDER_IPS` it is inert in both directions rather than just the lenient one. An operator reading it to work out whether they are covered needs that second half.

Wrote it as a follow-on paragraph to the leniency argument instead of a standalone note, so the two read as one point, and named `CAO_FORWARDED_ALLOW_IPS` so it connects to the block at `constants.py:655-661`.

### Tests

`uv run pytest test/test_constants.py`: 73 passed, 2 failed. Both failures are the pre-existing Windows ones in `TestCaoHomeDirEnvOverride` (`test_import_time_dirs_have_restricted_permissions`, `test_pre_existing_base_dir_is_chmodded`), which assert POSIX permission bits and also fail on an unmodified checkout here. All 37 tests in the origin selection pass, including the retargeted one.

`black --check`, `isort --check-only`, `mypy` clean on both touched files.

No behaviour change: one deleted private helper with no callers, one docstring paragraph, one import line in a test.
