### PR TITLE
fix(install): validate and contain filesystem paths derived from profile names (GHSA-6m35-gcf5-xm75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   isolated per-terminal MCP configuration, native hard tool restrictions,
   multi-turn TUI support, orchestration e2e coverage, and provider docs.
 
+### Security
+
+- **Path traversal in `cao install` (GHSA-6m35-gcf5-xm75, CWE-22/CWE-73, high).**
+  `cao install` derived the shared context-copy filename — and the per-provider
+  agent-file names — from a profile's *resolved* frontmatter `name:`. That value
+  is not covered by the install source-handle validation and is
+  attacker-controlled for URL installs, so a profile whose `name:` contained a
+  `../` traversal or an absolute path could overwrite an arbitrary `.md` file the
+  invoking user can write. Because `.md` is the trusted-instruction format across
+  this ecosystem, reachable targets included the user's own agent profiles and
+  global agent-instruction files, after which an agent run would follow
+  attacker-authored instructions with that agent's tool permissions. Reachable
+  from the CLI and from `POST /agents/profiles/install`. Affects 2.2.0–2.4.1.
+
+  The resolved name is now validated as a single path segment through the shared
+  `utils/path_validation.validate_path_component`, the write is confined to
+  `AGENT_CONTEXT_DIR` and opened with `O_NOFOLLOW` (POSIX) so it cannot be
+  redirected through a symlink, and the context copy is created mode `0o600`. The
+  provider agent-file sinks now flatten both `/` and `\` via a shared
+  `flatten_path_separators` helper, closing the class on Windows as well.
+
+  **Behavior change:** a profile whose frontmatter `name:` contains a path
+  separator is no longer installable. Such names only ever worked when the
+  intermediate context directory happened to already exist, and permitting them
+  is what allowed the traversal. Rename the profile to a plain identifier
+  (`[A-Za-z0-9._-]`) to install it.
+
 ### Fixed
 
 - tmux listing parse failures are retried once and reported as a distinct condition instead of surfacing as a bare `ValueError` that reads like "session not found" one layer up. libtmux 0.53.1+ zips `parse_output`'s fields with `strict=True`, so any short row (a pane or session vanishing mid-listing, or trailing fields tmux omits) raised `ValueError: zip() argument 2 is shorter than argument 1` — which propagated through `server.sessions`/`window.panes`, blocked launches outright, and left the pipe-liveness watchdog unable to tell a genuinely-gone session from a transient parse failure. Adds `TmuxLookupError` and routes the listing reads in `clients/tmux.py` through a single retry-and-classify wrapper; a failed `create_session` no longer leaves an orphaned tmux session that blocks relaunching the same name. Also caps `libtmux<0.53.1`, the last release that zips non-strict (caom-anv)

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -2,9 +2,7 @@
 
 import errno
 import logging
-import ntpath
 import os
-import posixpath
 import re
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple
@@ -43,6 +41,10 @@ from cli_agent_orchestrator.utils.opencode_config import (
     upsert_mcp_server,
 )
 from cli_agent_orchestrator.utils.opencode_permissions import cao_tools_to_opencode_permission
+from cli_agent_orchestrator.utils.path_validation import (
+    flatten_path_separators,
+    validate_path_component,
+)
 from cli_agent_orchestrator.utils.skill_injection import compose_agent_prompt
 from cli_agent_orchestrator.utils.tool_mapping import resolve_allowed_tools
 
@@ -221,80 +223,63 @@ def parse_env_assignment(env_assignment: str) -> Tuple[str, str]:
     return key, value
 
 
-def _contained_context_path(agent_name: str) -> Path:
-    """Resolve the context-copy path for ``agent_name``, refusing any escape.
+def _write_context_file(agent_name: str, raw_content: str) -> Path:
+    """Write the unresolved profile source to the shared context directory.
 
     The context copy's filename derives from the profile's RESOLVED frontmatter
     ``name:``. That value is NOT covered by ``_PROFILE_NAME_RE`` -- that regex
     validates the install *source handle* (the URL stem / bare-name argument),
     not the resolved name -- and a profile can be installed straight from a URL,
-    so the field is attacker-controlled. Without this guard a name like
-    ``../../foo`` or an absolute path steers the write outside
-    ``AGENT_CONTEXT_DIR``.
+    so the field is attacker-controlled. Without a guard, a name like
+    ``../../foo`` or an absolute path steers this write outside
+    ``AGENT_CONTEXT_DIR`` and can overwrite a trusted ``.md`` instruction file.
 
-    Two layers, mirroring ``services/profile_store._profile_path``:
+    Three layers, all in this function (see the barrier note below):
 
-    1. Validate the name is a single path segment -- reject empty, ``.``/``..``,
-       any ``/`` or ``\\`` separator, a NUL, or an absolute path (POSIX or
-       Windows). A profile ``name:`` is a plain filename here.
-    2. Canonical containment at the sink: resolve the full candidate and confirm
-       it stays inside the realpath of ``AGENT_CONTEXT_DIR``. This is defence in
-       depth -- it also refuses a target that resolves outside via a symlinked
-       component -- kept as a positive ``startswith`` guard dominating the
-       return so CodeQL recognises it as a path-injection barrier.
+    1. ``validate_path_component`` -- the shared segment validator, which rejects
+       empty, ``.``/``..``, NUL, every path separator, and anything outside
+       ``[A-Za-z0-9._-]``. The allowlist also makes Unicode normalization a
+       non-issue: a fullwidth solidus (U+FF0F) is rejected outright rather than
+       having to be caught before it folds to ``/`` under NFKC.
+    2. Lexical containment under the realpath of the base directory.
+    3. ``O_NOFOLLOW`` at the open, so the kernel refuses to write *through* a
+       symlink at the final component.
     """
-    # NOTE: these checks run on the name AS GIVEN, before any Unicode
-    # normalization. That is safe today because nothing on this path normalizes
-    # the resolved name. If NFKC/NFKD normalization is ever introduced upstream
-    # (e.g. for i18n or storage), apply it BEFORE these checks -- a character
-    # such as U+FF0F (fullwidth solidus) folds to "/" under NFKC and would
-    # otherwise slip past the separator check.
-    if (
-        not agent_name
-        or agent_name in (".", "..")
-        or "/" in agent_name
-        or "\\" in agent_name
-        or "\x00" in agent_name
-        or ntpath.isabs(agent_name)
-        or posixpath.isabs(agent_name)
-    ):
-        raise ValueError(
-            f"Refusing to write context copy: profile name {agent_name!r} is not a "
-            "single path segment (it is empty, absolute, or contains a path "
-            "separator or traversal). A profile's frontmatter 'name:' must be a "
-            "plain filename."
-        )
-    # Resolve only the BASE (so a symlinked context root is handled), and keep
-    # the final component UNRESOLVED. Resolving the whole candidate would follow
-    # a symlink planted at the target here and either silently write to its
-    # resolved location or shadow the O_NOFOLLOW guard at the write; leaving the
-    # final component lexical means a symlink at the target is caught at the
-    # write by O_NOFOLLOW instead. Separators are already rejected above, so the
-    # candidate is always a single child of base; the containment check is the
-    # readable, CodeQL-visible barrier.
+    AGENT_CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
+    # BARRIER PLACEMENT: the validation and the containment check are inlined
+    # here, in the same function as the os.open() sink, rather than factored into
+    # a helper. This mirrors the deliberate repetition in
+    # ``services/profile_store`` -- CodeQL's py/path-injection dataflow only
+    # recognises a barrier that guards, in the same function as the sink, the
+    # very variable that reaches it. A helper that returns a validated path is
+    # more readable but invisible to the analysis, and this repo has a history of
+    # that alert reopening (see profile_store._PROFILE_NAME_RE). Load-bearing,
+    # not an oversight.
+    safe_name = validate_path_component(agent_name, description="profile name")
+    # Resolve only the BASE (so a symlinked context root is handled) and keep the
+    # final component UNRESOLVED. Resolving the whole candidate -- as
+    # ``safe_join_under_base`` does -- would follow a symlink planted at the
+    # target and silently write to wherever it resolves; leaving the final
+    # component lexical means such a symlink is refused by O_NOFOLLOW below.
+    # That is why this does not simply call ``safe_join_under_base``.
     base = os.path.realpath(AGENT_CONTEXT_DIR)
-    candidate = os.path.join(base, f"{agent_name}.md")
+    candidate = os.path.join(base, f"{safe_name}.md")
     if candidate != base and not candidate.startswith(base + os.sep):
         raise ValueError(
             f"Refusing to write context copy: profile name {agent_name!r} resolves "
             f"to a path outside the agent context directory ({candidate!r})."
         )
-    return Path(candidate)
-
-
-def _write_context_file(agent_name: str, raw_content: str) -> Path:
-    """Write the unresolved profile source to the shared context directory."""
-    AGENT_CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
-    context_file = _contained_context_path(agent_name)
-    # Open with O_NOFOLLOW so the kernel itself refuses to write THROUGH a symlink
-    # at the final component: a plain ``write_text``/``open`` follows a symlink,
-    # so even after the containment check above, a symlink planted at the target
+    context_file = Path(candidate)
+    # O_NOFOLLOW so the kernel itself refuses to write THROUGH a symlink at the
+    # final component: a plain ``write_text``/``open`` follows a symlink, so even
+    # after the containment check above, a symlink planted at the target
     # (pre-existing, or swapped in via a check-then-write race) would let the
-    # write land outside the directory. O_NOFOLLOW closes that at the syscall --
-    # it is the enforcement; the containment check is the primary, readable
-    # barrier. O_TRUNC (not O_EXCL) so a normal reinstall still overwrites the
-    # profile's own regular-file copy. ELOOP on a symlink target becomes a clear
-    # refusal rather than an opaque OS error.
+    # write land outside the directory. O_TRUNC (not O_EXCL) so a normal
+    # reinstall still overwrites the profile's own regular-file copy. ELOOP on a
+    # symlink target becomes a clear refusal rather than an opaque OS error.
+    #
+    # Mode 0o600: this lives under ~/.aws/cli-agent-orchestrator/ and holds agent
+    # instruction content, so it does not need to be group/world readable.
     #
     # PLATFORM NOTE: os.O_NOFOLLOW does not exist on Windows, so getattr(...) is 0
     # there and the kernel-level symlink refusal degrades to a no-op. The name
@@ -304,7 +289,7 @@ def _write_context_file(agent_name: str, raw_content: str) -> Path:
     # vectors; flagged so it is a conscious limitation, not a silent gap.
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
     try:
-        fd = os.open(context_file, flags, 0o644)
+        fd = os.open(context_file, flags, 0o600)
     except OSError as exc:
         if exc.errno in (errno.ELOOP, errno.EISDIR, errno.ENXIO):
             raise ValueError(
@@ -431,12 +416,12 @@ def install_agent(
         allowed_tools = resolve_allowed_tools(profile.allowedTools, profile.role, mcp_server_names)
 
         agent_file: Optional[Path] = None
-        # Flatten BOTH path separators, not just "/": a backslash is a separator
-        # on Windows, so "..\\..\\x" would otherwise traverse out of the provider
-        # agent dir there. The resolved profile name is attacker-controlled (see
-        # _contained_context_path); the context-copy write above already aborts a
-        # separator-bearing name, but keep these provider sinks independently safe.
-        safe_filename = profile.name.replace("/", "__").replace("\\", "__")
+        # Defence in depth. The resolved profile name is attacker-controlled, but
+        # _write_context_file above has already REJECTED any name carrying a path
+        # separator, so nothing separator-bearing reaches these provider sinks in
+        # the normal flow. The flatten stays so each sink is independently safe if
+        # the order ever changes or a new caller appears.
+        safe_filename = flatten_path_separators(profile.name)
 
         if provider == ProviderType.KIRO_CLI.value:
             if profile.engine == KiroEngine.KAS:

--- a/src/cli_agent_orchestrator/services/install_service.py
+++ b/src/cli_agent_orchestrator/services/install_service.py
@@ -1,7 +1,10 @@
 """Service helpers for installing agent profiles."""
 
+import errno
 import logging
+import ntpath
 import os
+import posixpath
 import re
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple
@@ -218,11 +221,99 @@ def parse_env_assignment(env_assignment: str) -> Tuple[str, str]:
     return key, value
 
 
+def _contained_context_path(agent_name: str) -> Path:
+    """Resolve the context-copy path for ``agent_name``, refusing any escape.
+
+    The context copy's filename derives from the profile's RESOLVED frontmatter
+    ``name:``. That value is NOT covered by ``_PROFILE_NAME_RE`` -- that regex
+    validates the install *source handle* (the URL stem / bare-name argument),
+    not the resolved name -- and a profile can be installed straight from a URL,
+    so the field is attacker-controlled. Without this guard a name like
+    ``../../foo`` or an absolute path steers the write outside
+    ``AGENT_CONTEXT_DIR``.
+
+    Two layers, mirroring ``services/profile_store._profile_path``:
+
+    1. Validate the name is a single path segment -- reject empty, ``.``/``..``,
+       any ``/`` or ``\\`` separator, a NUL, or an absolute path (POSIX or
+       Windows). A profile ``name:`` is a plain filename here.
+    2. Canonical containment at the sink: resolve the full candidate and confirm
+       it stays inside the realpath of ``AGENT_CONTEXT_DIR``. This is defence in
+       depth -- it also refuses a target that resolves outside via a symlinked
+       component -- kept as a positive ``startswith`` guard dominating the
+       return so CodeQL recognises it as a path-injection barrier.
+    """
+    # NOTE: these checks run on the name AS GIVEN, before any Unicode
+    # normalization. That is safe today because nothing on this path normalizes
+    # the resolved name. If NFKC/NFKD normalization is ever introduced upstream
+    # (e.g. for i18n or storage), apply it BEFORE these checks -- a character
+    # such as U+FF0F (fullwidth solidus) folds to "/" under NFKC and would
+    # otherwise slip past the separator check.
+    if (
+        not agent_name
+        or agent_name in (".", "..")
+        or "/" in agent_name
+        or "\\" in agent_name
+        or "\x00" in agent_name
+        or ntpath.isabs(agent_name)
+        or posixpath.isabs(agent_name)
+    ):
+        raise ValueError(
+            f"Refusing to write context copy: profile name {agent_name!r} is not a "
+            "single path segment (it is empty, absolute, or contains a path "
+            "separator or traversal). A profile's frontmatter 'name:' must be a "
+            "plain filename."
+        )
+    # Resolve only the BASE (so a symlinked context root is handled), and keep
+    # the final component UNRESOLVED. Resolving the whole candidate would follow
+    # a symlink planted at the target here and either silently write to its
+    # resolved location or shadow the O_NOFOLLOW guard at the write; leaving the
+    # final component lexical means a symlink at the target is caught at the
+    # write by O_NOFOLLOW instead. Separators are already rejected above, so the
+    # candidate is always a single child of base; the containment check is the
+    # readable, CodeQL-visible barrier.
+    base = os.path.realpath(AGENT_CONTEXT_DIR)
+    candidate = os.path.join(base, f"{agent_name}.md")
+    if candidate != base and not candidate.startswith(base + os.sep):
+        raise ValueError(
+            f"Refusing to write context copy: profile name {agent_name!r} resolves "
+            f"to a path outside the agent context directory ({candidate!r})."
+        )
+    return Path(candidate)
+
+
 def _write_context_file(agent_name: str, raw_content: str) -> Path:
     """Write the unresolved profile source to the shared context directory."""
     AGENT_CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
-    context_file = AGENT_CONTEXT_DIR / f"{agent_name}.md"
-    context_file.write_text(raw_content, encoding="utf-8")
+    context_file = _contained_context_path(agent_name)
+    # Open with O_NOFOLLOW so the kernel itself refuses to write THROUGH a symlink
+    # at the final component: a plain ``write_text``/``open`` follows a symlink,
+    # so even after the containment check above, a symlink planted at the target
+    # (pre-existing, or swapped in via a check-then-write race) would let the
+    # write land outside the directory. O_NOFOLLOW closes that at the syscall --
+    # it is the enforcement; the containment check is the primary, readable
+    # barrier. O_TRUNC (not O_EXCL) so a normal reinstall still overwrites the
+    # profile's own regular-file copy. ELOOP on a symlink target becomes a clear
+    # refusal rather than an opaque OS error.
+    #
+    # PLATFORM NOTE: os.O_NOFOLLOW does not exist on Windows, so getattr(...) is 0
+    # there and the kernel-level symlink refusal degrades to a no-op. The name
+    # validation and containment check above still hold on Windows; only the
+    # write-time symlink/race guard is POSIX-only. Acceptable because the primary
+    # deployment target is POSIX and the validation already blocks the traversal
+    # vectors; flagged so it is a conscious limitation, not a silent gap.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(context_file, flags, 0o644)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.EISDIR, errno.ENXIO):
+            raise ValueError(
+                f"Refusing to write context copy: {context_file} exists and is not a "
+                "regular file (symlink, directory, or device). Remove it and reinstall."
+            ) from exc
+        raise
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(raw_content)
     return context_file
 
 
@@ -340,7 +431,12 @@ def install_agent(
         allowed_tools = resolve_allowed_tools(profile.allowedTools, profile.role, mcp_server_names)
 
         agent_file: Optional[Path] = None
-        safe_filename = profile.name.replace("/", "__")
+        # Flatten BOTH path separators, not just "/": a backslash is a separator
+        # on Windows, so "..\\..\\x" would otherwise traverse out of the provider
+        # agent dir there. The resolved profile name is attacker-controlled (see
+        # _contained_context_path); the context-copy write above already aborts a
+        # separator-bearing name, but keep these provider sinks independently safe.
+        safe_filename = profile.name.replace("/", "__").replace("\\", "__")
 
         if provider == ProviderType.KIRO_CLI.value:
             if profile.engine == KiroEngine.KAS:

--- a/src/cli_agent_orchestrator/utils/opencode_config.py
+++ b/src/cli_agent_orchestrator/utils/opencode_config.py
@@ -27,8 +27,12 @@ def to_opencode_agent_id(profile_name: str) -> str:
 
     OpenCode treats the filename stem of an agent ``.md`` file as its agent ID
     (used for ``--agent <id>`` and keyed by the same value under
-    ``agent.<id>`` in ``opencode.json``). Profile names may contain ``/`` —
-    illegal in filenames — so the conversion replaces every slash with ``__``.
+    ``agent.<id>`` in ``opencode.json``). Profile names may contain path
+    separators — illegal in a single filename — so the conversion replaces both
+    ``/`` and ``\\`` with ``__``. Flattening the backslash too matters because it
+    is a path separator on Windows: since the id becomes the ``<id>.md`` filename,
+    an attacker-controlled name like ``..\\..\\x`` would otherwise traverse out of
+    ``OPENCODE_AGENTS_DIR`` there.
 
     The output is the single source of truth for:
 
@@ -36,9 +40,9 @@ def to_opencode_agent_id(profile_name: str) -> str:
     - the ``agent.<id>.tools`` key written to ``opencode.json``
     - the value passed to ``opencode --agent <id>`` at runtime
 
-    Idempotent: inputs that contain no ``/`` are returned unchanged.
+    Idempotent: inputs that contain no separator are returned unchanged.
     """
-    return profile_name.replace("/", "__")
+    return profile_name.replace("/", "__").replace("\\", "__")
 
 
 def ensure_skills_symlink() -> None:

--- a/src/cli_agent_orchestrator/utils/opencode_config.py
+++ b/src/cli_agent_orchestrator/utils/opencode_config.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List
 
 from cli_agent_orchestrator.constants import OPENCODE_CONFIG_DIR, OPENCODE_CONFIG_FILE, SKILLS_DIR
 from cli_agent_orchestrator.utils.mcp_resolution import resolve_cao_mcp_command
+from cli_agent_orchestrator.utils.path_validation import flatten_path_separators
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +28,14 @@ def to_opencode_agent_id(profile_name: str) -> str:
 
     OpenCode treats the filename stem of an agent ``.md`` file as its agent ID
     (used for ``--agent <id>`` and keyed by the same value under
-    ``agent.<id>`` in ``opencode.json``). Profile names may contain path
-    separators — illegal in a single filename — so the conversion replaces both
-    ``/`` and ``\\`` with ``__``. Flattening the backslash too matters because it
-    is a path separator on Windows: since the id becomes the ``<id>.md`` filename,
-    an attacker-controlled name like ``..\\..\\x`` would otherwise traverse out of
-    ``OPENCODE_AGENTS_DIR`` there.
+    ``agent.<id>`` in ``opencode.json``).
+
+    Since the id becomes the ``<id>.md`` filename, any path separator left in it
+    would traverse out of ``OPENCODE_AGENTS_DIR``, so both ``/`` and ``\\`` are
+    flattened to ``__`` (backslash included because it is a separator on
+    Windows). ``install_service`` now *rejects* a resolved profile ``name:``
+    containing a separator outright, so this flatten is defence in depth rather
+    than the primary guard — and a namespaced ``name:`` is no longer installable.
 
     The output is the single source of truth for:
 
@@ -42,7 +45,7 @@ def to_opencode_agent_id(profile_name: str) -> str:
 
     Idempotent: inputs that contain no separator are returned unchanged.
     """
-    return profile_name.replace("/", "__").replace("\\", "__")
+    return flatten_path_separators(profile_name)
 
 
 def ensure_skills_symlink() -> None:

--- a/src/cli_agent_orchestrator/utils/path_validation.py
+++ b/src/cli_agent_orchestrator/utils/path_validation.py
@@ -138,6 +138,25 @@ def resolve_and_validate_path(
 _SAFE_PATH_COMPONENT_RE = re.compile(r"\A[A-Za-z0-9._-]+\Z")
 
 
+def flatten_path_separators(value: str) -> str:
+    """Flatten every path separator in ``value`` to ``__``.
+
+    Used where a user- or profile-derived string becomes a single filename
+    component and the separators should be folded rather than rejected (the
+    provider agent-file sinks, which historically accepted namespaced names).
+    Both ``/`` and ``\\`` are flattened: backslash is a path separator on
+    Windows, so leaving it intact would let a name like ``..\\..\\x`` traverse
+    out of the provider directory there.
+
+    Prefer :func:`validate_path_component` when the value should be *rejected*
+    rather than rewritten. This is the weaker, lossy primitive; it guarantees
+    the result contains no separator, not that the result is a sensible name.
+
+    Idempotent: a value with no separator is returned unchanged.
+    """
+    return value.replace("/", "__").replace("\\", "__")
+
+
 def validate_path_component(component: str, description: str = "path component") -> str:
     """Validate that ``component`` is a single, safe path segment.
 

--- a/src/cli_agent_orchestrator/utils/skill_injection.py
+++ b/src/cli_agent_orchestrator/utils/skill_injection.py
@@ -86,7 +86,10 @@ def refresh_agent_md_prompt(md_path: Path, profile: AgentProfile) -> bool:
 def refresh_installed_agent_for_profile(profile_name: str) -> List[Path]:
     """Refresh installed Copilot agents for one source profile."""
     profile = load_agent_profile(profile_name)
-    safe_name = profile.name.replace("/", "__")
+    # Flatten both path separators (see install_service): a backslash is a
+    # separator on Windows, and this filename is derived from the attacker-
+    # controlled resolved profile name.
+    safe_name = profile.name.replace("/", "__").replace("\\", "__")
     refreshed_paths: List[Path] = []
 
     copilot_path = COPILOT_AGENTS_DIR / f"{safe_name}.agent.md"

--- a/src/cli_agent_orchestrator/utils/skill_injection.py
+++ b/src/cli_agent_orchestrator/utils/skill_injection.py
@@ -17,6 +17,10 @@ from cli_agent_orchestrator.constants import (
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
 from cli_agent_orchestrator.utils.atomic_file import locked_atomic_rewrite
+from cli_agent_orchestrator.utils.path_validation import (
+    flatten_path_separators,
+    validate_path_component,
+)
 from cli_agent_orchestrator.utils.skills import build_skill_catalog
 
 logger = logging.getLogger(__name__)
@@ -86,10 +90,11 @@ def refresh_agent_md_prompt(md_path: Path, profile: AgentProfile) -> bool:
 def refresh_installed_agent_for_profile(profile_name: str) -> List[Path]:
     """Refresh installed Copilot agents for one source profile."""
     profile = load_agent_profile(profile_name)
-    # Flatten both path separators (see install_service): a backslash is a
-    # separator on Windows, and this filename is derived from the attacker-
-    # controlled resolved profile name.
-    safe_name = profile.name.replace("/", "__").replace("\\", "__")
+    # Flatten both separators (see install_service): this filename derives from
+    # the attacker-controlled resolved profile name, and a backslash is a
+    # separator on Windows. Defence in depth — install now rejects a
+    # separator-bearing name, so such a profile cannot have been installed.
+    safe_name = flatten_path_separators(profile.name)
     refreshed_paths: List[Path] = []
 
     copilot_path = COPILOT_AGENTS_DIR / f"{safe_name}.agent.md"
@@ -140,6 +145,17 @@ def _iter_installed_copilot_agents() -> Iterator[Path]:
 
 
 def _is_cao_managed_copilot_agent(name: str) -> bool:
-    """Return True when a corresponding CAO context file exists for this agent name."""
-    context_file = AGENT_CONTEXT_DIR / f"{name}.md"
+    """Return True when a corresponding CAO context file exists for this agent name.
+
+    ``name`` comes from the frontmatter of a file already sitting in the Copilot
+    agents directory, so it is not trusted. Validate it as a single path segment
+    before joining: an unsafe name simply is not CAO-managed (install would have
+    refused to write its context copy), so returning False is both correct and
+    keeps a traversal out of the join.
+    """
+    try:
+        safe_name = validate_path_component(name, description="agent name")
+    except ValueError:
+        return False
+    context_file = AGENT_CONTEXT_DIR / f"{safe_name}.md"
     return context_file.exists()

--- a/test/cli/commands/test_install_opencode.py
+++ b/test/cli/commands/test_install_opencode.py
@@ -428,14 +428,46 @@ class TestPreserveExistingConfig:
 
 
 # ---------------------------------------------------------------------------
-# Scenario: slash-safe agent ID parity (filename === opencode.json key)
+# Scenario: agent ID parity (filename === opencode.json key), and the refusal of
+# a namespaced frontmatter name
 # ---------------------------------------------------------------------------
 
 
-class TestSlashSafeAgentId:
-    """The sanitized agent ID must be used for both the .md filename and the
+class TestAgentIdParity:
+    """One sanitized agent ID must be used for both the .md filename and the
     ``agent.<id>.tools`` key in opencode.json, so the value passed to
     ``opencode --agent <id>`` at runtime lines up with its MCP grants."""
+
+    def test_filename_and_config_key_agree(
+        self, runner: CliRunner, install_workspace: Dict[str, Any]
+    ):
+        _write_profile(
+            install_workspace["local_store"] / "test-agent.md",
+            name="test-agent",
+            mcp_servers="  cao-mcp-server:\n    command: cao-mcp-server\n",
+        )
+
+        runner.invoke(install, ["test-agent", "--provider", "opencode_cli"])
+
+        assert (install_workspace["agents_dir"] / "test-agent.md").exists()
+        data = json.loads(install_workspace["config_file"].read_text())
+        assert "test-agent" in data["agent"], "agent ID must be the opencode.json key"
+        assert data["agent"]["test-agent"]["tools"]["cao-mcp-server*"] is True
+
+
+class TestNamespacedNameIsRefused:
+    """A frontmatter ``name:`` containing a path separator is no longer installable.
+
+    Security fix for GHSA-6m35-gcf5-xm75: the resolved ``name:`` is
+    attacker-controlled for URL installs and feeds the context-copy filename, so
+    it is now validated as a single path segment. Namespaced names like
+    ``my/agent`` are rejected as a consequence — they only ever worked when the
+    intermediate context directory happened to already exist, and permitting them
+    is exactly what let a hostile ``../..`` name escape.
+
+    Replaces the former ``TestSlashSafeAgentId``, which asserted the now-removed
+    behavior that such a profile installs successfully.
+    """
 
     def _write_slash_profile(self, install_workspace: Dict[str, Any]) -> None:
         _write_profile(
@@ -443,36 +475,37 @@ class TestSlashSafeAgentId:
             name="my/agent",
             mcp_servers="  cao-mcp-server:\n    command: cao-mcp-server\n",
         )
-        # profile.name "my/agent" → context path would be context_dir/my/agent.md;
-        # pre-create the intermediate dir so the context write doesn't fail before
-        # reaching the agent-file step that we want to assert on.
+        # The pre-fix code needed context_dir/my/ to exist for the write to land.
+        # Create it deliberately, so the refusal below is provably the name
+        # validation and not an incidental missing-parent-directory failure.
         (install_workspace["context_dir"] / "my").mkdir(parents=True, exist_ok=True)
 
-    def test_slash_replaced_in_agent_filename(
+    def test_install_reports_the_refusal(
+        self, runner: CliRunner, install_workspace: Dict[str, Any]
+    ):
+        self._write_slash_profile(install_workspace)
+
+        result = runner.invoke(install, ["my__agent", "--provider", "opencode_cli"])
+
+        # NOTE: asserted on the message, not the exit code. `cao install` echoes
+        # "Error: ..." and returns, so a failed install still exits 0 — a
+        # pre-existing CLI bug (see cli/commands/install.py, `if not
+        # result.success: ... return`) that is out of scope for this fix.
+        assert "Error" in result.output
+        assert "profile name" in result.output
+        assert "my/agent" in result.output
+
+    def test_no_agent_file_or_context_copy_is_written(
         self, runner: CliRunner, install_workspace: Dict[str, Any]
     ):
         self._write_slash_profile(install_workspace)
 
         runner.invoke(install, ["my__agent", "--provider", "opencode_cli"])
 
-        agent_file = install_workspace["agents_dir"] / "my__agent.md"
-        assert agent_file.exists()
-
-    def test_opencode_json_uses_sanitized_agent_id(
-        self, runner: CliRunner, install_workspace: Dict[str, Any]
-    ):
-        """The agent.<id>.tools key must use the sanitized filename, not the
-        frontmatter ``name`` with ``/`` in it."""
-        self._write_slash_profile(install_workspace)
-
-        runner.invoke(install, ["my__agent", "--provider", "opencode_cli"])
-
-        data = json.loads(install_workspace["config_file"].read_text())
-        assert "my__agent" in data["agent"], "sanitized agent ID must be the key"
-        assert data["agent"]["my__agent"]["tools"]["cao-mcp-server*"] is True
-        assert (
-            "my/agent" not in data["agent"]
-        ), "unsanitized profile.name must not be written as an agent key"
+        assert not (install_workspace["agents_dir"] / "my__agent.md").exists()
+        # nothing landed in the pre-created subdirectory either
+        assert list((install_workspace["context_dir"] / "my").iterdir()) == []
+        assert not install_workspace["config_file"].exists()
 
 
 # ---------------------------------------------------------------------------

--- a/test/services/test_install_context_path_containment.py
+++ b/test/services/test_install_context_path_containment.py
@@ -1,0 +1,168 @@
+"""Security regression: the agent context-copy path cannot escape its directory.
+
+`_write_context_file` builds the context-copy filename from the profile's
+RESOLVED frontmatter `name:`. That value is not covered by `_PROFILE_NAME_RE`
+(which guards the install *source handle*) and is attacker-controlled when a
+profile is installed from a URL, so an unguarded name could steer the write
+outside `AGENT_CONTEXT_DIR`. These tests pin the fix against the escape classes:
+relative traversal, absolute paths, backslash separators, and symlink escapes.
+"""
+
+import os
+import stat
+
+import pytest
+
+from cli_agent_orchestrator.services import install_service
+
+
+@pytest.fixture
+def context_dir(tmp_path, monkeypatch):
+    d = tmp_path / "agent-context"
+    d.mkdir()
+    monkeypatch.setattr("cli_agent_orchestrator.services.install_service.AGENT_CONTEXT_DIR", d)
+    return d
+
+
+class TestContextPathContainment:
+    @pytest.mark.parametrize(
+        "hostile_name",
+        [
+            "../../evil",
+            "a/../../evil",
+            "deep/../../../evil",
+            "/etc/evil",  # absolute (POSIX)
+            "C:\\Windows\\evil",  # absolute (Windows)
+            "..\\..\\evil",  # backslash traversal
+            "a\\b",  # backslash separator
+            "sub/dir",  # plain separator
+            "..",
+            ".",
+            "",
+        ],
+    )
+    def test_hostile_resolved_name_is_refused(self, context_dir, hostile_name):
+        with pytest.raises(ValueError):
+            install_service._write_context_file(hostile_name, "---\nname: x\n---\nbody\n")
+        # nothing was written anywhere under the parent of the context dir
+        assert list(context_dir.iterdir()) == []
+
+    def test_absolute_path_into_home_is_refused(self, context_dir, tmp_path):
+        decoy = tmp_path / "home" / ".claude"
+        decoy.mkdir(parents=True)
+        (decoy / "CLAUDE.md").write_text("ORIGINAL trusted instructions\n")
+        with pytest.raises(ValueError):
+            install_service._write_context_file(
+                str(decoy / "CLAUDE"), "---\nname: x\n---\nINJECTED\n"
+            )
+        assert (decoy / "CLAUDE.md").read_text() == "ORIGINAL trusted instructions\n"
+
+    def test_symlink_at_target_pointing_outside_is_not_followed(self, context_dir, tmp_path):
+        # A symlink planted at the target, pointing outside, must not be written
+        # through. The final component is left unresolved by the path guard, so
+        # this is caught by O_NOFOLLOW at the open, not by containment.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (context_dir / "evil.md").symlink_to(outside / "pwned.md")
+        with pytest.raises(ValueError):
+            install_service._write_context_file("evil", "---\nname: x\n---\nINJECTED\n")
+        assert not (outside / "pwned.md").exists()
+
+    def test_symlinked_target_regular_file_outside_is_refused(self, context_dir, tmp_path):
+        outside_file = tmp_path / "outside.md"
+        outside_file.write_text("original\n")
+        (context_dir / "evil.md").symlink_to(outside_file)
+        with pytest.raises(ValueError):
+            install_service._write_context_file("evil", "---\nname: x\n---\nINJECTED\n")
+        assert outside_file.read_text() == "original\n"
+
+    def test_symlink_at_target_pointing_INSIDE_base_is_still_refused(self, context_dir):
+        # Isolates the O_NOFOLLOW guard: this symlink resolves to a path INSIDE
+        # the context dir, so the realpath-containment check would ALLOW it — only
+        # the no-follow open refuses it. Guards against a future refactor silently
+        # dropping O_NOFOLLOW (the containment test would still pass without it).
+        (context_dir / "real.md").write_text("real target\n")
+        (context_dir / "evil.md").symlink_to(context_dir / "real.md")
+        with pytest.raises(ValueError):
+            install_service._write_context_file("evil", "---\nname: x\n---\nINJECTED\n")
+        # the symlink's in-base target was not written through
+        assert (context_dir / "real.md").read_text() == "real target\n"
+
+    def test_nul_byte_in_name_is_refused(self, context_dir):
+        with pytest.raises(ValueError):
+            install_service._write_context_file("a\x00b", "---\nname: x\n---\nbody\n")
+        assert list(context_dir.iterdir()) == []
+
+    def test_normal_name_writes_inside(self, context_dir):
+        written = install_service._write_context_file(
+            "developer", "---\nname: developer\n---\nBe helpful.\n"
+        )
+        assert written == context_dir / "developer.md"
+        assert written.is_file()
+        assert not written.is_symlink()
+        assert os.path.realpath(written).startswith(os.path.realpath(context_dir) + os.sep)
+
+    def test_reinstall_over_own_regular_copy_is_allowed(self, context_dir):
+        install_service._write_context_file("developer", "---\nname: developer\n---\nv1\n")
+        # a normal reinstall overwrites the profile's own prior regular-file copy
+        written = install_service._write_context_file(
+            "developer", "---\nname: developer\n---\nv2\n"
+        )
+        assert "v2" in written.read_text()
+        assert stat.S_ISREG(os.lstat(written).st_mode)
+
+
+class TestProviderFilenameSeparatorFlattening:
+    """The provider agent-file sinks flatten BOTH path separators.
+
+    These sinks derive a flat filename from the attacker-controlled resolved
+    profile name. `/` was already flattened; a bare `\\` survived, which is a
+    path separator on Windows and would traverse out of the provider dir there.
+    """
+
+    @pytest.mark.parametrize(
+        "hostile_name",
+        ["..\\..\\evil", "a\\b", "..\\../mixed", "C:\\Windows\\evil"],
+    )
+    def test_no_separator_survives_the_flatten(self, hostile_name):
+        from cli_agent_orchestrator.utils.opencode_config import to_opencode_agent_id
+
+        # install_service's kiro/copilot safe_filename + opencode's agent id must
+        # leave no OS path separator that could traverse on any platform.
+        for produced in (
+            hostile_name.replace("/", "__").replace("\\", "__"),  # the safe_filename form
+            to_opencode_agent_id(hostile_name),
+        ):
+            assert "/" not in produced
+            assert "\\" not in produced
+
+    def test_skill_injection_refresh_flattens_backslash(self, tmp_path, monkeypatch):
+        # refresh_installed_agent_for_profile builds a Copilot filename from the
+        # resolved name; confirm the path it targets has no surviving separator.
+        from types import SimpleNamespace
+
+        from cli_agent_orchestrator.utils import skill_injection
+
+        copilot_dir = tmp_path / "copilot"
+        copilot_dir.mkdir()
+        monkeypatch.setattr(skill_injection, "COPILOT_AGENTS_DIR", copilot_dir)
+        monkeypatch.setattr(
+            skill_injection,
+            "load_agent_profile",
+            lambda name: SimpleNamespace(name="..\\..\\evil"),
+        )
+        captured = {}
+
+        def _fake_refresh(md_path, profile):
+            captured["path"] = md_path
+            return False  # simulate "no existing file", as the real code would
+
+        monkeypatch.setattr(skill_injection, "refresh_agent_md_prompt", _fake_refresh)
+
+        skill_injection.refresh_installed_agent_for_profile("some-source")
+
+        target = captured["path"]
+        # the target stays a direct child of COPILOT_AGENTS_DIR (no traversal)
+        assert target.parent == copilot_dir
+        assert "\\" not in target.name.replace(".agent.md", "")
+        assert "/" not in target.name.replace(".agent.md", "")

--- a/test/services/test_install_context_path_containment.py
+++ b/test/services/test_install_context_path_containment.py
@@ -1,11 +1,19 @@
 """Security regression: the agent context-copy path cannot escape its directory.
 
-`_write_context_file` builds the context-copy filename from the profile's
-RESOLVED frontmatter `name:`. That value is not covered by `_PROFILE_NAME_RE`
-(which guards the install *source handle*) and is attacker-controlled when a
-profile is installed from a URL, so an unguarded name could steer the write
-outside `AGENT_CONTEXT_DIR`. These tests pin the fix against the escape classes:
-relative traversal, absolute paths, backslash separators, and symlink escapes.
+Covers GHSA-6m35-gcf5-xm75. `_write_context_file` builds the context-copy
+filename from the profile's RESOLVED frontmatter `name:`. That value is not
+covered by `_PROFILE_NAME_RE` (which guards the install *source handle*) and is
+attacker-controlled when a profile is installed from a URL, so an unguarded name
+could steer the write outside `AGENT_CONTEXT_DIR`.
+
+Two layers of coverage:
+
+- `TestContextPathContainment` exercises `_write_context_file` directly against
+  each escape class: relative traversal, absolute paths, backslash separators,
+  NUL, and three symlink shapes (including one resolving *inside* the base, which
+  isolates the `O_NOFOLLOW` guard from the containment check).
+- `TestInstallAgentRefusesHostileResolvedName` drives the public `install_agent`
+  entry point, pinning the actual attack path end to end.
 """
 
 import os
@@ -44,7 +52,8 @@ class TestContextPathContainment:
     def test_hostile_resolved_name_is_refused(self, context_dir, hostile_name):
         with pytest.raises(ValueError):
             install_service._write_context_file(hostile_name, "---\nname: x\n---\nbody\n")
-        # nothing was written anywhere under the parent of the context dir
+        # the context dir stayed empty (see the install_agent tests below for the
+        # broader "nothing written anywhere" assertion)
         assert list(context_dir.iterdir()) == []
 
     def test_absolute_path_into_home_is_refused(self, context_dir, tmp_path):
@@ -112,57 +121,100 @@ class TestContextPathContainment:
         assert stat.S_ISREG(os.lstat(written).st_mode)
 
 
-class TestProviderFilenameSeparatorFlattening:
-    """The provider agent-file sinks flatten BOTH path separators.
+@pytest.fixture
+def install_env(tmp_path, monkeypatch):
+    """Redirect every directory ``install_agent`` writes to under tmp_path.
 
-    These sinks derive a flat filename from the attacker-controlled resolved
-    profile name. `/` was already flattened; a bare `\\` survived, which is a
-    path separator on Windows and would traverse out of the provider dir there.
+    Mirrors the fixture in test/cli/commands/test_install_opencode.py, but for
+    the service entry point rather than the CLI, and it also redirects the kiro
+    and copilot agent dirs so a hostile name cannot escape into a real one.
+    """
+    store = tmp_path / "agent-store"
+    context = tmp_path / "agent-context"
+    store.mkdir()
+    context.mkdir()
+    provider_dirs = {}
+    for key, attr in (
+        ("opencode", "OPENCODE_AGENTS_DIR"),
+        ("kiro", "KIRO_AGENTS_DIR"),
+        ("copilot", "COPILOT_AGENTS_DIR"),
+    ):
+        d = tmp_path / key
+        provider_dirs[key] = d
+        monkeypatch.setattr(f"cli_agent_orchestrator.services.install_service.{attr}", d)
+
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.profile_store.LOCAL_AGENT_STORE_DIR", store
+    )
+    monkeypatch.setattr("cli_agent_orchestrator.utils.agent_profiles.LOCAL_AGENT_STORE_DIR", store)
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.install_service.AGENT_CONTEXT_DIR", context
+    )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_agent_dirs", lambda: {}
+    )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.settings_service.get_extra_agent_dirs", lambda: []
+    )
+    monkeypatch.setattr(
+        "cli_agent_orchestrator.services.install_service.ensure_skills_symlink", lambda: None
+    )
+    return {"store": store, "context": context, "providers": provider_dirs, "root": tmp_path}
+
+
+class TestInstallAgentRefusesHostileResolvedName:
+    """End-to-end: the ACTUAL attack path, through the public entry point.
+
+    The tests above exercise `_write_context_file` directly. These drive
+    `install_agent`, which is what `cao install` and the
+    `POST /agents/profiles/install` endpoint call, so they pin the property that
+    matters: a profile whose *source handle* is perfectly valid but whose
+    frontmatter `name:` is hostile fails the install and writes nothing. This is
+    the layer that proves the guard is actually reachable from user input.
     """
 
-    @pytest.mark.parametrize(
-        "hostile_name",
-        ["..\\..\\evil", "a\\b", "..\\../mixed", "C:\\Windows\\evil"],
-    )
-    def test_no_separator_survives_the_flatten(self, hostile_name):
-        from cli_agent_orchestrator.utils.opencode_config import to_opencode_agent_id
-
-        # install_service's kiro/copilot safe_filename + opencode's agent id must
-        # leave no OS path separator that could traverse on any platform.
-        for produced in (
-            hostile_name.replace("/", "__").replace("\\", "__"),  # the safe_filename form
-            to_opencode_agent_id(hostile_name),
-        ):
-            assert "/" not in produced
-            assert "\\" not in produced
-
-    def test_skill_injection_refresh_flattens_backslash(self, tmp_path, monkeypatch):
-        # refresh_installed_agent_for_profile builds a Copilot filename from the
-        # resolved name; confirm the path it targets has no surviving separator.
-        from types import SimpleNamespace
-
-        from cli_agent_orchestrator.utils import skill_injection
-
-        copilot_dir = tmp_path / "copilot"
-        copilot_dir.mkdir()
-        monkeypatch.setattr(skill_injection, "COPILOT_AGENTS_DIR", copilot_dir)
-        monkeypatch.setattr(
-            skill_injection,
-            "load_agent_profile",
-            lambda name: SimpleNamespace(name="..\\..\\evil"),
+    def _write_profile(self, install_env, resolved_name: str) -> None:
+        # The handle "trusted-handle" passes _PROFILE_NAME_RE; the frontmatter
+        # name is what an attacker controls when the profile is fetched by URL.
+        (install_env["store"] / "trusted-handle.md").write_text(
+            f"---\nname: {resolved_name}\ndescription: Hostile\n---\nBody\n",
+            encoding="utf-8",
         )
-        captured = {}
 
-        def _fake_refresh(md_path, profile):
-            captured["path"] = md_path
-            return False  # simulate "no existing file", as the real code would
+    @pytest.mark.parametrize(
+        "resolved_name",
+        [
+            "../../evil",
+            "a/../../evil",
+            "/etc/evil",
+            "..\\..\\evil",
+            "sub/dir",
+            "..",
+        ],
+    )
+    @pytest.mark.parametrize("provider", ["opencode_cli", "kiro_cli", "copilot_cli"])
+    def test_install_fails_and_writes_nothing(self, install_env, resolved_name, provider):
+        self._write_profile(install_env, resolved_name)
 
-        monkeypatch.setattr(skill_injection, "refresh_agent_md_prompt", _fake_refresh)
+        result = install_service.install_agent("trusted-handle", provider=provider)
 
-        skill_injection.refresh_installed_agent_for_profile("some-source")
+        assert result.success is False
+        assert "profile name" in result.message
+        # No context copy, and no provider agent file anywhere.
+        assert list(install_env["context"].iterdir()) == []
+        for d in install_env["providers"].values():
+            assert not d.exists() or list(d.iterdir()) == []
+        # And nothing escaped into the tmp root beside the dirs we created.
+        assert sorted(p.name for p in install_env["root"].iterdir()) == [
+            "agent-context",
+            "agent-store",
+        ]
 
-        target = captured["path"]
-        # the target stays a direct child of COPILOT_AGENTS_DIR (no traversal)
-        assert target.parent == copilot_dir
-        assert "\\" not in target.name.replace(".agent.md", "")
-        assert "/" not in target.name.replace(".agent.md", "")
+    def test_legitimate_name_still_installs(self, install_env):
+        self._write_profile(install_env, "developer")
+
+        result = install_service.install_agent("trusted-handle", provider="opencode_cli")
+
+        assert result.success is True, result.message
+        assert (install_env["context"] / "developer.md").is_file()
+        assert (install_env["providers"]["opencode"] / "developer.md").is_file()

--- a/test/utils/test_opencode_config.py
+++ b/test/utils/test_opencode_config.py
@@ -11,11 +11,33 @@ from cli_agent_orchestrator.utils.opencode_config import (
     ensure_skills_symlink,
     read_config,
     remove_agent_tools,
+    to_opencode_agent_id,
     translate_mcp_server_config,
     upsert_agent_tools,
     upsert_mcp_server,
     write_config,
 )
+
+
+class TestToOpencodeAgentId:
+    """The id becomes the ``<id>.md`` filename under OPENCODE_AGENTS_DIR, so no
+    path separator may survive it.
+
+    Security regression for GHSA-6m35-gcf5-xm75: only ``/`` was folded, leaving a
+    resolved profile name like ``..\\..\\evil`` able to traverse on Windows.
+    """
+
+    @pytest.mark.parametrize(
+        "hostile_name",
+        ["..\\..\\evil", "a\\b", "..\\../mixed", "C:\\Windows\\evil", "../../evil"],
+    )
+    def test_no_separator_survives(self, hostile_name):
+        produced = to_opencode_agent_id(hostile_name)
+        assert "/" not in produced
+        assert "\\" not in produced
+
+    def test_plain_name_is_unchanged(self):
+        assert to_opencode_agent_id("developer") == "developer"
 
 
 @pytest.fixture()

--- a/test/utils/test_path_validation.py
+++ b/test/utils/test_path_validation.py
@@ -166,9 +166,44 @@ class TestTmuxDelegationRegression:
 
 
 from cli_agent_orchestrator.utils.path_validation import (  # noqa: E402
+    flatten_path_separators,
     safe_join_under_base,
     validate_path_component,
 )
+
+
+class TestFlattenPathSeparators:
+    """The lossy sibling of ``validate_path_component``, used by the provider
+    agent-file sinks where a separator is folded rather than rejected.
+
+    Security regression for GHSA-6m35-gcf5-xm75: only ``/`` was folded, so a
+    resolved profile ``name:`` of ``..\\..\\evil`` kept its backslashes and
+    traversed out of the provider agent directory on Windows.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "..\\..\\evil",
+            "a\\b",
+            "..\\../mixed",
+            "C:\\Windows\\evil",
+            "../../evil",
+            "sub/dir",
+        ],
+    )
+    def test_no_separator_survives(self, value):
+        produced = flatten_path_separators(value)
+        assert "/" not in produced
+        assert "\\" not in produced
+
+    @pytest.mark.parametrize("value", ["developer", "my__agent", "a.b-c_d", ""])
+    def test_separator_free_input_is_unchanged(self, value):
+        assert flatten_path_separators(value) == value
+
+    def test_idempotent(self):
+        once = flatten_path_separators("a/b\\c")
+        assert flatten_path_separators(once) == once
 
 
 class TestValidatePathComponent:

--- a/test/utils/test_skill_injection.py
+++ b/test/utils/test_skill_injection.py
@@ -218,6 +218,86 @@ class TestRefreshInstalledAgentForProfile:
 
         assert skill_injection.refresh_installed_agent_for_profile("team-developer") == []
 
+    @pytest.mark.parametrize(
+        "resolved_name", ["..\\..\\evil", "a\\b", "C:\\Windows\\evil", "../../evil"]
+    )
+    def test_separator_bearing_name_stays_a_direct_child(
+        self, tmp_path, monkeypatch, resolved_name
+    ):
+        """Security regression (GHSA-6m35-gcf5-xm75): the Copilot filename is
+        derived from the resolved profile name, so a surviving separator would
+        traverse out of COPILOT_AGENTS_DIR. Only ``/`` was folded before the fix,
+        leaving ``\\`` live on Windows."""
+        copilot_dir = tmp_path / "copilot"
+        copilot_dir.mkdir()
+        monkeypatch.setattr(skill_injection, "COPILOT_AGENTS_DIR", copilot_dir)
+        monkeypatch.setattr(
+            skill_injection,
+            "load_agent_profile",
+            lambda name: AgentProfile(name=resolved_name, description="d", prompt="p"),
+        )
+        captured = {}
+
+        def _capture(md_path, profile):
+            captured["path"] = md_path
+            return False  # as the real code does when no file exists
+
+        monkeypatch.setattr(skill_injection, "refresh_agent_md_prompt", _capture)
+
+        skill_injection.refresh_installed_agent_for_profile("some-handle")
+
+        target = captured["path"]
+        assert target.parent == copilot_dir
+        stem = target.name.replace(".agent.md", "")
+        assert "/" not in stem
+        assert "\\" not in stem
+
+
+class TestIsCaoManagedCopilotAgent:
+    """The context-file existence probe validates its segment before joining.
+
+    The name comes from the frontmatter of a file already sitting in the Copilot
+    agents dir, so it is untrusted. An unsafe name is simply not CAO-managed.
+    """
+
+    def test_valid_name_with_context_file_is_managed(self, tmp_path, monkeypatch):
+        context_dir = tmp_path / "context"
+        context_dir.mkdir()
+        (context_dir / "developer.md").write_text("x", encoding="utf-8")
+        monkeypatch.setattr(skill_injection, "AGENT_CONTEXT_DIR", context_dir)
+
+        assert skill_injection._is_cao_managed_copilot_agent("developer") is True
+
+    def test_valid_name_without_context_file_is_not_managed(self, tmp_path, monkeypatch):
+        context_dir = tmp_path / "context"
+        context_dir.mkdir()
+        monkeypatch.setattr(skill_injection, "AGENT_CONTEXT_DIR", context_dir)
+
+        assert skill_injection._is_cao_managed_copilot_agent("developer") is False
+
+    @pytest.mark.parametrize("hostile", ["../../evil", "..", ".", "", "a/b", "a\\b", "a\x00b"])
+    def test_unsafe_name_is_refused(self, tmp_path, monkeypatch, hostile):
+        context_dir = tmp_path / "context"
+        context_dir.mkdir()
+        monkeypatch.setattr(skill_injection, "AGENT_CONTEXT_DIR", context_dir)
+
+        assert skill_injection._is_cao_managed_copilot_agent(hostile) is False
+
+    def test_traversal_to_an_existing_file_outside_is_refused(self, tmp_path, monkeypatch):
+        """The case that isolates the segment guard from the existence check.
+
+        Without validation, ``"../evil"`` joins to ``<context>/../evil.md`` — a
+        real file here — so the probe would answer True and treat an agent whose
+        context file lives OUTSIDE the context dir as CAO-managed, feeding it to
+        the refresh path. The guard makes the answer False.
+        """
+        context_dir = tmp_path / "context"
+        context_dir.mkdir()
+        (tmp_path / "evil.md").write_text("outside", encoding="utf-8")
+        monkeypatch.setattr(skill_injection, "AGENT_CONTEXT_DIR", context_dir)
+
+        assert skill_injection._is_cao_managed_copilot_agent("../evil") is False
+
 
 class TestRefreshAllCaoManagedAgents:
     """Tests for refresh_all_cao_managed_agents."""


### PR DESCRIPTION
Fixes the path traversal in `cao install` tracked as **GHSA-6m35-gcf5-xm75** (CWE-22 / CWE-73, high). Affects 2.2.0–2.4.1.

## The problem

`cao install` derived the shared context-copy filename — and the per-provider agent-file names — from a profile's *resolved* frontmatter `name:`. That value is not covered by the install source-handle validation and is attacker-controlled for URL installs, so a profile whose `name:` contained a `../` traversal or an absolute path could overwrite an arbitrary `.md` file the invoking user can write.

`.md` is the trusted-instruction format across this ecosystem, so reachable targets included the user's own agent profiles and global agent-instruction files — after which an agent run would follow attacker-authored instructions with that agent's tool permissions. Reachable from the CLI and from `POST /agents/profiles/install`.

## The fix

- The resolved name is validated as a single path segment via the shared `utils/path_validation.validate_path_component` (strict `[A-Za-z0-9._-]` allowlist), rather than a bespoke reimplementation. The allowlist also makes the Unicode-normalization caveat moot: `U+FF0F` is rejected outright instead of needing to be caught before it folds to `/`.
- The write is confined to `AGENT_CONTEXT_DIR` and opened with `O_NOFOLLOW` (POSIX), so it cannot be redirected through a symlink planted at the target. This closes the check-then-write race a plain containment check would leave open.
- Validation and containment live **inside** `_write_context_file`, the same function as the `os.open` sink. This placement is load-bearing and documented in the source: CodeQL's `py/path-injection` dataflow only recognises a barrier guarding the variable that reaches the sink, in the sink's own function.
- The kiro / copilot / opencode agent-file sinks now flatten both `/` and `\` through a shared `flatten_path_separators` helper, closing the class on Windows too (previously triplicated inline).
- `_is_cao_managed_copilot_agent` validates its segment before joining — the last unguarded `AGENT_CONTEXT_DIR` join.
- The context copy is created mode `0o600` rather than `0o644`; it lives under `~/.aws/cli-agent-orchestrator/` and needs no group/world read.

Note it deliberately does **not** call `safe_join_under_base`: that realpaths the full candidate and would follow a symlink planted at the target. The final component is left lexical so `O_NOFOLLOW` refuses it at the write.

## Behavior change

A profile whose frontmatter `name:` contains a path separator is **no longer installable**. Such names only ever worked when the intermediate context directory happened to already exist, and permitting them is what allowed the traversal. Rename the profile to a plain identifier (`[A-Za-z0-9._-]`) to install it. Documented in the changelog under Security.

All 50 profile names in this repo pass the validator.

## Testing

Regression coverage for relative traversal, absolute paths, backslash separators, and symlink escapes — including a symlink whose target is *inside* the directory, which isolates the `O_NOFOLLOW` guard from the containment check.

Every guard was mutation-checked: removing any one of the four fails a test. (The original review caught two tests that did not do this — one re-implemented the production transform inline, so reverting the backslash flatten left the suite green.)

Full unit suite: 5 failed, 7030 passed. All 5 failures reproduce on the unfixed base (memory API, mcp_apps, otel_init) and are unrelated. `black` and `isort` clean; the one mypy finding in a touched file is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
