### PR TITLE
docs: the documented unit-test command selects the e2e tests it says it excludes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,10 +86,10 @@ Unit tests are fast and use mocked dependencies:
 
 ```bash
 # Run all unit tests (excludes E2E and integration tests)
-uv run pytest test/ --ignore=test/e2e -m "not integration" -v
+uv run pytest test/ --ignore=test/e2e -m "not e2e and not integration" -v
 
 # Run with coverage report
-uv run pytest test/ --ignore=test/e2e -m "not integration" --cov=src --cov-report=term-missing -v
+uv run pytest test/ --ignore=test/e2e -m "not e2e and not integration" --cov=src --cov-report=term-missing -v
 
 # Run specific test file
 uv run pytest test/providers/test_claude_code_unit.py -v
@@ -107,8 +107,13 @@ Integration tests require the provider CLI to be installed and authenticated:
 uv run pytest test/providers/test_kiro_cli_integration.py -v
 
 # Skip integration tests
-uv run pytest test/providers/ -m "not integration" -v
+uv run pytest test/providers/ -m "not e2e and not integration" -v
 ```
+
+A marker expression passed on the command line **replaces** the `-m 'not e2e'` in
+`addopts` (pyproject.toml) rather than adding to it, so every `-m` above spells out
+`not e2e` explicitly. Drop it and the 15 e2e-marked tests that live outside
+`test/e2e/` are selected — they need a running CAO server and a provider CLI.
 
 ### E2E Tests
 
@@ -125,14 +130,29 @@ uv run pytest -m e2e test/e2e/ -v -k codex
 ### Run All Tests
 
 ```bash
-# Run all tests
+# Run everything except E2E (the `addopts` in pyproject.toml deselects e2e by default)
 uv run pytest -v
 
-# Run tests with coverage for all modules
+# Same, with coverage for all modules
 uv run pytest --cov=src --cov-report=term-missing -v
 
 # Run tests in parallel (faster)
 uv run pytest -n auto
+```
+
+### What CI runs on your pull request
+
+Run this before opening a PR — it is the exact command in `.github/workflows/ci.yml`,
+and it is a strictly larger set than the unit-test command above:
+
+```bash
+uv run pytest test/ \
+  --ignore=test/providers/test_kiro_cli_integration.py \
+  --ignore=test/e2e \
+  -m "not e2e" \
+  --cov=src/cli_agent_orchestrator --cov-report=term-missing -v
+
+uv run python scripts/validate_markdown_links.py
 ```
 
 ### Test Markers


### PR DESCRIPTION
`DEVELOPMENT.md` § Unit Tests calls its command "fast and use mocked dependencies", but on a checkout without a provider CLI it errors out. The cause is a pytest detail rather than anything in the test suite: a marker expression passed on the command line **replaces** `addopts = "-m 'not e2e'"` from `pyproject.toml` instead of being ANDed with it.

## Measured on `ceab767` (macOS, `uv sync --all-extras --dev`, no provider CLI installed)

Documented command, before this PR:

```
uv run pytest test/ --ignore=test/e2e -m "not integration" -v
  -> 8079 collected
```

Of those, **all 15 e2e-marked tests that live outside `test/e2e/`** are selected — the `--ignore=test/e2e` only removes the directory, not the marker. CI's command selects **0** of the same 15. Running two of the affected files as the docs tell you to:

```
uv run pytest test/fixtures/test_cao_server.py test/test_command_catalog_matches_click.py -m "not integration"
  -> 18 passed, 1 error
  ERROR test/fixtures/test_cao_server.py::test_cao_terminal_create_and_get
  RuntimeError: POST /sessions failed: 400 {"detail":"Kiro engine 'v2' cannot start
  because 'kiro-cli' was not found. Install Kiro CLI or select another provider."}
```

That reads like a broken environment, and the section it comes from promises mocked dependencies.

The same command is also wrong in the other direction: it deselects **68 tests that CI does run** (integration-marked, not e2e-marked, outside the ignored kiro file). Those 68 are not environment-bound — the full integration-marked set runs clean here with nothing installed:

```
uv run pytest test/ --ignore=test/providers/test_kiro_cli_integration.py --ignore=test/e2e -m "integration and not e2e"
  -> 82 passed, 1 skipped in 27s
```

So somebody who follows the guide runs 15 tests that need a live server and skips 68 that will grade their PR.

## Change

Docs only, no source or workflow touched.

- Spell out `not e2e` in the three `-m` expressions in `DEVELOPMENT.md`, and add one sentence naming the `addopts` override so the next edit does not lose it again.
- Reword "Run all tests" for `uv run pytest -v`, which does not run all tests — with no `-m` on the command line, `addopts` applies and e2e is deselected.
- Add a **What CI runs on your pull request** block carrying the exact command from `.github/workflows/ci.yml`, since that is the set a PR is graded against.

## Verification

Every command as it now appears in the file, run here:

```
uv run pytest test/ --ignore=test/e2e -m "not e2e and not integration"      -> 8064 collected (the 15 leaked e2e tests are gone)
uv run pytest test/providers/ -m "not e2e and not integration"              -> 1481 collected
uv run pytest test/fixtures/... test/test_command_catalog_matches_click.py  -> 4 passed, 15 deselected   (was 18 passed, 1 error)
uv run python scripts/validate_markdown_links.py                            -> exit 0
```

And the CI command the new block documents, end to end on this branch:

```
8110 passed, 36 skipped, 15 deselected, 1 xfailed in 338s
```

I did not touch `pyproject.toml`. Making `addopts` and the docs agree at the source — a `-m` that composes, or a make target both CI and the guide call — would remove the second copy of this list entirely, but that is a bigger change than the one this PR is about; happy to open it separately if you want it.
