### PR TITLE
fix(providers): route Hermes and status through backend

### DIFF
--- a/src/cli_agent_orchestrator/providers/cursor_cli.py
+++ b/src/cli_agent_orchestrator/providers/cursor_cli.py
@@ -289,8 +289,8 @@ class CursorCliProvider(BaseProvider):
         orchestration (handoff / assign) continues to work because the
         inbox / MCP tools are the same across all profiles.
 
-        Returns a properly escaped shell command string suitable for
-        :func:`tmux_client.send_keys`. Uses :func:`shlex.join` to handle
+        Returns a properly escaped shell command string suitable for the
+        configured terminal backend's ``send_keys`` method. Uses :func:`shlex.join` to handle
         multiline strings and special characters correctly.
         """
         profile = None

--- a/src/cli_agent_orchestrator/providers/hermes.py
+++ b/src/cli_agent_orchestrator/providers/hermes.py
@@ -6,7 +6,7 @@ import re
 import shlex
 from typing import Optional
 
-from cli_agent_orchestrator.clients.tmux import tmux_client
+from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.services.settings_service import get_server_settings
@@ -188,7 +188,7 @@ class HermesProvider(BaseProvider):
             raise TimeoutError(f"Shell initialization timed out after {init_timeout}s")
 
         command = self._build_hermes_command()
-        tmux_client.send_keys(self.session_name, self.window_name, command)
+        get_backend().send_keys(self.session_name, self.window_name, command)
 
         if not await wait_until_status(
             self.terminal_id,

--- a/src/cli_agent_orchestrator/providers/mock_cli.py
+++ b/src/cli_agent_orchestrator/providers/mock_cli.py
@@ -90,6 +90,14 @@ class MockCliProvider(BaseProvider):
 
     def get_status(self, buffer: str) -> TerminalStatus:
         """Pattern-match the binary's output buffer to determine current state."""
+        native = self._resolve_native_status(buffer)
+        if native is not None:
+            return native
+
+        # Herdr does not feed the StatusMonitor pipe buffer. BaseProvider's
+        # resolver reads the live pane history when native status is unknown,
+        # so the mock provider follows the same backend contract as real CLIs.
+        buffer = self._resolve_buffer(buffer)
         if not buffer:
             return TerminalStatus.UNKNOWN
 

--- a/test/providers/test_hermes_provider_unit.py
+++ b/test/providers/test_hermes_provider_unit.py
@@ -292,9 +292,9 @@ class TestHermesInitialization:
     @patch("cli_agent_orchestrator.providers.hermes.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.hermes.wait_until_status")
     @patch("cli_agent_orchestrator.providers.hermes.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.hermes.tmux_client")
+    @patch("cli_agent_orchestrator.providers.hermes.get_backend")
     async def test_initialize_success(
-        self, mock_tmux, mock_wait_shell, mock_wait_status, mock_load
+        self, mock_backend_factory, mock_wait_shell, mock_wait_status, mock_load
     ):
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = True
@@ -304,7 +304,7 @@ class TestHermesInitialization:
         result = await provider.initialize()
 
         assert result is True
-        mock_tmux.send_keys.assert_called_once_with(
+        mock_backend_factory.return_value.send_keys.assert_called_once_with(
             "sess", "win", "test-worker chat --yolo --accept-hooks --source cao"
         )
 
@@ -321,9 +321,9 @@ class TestHermesInitialization:
     @patch("cli_agent_orchestrator.providers.hermes.load_agent_profile")
     @patch("cli_agent_orchestrator.providers.hermes.wait_until_status")
     @patch("cli_agent_orchestrator.providers.hermes.wait_for_shell")
-    @patch("cli_agent_orchestrator.providers.hermes.tmux_client")
+    @patch("cli_agent_orchestrator.providers.hermes.get_backend")
     async def test_initialize_hermes_timeout(
-        self, mock_tmux, mock_wait_shell, mock_wait_status, mock_load
+        self, mock_backend_factory, mock_wait_shell, mock_wait_status, mock_load
     ):
         mock_wait_shell.return_value = True
         mock_wait_status.return_value = False

--- a/test/providers/test_native_status_shared.py
+++ b/test/providers/test_native_status_shared.py
@@ -30,6 +30,7 @@ from cli_agent_orchestrator.providers.claude_code import ClaudeCodeProvider
 from cli_agent_orchestrator.providers.codex import CodexProvider
 from cli_agent_orchestrator.providers.copilot_cli import CopilotCliProvider
 from cli_agent_orchestrator.providers.cursor_cli import CursorCliProvider
+from cli_agent_orchestrator.providers.grok_cli import GrokCliProvider
 from cli_agent_orchestrator.providers.hermes import HermesProvider
 from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
@@ -37,7 +38,6 @@ from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
 from cli_agent_orchestrator.providers.mock_cli import MockCliProvider
 from cli_agent_orchestrator.providers.omp import OmpProvider
 from cli_agent_orchestrator.providers.opencode_cli import OpenCodeCliProvider
-from cli_agent_orchestrator.providers.grok_cli import GrokCliProvider
 
 
 def _make(provider_cls):

--- a/test/providers/test_native_status_shared.py
+++ b/test/providers/test_native_status_shared.py
@@ -1,4 +1,4 @@
-"""Shared native-status (herdr backend) tests across all herdr-capable providers.
+"""Shared native-status (herdr backend) tests across all registered providers.
 
 Every provider's ``get_status()`` must consult the backend's native agent state
 before parsing its output buffer, because on the herdr backend ``pipe_pane`` is a
@@ -14,8 +14,9 @@ the None fall-through to buffer parsing on the tmux backend.
 
 ``claude_code`` keeps its own detailed suite (``TestClaudeCodeProviderNativeStatus``
 in test_claude_code_unit.py); it is included here for breadth alongside the
-providers that previously had no native-status coverage. ``q_cli`` and
-``gemini_cli`` are out of scope for the herdr backend and excluded.
+providers that previously had no native-status coverage. The credential-free
+``mock_cli`` provider is included too because it is a registered provider used
+by orchestration tests and must obey the same backend contract.
 """
 
 import time
@@ -32,12 +33,17 @@ from cli_agent_orchestrator.providers.cursor_cli import CursorCliProvider
 from cli_agent_orchestrator.providers.hermes import HermesProvider
 from cli_agent_orchestrator.providers.kimi_cli import KimiCliProvider
 from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
+from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
+from cli_agent_orchestrator.providers.mock_cli import MockCliProvider
 from cli_agent_orchestrator.providers.omp import OmpProvider
 from cli_agent_orchestrator.providers.opencode_cli import OpenCodeCliProvider
+from cli_agent_orchestrator.providers.grok_cli import GrokCliProvider
 
 
 def _make(provider_cls):
     """Construct a provider with the minimal args each constructor requires."""
+    if provider_cls is MockCliProvider:
+        return provider_cls("test1234", "test-session", "window-0")
     return provider_cls("test1234", "test-session", "window-0", "developer")
 
 
@@ -54,6 +60,9 @@ PROVIDERS = [
     pytest.param(AntigravityCliProvider, "_turns", id="antigravity_cli"),
     pytest.param(HermesProvider, None, id="hermes"),
     pytest.param(ClaudeCodeProvider, None, id="claude_code"),
+    pytest.param(GrokCliProvider, "_turns", id="grok_cli"),
+    pytest.param(MiniMaxCodeProvider, "_has_received_input", id="mcode"),
+    pytest.param(MockCliProvider, None, id="mock_cli"),
 ]
 
 


### PR DESCRIPTION
## Summary

- route Hermes startup commands through the configured terminal backend
- make MockCli follow the native-status and live-pane fallback contract
- expand native-status coverage to all registered providers covered by Herdr

## Tests

- `uv run pytest -q test/providers/test_hermes_provider_unit.py test/providers/test_native_status_shared.py`
- 178 passed