### PR TITLE
test(tmux): wait for the server to exit before asserting the absence

### DIFF
--- a/test/clients/test_tmux_session_exists_strict.py
+++ b/test/clients/test_tmux_session_exists_strict.py
@@ -259,11 +259,18 @@ class TestConfirmedAnswers:
         """
         _start_session(tmux_socket, "cao-alive")
         client = _client_on(tmux_socket)
+        server_pid = _server_pid(tmux_socket)
         assert client.session_exists_strict("cao-alive") is True
 
         subprocess.run(
             ["tmux", "-S", str(tmux_socket), "kill-server"], capture_output=True, check=True
         )
+        # kill-server returns once the kill is delivered, not once the server is
+        # gone. A list-sessions that connects while it is still tearing down is
+        # answered "server exited unexpectedly", which is neither of the markers
+        # this vector is meant to exercise, so the lookup fails closed and the
+        # test flakes. Wait for the process the way every other kill here does.
+        assert _wait_until(lambda: not _process_is_alive(server_pid))
 
         assert client.session_exists_strict("cao-alive") is False
 


### PR DESCRIPTION
Fixes #681. I filed that one from a machine with no tmux and said the mechanism was read off the classifier rather than observed. It is observed now, so here is the evidence and the fix.

### Reproducing it

`kill-server` returns once the kill is delivered, not once the server has exited. Driving that race directly on tmux 3.4, 300 iterations with the CPUs saturated:

```
no server running:           282
server exited unexpectedly:   18
```

6% of the time `list-sessions` connects while the server is still tearing down and gets the second message. It is in neither `_NO_SERVER_STDERR_MARKERS` nor `_SOCKET_MISSING_STDERR_MARKERS`, so `_classify_session_lookup` raises, which is the classifier doing exactly what it should with wording it does not recognise.

Through the test itself, same load, on `main`:

```
FAILURES UNDER LOAD: 2 / 25
```

```
>       assert client.session_exists_strict("cao-alive") is False
test/clients/test_tmux_session_exists_strict.py:268:
src/cli_agent_orchestrator/clients/tmux.py:1427: in session_exists_strict
    return self._classify_session_lookup(session_name)
E   TmuxLookupError: could not determine whether tmux session 'cao-alive' exists:
E   list-sessions exited 1 (server exited unexpectedly)
```

Idle, it passed 40/40, which is why it only shows up on CI.

### The fix

The assumption is in the test, not the classifier. The `kill-server` vector can produce either message depending on how far the shutdown got, and the test asserts on one of them.

`test_server_shut_down_under_us_is_a_confirmed_absence` turns out to be the only test in this file that kills a server and then asserts on the result without waiting for the process. Three others already gate on `_wait_until(lambda: not _process_is_alive(server_pid))` before their assertion, `test_unlinked_socket_with_a_dead_server_is_a_confirmed_absence` being the closest parallel. So this uses the helpers already in the file rather than adding anything.

(Corrected: an earlier version of this paragraph said "the six others", which conflated the seven tests that capture `_server_pid` with the three that gate on the wait. The rest capture the pid for cleanup or for a liveness assertion instead. Thanks to @gutosantos82 for checking the count rather than taking it.)

I did not add `server exited unexpectedly` to `_NO_SERVER_STDERR_MARKERS`, which would also turn the job green. A dropped connection does not prove the server held no sessions, so it widens "confirmed absence" in the direction #498 deliberately narrowed, and the file's own warning argues against growing those tables from one version's observed output.

### Tests

Ubuntu 24.04, tmux 3.4, Python 3.12, all with 16 busy loops running to force the race.

| | before | after |
| --- | --- | --- |
| the one test, under load | 2 failures / 25 | **0 failures / 60** |

Whole file under load: `26 passed, 1 skipped`. `black --check` and `isort --check-only` clean on the touched file.

I have not reproduced the original CI failure on 3.11 specifically; the runs above are 3.12. The race is in tmux's shutdown rather than in anything version-dependent, and the CI job that failed was 3.11 only because that leg happened to lose the race.

