### PR TITLE
fix(tmux): enable mouse scrolling and cancel copy mode before orchestrated input

### DIFF
--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -729,6 +729,17 @@ class TmuxClient:
                     "been removed; the launch can be retried with the same name."
                 ) from e
 
+            # Keep mouse-wheel input inside tmux. With mouse mode disabled,
+            # tmux forwards wheel events to the foreground application as
+            # Up/Down keys, which makes shells and agent TUIs navigate their
+            # command history instead of entering copy mode to scroll output
+            # (#546). This is a session option, so it does not change the
+            # user's other tmux sessions or their global configuration. The
+            # flip side -- a wheel-scrolled pane now routinely sits in copy
+            # mode, where it consumes orchestrated keys (#654) -- is handled
+            # by the mode-cancel guard in each send path below.
+            session.set_option("mouse", "on")
+
             logger.info(
                 f"Created tmux session: {session_name} with window: {window_name} in directory: {working_directory}"
             )
@@ -937,6 +948,20 @@ class TmuxClient:
             # available here at DEBUG for local delivery troubleshooting.
             logger.info(f"send_keys: {target} - keys length: {len(keys)}")
             logger.debug(f"send_keys: {target} - keys: {keys}")
+            # A pane the user has wheel-scrolled sits in copy mode (routine
+            # now that sessions enable mouse), and a pane in a mode consumes
+            # send-keys through the mode's key table instead of delivering
+            # them to the application: the submitting Enter below would be
+            # eaten by copy mode while the pasted message sits unsubmitted
+            # (#654, verified on tmux 3.4). Cancel any active mode first.
+            # Unconditional on purpose -- when the pane is not in a mode the
+            # command fails with "not in a mode" and delivers nothing, so no
+            # pane-state pre-check is needed (and none would be race-free).
+            subprocess.run(
+                ["tmux", "send-keys", "-t", target, "-X", "cancel"],
+                check=False,
+                capture_output=True,
+            )
             if force_bracketed_paste and self._pane_is_bracketed_paste_incompatible(
                 validated_session, validated_window
             ):
@@ -1044,6 +1069,12 @@ class TmuxClient:
             if pane:
                 buf_name = "cao_paste"
 
+                # Punch through any active copy mode first -- keys sent to a
+                # pane in a mode go to the mode's key table, not the
+                # application, so the submitting C-m below would be eaten
+                # (#654). Harmless "not in a mode" failure when there is none.
+                pane.cmd("send-keys", "-X", "cancel")
+
                 # Load text into tmux buffer
                 self.server.cmd("set-buffer", "-b", buf_name, text)
 
@@ -1092,6 +1123,10 @@ class TmuxClient:
 
             pane = self._find_active_pane(window, session_name, window_name)
             if pane:
+                # Same copy-mode guard as the paste paths (#654): a control
+                # key like C-c sent into an active mode is consumed by the
+                # mode's key table and never reaches the application.
+                pane.cmd("send-keys", "-X", "cancel")
                 pane.send_keys(key, enter=False)
                 logger.debug(f"Sent special key to {session_name}:{window_name}")
         except Exception as e:

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -734,11 +734,24 @@ class TmuxClient:
             # Up/Down keys, which makes shells and agent TUIs navigate their
             # command history instead of entering copy mode to scroll output
             # (#546). This is a session option, so it does not change the
-            # user's other tmux sessions or their global configuration. The
-            # flip side -- a wheel-scrolled pane now routinely sits in copy
-            # mode, where it consumes orchestrated keys (#654) -- is handled
-            # by the mode-cancel guard in each send path below.
-            session.set_option("mouse", "on")
+            # user's other tmux sessions or their global configuration.
+            # Standard tmux trade-off: click-drag now makes a tmux selection
+            # rather than the terminal's (Shift-drag reaches the native one).
+            # The flip side -- a wheel-scrolled pane now routinely sits in
+            # copy mode, where it consumes orchestrated keys (#654) -- is
+            # handled by the mode-cancel guards in each send path below.
+            # Best-effort on purpose: mouse-on is a scroll convenience, not a
+            # precondition for a usable session, and this line sits after
+            # new_session but outside the rollback guard below -- raising
+            # here would orphan a perfectly good session and block relaunch
+            # under the same name.
+            try:
+                session.set_option("mouse", "on")
+            except Exception as mouse_error:
+                logger.warning(
+                    f"Could not enable mouse mode on session {session_name}: "
+                    f"{mouse_error} — continuing without wheel scrolling."
+                )
 
             logger.info(
                 f"Created tmux session: {session_name} with window: {window_name} in directory: {working_directory}"
@@ -1024,6 +1037,17 @@ class TmuxClient:
                     # process the previous Enter (e.g., Ink adding a newline)
                     # before the next Enter triggers form submission.
                     time.sleep(0.5)
+                # Re-cancel right before each submitting Enter: submit_delay
+                # is up to 2s (claude_code's paste_submit_delay), and a wheel
+                # scroll inside that window would put the pane back in copy
+                # mode and eat the Enter -- the exact #654 stall the leading
+                # cancel exists to prevent (text in the composer, submission
+                # never fires, nothing raises).
+                subprocess.run(
+                    ["tmux", "send-keys", "-t", target, "-X", "cancel"],
+                    check=False,
+                    capture_output=True,
+                )
                 subprocess.run(
                     ["tmux", "send-keys", "-t", target, "Enter"],
                     check=True,
@@ -1084,6 +1108,11 @@ class TmuxClient:
                 pane.cmd("paste-buffer", "-p", "-b", buf_name)
 
                 time.sleep(0.3)
+
+                # Re-cancel before the submitting C-m for the same reason as
+                # send_keys: a wheel scroll during the 0.3s sleep would put
+                # the pane back in copy mode and eat the submission (#654).
+                pane.cmd("send-keys", "-X", "cancel")
 
                 # Send Enter to submit the pasted text
                 pane.send_keys("C-m", enter=False)

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -93,6 +93,22 @@ class TestCreateSession:
 
         mock_session.set_option.assert_called_once_with("mouse", "on")
 
+    def test_create_session_survives_mouse_option_failure(self, tmux, tmp_path):
+        """set_option runs after new_session but outside the rollback guard,
+        and libtmux raises on ANY set-option stderr -- if that propagated,
+        a scroll convenience would orphan a live session and block relaunch
+        under the same name. It must degrade to a warning instead."""
+        mock_window = MagicMock()
+        mock_window.name = "my-window"
+        mock_session = MagicMock()
+        mock_session.windows = [mock_window]
+        mock_session.set_option.side_effect = RuntimeError("unknown option: mouse")
+        tmux.server.new_session.return_value = mock_session
+
+        result = tmux.create_session("ses", "my-window", "tid1", str(tmp_path))
+
+        assert result == "my-window"
+
     def test_create_session_uses_explicit_dimensions(self, tmux, tmp_path):
         """Guard against regressing the kiro-cli 2.1.x SIGWINCH-repaint bug (#216).
 
@@ -293,9 +309,9 @@ class TestSendKeys:
         mock_subprocess.run.return_value = MagicMock(returncode=0)
         tmux.send_keys("ses", "win", "hello", enter_count=1)
 
-        # copy-mode cancel, load-buffer, paste-buffer, send-keys Enter,
-        # delete-buffer
-        assert mock_subprocess.run.call_count == 5
+        # copy-mode cancel, load-buffer, paste-buffer, pre-Enter cancel,
+        # send-keys Enter, delete-buffer
+        assert mock_subprocess.run.call_count == 6
 
     @patch("cli_agent_orchestrator.clients.tmux.time")
     @patch("cli_agent_orchestrator.clients.tmux.subprocess")
@@ -303,9 +319,9 @@ class TestSendKeys:
         mock_subprocess.run.return_value = MagicMock(returncode=0)
         tmux.send_keys("ses", "win", "hello", enter_count=3)
 
-        # copy-mode cancel + load-buffer + paste-buffer + 3 send-keys Enter
-        # + delete-buffer = 7
-        assert mock_subprocess.run.call_count == 7
+        # copy-mode cancel + load-buffer + paste-buffer
+        # + 3 x (pre-Enter cancel + send-keys Enter) + delete-buffer = 10
+        assert mock_subprocess.run.call_count == 10
 
     @patch("cli_agent_orchestrator.clients.tmux.time")
     @patch("cli_agent_orchestrator.clients.tmux.subprocess")
@@ -321,6 +337,26 @@ class TestSendKeys:
         first = mock_subprocess.run.call_args_list[0]
         assert first.args[0] == ["tmux", "send-keys", "-t", "ses:win", "-X", "cancel"]
         assert first.kwargs.get("check") is False
+
+    @patch("cli_agent_orchestrator.clients.tmux.time")
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess")
+    def test_send_keys_cancels_copy_mode_before_each_enter(self, mock_subprocess, mock_time, tmux):
+        """The leading cancel alone is not enough: submit_delay is up to 2s
+        (claude_code's paste_submit_delay), and a wheel scroll inside that
+        window re-enters copy mode and eats the submitting Enter -- the
+        message sits typed but unsubmitted (#654). Every Enter must be
+        immediately preceded by its own cancel."""
+        mock_subprocess.run.return_value = MagicMock(returncode=0)
+        tmux.send_keys("ses", "win", "hello", enter_count=2)
+
+        calls = mock_subprocess.run.call_args_list
+        cancel_argv = ["tmux", "send-keys", "-t", "ses:win", "-X", "cancel"]
+        enter_argv = ["tmux", "send-keys", "-t", "ses:win", "Enter"]
+        enter_indices = [i for i, c in enumerate(calls) if c.args[0] == enter_argv]
+        assert len(enter_indices) == 2
+        for i in enter_indices:
+            assert calls[i - 1].args[0] == cancel_argv
+            assert calls[i - 1].kwargs.get("check") is False
 
     @patch("cli_agent_orchestrator.clients.tmux.time")
     @patch("cli_agent_orchestrator.clients.tmux.subprocess")
@@ -347,9 +383,12 @@ class TestSendKeysViaPaste:
         tmux.send_keys_via_paste("ses", "win", "hello")
 
         tmux.server.cmd.assert_any_call("set-buffer", "-b", "cao_paste", "hello")
-        # Copy-mode cancel (#654) must precede the paste.
+        # Copy-mode cancel (#654) must precede the paste, and again right
+        # before the submitting C-m -- a wheel scroll during the 0.3s
+        # post-paste sleep would re-enter copy mode and eat the submission.
         assert mock_pane.cmd.call_args_list[0] == call("send-keys", "-X", "cancel")
         assert mock_pane.cmd.call_args_list[1] == call("paste-buffer", "-p", "-b", "cao_paste")
+        assert mock_pane.cmd.call_args_list[2] == call("send-keys", "-X", "cancel")
         mock_pane.send_keys.assert_called_once_with("C-m", enter=False)
 
     @patch("cli_agent_orchestrator.clients.tmux.time")

--- a/test/clients/test_tmux_client.py
+++ b/test/clients/test_tmux_client.py
@@ -78,6 +78,21 @@ class TestCreateSession:
         with pytest.raises(Exception, match="tmux error"):
             tmux.create_session("ses", "w", "tid1", str(tmp_path))
 
+    def test_create_session_enables_mouse(self, tmux, tmp_path):
+        """Mouse mode keeps wheel scroll inside tmux (#546): without it tmux
+        forwards wheel events to the foreground application as Up/Down keys,
+        so agent TUIs walk their input history instead of scrolling output.
+        Session-level option: the user's other sessions are untouched."""
+        mock_window = MagicMock()
+        mock_window.name = "my-window"
+        mock_session = MagicMock()
+        mock_session.windows = [mock_window]
+        tmux.server.new_session.return_value = mock_session
+
+        tmux.create_session("ses", "my-window", "tid1", str(tmp_path))
+
+        mock_session.set_option.assert_called_once_with("mouse", "on")
+
     def test_create_session_uses_explicit_dimensions(self, tmux, tmp_path):
         """Guard against regressing the kiro-cli 2.1.x SIGWINCH-repaint bug (#216).
 
@@ -278,8 +293,9 @@ class TestSendKeys:
         mock_subprocess.run.return_value = MagicMock(returncode=0)
         tmux.send_keys("ses", "win", "hello", enter_count=1)
 
-        # load-buffer, paste-buffer, send-keys Enter, delete-buffer
-        assert mock_subprocess.run.call_count == 4
+        # copy-mode cancel, load-buffer, paste-buffer, send-keys Enter,
+        # delete-buffer
+        assert mock_subprocess.run.call_count == 5
 
     @patch("cli_agent_orchestrator.clients.tmux.time")
     @patch("cli_agent_orchestrator.clients.tmux.subprocess")
@@ -287,8 +303,24 @@ class TestSendKeys:
         mock_subprocess.run.return_value = MagicMock(returncode=0)
         tmux.send_keys("ses", "win", "hello", enter_count=3)
 
-        # load-buffer + paste-buffer + 3 send-keys Enter + delete-buffer = 6
-        assert mock_subprocess.run.call_count == 6
+        # copy-mode cancel + load-buffer + paste-buffer + 3 send-keys Enter
+        # + delete-buffer = 7
+        assert mock_subprocess.run.call_count == 7
+
+    @patch("cli_agent_orchestrator.clients.tmux.time")
+    @patch("cli_agent_orchestrator.clients.tmux.subprocess")
+    def test_send_keys_cancels_copy_mode_before_paste(self, mock_subprocess, mock_time, tmux):
+        """A pane in copy mode consumes send-keys through the mode's key
+        table instead of delivering them to the application, so the
+        submitting Enter after paste-buffer is silently eaten (#654). The
+        cancel must come first, and must not check the exit code: on a pane
+        not in a mode the command fails with "not in a mode" by design."""
+        mock_subprocess.run.return_value = MagicMock(returncode=0)
+        tmux.send_keys("ses", "win", "hello")
+
+        first = mock_subprocess.run.call_args_list[0]
+        assert first.args[0] == ["tmux", "send-keys", "-t", "ses:win", "-X", "cancel"]
+        assert first.kwargs.get("check") is False
 
     @patch("cli_agent_orchestrator.clients.tmux.time")
     @patch("cli_agent_orchestrator.clients.tmux.subprocess")
@@ -315,7 +347,9 @@ class TestSendKeysViaPaste:
         tmux.send_keys_via_paste("ses", "win", "hello")
 
         tmux.server.cmd.assert_any_call("set-buffer", "-b", "cao_paste", "hello")
-        mock_pane.cmd.assert_called_once_with("paste-buffer", "-p", "-b", "cao_paste")
+        # Copy-mode cancel (#654) must precede the paste.
+        assert mock_pane.cmd.call_args_list[0] == call("send-keys", "-X", "cancel")
+        assert mock_pane.cmd.call_args_list[1] == call("paste-buffer", "-p", "-b", "cao_paste")
         mock_pane.send_keys.assert_called_once_with("C-m", enter=False)
 
     @patch("cli_agent_orchestrator.clients.tmux.time")
@@ -349,6 +383,9 @@ class TestSendSpecialKey:
 
         tmux.send_special_key("ses", "win", "C-d")
 
+        # Copy-mode cancel (#654) must precede the key: a C-c/C-d sent into
+        # an active mode is consumed by the mode's key table.
+        mock_pane.cmd.assert_called_once_with("send-keys", "-X", "cancel")
         mock_pane.send_keys.assert_called_once_with("C-d", enter=False)
 
     def test_send_special_key_session_not_found(self, tmux):

--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -35,6 +35,17 @@ def reset_version_cache():
     TmuxClient._paste_buffer_sanitizes = None
 
 
+def payload_calls(mock_subprocess):
+    """The paste pipeline minus send_keys' leading copy-mode cancel.
+
+    Every send_keys call opens with ``send-keys -X cancel`` so a
+    wheel-scrolled pane sitting in copy mode cannot eat the delivery (#654);
+    that call is pinned by its own test in test_tmux_client.py. The tests
+    here assert the payload pipeline that follows it.
+    """
+    return mock_subprocess.run.call_args_list[1:]
+
+
 @pytest.fixture
 def sanitizing_tmux():
     """Host tmux >= 3.7 (vis(3)-sanitizes pasted buffers)."""
@@ -53,11 +64,12 @@ class TestSendKeys:
     """Tests for the paste-buffer based send_keys implementation."""
 
     def test_basic_message(self, client, mock_subprocess, mock_uuid):
-        """Sends load-buffer, paste-buffer -p, send-keys Enter, delete-buffer."""
+        """Sends copy-mode cancel, then load-buffer, paste-buffer -p,
+        send-keys Enter, delete-buffer."""
         client.send_keys("sess", "win", "hello")
 
-        assert mock_subprocess.run.call_count == 4
-        calls = mock_subprocess.run.call_args_list
+        assert mock_subprocess.run.call_count == 5
+        calls = payload_calls(mock_subprocess)
 
         # load-buffer with unique name and message as stdin
         assert calls[0] == call(
@@ -86,7 +98,7 @@ class TestSendKeys:
         msg = "line 1\nline 2\nline 3"
         client.send_keys("sess", "win", msg)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call == call(
             ["tmux", "load-buffer", "-b", "cao_abcd1234", "-"],
             input=msg.encode(),
@@ -98,20 +110,21 @@ class TestSendKeys:
         msg = """He said "hello" and ran `cmd` with $VAR"""
         client.send_keys("sess", "win", msg)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == msg.encode()
 
     def test_empty_message(self, client, mock_subprocess, mock_uuid):
         """Empty string still goes through the full pipeline."""
         client.send_keys("sess", "win", "")
 
-        assert mock_subprocess.run.call_count == 4
-        load_call = mock_subprocess.run.call_args_list[0]
+        assert mock_subprocess.run.call_count == 5
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == b""
 
     def test_buffer_cleanup_on_error(self, client, mock_subprocess, mock_uuid):
         """Buffer is deleted even when paste-buffer fails."""
         mock_subprocess.run.side_effect = [
+            None,  # copy-mode cancel
             None,  # load-buffer succeeds
             Exception("paste failed"),  # paste-buffer fails
             None,  # delete-buffer in finally
@@ -137,17 +150,20 @@ class TestSendKeys:
             client.send_keys("sess", "win", "msg2")
 
         calls = mock_subprocess.run.call_args_list
-        # First call uses cao_aaaa1111
-        assert calls[0][0][0][3] == "cao_aaaa1111"
-        # Second call (index 4, after 4 calls from first send_keys) uses cao_cccc2222
-        assert calls[4][0][0][3] == "cao_cccc2222"
+        # First send's load-buffer (index 1, after its copy-mode cancel)
+        # uses cao_aaaa1111
+        assert calls[1][0][0][3] == "cao_aaaa1111"
+        # Second send's load-buffer (index 6, after 5 calls from the first
+        # send_keys and the second's cancel) uses cao_cccc2222
+        assert calls[6][0][0][3] == "cao_cccc2222"
 
     def test_double_enter(self, client, mock_subprocess, mock_uuid):
         """When enter_count=2, two Enter keys are sent after pasting."""
         client.send_keys("sess", "win", "hello", enter_count=2)
 
-        assert mock_subprocess.run.call_count == 5  # load + paste + 2 Enter + delete
-        calls = mock_subprocess.run.call_args_list
+        # cancel + load + paste + 2 Enter + delete
+        assert mock_subprocess.run.call_count == 6
+        calls = payload_calls(mock_subprocess)
         # Both Enters
         assert calls[2] == call(
             ["tmux", "send-keys", "-t", "sess:win", "Enter"],
@@ -163,9 +179,9 @@ class TestSendKeys:
         msg = "X" * 50000
         client.send_keys("sess", "win", msg)
 
-        # Still exactly 4 subprocess calls — no chunking
-        assert mock_subprocess.run.call_count == 4
-        load_call = mock_subprocess.run.call_args_list[0]
+        # Still exactly 5 subprocess calls — no chunking
+        assert mock_subprocess.run.call_count == 5
+        load_call = payload_calls(mock_subprocess)[0]
         assert len(load_call[1]["input"]) == 50000
 
 
@@ -186,7 +202,7 @@ class TestSendKeysNoHandCraftedMarkersOnModernTmux:
         """Loaded buffer contains only raw message bytes — no ESC, no markers."""
         client.send_keys("sess", "win", "hello world", force_bracketed_paste=True)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         buf_content = load_call[1]["input"]
         assert b"\x1b" not in buf_content
         assert b"[200~" not in buf_content
@@ -199,7 +215,7 @@ class TestSendKeysNoHandCraftedMarkersOnModernTmux:
         """paste-buffer is invoked with -p and never -r or -S."""
         client.send_keys("sess", "win", "hello", force_bracketed_paste=True)
 
-        paste_call = mock_subprocess.run.call_args_list[1]
+        paste_call = payload_calls(mock_subprocess)[1]
         paste_argv = paste_call[0][0]
         assert paste_argv[:2] == ["tmux", "paste-buffer"]
         assert "-p" in paste_argv
@@ -213,7 +229,7 @@ class TestSendKeysNoHandCraftedMarkersOnModernTmux:
         msg = "line 1\nline 2\n\nline 4 with \x03 control char"
         client.send_keys("sess", "win", msg, force_bracketed_paste=True)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call == call(
             ["tmux", "load-buffer", "-b", "cao_abcd1234", "-"],
             input=msg.encode(),
@@ -247,7 +263,7 @@ class TestSendKeysLegacyWrapOnOldTmux:
         msg = "task line 1\n\n[Assigned by terminal abc]"
         client.send_keys("sess", "win", msg, force_bracketed_paste=True)
 
-        calls = mock_subprocess.run.call_args_list
+        calls = payload_calls(mock_subprocess)
         assert calls[0] == call(
             ["tmux", "load-buffer", "-b", "cao_abcd1234", "-"],
             input=b"\x1b[200~" + msg.encode() + b"\x1b[201~",
@@ -262,7 +278,7 @@ class TestSendKeysLegacyWrapOnOldTmux:
         """Init-time shell commands keep the raw + -p path on every version."""
         client.send_keys("sess", "win", "ls -la", force_bracketed_paste=False)
 
-        calls = mock_subprocess.run.call_args_list
+        calls = payload_calls(mock_subprocess)
         assert calls[0][1]["input"] == b"ls -la"
         assert calls[1] == call(
             ["tmux", "paste-buffer", "-p", "-b", "cao_abcd1234", "-t", "sess:win"],
@@ -287,12 +303,12 @@ class TestSendKeysForcedBracketedPasteShellDetection:
         with patch.object(client, "get_pane_current_command", return_value="node"):
             client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
 
-        paste_call = mock_subprocess.run.call_args_list[1]
+        paste_call = payload_calls(mock_subprocess)[1]
         assert paste_call == call(
             ["tmux", "paste-buffer", "-r", "-b", "cao_abcd1234", "-t", "sess:win"],
             check=True,
         )
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == b"\x1b[200~claude --continue\x1b[201~"
 
     @pytest.mark.parametrize("shell", ["sh", "dash", "bash", "zsh", "fish"])
@@ -307,9 +323,9 @@ class TestSendKeysForcedBracketedPasteShellDetection:
         with patch.object(client, "get_pane_current_command", return_value=shell):
             client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == b"claude --continue"
-        paste_call = mock_subprocess.run.call_args_list[1]
+        paste_call = payload_calls(mock_subprocess)[1]
         assert paste_call == call(
             ["tmux", "paste-buffer", "-b", "cao_abcd1234", "-t", "sess:win"],
             check=True,
@@ -327,7 +343,7 @@ class TestSendKeysForcedBracketedPasteShellDetection:
         with patch.object(client, "get_pane_current_command", return_value=None):
             client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == b"\x1b[200~claude --continue\x1b[201~"
 
     def test_non_forced_calls_are_unaffected_by_shell_detection(
@@ -341,7 +357,7 @@ class TestSendKeysForcedBracketedPasteShellDetection:
             client.send_keys("sess", "win", "echo ready")
 
         mock_get.assert_not_called()
-        paste_call = mock_subprocess.run.call_args_list[1]
+        paste_call = payload_calls(mock_subprocess)[1]
         assert paste_call == call(
             ["tmux", "paste-buffer", "-p", "-b", "cao_abcd1234", "-t", "sess:win"],
             check=True,
@@ -363,9 +379,9 @@ class TestSendKeysShellDetectionCrossedWithTmuxVersion:
         with patch.object(client, "get_pane_current_command", return_value="bash"):
             client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == b"claude --continue"
-        paste_call = mock_subprocess.run.call_args_list[1]
+        paste_call = payload_calls(mock_subprocess)[1]
         assert paste_call == call(
             ["tmux", "paste-buffer", "-b", "cao_abcd1234", "-t", "sess:win"],
             check=True,
@@ -381,10 +397,10 @@ class TestSendKeysShellDetectionCrossedWithTmuxVersion:
         with patch.object(client, "get_pane_current_command", return_value="node"):
             client.send_keys("sess", "win", "claude --continue", force_bracketed_paste=True)
 
-        load_call = mock_subprocess.run.call_args_list[0]
+        load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == b"claude --continue"
         assert b"\x1b" not in load_call[1]["input"]
-        paste_call = mock_subprocess.run.call_args_list[1]
+        paste_call = payload_calls(mock_subprocess)[1]
         assert paste_call == call(
             ["tmux", "paste-buffer", "-p", "-b", "cao_abcd1234", "-t", "sess:win"],
             check=True,

--- a/test/clients/test_tmux_send_keys.py
+++ b/test/clients/test_tmux_send_keys.py
@@ -36,14 +36,16 @@ def reset_version_cache():
 
 
 def payload_calls(mock_subprocess):
-    """The paste pipeline minus send_keys' leading copy-mode cancel.
+    """The paste pipeline minus the copy-mode cancels.
 
-    Every send_keys call opens with ``send-keys -X cancel`` so a
-    wheel-scrolled pane sitting in copy mode cannot eat the delivery (#654);
-    that call is pinned by its own test in test_tmux_client.py. The tests
-    here assert the payload pipeline that follows it.
+    Every send_keys call cancels any active pane mode before the paste and
+    again immediately before each submitting Enter, so a wheel-scrolled pane
+    sitting in copy mode cannot eat the delivery or the submission (#654);
+    those guards are pinned by their own tests in test_tmux_client.py. The
+    tests here assert the payload pipeline threaded between them, at the
+    same indices as before the guards existed.
     """
-    return mock_subprocess.run.call_args_list[1:]
+    return [c for c in mock_subprocess.run.call_args_list if c[0][0][-2:] != ["-X", "cancel"]]
 
 
 @pytest.fixture
@@ -64,11 +66,11 @@ class TestSendKeys:
     """Tests for the paste-buffer based send_keys implementation."""
 
     def test_basic_message(self, client, mock_subprocess, mock_uuid):
-        """Sends copy-mode cancel, then load-buffer, paste-buffer -p,
-        send-keys Enter, delete-buffer."""
+        """Sends copy-mode cancel, load-buffer, paste-buffer -p, another
+        cancel, send-keys Enter, delete-buffer."""
         client.send_keys("sess", "win", "hello")
 
-        assert mock_subprocess.run.call_count == 5
+        assert mock_subprocess.run.call_count == 6
         calls = payload_calls(mock_subprocess)
 
         # load-buffer with unique name and message as stdin
@@ -117,7 +119,7 @@ class TestSendKeys:
         """Empty string still goes through the full pipeline."""
         client.send_keys("sess", "win", "")
 
-        assert mock_subprocess.run.call_count == 5
+        assert mock_subprocess.run.call_count == 6
         load_call = payload_calls(mock_subprocess)[0]
         assert load_call[1]["input"] == b""
 
@@ -150,19 +152,19 @@ class TestSendKeys:
             client.send_keys("sess", "win", "msg2")
 
         calls = mock_subprocess.run.call_args_list
-        # First send's load-buffer (index 1, after its copy-mode cancel)
-        # uses cao_aaaa1111
+        # First send's load-buffer (index 1, after its leading copy-mode
+        # cancel) uses cao_aaaa1111
         assert calls[1][0][0][3] == "cao_aaaa1111"
-        # Second send's load-buffer (index 6, after 5 calls from the first
-        # send_keys and the second's cancel) uses cao_cccc2222
-        assert calls[6][0][0][3] == "cao_cccc2222"
+        # Second send's load-buffer (index 7, after 6 calls from the first
+        # send_keys and the second's leading cancel) uses cao_cccc2222
+        assert calls[7][0][0][3] == "cao_cccc2222"
 
     def test_double_enter(self, client, mock_subprocess, mock_uuid):
         """When enter_count=2, two Enter keys are sent after pasting."""
         client.send_keys("sess", "win", "hello", enter_count=2)
 
-        # cancel + load + paste + 2 Enter + delete
-        assert mock_subprocess.run.call_count == 6
+        # cancel + load + paste + 2 x (cancel + Enter) + delete
+        assert mock_subprocess.run.call_count == 8
         calls = payload_calls(mock_subprocess)
         # Both Enters
         assert calls[2] == call(
@@ -179,8 +181,8 @@ class TestSendKeys:
         msg = "X" * 50000
         client.send_keys("sess", "win", msg)
 
-        # Still exactly 5 subprocess calls — no chunking
-        assert mock_subprocess.run.call_count == 5
+        # Still exactly 6 subprocess calls — no chunking
+        assert mock_subprocess.run.call_count == 6
         load_call = payload_calls(mock_subprocess)[0]
         assert len(load_call[1]["input"]) == 50000
 


### PR DESCRIPTION
Closes #654. Supersedes #546 (adopted with credit — see below).

## What

1. **Enable the tmux `mouse` option on CAO sessions** (`create_session`). Without it, tmux forwards wheel events to the foreground application as Up/Down keys, so scrolling an agent TUI walks its input history instead of scrolling output. Session-level option — the user's other tmux sessions and global config are untouched. This part is adopted from #546 by @PlutoEr-001, whose PR identified the problem and the fix; they've been unreachable since early August (three options offered on the thread 08-07, week expired), so this carries their idea forward with credit.

2. **Cancel any active pane mode before every orchestrated send** (`send_keys`, `send_keys_via_paste`, `send_special_key`). This is the blocker that #654 documented against #546: with mouse on, copy mode becomes routine (any wheel scroll enters it), and a pane in a mode consumes `send-keys` through the mode's key table instead of delivering to the application.

## The failure mode, precisely (verified on tmux 3.4)

The earlier #546 thread described the paste as "swallowed"; the mechanism is a bit sharper than that:

- `paste-buffer` bytes DO reach the pty even in copy mode.
- What copy mode intercepts is the **`send-keys Enter` that submits** — it lands in the copy-mode key table (where Enter means copy-selection), not the application.
- So for a TUI: the handoff message text arrives in the composer, but submission never fires — the worker sits with a typed, unsubmitted message and the orchestration stalls. For canonical-mode readers the unterminated line never flushes either, which is why it presents as a total swallow.
- Same interception applies to control keys: a `C-c`/`C-d` sent via `send_special_key` into a scrolled pane is eaten.

Repro (deterministic, 3/3 runs each): pane running `cat > f`; `tmux copy-mode`; paste + Enter → 0 bytes delivered, pane still in mode. With `send-keys -X cancel` first → full delivery, mode exited.

## Why unconditional cancel (no pane-state check)

`send-keys -X cancel` on a pane **not** in a mode fails with "not in a mode" and delivers nothing to the application (verified) — so the guard needs no `#{pane_in_mode}` pre-check, and a pre-check would be a TOCTOU race anyway (the user can scroll between check and paste). `check=False`, stderr captured.

## Testing

- **Live e2e through the real `TmuxClient`** on tmux 3.4: session created with mouse on; pane put in copy mode; `send_keys` delivered `HANDOFF-MESSAGE-654\n` intact and exited the mode; `send_special_key("C-d")` through copy mode terminated the pane's `cat` (back to shell).
- **Unit tests**: new tests pin the cancel-first ordering in all three paths + the mouse option at session creation; mutation-checked — reverting the src change fails all five new/updated tests.
- `test_tmux_send_keys.py`'s positional assertions updated via a documented `payload_calls` helper (strips the pinned leading cancel) rather than magic-index shifts.
- Full suite: the only failures are the pre-existing agui/otel/fifo-ordering families, which fail identically on clean `main` with this change stashed (verified both ways). `black`/`isort`/`mypy` clean.

## Review notes

- CAO never enters copy mode intentionally anywhere in `src/`, so the cancel cannot break a legitimate flow.
- If maintainers prefer mouse-on behind a settings gate rather than default-on, that's a 3-line follow-up — kept default-on here since scroll-on-wheel matches every other terminal app users touch, and #546's review rounds didn't object to the default.
