### PR TITLE
test: centralize contributor suite selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Run unit tests with coverage
         run: |
+          # CI intentionally includes integration-marked tests except for the Kiro
+          # provider test, which requires an authenticated external CLI.
           uv run pytest test/ \
             --ignore=test/providers/test_kiro_cli_integration.py \
             --ignore=test/e2e \

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,7 +104,7 @@ Integration tests require the provider CLI to be installed and authenticated:
 
 ```bash
 # Run integration tests for a specific provider (example: Kiro CLI)
-uv run pytest test/providers/test_kiro_cli_integration.py -v
+uv run pytest test/providers/test_kiro_cli_integration.py -m integration -v
 
 # Skip integration tests
 uv run pytest test/providers/ -v
@@ -114,6 +114,8 @@ The default pytest configuration is the contributor unit-suite entry point and o
 the marker selection. A regression test keeps integration tests and the 15 e2e-marked
 tests outside `test/e2e/` out of that suite. A command-line `-m` replaces the configured
 marker rather than composing with it, so use plain `uv run pytest` for this suite.
+For the same reason, running an integration suite requires opting back into its
+excluded marker explicitly with `-m integration`.
 
 ### E2E Tests
 
@@ -317,7 +319,7 @@ which kiro
 kiro --help
 
 # Run that provider's integration tests
-uv run pytest test/providers/test_kiro_cli_integration.py -v
+uv run pytest test/providers/test_kiro_cli_integration.py -m integration -v
 ```
 
 The same pattern applies to every provider that ships an `<provider>_integration.py` file — substitute the binary and the test filename.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,10 +86,10 @@ Unit tests are fast and use mocked dependencies:
 
 ```bash
 # Run all unit tests (excludes E2E and integration tests)
-uv run pytest test/ --ignore=test/e2e -m "not e2e and not integration" -v
+uv run pytest -v
 
 # Run with coverage report
-uv run pytest test/ --ignore=test/e2e -m "not e2e and not integration" --cov=src --cov-report=term-missing -v
+uv run pytest --cov=src --cov-report=term-missing -v
 
 # Run specific test file
 uv run pytest test/providers/test_claude_code_unit.py -v
@@ -107,13 +107,13 @@ Integration tests require the provider CLI to be installed and authenticated:
 uv run pytest test/providers/test_kiro_cli_integration.py -v
 
 # Skip integration tests
-uv run pytest test/providers/ -m "not e2e and not integration" -v
+uv run pytest test/providers/ -v
 ```
 
-A marker expression passed on the command line **replaces** the `-m 'not e2e'` in
-`addopts` (pyproject.toml) rather than adding to it, so every `-m` above spells out
-`not e2e` explicitly. Drop it and the 15 e2e-marked tests that live outside
-`test/e2e/` are selected — they need a running CAO server and a provider CLI.
+The default pytest configuration is the contributor unit-suite entry point and owns
+the marker selection. A regression test keeps integration tests and the 15 e2e-marked
+tests outside `test/e2e/` out of that suite. A command-line `-m` replaces the configured
+marker rather than composing with it, so use plain `uv run pytest` for this suite.
 
 ### E2E Tests
 
@@ -243,10 +243,12 @@ Add or update tests in `test/`
 
 ```bash
 # Run unit tests (fast, excludes E2E and integration)
-uv run pytest test/ --ignore=test/e2e -m "not integration" -v
+uv run pytest -v
 
-# Run all tests with coverage
-uv run pytest test/ --ignore=test/e2e --cov=src --cov-report=term-missing -v
+# Run the larger CI suite with coverage (see the exact command above)
+uv run pytest test/ --ignore=test/providers/test_kiro_cli_integration.py \
+  --ignore=test/e2e -m "not e2e" --cov=src/cli_agent_orchestrator \
+  --cov-report=term-missing -v
 ```
 
 ### 5. Check Code Quality

--- a/cao_mcp_apps/.husky/pre-push
+++ b/cao_mcp_apps/.husky/pre-push
@@ -11,11 +11,11 @@ cd "$(dirname "$0")/.."
 
 echo "[pre-push] Python unit tests"
 if command -v uv >/dev/null 2>&1; then
-  uv run --project .. pytest ../test -m "not e2e" -q --disable-warnings || exit 1
+  uv run --project .. pytest -q --disable-warnings || exit 1
 elif command -v python >/dev/null 2>&1 && python -c "import pytest" >/dev/null 2>&1; then
-  python -m pytest ../test -m "not e2e" -q --disable-warnings || exit 1
+  (cd .. && python -m pytest -q --disable-warnings) || exit 1
 elif command -v python3 >/dev/null 2>&1 && python3 -c "import pytest" >/dev/null 2>&1; then
-  python3 -m pytest ../test -m "not e2e" -q --disable-warnings || exit 1
+  (cd .. && python3 -m pytest -q --disable-warnings) || exit 1
 else
   echo "[pre-push] skipping python tests: no uv/pytest runner on PATH"
 fi

--- a/cao_mcp_apps/.husky/pre-push
+++ b/cao_mcp_apps/.husky/pre-push
@@ -11,7 +11,7 @@ cd "$(dirname "$0")/.."
 
 echo "[pre-push] Python unit tests"
 if command -v uv >/dev/null 2>&1; then
-  uv run --project .. pytest -q --disable-warnings || exit 1
+  (cd .. && uv run pytest -q --disable-warnings) || exit 1
 elif command -v python >/dev/null 2>&1 && python -c "import pytest" >/dev/null 2>&1; then
   (cd .. && python -m pytest -q --disable-warnings) || exit 1
 elif command -v python3 >/dev/null 2>&1 && python3 -c "import pytest" >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,4 +337,4 @@ testpaths = ["test"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "--cov=src --cov-report=term-missing -m 'not e2e'"
+addopts = "--cov=src --cov-report=term-missing -m 'not e2e and not integration'"

--- a/test/test_suite_selection.py
+++ b/test/test_suite_selection.py
@@ -1,0 +1,58 @@
+"""Regression tests for the named contributor and CI Python suites."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _collect(path: Path, *args: str) -> str:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(path),
+            "-c",
+            str(REPO_ROOT / "pyproject.toml"),
+            "--collect-only",
+            "-q",
+            "--no-cov",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result.stdout
+
+
+def test_contributor_and_ci_suites_keep_their_intentional_difference(tmp_path: Path) -> None:
+    regression = tmp_path / "test_selection.py"
+    regression.write_text(
+        "import pytest\n\n"
+        "def test_unit():\n"
+        "    pass\n\n"
+        "@pytest.mark.integration\n"
+        "def test_integration():\n"
+        "    pass\n\n"
+        "@pytest.mark.e2e\n"
+        "def test_e2e_outside_e2e_directory():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    contributor = _collect(regression)
+    ci = _collect(regression, "-m", "not e2e")
+
+    assert "test_unit" in contributor
+    assert "test_integration" not in contributor
+    assert "test_e2e_outside_e2e_directory" not in contributor
+    assert "test_unit" in ci
+    assert "test_integration" in ci
+    assert "test_e2e_outside_e2e_directory" not in ci

--- a/test/test_suite_selection.py
+++ b/test/test_suite_selection.py
@@ -49,6 +49,7 @@ def test_contributor_and_ci_suites_keep_their_intentional_difference(tmp_path: P
 
     contributor = _collect(regression)
     ci = _collect(regression, "-m", "not e2e")
+    integration = _collect(regression, "-m", "integration")
 
     assert "test_unit" in contributor
     assert "test_integration" not in contributor
@@ -56,3 +57,6 @@ def test_contributor_and_ci_suites_keep_their_intentional_difference(tmp_path: P
     assert "test_unit" in ci
     assert "test_integration" in ci
     assert "test_e2e_outside_e2e_directory" not in ci
+    assert "test_unit" not in integration
+    assert "test_integration" in integration
+    assert "test_e2e_outside_e2e_directory" not in integration


### PR DESCRIPTION
Closes #680.

## What changed

- Makes the default pytest configuration the single entry point for the contributor unit suite: it excludes both `e2e` and `integration` markers.
- Makes `DEVELOPMENT.md` and the pre-push hook invoke that configured suite instead of copying marker expressions.
- Keeps the CI suite intentionally larger. Its workflow comment explains why it runs integration-marked tests while excluding the authenticated Kiro provider test and all e2e tests.
- Adds a subprocess-level regression test with unit, integration, and e2e-marked cases in the same file outside `test/e2e/`. It proves the default contributor suite selects only the unit case, while the CI marker selects unit + integration and still excludes e2e.

This keeps the two intended suites distinct without requiring synchronized edits across config, docs, and three hook fallback branches.

## Verification

- `uv run pytest test/test_suite_selection.py -q --no-cov` — 1 passed
- Mutation: restoring the old `-m 'not e2e'` default makes the new regression test fail because it collects the integration case
- `uv run black --check test/test_suite_selection.py`
- `uv run isort --check-only test/test_suite_selection.py`
- `uv run python scripts/validate_markdown_links.py`
- `sh -n cao_mcp_apps/.husky/pre-push`

AI tooling assisted with the implementation. I reviewed the diff, ran the commands above, and can explain or revise each part.
