### PR TITLE
docs: add a contributor blog to the documentation site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,87 @@ to catch secrets before they enter a commit. If a secret ever lands, follow the
 severity triage table.
 
 
+## Writing a blog post
+
+The documentation site has a [blog](https://awslabs.github.io/cli-agent-orchestrator/blog)
+for content that doesn't fit the reference docs: tutorials, design deep dives,
+and accounts of using CAO on real work. Posts live in `docusaurus/blog/` and go
+through normal pull request review.
+
+**In scope:** tutorials and how-tos, deep dives on how a subsystem works,
+orchestration patterns composed into something real, provider or MCP integration
+write-ups, and case studies — including the parts that didn't work.
+
+**Out of scope:** release announcements (`CHANGELOG.md` and GitHub Releases
+already cover those, and we deliberately don't mirror them here) and product
+marketing.
+
+**Editorial review:** [@haofeif](https://github.com/haofeif) (Haofei Feng) owns
+editorial review for the blog — request their review on your PR. The build
+enforces structure, but whether a post is worth publishing, and whether it reads
+well, is their call. If you're unsure an idea fits, ask in a
+[discussion](https://github.com/awslabs/cli-agent-orchestrator/discussions)
+before you write; that's a cheaper conversation than a rejected draft.
+
+To add a post:
+
+1. Create `docusaurus/blog/YYYY-MM-DD-short-slug/index.md`. Use a *directory*
+   rather than a bare `.md` file so images sit next to the post and can be
+   referenced relatively (`![alt](./diagram.png)`).
+2. Add front matter — `title`, `authors`, and optionally `tags`, `slug`,
+   `description`, `image`:
+
+   ```yaml
+   ---
+   title: Orchestrating a three-agent review pipeline
+   authors: [your-github-handle]
+   tags: [tutorial, orchestration-patterns]
+   description: One sentence for search results and social previews.
+   ---
+   ```
+
+3. Make sure you have an entry in [`docusaurus/blog/authors.yml`](docusaurus/blog/authors.yml)
+   — several contributors are already seeded there from public GitHub profile
+   data, so check before adding a duplicate, and correct your own name, title, or
+   avatar if the seeded values aren't what you'd want on a byline. The build
+   **fails** on an author with no entry, so this isn't optional. That file's
+   comments also cover the optional per-author listing page.
+4. Pick tags from [`docusaurus/blog/tags.yml`](docusaurus/blog/tags.yml). The
+   build **fails** on an unlisted tag; adding a new one is fine, just do it in
+   the same PR and say why. A post with no tags is also fine.
+5. Put `{/* truncate */}` after the first paragraph or two. Everything above it
+   becomes the summary on the blog index, and it must stand on its own. The build
+   **fails** without it. Use that MDX comment form, not the HTML `<!-- -->` one —
+   this site processes `.md` as MDX, where HTML comments are a syntax error.
+6. Verify locally before pushing:
+
+   ```bash
+   cd docusaurus
+   npm install
+   npm run build   # onBrokenLinks: 'throw' — a dead link fails the build
+   npm run serve   # preview the built site
+   ```
+
+Style notes, mostly borrowed from how other AWS open source projects run their
+blogs:
+
+* Write for a global audience — skip regional slang and idioms.
+* Avoid "easy" and "simple"; describe what a step actually involves instead.
+* Avoid absolute claims ("always", "never", "guarantees") and comparisons against
+  other products.
+* Run every command and code sample against a released version before you publish
+  it, and say which version you used.
+* Link to documentation pages by site route — `[handoff](/docs/patterns/handoff)`,
+  not a relative `../../docs/patterns/handoff.md` path, which Docusaurus can't
+  resolve from a blog post. `scripts/validate_markdown_links.py` skips
+  `docusaurus/blog/` for that reason; the site build is what checks these links.
+* Give images alt text, and don't include screenshots containing personal data —
+  the same scrubbing rules as test fixtures apply.
+
+Your post is contributed under the repository's Apache-2.0 license, like any
+other change.
+
+
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 

--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -29,6 +29,18 @@ This generates static content into the `build` directory.
 3. Run `npm run build` to verify there are no broken links
 4. Submit a PR — the site auto-deploys when changes merge to `main`
 
+## Adding a blog post
+
+Posts live in `blog/`, one directory per post
+(`blog/YYYY-MM-DD-short-slug/index.md`). Authors and tags are registries rather
+than free-form front matter: the build fails on an author missing from
+`blog/authors.yml`, a tag missing from `blog/tags.yml`, or a post with no
+`{/* truncate */}` marker.
+
+See [Writing a blog post](../CONTRIBUTING.md#writing-a-blog-post) for the full
+process and style rules.
+
+
 ## Deploying on a fork
 
 The `Docs site` workflow (`.github/workflows/gh-pages.yml`) always builds the
@@ -64,6 +76,9 @@ docusaurus/
 │   ├── features/
 │   ├── guides/
 │   └── reference/
+├── blog/                  # Blog posts, one directory per post
+│   ├── authors.yml        # Registry of blog authors (enforced at build time)
+│   └── tags.yml           # Registry of blog tags (enforced at build time)
 ├── course-src/            # Interactive course sources (assembled into static/)
 │   ├── build.sh           # Concatenates each course into a single page
 │   ├── shared/            # styles.css + main.js shared by both courses

--- a/docusaurus/blog/2026-08-26-welcome-to-the-cao-blog/index.md
+++ b/docusaurus/blog/2026-08-26-welcome-to-the-cao-blog/index.md
@@ -1,0 +1,56 @@
+---
+slug: welcome
+title: Welcome to the CAO blog
+authors: [cao-maintainers]
+tags: [community]
+description: Why this blog exists, what belongs here, and how to publish a post.
+---
+
+The reference documentation tells you what CAO does. It's a poor fit for the
+other half of the story — the walkthrough that takes an hour, the design
+decision that needs three diagrams to justify, the write-up of an orchestration
+that worked on real work and the two that didn't. This blog is where that goes.
+
+Anyone who contributes to CLI Agent Orchestrator can publish here. Posts live in
+`docusaurus/blog/` and ship through the same pull request review as the rest of
+the repository.
+
+{/* truncate */}
+
+## What belongs here
+
+- **Tutorials and how-tos** — a task followed end to end, with commands a reader
+  can run.
+- **Deep dives** — how a subsystem works and why it's built that way. Sessions,
+  the MCP server, and provider adapters all have more depth than their reference
+  pages carry.
+- **Orchestration patterns in practice** — [handoff](/docs/patterns/handoff),
+  [assign](/docs/patterns/assign), and
+  [send-message](/docs/patterns/send-message) composed into something real.
+- **Case studies** — what you built, what it cost, and where it fell over. The
+  failures are the useful part.
+
+## What doesn't
+
+**Release announcements.** [`CHANGELOG.md`][changelog] and
+[GitHub Releases][releases] already carry them, and a blog that mirrors a
+changelog becomes a stale changelog. We're deliberately not doing that.
+
+**Marketing.** No product pitches, no competitor comparisons, no claims a reader
+can't verify from the repository.
+
+## Publishing a post
+
+The [contributing guide][contributing] has the mechanics: the file layout, the
+front matter, registering yourself in `blog/authors.yml`, and the style rules the
+build enforces. The short version is that a post is a directory, a Markdown
+file, and a pull request.
+
+If you're not sure whether an idea fits, open a
+[discussion][discussions] and ask before you write. It's a cheaper conversation
+than a rejected draft.
+
+[changelog]: https://github.com/awslabs/cli-agent-orchestrator/blob/main/CHANGELOG.md
+[releases]: https://github.com/awslabs/cli-agent-orchestrator/releases
+[contributing]: https://github.com/awslabs/cli-agent-orchestrator/blob/main/CONTRIBUTING.md#writing-a-blog-post
+[discussions]: https://github.com/awslabs/cli-agent-orchestrator/discussions

--- a/docusaurus/blog/authors.yml
+++ b/docusaurus/blog/authors.yml
@@ -1,0 +1,90 @@
+# Blog authors, referenced by key from a post's `authors:` front matter.
+#
+# `onInlineAuthors: 'throw'` in docusaurus.config.ts means every author a post
+# names MUST have an entry here. That is deliberate: author identities get
+# reviewed in a PR instead of being invented per post. Add only details you're
+# happy to publish under Apache-2.0.
+#
+# A post credits one or more people with `authors: [handle-one, handle-two]`.
+#
+# To add yourself, copy this template and use your GitHub handle as the key:
+#
+#   your-github-handle:
+#     name: Your Name
+#     title: Your role or affiliation
+#     url: https://github.com/your-github-handle
+#     image_url: https://github.com/your-github-handle.png
+#     socials:
+#       github: your-github-handle
+#
+# Optional `page:` gives you a listing page of everything you've written, and
+# adds you to the /blog/authors index. Leave it off until you've published a
+# post — otherwise you get a reachable page reading "This author has not written
+# any posts yet" and a 0 next to your name on the index. When you do add it:
+#
+#     page: true                          # -> /blog/authors/your-github-handle
+#
+# One gotcha: Docusaurus slugifies the key at letter/digit boundaries, so
+# `handle82` becomes `/blog/authors/handle-82`. Set the URL explicitly to avoid
+# that — the permalink is relative to /blog/authors, not the site root:
+#
+#     page:
+#       permalink: /handle82                # -> /blog/authors/handle82
+#
+# Entry order is intentional, not alphabetical: the /blog/authors index lists
+# authors in this file's order. Append rather than re-sorting.
+#
+# The entries below are seeded, with names taken from the contributor's public
+# GitHub profile or supplied by them directly. Edit your own freely — it's your
+# byline. `title` is deliberately left blank rather than guessed; fill in your
+# own if you want one, bearing in mind that naming an employer there reads as an
+# affiliation claim on an awslabs site.
+
+cao-maintainers:
+  name: CAO Maintainers
+  title: CLI Agent Orchestrator team
+  url: https://github.com/awslabs/cli-agent-orchestrator
+  image_url: https://github.com/awslabs.png
+  page: true
+
+haofeif:
+  name: Haofei Feng
+  url: https://github.com/haofeif
+  image_url: https://github.com/haofeif.png
+  socials:
+    github: haofeif
+
+fanhongy:
+  name: Stan Fan
+  url: https://github.com/fanhongy
+  image_url: https://github.com/fanhongy.png
+  socials:
+    github: fanhongy
+
+anilkmr-a2z:
+  name: Anil Kumar
+  url: https://github.com/anilkmr-a2z
+  image_url: https://github.com/anilkmr-a2z.png
+  socials:
+    github: anilkmr-a2z
+
+gutosantos82:
+  name: Augusto Dias
+  url: https://github.com/gutosantos82
+  image_url: https://github.com/gutosantos82.png
+  socials:
+    github: gutosantos82
+
+sujoydc:
+  name: Sujoy Datta Choudhury
+  url: https://github.com/sujoydc
+  image_url: https://github.com/sujoydc.png
+  socials:
+    github: sujoydc
+
+guojing1217:
+  name: Joe Guo
+  url: https://github.com/guojing1217
+  image_url: https://github.com/guojing1217.png
+  socials:
+    github: guojing1217

--- a/docusaurus/blog/tags.yml
+++ b/docusaurus/blog/tags.yml
@@ -1,0 +1,41 @@
+# Predefined blog tags.
+#
+# `onInlineTags: 'throw'` in docusaurus.config.ts means a post can only use tags
+# listed here, which keeps the taxonomy small instead of growing a near-duplicate
+# tag per post. Needing a new tag is fine — add it in the same PR and explain why
+# in the PR description. Posts may also carry no tags at all.
+
+tutorial:
+  label: Tutorial
+  permalink: /tutorial
+  description: Step-by-step walkthroughs of a task you can follow end to end.
+
+deep-dive:
+  label: Deep dive
+  permalink: /deep-dive
+  description: How something works under the hood, and why it was built that way.
+
+orchestration-patterns:
+  label: Orchestration patterns
+  permalink: /orchestration-patterns
+  description: Working with handoff, assign, and send-message in real workflows.
+
+providers:
+  label: Providers
+  permalink: /providers
+  description: Running CAO against a specific CLI agent provider.
+
+mcp:
+  label: MCP
+  permalink: /mcp
+  description: The CAO MCP server, and integrating CAO with other MCP clients.
+
+case-study:
+  label: Case study
+  permalink: /case-study
+  description: An account of using CAO on real work, including what didn't work.
+
+community:
+  label: Community
+  permalink: /community
+  description: Project news, contributor spotlights, and events.

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -39,7 +39,32 @@ const config: Config = {
           editUrl:
             'https://github.com/awslabs/cli-agent-orchestrator/tree/main/docusaurus/',
         },
-        blog: false,
+        blog: {
+          blogTitle: 'CAO Blog',
+          blogDescription:
+            'Tutorials, deep dives, and community stories about orchestrating multi-agent CLI workflows.',
+          blogSidebarTitle: 'Recent posts',
+          blogSidebarCount: 'ALL',
+          postsPerPage: 10,
+          showReadingTime: true,
+          editUrl:
+            'https://github.com/awslabs/cli-agent-orchestrator/tree/main/docusaurus/',
+          feedOptions: {
+            type: ['rss', 'atom'],
+            title: 'CAO Blog',
+            description:
+              'Tutorials, deep dives, and community stories about CLI Agent Orchestrator.',
+            copyright: `Copyright © ${new Date().getFullYear()} Amazon.com, Inc. or its affiliates.`,
+            xslt: true,
+          },
+          // Contributors must register in blog/authors.yml and pick a tag from
+          // blog/tags.yml, so both go through PR review instead of accumulating
+          // one-off values. A missing truncate marker dumps a whole post onto
+          // the list page, so that fails the build too. See CONTRIBUTING.md.
+          onInlineAuthors: 'throw',
+          onInlineTags: 'throw',
+          onUntruncatedBlogPosts: 'throw',
+        },
         theme: {
           customCss: './src/css/custom.css',
         },
@@ -63,6 +88,11 @@ const config: Config = {
         {
           href: 'pathname:///course/index.html',
           label: 'Interactive Course',
+          position: 'left',
+        },
+        {
+          to: '/blog',
+          label: 'Blog',
           position: 'left',
         },
         {
@@ -91,6 +121,10 @@ const config: Config = {
         {
           title: 'Community',
           items: [
+            {
+              label: 'Blog',
+              to: '/blog',
+            },
             {
               label: 'GitHub Discussions',
               href: 'https://github.com/awslabs/cli-agent-orchestrator/discussions',

--- a/src/cli_agent_orchestrator/utils/markdown_links.py
+++ b/src/cli_agent_orchestrator/utils/markdown_links.py
@@ -22,6 +22,10 @@ _EXCLUDED_PREFIXES = (
     Path("src/cli_agent_orchestrator/skills"),
     Path("test/fixtures"),
     Path("test/providers/fixtures"),
+    # Blog posts link to documentation pages by rendered site route
+    # (/docs/patterns/handoff), which has no repository path. Docusaurus
+    # validates those links at build time with onBrokenLinks: 'throw'.
+    Path("docusaurus/blog"),
 )
 _EXCLUDED_FILES = (
     # This profile contains a literal, generic README template with deliberately

--- a/test/utils/test_markdown_links.py
+++ b/test/utils/test_markdown_links.py
@@ -377,3 +377,23 @@ def test_discovers_tracked_markdown_and_excludes_vendored_and_fixture_trees(
     )
 
     assert discover_markdown_files(tmp_path) == [tmp_path / "README.md"]
+
+
+def test_discovery_excludes_blog_posts_that_link_by_site_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(tmp_path / "README.md", "# Maintained\n")
+    _write(
+        tmp_path / "docusaurus" / "blog" / "2026-01-01-post" / "index.md",
+        "# Post\n\n[handoff](/docs/patterns/handoff)\n",
+    )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.utils.markdown_links.subprocess.run",
+        lambda *args, **kwargs: type(
+            "Completed",
+            (),
+            {"stdout": "README.md\ndocusaurus/blog/2026-01-01-post/index.md\n"},
+        )(),
+    )
+
+    assert discover_markdown_files(tmp_path) == [tmp_path / "README.md"]


### PR DESCRIPTION
Enables the Docusaurus blog plugin (bundled but disabled until now) so contributors can publish tutorials, deep dives, and case studies alongside the reference docs.

`onInlineAuthors`, `onInlineTags`, and `onUntruncatedBlogPosts` are all set to `throw`, so an unregistered author, an ad-hoc tag, or a missing summary marker fails the build instead of landing quietly. Authors and tags live in reviewed registries (`blog/authors.yml`, `blog/tags.yml`); six contributors are seeded from public profile data with `title` left blank.

Release announcements are explicitly out of scope — `CHANGELOG.md` and GitHub Releases already cover them.

Includes a "Writing a blog post" section in CONTRIBUTING.md, RSS/Atom feeds, navbar and footer links, and one welcome post.

No workflow changes needed: `gh-pages.yml` already triggers on `docusaurus/**`. `npm run build` passes clean.