### PR TITLE
fix(release): repair the per-platform wheel matrix on its first real run

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -49,11 +49,28 @@ jobs:
           # It must stay in lock-step with `scripts/build_tui.py`'s `_ARCHFLAGS_TO_RUST_TARGET`;
           # `test_wheel_matrix.py` asserts that agreement rather than trusting it. (#321)
           #
-          # macOS arm64 — native on GitHub's `macos-latest` (arm64 since macOS 14).
+          # `macos-target` is this leg's MACOSX_DEPLOYMENT_TARGET, and it is REQUIRED, not a
+          # tuning knob. cibuildwheel defaults it to 10.9 for x86_64 and 11.0 for arm64, but
+          # rustc's `x86_64-apple-darwin` emits a binary whose LC_BUILD_VERSION minimum is
+          # 10.12. `delocate-wheel` compares the two and REFUSES the wheel:
+          #
+          #   DelocationError: Library dependencies do not satisfy target MacOS version 10.9:
+          #     .../cao-tui has a minimum target of 10.12
+          #
+          # That is what failed the v2.5.0 x86_64 leg — at REPAIR time, before the smoke test
+          # this config expected to be the x86_64 gap. It is set PER LEG and not once for all
+          # of macOS on purpose: a blanket 10.12 would put arm64 BELOW its own binary's 11.0
+          # floor and break the one macOS leg that already works. Empty on Linux, where the
+          # variable is meaningless. (#321)
+          #
+          # macOS arm64 — native on GitHub's `macos-latest` (arm64 since macOS 14). 11.0 is
+          # cibuildwheel's own arm64 default, pinned here so the pair stays visible and a
+          # future default change cannot silently reintroduce the mismatch above.
           - os: macos-latest
             label: macOS arm64
             archs: arm64
             rust-target: ''
+            macos-target: '11.0'
           # macOS x86_64 — CROSS-COMPILED from the same arm64 runner. cibuildwheel sets
           # ARCHFLAGS, hatchling's tag inference honours it, and scripts/build_tui.py maps it
           # to `--target x86_64-apple-darwin`. See the UNVERIFIED note below: the binary
@@ -62,16 +79,43 @@ jobs:
             label: macOS x86_64
             archs: x86_64
             rust-target: x86_64-apple-darwin
+            macos-target: '10.12'
           - os: ubuntu-latest
             label: Linux x86_64
             archs: x86_64
             rust-target: ''
-          - os: windows-latest
-            label: Windows AMD64
-            archs: AMD64
-            rust-target: ''
+            macos-target: ''
+          # NO WINDOWS LEG. `cli_agent_orchestrator` cannot be IMPORTED on Windows: four
+          # modules import `fcntl` at module scope (services/memory_reconciliation.py,
+          # services/memory_service.py, services/wiki_healer.py, api/main.py — which also
+          # imports `termios`), and `cli/main.py` reaches the first of them through
+          # `cli/commands/init.py`. So every `cao` entry point dies on
+          # `ModuleNotFoundError: No module named 'fcntl'`, not just `cao tui`. Underneath
+          # that, the terminal backend is tmux, which has no native Windows build.
+          #
+          # Windows was therefore never a supported platform; the v2.5.0 matrix asserted one
+          # into existence and the smoke test correctly refused it — the Rust side was clean
+          # (`cao-tui.exe` built, tagged `win_amd64`, 1,110,528 bytes), the Python side was
+          # not. Restoring this leg requires making the package import on Windows AND giving
+          # it a working backend; until then a leg here would only publish a wheel that
+          # installs and then fails, which is the exact outcome #321 exists to prevent.
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      # REQUIRED by the `Assert TUI binary is inside each wheel` step below, which invokes
+      # `python`. cibuildwheel brings its own interpreters for the BUILD, so this job carried
+      # no setup-python — but that step runs on the HOST, and the macOS runner images provide
+      # only `python3`. The v2.5.0 arm64 leg died on `python: command not found` (exit 127)
+      # AFTER cibuildwheel had already built, repaired, and smoke-tested a good wheel.
+      #
+      # setup-python rather than s/python/python3/: the same bare `python` is what the two
+      # publish jobs already use for scripts/assert_wheel_matrix.py, so making the interpreter
+      # explicit keeps one convention instead of two, and does not depend on which image
+      # happens to ship a `python` shim. It cannot affect the wheels — cibuildwheel ignores
+      # the host interpreter when selecting build Pythons. (#321)
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
 
       # The Web UI is built here too so each platform wheel carries it. Without this the
       # web_ui/** artifacts glob resolves empty and hatchling silently omits it (defect D1).
@@ -118,6 +162,11 @@ jobs:
       - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
+          # See `macos-target` in the matrix: this is what keeps delocate from rejecting the
+          # x86_64 wheel over the Rust binary's 10.12 floor. cibuildwheel reads
+          # MACOSX_DEPLOYMENT_TARGET from the environment and only supplies its own default
+          # when unset, so an explicit value wins. Empty on Linux, where it is inert.
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
 
       # Belt-and-braces on top of cibuildwheel's own test-command: assert the binary is
       # inside each produced wheel and within NFR-2's ceiling. Cheap, and it attests the
@@ -232,17 +281,19 @@ jobs:
             label: macOS arm64
           - os: ubuntu-latest
             label: Linux x86_64
-          - os: windows-latest
-            label: Windows AMD64
+          # No Windows leg, for the reason given on the `build-wheels` matrix: the package
+          # cannot be imported on Windows at all, so there is no wheel to smoke-test.
     steps:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Install from TestPyPI (retry while index propagates)
-        # `shell: bash` explicitly: this job now runs on windows-latest too, where the
-        # default shell is PowerShell and none of the parameter expansion or `for` syntax
-        # below would parse. Bash is available on all three GitHub runner images.
+        # `shell: bash` explicitly. It was added when this job also ran on windows-latest,
+        # where the default shell is PowerShell and none of the parameter expansion or `for`
+        # syntax below would parse. That leg is gone, but the pin stays: it makes the shell
+        # independent of the runner's default, so re-adding a platform cannot silently change
+        # how this script is interpreted.
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - validate and contain filesystem paths derived from profile names (GHSA-6m35-gcf5-xm75) (#695)
 
+- install a host Python in build-wheels so the post-build wheel assertion can run at all
+  (the macOS runners ship only `python3`, so `python scripts/build_tui.py check` exited 127)
+
+- set MACOSX_DEPLOYMENT_TARGET per matrix leg (11.0 arm64, 10.12 x86_64) so delocate's
+  minimum-OS check matches the Rust binary's actual floor instead of cibuildwheel's 10.9 default
+
+- stop building and requiring a Windows wheel, and refuse Windows at import with an
+  explanation: four modules import `fcntl` at module scope and the backend is tmux, so the
+  sdist fallback installed but could not import
+
 
 ### Other
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,18 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    # POSIX only, and stated rather than left to be discovered at runtime: the package
+    # imports `fcntl`/`termios` at module scope and orchestrates through tmux, neither of
+    # which exists on Windows.
+    #
+    # These are INFORMATIONAL. No installer enforces an `Operating System` classifier, and
+    # metadata has no way to express an OS constraint the way `requires-python` expresses an
+    # interpreter one. What a Windows operator actually hits is: no matching wheel -> pip
+    # falls back to the sdist -> the sdist installs (the Rust hook is inert without cargo)
+    # -> the first `cao` command raises. `cli_agent_orchestrator/__init__.py` carries the
+    # guard that makes that last step say why.
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
@@ -148,9 +160,15 @@ path = "scripts/hatch_build_tui_tag.py"
 # binary cannot execute on. Per-platform wheels make pip REFUSE an incompatible wheel
 # rather than install a broken one — that refusal is the whole feature.
 #
-# The 4 targets (interview Q2): macOS arm64, macOS x86_64, Linux x86_64, Windows AMD64.
-# Each is built on its own runner in publish-to-pypi.yml; this repo had ZERO non-Linux
-# runners before this change (measured: 25 of 25 `runs-on:` were ubuntu-latest).
+# The targets: macOS arm64, macOS x86_64, Linux x86_64. Each is built on its own runner in
+# publish-to-pypi.yml; this repo had ZERO non-Linux runners before this change (measured:
+# 25 of 25 `runs-on:` were ubuntu-latest).
+#
+# Interview Q2 named a fourth, Windows AMD64, and v2.5.0 tried to ship it. It is NOT built:
+# `cli_agent_orchestrator` cannot be imported on Windows (`fcntl` at module scope in four
+# modules, plus a tmux-only backend), so the smoke test rejected the wheel — correctly. The
+# Rust half was fine; the Python half has never run there. See the `build-wheels` matrix in
+# publish-to-pypi.yml for the full reasoning and what restoring it would require.
 # ---------------------------------------------------------------------------------------
 [tool.cibuildwheel]
 # ONE wheel per platform, not one per Python version. The wheel contains a Rust binary and
@@ -170,7 +188,12 @@ archs = ["auto64"]
 # here executes Alpine, so shipping one would be an unexercised wheel. An Alpine operator
 # gets a clean "no matching distribution" from pip — the correct, loud outcome — rather
 # than a wheel whose binary is dynamically linked against glibc. (#321)
-skip = ["*-musllinux_*"]
+#
+# Windows is skipped for the reason in the header: the package cannot be imported there.
+# Belt to the removed matrix leg's suspenders — the workflow no longer provides a Windows
+# runner, so this cannot trigger in CI, but it also stops a local `cibuildwheel` run on a
+# Windows host from producing a wheel that installs and then raises.
+skip = ["*-musllinux_*", "*-win*"]
 
 # Stage the Rust binary BEFORE hatchling evaluates the artifacts glob. Ordering is
 # load-bearing: hatchling treats a glob matching nothing as a SILENT no-op (defect D1's
@@ -197,20 +220,27 @@ before-build = "python {project}/scripts/build_tui.py build"
 # anyway, since `cao-tui` is a standalone executable, not a linked extension module. (#321)
 test-command = "python {project}/scripts/smoke_test_wheel.py --wheel {wheel} --max-binary-bytes 10485760"
 
-# macOS AND Windows need NO platform-specific keys, and deliberately have no
-# `[tool.cibuildwheel.macos]` / `[...windows]` table: an empty table holding only comments
-# reads like active configuration while setting nothing, so the notes live here instead.
+# macOS needs NO platform-specific keys, and deliberately has no `[tool.cibuildwheel.macos]`
+# table: an empty table holding only comments reads like active configuration while setting
+# nothing, so the notes live here instead. (There is no `[...windows]` table either, but for
+# a different reason — Windows is not built at all; see `skip` above.)
 #
-# - Neither has a build container, so `before-build` runs on the host and needs cargo on
+# - macOS has no build container, so `before-build` runs on the host and needs cargo on
 #   PATH. The publish workflow installs it with a SHA-pinned dtolnay/rust-toolchain step
 #   before invoking cibuildwheel (skipped on Linux, where the toolchain must go INSIDE the
 #   container — see `[tool.cibuildwheel.linux] before-all`).
 # - `repair-wheel-command` is NOT overridden, so cibuildwheel's platform DEFAULT runs
-#   (`delocate-wheel --require-archs {delocate_archs}` on macOS, `delvewheel repair` on
-#   Windows). Those tools vendor shared libraries by inspecting a wheel's extension modules,
-#   and there are none here — `cao-tui` is a standalone executable, not a linked `.so`/`.pyd`
-#   (verified: the built wheel contains zero `.so`/`.pyd` files, and the binary links only
-#   `/usr/lib/libSystem.B.dylib`).
+#   (`delocate-wheel --require-archs {delocate_archs}` on macOS). That tool vendors shared
+#   libraries by inspecting a wheel's extension modules, and there are none here — `cao-tui`
+#   is a standalone executable, not a linked `.so`/`.pyd` (verified: the built wheel contains
+#   zero `.so`/`.pyd` files, and the binary links only `/usr/lib/libSystem.B.dylib`).
+#
+#   IT DOES MORE THAN VENDOR, THOUGH, AND THAT BIT IS LOAD-BEARING: delocate also checks
+#   every Mach-O member's minimum OS version against the wheel's platform tag and REFUSES a
+#   wheel where the binary's floor is higher. On the x86_64 leg, cibuildwheel's default tag
+#   is 10.9 and rustc's `x86_64-apple-darwin` output declares 10.12, so v2.5.0 failed with
+#   `DelocationError: Library dependencies do not satisfy target MacOS version 10.9`. The
+#   fix is the per-leg `macos-target` in the workflow matrix, NOT a change here — see there.
 #
 #   The default was left in place rather than blanked because it was MEASURED to be
 #   beneficial, not merely harmless: run against the real wheel, `delocate-wheel` exits 0 and
@@ -232,6 +262,20 @@ test-command = "python {project}/scripts/smoke_test_wheel.py --wheel {wheel} --m
 # this configuration — exactly the state SR-1 names as unacceptable for a shipped wheel. It
 # is recorded as an explicitly UNVERIFIED platform rather than assumed good; closing it needs
 # a native x86_64 runner. (#321)
+#
+# v2.5.0 UPDATE — the gap was real but it bit EARLIER than predicted. The note above assumed
+# the leg would build a wheel and merely leave it untested. It did not get that far: the
+# deployment-target mismatch described under `repair-wheel-command` killed it during repair,
+# so no x86_64 wheel existed at all. Two lessons worth keeping:
+#
+#   * "built but not executed" was the optimistic reading. A cross-build can fail at any
+#     stage the host can still evaluate, and repair is one of those stages.
+#   * The `smoke-test` job in publish-to-pypi.yml is gated on `github.event_name == 'release'`
+#     and so is SKIPPED on a `workflow_dispatch` publish — and `publish-pypi` accepts a
+#     skipped smoke test on that path. A manual dispatch therefore ships without the
+#     TestPyPI-install-and-exec check. That remains true and is UNVERIFIED coverage, not a
+#     verified platform. Fixing it means either requiring the release event for PyPI
+#     publishes or running the smoke test on dispatch too.
 
 [tool.cibuildwheel.linux]
 # The manylinux CONTAINER has no Rust toolchain, and `before-build` runs inside it — so

--- a/scripts/assert_wheel_matrix.py
+++ b/scripts/assert_wheel_matrix.py
@@ -45,8 +45,14 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
-# The 4-platform set this repo's wheel matrix builds (interview Q2), as patterns matched
-# against the wheel filename's platform tag.
+# The platform set this repo's wheel matrix builds, as patterns matched against the wheel
+# filename's platform tag.
+#
+# WINDOWS IS DELIBERATELY ABSENT. Interview Q2 named four platforms, but
+# `cli_agent_orchestrator` cannot be imported on Windows — four modules import `fcntl` at
+# module scope and the backend is tmux — so `win_amd64` is not built and must not be
+# required here. Requiring a platform the matrix does not build would fail every publish;
+# accepting one that cannot run would be worse. See `build-wheels` in publish-to-pypi.yml.
 #
 # Patterns rather than literals because the tags carry version numbers that legitimately
 # move with the runner image — `macosx_26_0_arm64` tracks the macOS SDK, and a Linux tag may
@@ -73,7 +79,6 @@ REQUIRED_PLATFORM_PATTERNS: Dict[str, List[str]] = {
     "macOS arm64": ["macosx_*_arm64"],
     "macOS x86_64": ["macosx_*_x86_64"],
     "Linux x86_64": ["manylinux_*_x86_64", "linux_x86_64"],
-    "Windows AMD64": ["win_amd64"],
 }
 
 
@@ -197,7 +202,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         nargs="*",
         default=None,
         metavar="PATTERN",
-        help="override the expected platform patterns (default: the 4-platform matrix)",
+        help="override the expected platform patterns (default: the platforms the wheel "
+        "matrix builds)",
     )
     args = parser.parse_args(argv)
 

--- a/src/cli_agent_orchestrator/__init__.py
+++ b/src/cli_agent_orchestrator/__init__.py
@@ -1,0 +1,28 @@
+"""CLI Agent Orchestrator.
+
+This package is POSIX-only. The guard below is the first thing it does, so an unsupported
+platform gets a sentence instead of a traceback from whichever submodule happened to import
+a POSIX-only stdlib module first.
+
+WHY A RUNTIME GUARD AND NOT PACKAGING METADATA: there is no metadata that can stop the
+install. `requires-python` constrains the interpreter, not the OS, and the `Operating System`
+classifiers in pyproject.toml are purely informational — no installer enforces them. Not
+publishing a `win_amd64` wheel only makes pip fall back to the sdist, which builds and
+installs fine (the Rust build hook is inert without cargo). So the first honest failure point
+available is import time, which is here.
+"""
+
+import sys
+
+if sys.platform == "win32":  # pragma: no cover - asserted by a monkeypatched unit test
+    raise ImportError(
+        "cli-agent-orchestrator does not support Windows.\n"
+        "\n"
+        "This package imports POSIX-only stdlib modules (fcntl, termios) at module scope and "
+        "orchestrates agents through tmux, which has no native Windows build. pip installed "
+        "the source distribution because no Windows wheel is published; that install cannot "
+        "run.\n"
+        "\n"
+        "Supported: macOS (arm64, x86_64) and Linux (x86_64). On Windows, run CAO under WSL2 "
+        "or a Linux container, where tmux and the POSIX APIs are available."
+    )

--- a/test/scripts/test_wheel_matrix.py
+++ b/test/scripts/test_wheel_matrix.py
@@ -9,9 +9,11 @@ Every test here either (a) exercises the tag-selection logic that produces the p
 or (b) asserts a guard actually FAILS on the bad input it exists to catch. The second kind
 matters more: a guard that cannot fail is worse than no guard, because it reports success.
 
-What these tests deliberately do NOT claim: that Linux or Windows wheels work. Those cannot
-be built or executed on the development machine (macOS arm64), and no test here pretends
-otherwise — see `test_wheel_matrix_documents_unverified_platforms`.
+What these tests deliberately do NOT claim: that the Linux or macOS x86_64 wheels work.
+Neither can be built or executed on the development machine (macOS arm64), and no test here
+pretends otherwise — see `test_wheel_matrix_documents_unverified_platforms`. Windows is not
+built at all; the `win_amd64` cases below exercise the tag-selection logic and the assertion
+gate on that input, not a shippable artifact.
 """
 
 from __future__ import annotations
@@ -28,6 +30,33 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
+PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-to-pypi.yml"
+
+
+def _publish_workflow() -> Dict[str, Any]:
+    """The publish workflow, PARSED rather than grepped.
+
+    Substring assertions over the raw YAML are what let two of the v2.5.0 release defects
+    through: a missing ``setup-python`` step and an unset ``MACOSX_DEPLOYMENT_TARGET`` are both
+    ABSENCES, and ``assert "x" in text`` cannot see an absence nobody thought to name. Parsing
+    lets a test assert structure instead — which step precedes which, and what value one
+    specific matrix leg carries.
+
+    Module-level so every class that needs the workflow shares one reader; there were two
+    copies of this before.
+    """
+    import yaml
+
+    return yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _wheel_matrix_legs() -> list:
+    """The `build-wheels` matrix legs, as dicts."""
+    return _publish_workflow()["jobs"]["build-wheels"]["strategy"]["matrix"]["include"]
+
+
+def _build_wheels_steps() -> list:
+    return _publish_workflow()["jobs"]["build-wheels"]["steps"]
 
 
 def _load_script(name: str) -> Any:
@@ -603,12 +632,17 @@ class TestAutobuildStagesTheBinary:
 
 
 class TestAssertWheelMatrix:
-    def test_full_four_platform_set_passes(self, tmp_path):
+    def test_full_platform_set_passes_without_a_windows_wheel(self, tmp_path):
+        """The three platforms the matrix builds are the whole requirement.
+
+        Doubles as the regression test for the v2.5.0 publish gate: while `Windows AMD64` was
+        still in ``REQUIRED_PLATFORM_PATTERNS``, this exact directory — every wheel the matrix
+        can actually produce — would have been rejected as incomplete.
+        """
         for tag in (
             "py3-none-macosx_26_0_arm64",
             "py3-none-macosx_26_0_x86_64",
             "py3-none-linux_x86_64",
-            "py3-none-win_amd64",
         ):
             _wheel_with_tag(tmp_path, tag)
         assert assert_wheel_matrix.main(["--dist", str(tmp_path)]) == 0
@@ -618,7 +652,6 @@ class TestAssertWheelMatrix:
         for tag in (
             "py3-none-macosx_26_0_arm64",
             "py3-none-linux_x86_64",
-            "py3-none-win_amd64",
         ):
             _wheel_with_tag(tmp_path, tag)
         assert assert_wheel_matrix.main(["--dist", str(tmp_path)]) == 1
@@ -629,7 +662,6 @@ class TestAssertWheelMatrix:
             "py3-none-macosx_26_0_arm64",
             "py3-none-macosx_26_0_x86_64",
             "py3-none-linux_x86_64",
-            "py3-none-win_amd64",
             "py3-none-any",
         ):
             _wheel_with_tag(tmp_path, tag)
@@ -659,7 +691,6 @@ class TestAssertWheelMatrix:
             "py3-none-macosx_26_0_arm64",
             "py3-none-macosx_26_0_x86_64",
             "py3-none-manylinux_2_28_x86_64",
-            "py3-none-win_amd64",
         ):
             _wheel_with_tag(tmp_path, tag)
         assert assert_wheel_matrix.main(["--dist", str(tmp_path)]) == 0
@@ -676,7 +707,6 @@ class TestAssertWheelMatrix:
             "py3-none-macosx_26_0_arm64",
             "py3-none-macosx_26_0_x86_64",
             "py3-none-musllinux_1_2_x86_64",
-            "py3-none-win_amd64",
         ):
             _wheel_with_tag(tmp_path, tag)
         assert assert_wheel_matrix.main(["--dist", str(tmp_path)]) == 1
@@ -687,7 +717,6 @@ class TestAssertWheelMatrix:
             "py3-none-macosx_26_0_arm64",
             "py3-none-macosx_26_0_x86_64",
             "py3-none-manylinux_2_28_aarch64",
-            "py3-none-win_amd64",
         ):
             _wheel_with_tag(tmp_path, tag)
         assert assert_wheel_matrix.main(["--dist", str(tmp_path)]) == 1
@@ -812,25 +841,15 @@ class TestReleaseToolchainInstallsEveryCrossTarget:
     later without one, which is the same silence the original defect had.
     """
 
-    WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-to-pypi.yml"
+    WORKFLOW = PUBLISH_WORKFLOW
 
     @staticmethod
     def _wheel_matrix() -> list:
-        import yaml
-
-        workflow = yaml.safe_load(
-            TestReleaseToolchainInstallsEveryCrossTarget.WORKFLOW.read_text(encoding="utf-8")
-        )
-        return workflow["jobs"]["build-wheels"]["strategy"]["matrix"]["include"]
+        return _wheel_matrix_legs()
 
     @staticmethod
     def _toolchain_step() -> dict:
-        import yaml
-
-        workflow = yaml.safe_load(
-            TestReleaseToolchainInstallsEveryCrossTarget.WORKFLOW.read_text(encoding="utf-8")
-        )
-        steps = workflow["jobs"]["build-wheels"]["steps"]
+        steps = _build_wheels_steps()
         matches = [s for s in steps if "dtolnay/rust-toolchain" in str(s.get("uses", ""))]
         assert len(matches) == 1, (
             f"expected exactly one rust-toolchain step in build-wheels, found {len(matches)}; "
@@ -1013,19 +1032,138 @@ class TestConfigurationInvariants:
         )
         assert text.count("timeout-minutes:") >= 5
 
-    def test_matrix_covers_the_four_named_platforms(self):
-        """Interview Q2. This repo had ZERO non-Linux runners before this unit."""
-        text = (REPO_ROOT / ".github" / "workflows" / "publish-to-pypi.yml").read_text(
-            encoding="utf-8"
+    def test_matrix_covers_the_three_supported_platforms(self):
+        """Interview Q2 named four; Windows is not one of them. See the next test."""
+        legs = _wheel_matrix_legs()
+        assert {leg["label"] for leg in legs} == {
+            "macOS arm64",
+            "macOS x86_64",
+            "Linux x86_64",
+        }
+        assert {leg["os"] for leg in legs} == {"macos-latest", "ubuntu-latest"}
+        assert {leg["archs"] for leg in legs} == {"arm64", "x86_64"}
+
+    def test_no_windows_leg_is_built_or_smoke_tested(self):
+        """Windows cannot import this package, so a wheel for it must not be produced.
+
+        v2.5.0 shipped a matrix that built one. `cao-tui.exe` was fine; the Python package
+        died on `ModuleNotFoundError: No module named 'fcntl'` in the smoke test. Pinned in
+        FOUR places because a leg restored in any one of them alone would either publish a
+        broken wheel or deadlock the publish gate on an artifact nobody builds.
+
+        Asserted over the PARSED runner values, not a grep for "windows-latest": the first
+        draft of this test grepped, and failed on its own explanatory comment. A substring
+        check over YAML cannot tell configuration from prose ABOUT configuration.
+        """
+        workflow = _publish_workflow()
+        for job in ("build-wheels", "smoke-test"):
+            runners = {
+                str(leg["os"]) for leg in workflow["jobs"][job]["strategy"]["matrix"]["include"]
+            }
+            assert not any("windows" in r for r in runners), (
+                f"a Windows runner is back in the {job} matrix ({sorted(runners)}); the "
+                "package still cannot be imported on Windows (fcntl at module scope, "
+                "tmux-only backend)"
+            )
+        assert (
+            "Windows AMD64" not in assert_wheel_matrix.REQUIRED_PLATFORM_PATTERNS
+        ), "the publish gate would block on a wheel the matrix no longer builds"
+        assert "*-win*" in self._pyproject()["tool"]["cibuildwheel"]["skip"]
+
+    def test_wheel_job_provides_a_host_python_for_the_assert_step(self):
+        """The v2.5.0 macOS arm64 failure: `python: command not found`, exit 127.
+
+        cibuildwheel supplies interpreters for the BUILD, so this job originally had no
+        setup-python — but the `Assert TUI binary is inside each wheel` step shells out to
+        `python` on the HOST, and the macOS images provide only `python3`. That step runs
+        AFTER cibuildwheel has already produced and smoke-tested a good wheel, so the whole
+        leg failed on a working artifact.
+        """
+        steps = _build_wheels_steps()
+        setup_python = [s for s in steps if "actions/setup-python@" in s.get("uses", "")]
+        assert setup_python, (
+            "build-wheels invokes `python` on the host but sets up no interpreter; the macOS "
+            "runner images have only `python3`"
         )
-        for runner in ("macos-latest", "ubuntu-latest", "windows-latest"):
-            assert f"os: {runner}" in text, f"{runner} missing from the wheel matrix"
-        for arch in ("arm64", "x86_64", "AMD64"):
-            assert f"archs: {arch}" in text
+
+        # Ordering is the whole point: an interpreter configured after the step that needs it
+        # is no interpreter at all.
+        def index_of(predicate) -> int:
+            return next(i for i, s in enumerate(steps) if predicate(s))
+
+        assert index_of(lambda s: "actions/setup-python@" in s.get("uses", "")) < index_of(
+            lambda s: "python scripts/build_tui.py check" in s.get("run", "")
+        )
+
+    def test_macos_deployment_target_clears_the_rust_binary_floor_per_leg(self):
+        """The v2.5.0 macOS x86_64 failure, in delocate:
+
+            DelocationError: Library dependencies do not satisfy target MacOS version 10.9:
+              .../cao-tui has a minimum target of 10.12
+
+        cibuildwheel defaults x86_64 to 10.9, but rustc's `x86_64-apple-darwin` output
+        declares 10.12, and delocate refuses the wheel. Asserted PER LEG rather than as one
+        macOS-wide value: a blanket 10.12 would drop arm64 below its own binary's 11.0 floor
+        and break the leg that already worked, so a single shared value is itself the bug.
+        """
+        targets = {leg["label"]: leg["macos-target"] for leg in _wheel_matrix_legs()}
+        assert targets["macOS x86_64"] == "10.12", (
+            "the x86_64 leg's deployment target must clear rustc's 10.12 floor or "
+            "delocate-wheel rejects the wheel during repair"
+        )
+        assert (
+            targets["macOS arm64"] == "11.0"
+        ), "arm64's binary floor is 11.0; lowering this leg to match x86_64 would break it"
+        assert targets["Linux x86_64"] == "", "the variable is meaningless on Linux"
+
+        # And the value has to actually reach cibuildwheel.
+        steps = _build_wheels_steps()
+        cibw = next(s for s in steps if "pypa/cibuildwheel@" in s.get("uses", ""))
+        assert cibw["env"]["MACOSX_DEPLOYMENT_TARGET"] == "${{ matrix.macos-target }}"
 
     def test_wheelhouse_is_gitignored(self):
         """cibuildwheel's output dir holds multi-MB binaries; it must not enter history."""
         assert "wheelhouse/" in (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+
+
+class TestWindowsIsRefusedAtImport:
+    """Not publishing a Windows wheel is NOT the same as refusing to install on Windows.
+
+    No installer enforces an ``Operating System`` classifier, and metadata cannot express an
+    OS constraint. Without a wheel, pip falls back to the sdist, which builds and installs
+    fine — the Rust hook is inert without cargo. So the guard in
+    ``cli_agent_orchestrator/__init__.py`` is the only thing standing between a Windows
+    operator and ``ModuleNotFoundError: No module named 'fcntl'`` from whichever submodule
+    happened to be imported first.
+
+    The module source is exec'd under a patched ``sys.platform`` because the real package is
+    already imported by the time these tests run, so a plain ``import`` cannot re-trigger it.
+    """
+
+    SOURCE = REPO_ROOT / "src" / "cli_agent_orchestrator" / "__init__.py"
+
+    def _exec(self) -> None:
+        exec(  # noqa: S102 - executing our own source under a patched platform is the test
+            compile(self.SOURCE.read_text(encoding="utf-8"), str(self.SOURCE), "exec"),
+            {"__name__": "cli_agent_orchestrator"},
+        )
+
+    def test_import_on_win32_raises_and_says_why(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        with pytest.raises(ImportError) as excinfo:
+            self._exec()
+        message = str(excinfo.value)
+        # The diagnosis, the cause, and the way forward — a bare "unsupported" would leave the
+        # operator no better off than the ModuleNotFoundError it replaces.
+        assert "does not support Windows" in message
+        assert "fcntl" in message and "tmux" in message
+        assert "WSL2" in message
+
+    @pytest.mark.parametrize("platform", ["darwin", "linux"])
+    def test_the_guard_is_inert_on_supported_platforms(self, monkeypatch, platform):
+        """The negative control. A guard that fires everywhere would break every install."""
+        monkeypatch.setattr(sys, "platform", platform)
+        self._exec()
 
 
 def test_wheel_matrix_documents_unverified_platforms():

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ wheels = [
 
 [[package]]
 name = "cli-agent-orchestrator"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Problem

The v2.5.0 release run (`33142381236`) failed three of four wheel-matrix legs. Nothing was published — `publish-testpypi`, `publish-pypi` and `smoke-test` all skipped — so no PyPI filename is burned and the tag is still recoverable.

The per-platform wheel machinery landed in #547 (issue #321) and has never been exercised until now. `git tag --contains 2a6f20c` returns `v2.5.0` and nothing else. Two structural reasons it went uncaught:

- `publish-to-pypi.yml` only triggers on `release: published` and `workflow_dispatch`. No PR check runs it.
- `test/scripts/test_wheel_matrix.py` covers the **Python scripts** (tag selection, the assertion gate, the hatch hook), not the **runners**. Every assertion in it passed on a workflow that could not execute.

The three failures are **not** a common cause. They only share that this workflow had never run on a non-Linux runner.

## Fixes

### 1. macOS arm64 — `python: command not found`, exit 127

`build-wheels` runs `python scripts/build_tui.py check` on the host after cibuildwheel. The macOS runner images ship only `python3`, and the job had no `setup-python`.

Worth noting what actually happened on this leg: cibuildwheel had already built the wheel, repaired it, and executed `cao tui` successfully. The failure was in the belt-and-braces step *after* the real work.

Fix: add `actions/setup-python` (SHA-pinned, 3.12) before the assert step.

### 2. macOS x86_64 — `DelocationError` at repair

```
delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.9:
  .../cao-tui has a minimum target of 10.12
```

`delocate-wheel` does not just vendor libraries — it validates each Mach-O's minimum-OS against the wheel's platform tag. cibuildwheel defaults `MACOSX_DEPLOYMENT_TARGET` to 10.9 for x86_64, while rustc's `x86_64-apple-darwin` emits a 10.12 minimum. The variable was set nowhere in the repo.

Fix: a `macos-target` matrix key, **per leg** — `10.12` on x86_64, `11.0` on arm64. This has to be per-leg: a blanket 10.12 would drop arm64 below its own 11.0 floor.

This also failed *earlier* than #547's own comment predicted. That comment said the cross-compiled wheel would be "built but not executed"; in fact it never got past repair.

### 3. Windows AMD64 — `ModuleNotFoundError: No module named 'fcntl'`

Pre-existing, and not a release-plumbing defect. `fcntl` is imported at module scope in `services/memory_reconciliation.py:10`, `services/memory_service.py:4`, `services/wiki_healer.py:33` and `api/main.py:4` (which also imports `termios` at :13). The chain that fires is `cli/main.py:10` → `cli/commands/init.py:13` → `memory_reconciliation.py:10`. The only terminal backend is tmux, which has no native Windows build.

The Rust half was fine — `cao-tui.exe` built, tagged `py3-none-win_amd64`, 1,110,528 bytes. The Python package simply cannot import.

Fix: drop the leg from `build-wheels`, from `smoke-test`, and from `assert_wheel_matrix.py`'s required set. Requiring a platform the matrix does not build would fail every publish; accepting one that cannot run would be worse.

## Why a runtime guard and not packaging metadata

There is no metadata that can stop a Windows install:

- `requires-python` constrains the interpreter, not the OS.
- `Operating System` classifiers are **informational**. No installer enforces them. They are added here for discoverability, with a comment saying exactly that so nobody later mistakes them for a gate.
- Publishing no `win_amd64` wheel only makes pip fall back to the **sdist**, which builds and installs cleanly — the Rust build hook is deliberately inert without cargo.

So the first honest failure point available is import time. `src/cli_agent_orchestrator/__init__.py` (previously empty) now raises an `ImportError` on `win32` naming the reason and pointing at WSL2 or a Linux container, instead of a bare `ModuleNotFoundError` from whichever submodule happened to import `fcntl` first.

## Testing

Four new tests, all mutation-checked:

- `test_no_windows_leg_is_built_or_smoke_tested` — asserts over **parsed YAML** runners across both job matrices, plus the required-platform set and the cibuildwheel `skip`. The first draft of this test used a substring check and passed against my own comment prose *about* the removed leg; a substring check over YAML cannot tell configuration from prose about configuration, and the docstring now records that.
- `test_wheel_job_provides_a_host_python_for_the_assert_step` — presence **and** ordering: setup-python must precede the assert step.
- `test_macos_deployment_target_clears_the_rust_binary_floor_per_leg` — per-leg values, and that the variable actually reaches cibuildwheel's env.
- `TestWindowsIsRefusedAtImport` — execs `__init__.py`'s source under a monkeypatched `sys.platform`, with a parametrized negative control for `darwin` and `linux` so the guard cannot pass by never firing.

Verification run:

- `uv run pytest -m 'not e2e' -n 8` → **8403 passed**, 38 skipped, 1 xfailed, 2 failed.
  - `test_kimi_session.py::TestT3BoundedRegex::test_extract_completes_under_one_second_for_realistic_stress` — wall-clock assertion, flakes under `-n 8`, passes serially.
  - `test_launch.py::test_launch_builtin_profile_resolves_role_defaults` — **an environment leak in the test, not a product defect.** The test asserts on the *built-in* `code_supervisor` profile, but `_read_agent_profile_source` searches the local store (`$CAO_HOME_DIR/agent-store/`) first, and this developer machine has a hand-authored `code_supervisor.md` there with `allowedTools: ['*']`. Running the same test with `CAO_HOME_DIR` pointed at an empty temp dir passes. CI is unaffected because runners have no local store. This is the same class of leakage #684 addressed, in a test that fix did not cover; worth its own small change to isolate `CAO_HOME_DIR`, and out of scope here.
- `test/scripts/test_wheel_matrix.py` → 77 passed.
- 7/7 mutations caught: remove setup-python; blank the x86_64 target; drop the env var; restore the Windows build leg; re-require a Windows wheel at the gate; neuter the win32 guard; un-skip windows in cibuildwheel.
- `black` / `isort` clean across `src/ test/ scripts/` (611 files); `mypy` clean on both changed source files.

## Known gap, documented but not fixed here

`smoke-test` is gated on `github.event_name == 'release'`, and `publish-pypi` accepts a skipped smoke test. So the `workflow_dispatch` path — the one this release actually used — publishes to PyPI **without** the TestPyPI install-and-exec check. Recorded in `pyproject.toml`'s CONSEQUENCE section; fixing it is a separate change.

## Also

`uv.lock` still said `2.4.1`; the release commit did not refresh it. Any `uv run` rewrites it, so it is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
