### PR TITLE
fix(release): stop publishing a macOS x86_64 wheel that cannot install

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -50,18 +50,18 @@ jobs:
           # `test_wheel_matrix.py` asserts that agreement rather than trusting it. (#321)
           #
           # `macos-target` is this leg's MACOSX_DEPLOYMENT_TARGET, and it is REQUIRED, not a
-          # tuning knob. cibuildwheel defaults it to 10.9 for x86_64 and 11.0 for arm64, but
-          # rustc's `x86_64-apple-darwin` emits a binary whose LC_BUILD_VERSION minimum is
-          # 10.12. `delocate-wheel` compares the two and REFUSES the wheel:
+          # tuning knob. `delocate-wheel` compares every bundled Mach-O member's
+          # LC_BUILD_VERSION minimum against the wheel's platform tag and REFUSES a wheel whose
+          # binary floor is higher:
           #
           #   DelocationError: Library dependencies do not satisfy target MacOS version 10.9:
           #     .../cao-tui has a minimum target of 10.12
           #
-          # That is what failed the v2.5.0 x86_64 leg — at REPAIR time, before the smoke test
-          # this config expected to be the x86_64 gap. It is set PER LEG and not once for all
-          # of macOS on purpose: a blanket 10.12 would put arm64 BELOW its own binary's 11.0
-          # floor and break the one macOS leg that already works. Empty on Linux, where the
-          # variable is meaningless. (#321)
+          # That is verbatim what failed v2.5.0's x86_64 leg — at REPAIR time, before the smoke
+          # test that config expected to be the x86_64 gap. That leg is gone now (see below),
+          # but the key stays PER LEG rather than collapsing to one macOS-wide value: rustc's
+          # floor differs by target, so a blanket value correct for one arch puts another BELOW
+          # its own binary's floor. Empty on Linux, where the variable is meaningless. (#321)
           #
           # macOS arm64 — native on GitHub's `macos-latest` (arm64 since macOS 14). 11.0 is
           # cibuildwheel's own arm64 default, pinned here so the pair stays visible and a
@@ -71,20 +71,34 @@ jobs:
             archs: arm64
             rust-target: ''
             macos-target: '11.0'
-          # macOS x86_64 — CROSS-COMPILED from the same arm64 runner. cibuildwheel sets
-          # ARCHFLAGS, hatchling's tag inference honours it, and scripts/build_tui.py maps it
-          # to `--target x86_64-apple-darwin`. See the UNVERIFIED note below: the binary
-          # cannot be EXECUTED here, so its smoke test is skipped by cibuildwheel.
-          - os: macos-latest
-            label: macOS x86_64
-            archs: x86_64
-            rust-target: x86_64-apple-darwin
-            macos-target: '10.12'
           - os: ubuntu-latest
             label: Linux x86_64
             archs: x86_64
             rust-target: ''
             macos-target: ''
+          # NO macOS x86_64 (INTEL) LEG. Not because it cannot be BUILT — v2.5.0's cross-build
+          # produced a correctly tagged wheel once the deployment target above was fixed — but
+          # because the wheel cannot be INSTALLED on the platform it targets.
+          #
+          # Measured over every `cryptography` release on PyPI: 48.0.1 and earlier ship
+          # `macosx_10_9_universal2`; 49.0.0 onward ship `macosx_11_0_arm64` and nothing else
+          # for macOS. This project floors at `cryptography>=50.0.0` (49.0.0 fixes
+          # CVE-2026-69249, 50.0.0 fixes CVE-2026-69247, both HIGH, and Trivy's gate is
+          # blocking) — so EVERY version we are permitted to resolve is one with no Intel wheel,
+          # and an Intel Mac must build it from source, which needs OpenSSL headers and a Rust
+          # toolchain.
+          #
+          # That is where v2.5.0's leg actually died: inside cibuildwheel's own test venv, where
+          # pip tried to build cryptography for x86_64 from an arm64 host and `openssl-sys`
+          # reported `pkg-config has not been configured to support cross-compilation`
+          # ($HOST = aarch64-apple-darwin, $TARGET = x86_64-apple-darwin).
+          #
+          # `test-skip` was considered and REJECTED: silencing the test would have published a
+          # wheel whose install fails the same way on the operator's machine, only later and
+          # with no CI record. Dropping the leg means an Intel Mac gets a clean "no matching
+          # distribution" from pip instead. Restoring it needs cryptography to ship Intel wheels
+          # again (or a vendored OpenSSL) AND a native x86_64 runner to execute the result.
+          #
           # NO WINDOWS LEG. `cli_agent_orchestrator` cannot be IMPORTED on Windows: four
           # modules import `fcntl` at module scope (services/memory_reconciliation.py,
           # services/memory_service.py, services/wiki_healer.py, api/main.py — which also
@@ -141,13 +155,16 @@ jobs:
       # `@stable` re-resolves on every run and is unreviewable supply chain. The toolchain
       # channel is selected by the `toolchain` input, which is what `@stable` really did.
       #
-      # `targets:` is what makes the macOS x86_64 leg compile at all. `build_tui.py` passes
-      # `--target x86_64-apple-darwin` whenever cibuildwheel sets `ARCHFLAGS=-arch x86_64`,
-      # and cargo cannot build for a target whose std is not installed. Without this the leg
-      # dies on "target may not be installed", and because `publish-testpypi` `needs:
-      # build-wheels`, the FIRST release after this lands would fail outright. The action
-      # expands the input to `rustup toolchain install <channel> --target <triple>`; an empty
-      # value expands to nothing, which is correct for the three host-target legs.
+      # `targets:` installs the target std a CROSS-BUILD needs before cargo runs; cargo cannot
+      # build for a target whose std is absent, and the failure is "target may not be
+      # installed". EVERY LEG IS CURRENTLY HOST-TARGET, so `matrix.rust-target` is empty
+      # throughout and the action expands the input to nothing.
+      #
+      # The plumbing stays rather than being deleted with the cross-compiled leg it was added
+      # for: `build_tui.py` still maps ARCHFLAGS to `--target <triple>`, so the day a
+      # cross-build returns, omitting this input fails the leg — and because
+      # `publish-testpypi` `needs: build-wheels`, it fails at release time, where no PR check
+      # can see it. `test_wheel_matrix.py` asserts the matrix and the arch map agree.
       # (Reported by review on PR #547.)
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4  # stable @ 2026-07-16
         if: runner.os != 'Linux'
@@ -162,10 +179,11 @@ jobs:
       - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
-          # See `macos-target` in the matrix: this is what keeps delocate from rejecting the
-          # x86_64 wheel over the Rust binary's 10.12 floor. cibuildwheel reads
-          # MACOSX_DEPLOYMENT_TARGET from the environment and only supplies its own default
-          # when unset, so an explicit value wins. Empty on Linux, where it is inert.
+          # See `macos-target` in the matrix: this is what keeps delocate from rejecting a
+          # macOS wheel whose Rust binary declares a higher minimum than the wheel's tag.
+          # cibuildwheel reads MACOSX_DEPLOYMENT_TARGET from the environment and only supplies
+          # its own default when unset, so an explicit value wins. Empty on Linux, where it is
+          # inert.
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
 
       # Belt-and-braces on top of cibuildwheel's own test-command: assert the binary is
@@ -187,7 +205,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           # Per-platform artifact names, merged by the publish jobs via `pattern:` +
-          # `merge-multiple:`. A shared name would make the four uploads race.
+          # `merge-multiple:`. A shared name would make the legs race each other.
           name: dist-${{ matrix.os }}-${{ matrix.archs }}
           path: wheelhouse/*.whl
           if-no-files-found: error
@@ -281,8 +299,10 @@ jobs:
             label: macOS arm64
           - os: ubuntu-latest
             label: Linux x86_64
-          # No Windows leg, for the reason given on the `build-wheels` matrix: the package
-          # cannot be imported on Windows at all, so there is no wheel to smoke-test.
+          # One leg per PUBLISHED wheel, and no more: there is no Windows or Intel-macOS wheel
+          # to smoke-test, for the reasons given on the `build-wheels` matrix. Keeping this
+          # matrix in step with that one is what makes "every wheel we ship is installed and
+          # executed by CI" true rather than aspirational.
     steps:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,12 +128,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - install a host Python in build-wheels so the post-build wheel assertion can run at all
   (the macOS runners ship only `python3`, so `python scripts/build_tui.py check` exited 127)
 
-- set MACOSX_DEPLOYMENT_TARGET per matrix leg (11.0 arm64, 10.12 x86_64) so delocate's
-  minimum-OS check matches the Rust binary's actual floor instead of cibuildwheel's 10.9 default
+- set MACOSX_DEPLOYMENT_TARGET per matrix leg so delocate's minimum-OS check matches the Rust
+  binary's actual floor instead of cibuildwheel's 10.9 default
 
 - stop building and requiring a Windows wheel, and refuse Windows at import with an
   explanation: four modules import `fcntl` at module scope and the backend is tmux, so the
   sdist fallback installed but could not import
+
+- stop building and requiring a macOS x86_64 (Intel) wheel: `cryptography` ships no
+  Intel-macOS wheel at 49.0.0 or above, and CAO floors at `cryptography>=50.0.0` for two HIGH
+  CVEs, so an Intel Mac cannot resolve its dependencies from wheels at all. Intel Macs now get
+  a clean "no matching distribution" from pip rather than a wheel that installs and then fails.
+  Every wheel CAO publishes is now both built and executed by CI.
 
 
 ### Other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,15 +160,24 @@ path = "scripts/hatch_build_tui_tag.py"
 # binary cannot execute on. Per-platform wheels make pip REFUSE an incompatible wheel
 # rather than install a broken one — that refusal is the whole feature.
 #
-# The targets: macOS arm64, macOS x86_64, Linux x86_64. Each is built on its own runner in
-# publish-to-pypi.yml; this repo had ZERO non-Linux runners before this change (measured:
-# 25 of 25 `runs-on:` were ubuntu-latest).
+# The targets: macOS arm64 and Linux x86_64. Each is built on its own runner in
+# publish-to-pypi.yml, and each is then installed from TestPyPI and EXECUTED by the
+# `smoke-test` job — so every wheel this project publishes has been both built and run by CI.
+# This repo had ZERO non-Linux runners before this change (measured: 25 of 25 `runs-on:` were
+# ubuntu-latest).
 #
-# Interview Q2 named a fourth, Windows AMD64, and v2.5.0 tried to ship it. It is NOT built:
-# `cli_agent_orchestrator` cannot be imported on Windows (`fcntl` at module scope in four
-# modules, plus a tmux-only backend), so the smoke test rejected the wheel — correctly. The
-# Rust half was fine; the Python half has never run there. See the `build-wheels` matrix in
-# publish-to-pypi.yml for the full reasoning and what restoring it would require.
+# Interview Q2 named two more, and v2.5.0 tried to ship both. Neither is built:
+#
+#   * Windows AMD64 — `cli_agent_orchestrator` cannot be imported on Windows (`fcntl` at module
+#     scope in four modules, plus a tmux-only backend), so the smoke test rejected the wheel —
+#     correctly.
+#   * macOS x86_64 — `cryptography` ships no Intel-macOS wheel at 49.0.0 or above, and this
+#     project's CVE floor is `cryptography>=50.0.0`, so an Intel Mac cannot resolve its
+#     dependencies from wheels at all. The leg died inside cibuildwheel's own test venv.
+#
+# Both are BUILDABLE — that was never the problem. The Rust half of each was fine; what fails
+# is the install on the platform the wheel claims to serve. See the `build-wheels` matrix in
+# publish-to-pypi.yml for the measurements and what restoring either would require.
 # ---------------------------------------------------------------------------------------
 [tool.cibuildwheel]
 # ONE wheel per platform, not one per Python version. The wheel contains a Rust binary and
@@ -189,11 +198,14 @@ archs = ["auto64"]
 # gets a clean "no matching distribution" from pip — the correct, loud outcome — rather
 # than a wheel whose binary is dynamically linked against glibc. (#321)
 #
-# Windows is skipped for the reason in the header: the package cannot be imported there.
-# Belt to the removed matrix leg's suspenders — the workflow no longer provides a Windows
-# runner, so this cannot trigger in CI, but it also stops a local `cibuildwheel` run on a
-# Windows host from producing a wheel that installs and then raises.
-skip = ["*-musllinux_*", "*-win*"]
+# Windows and Intel macOS are skipped for the reasons in the header: the package cannot be
+# imported on the former, and cannot resolve `cryptography>=50` from wheels on the latter.
+# Belt to the removed matrix legs' suspenders — the workflow provides neither runner nor arch,
+# so neither can trigger in CI, but this also stops a LOCAL `cibuildwheel` run (on a Windows
+# host, or on an Intel Mac, or with `--archs x86_64` on Apple silicon) from producing a wheel
+# that installs and then fails. A skip here is inert when the matrix agrees and load-bearing
+# when a human runs the tool by hand.
+skip = ["*-musllinux_*", "*-win*", "*-macosx_x86_64"]
 
 # Stage the Rust binary BEFORE hatchling evaluates the artifacts glob. Ordering is
 # load-bearing: hatchling treats a glob matching nothing as a SILENT no-op (defect D1's
@@ -237,10 +249,12 @@ test-command = "python {project}/scripts/smoke_test_wheel.py --wheel {wheel} --m
 #
 #   IT DOES MORE THAN VENDOR, THOUGH, AND THAT BIT IS LOAD-BEARING: delocate also checks
 #   every Mach-O member's minimum OS version against the wheel's platform tag and REFUSES a
-#   wheel where the binary's floor is higher. On the x86_64 leg, cibuildwheel's default tag
-#   is 10.9 and rustc's `x86_64-apple-darwin` output declares 10.12, so v2.5.0 failed with
-#   `DelocationError: Library dependencies do not satisfy target MacOS version 10.9`. The
-#   fix is the per-leg `macos-target` in the workflow matrix, NOT a change here — see there.
+#   wheel where the binary's floor is higher. That is how v2.5.0's x86_64 leg first failed:
+#   cibuildwheel's default x86_64 tag is 10.9, rustc's `x86_64-apple-darwin` output declares
+#   10.12, and the result was
+#   `DelocationError: Library dependencies do not satisfy target MacOS version 10.9`. The fix
+#   was the per-leg `macos-target` in the workflow matrix, NOT a change here — see there. It
+#   still guards the arm64 leg, whose 11.0 floor is pinned for the same reason.
 #
 #   The default was left in place rather than blanked because it was MEASURED to be
 #   beneficial, not merely harmless: run against the real wheel, `delocate-wheel` exits 0 and
@@ -249,33 +263,39 @@ test-command = "python {project}/scripts/smoke_test_wheel.py --wheel {wheel} --m
 #   still `Mach-O 64-bit executable arm64`) and the smoke test passes on the repaired wheel.
 #   Blanking this would have shipped a needlessly narrow macOS floor. (#321)
 #
-# THE macOS x86_64 WHEEL IS CROSS-COMPILED, AND THAT HAS A CONSEQUENCE.
-# GitHub's `macos-latest` is arm64; the x86_64 labels (`macos-15-intel`, `*-large`) are
-# separate images. cibuildwheel drives the cross-build by setting ARCHFLAGS and
-# _PYTHON_HOST_PLATFORM per build identifier; hatchling's tag inference honours both
-# (verified locally: ARCHFLAGS='-arch x86_64' yields a `macosx_*_x86_64` tag), and
-# scripts/build_tui.py maps the same ARCHFLAGS to `--target x86_64-apple-darwin`.
+# THE macOS x86_64 WHEEL WAS CROSS-COMPILED, AND IT IS NO LONGER BUILT AT ALL.
+# The original design cross-built it from the arm64 runner: GitHub's `macos-latest` is arm64
+# and the x86_64 labels (`macos-15-intel`, `*-large`) are separate images, so cibuildwheel
+# drove the cross-build via ARCHFLAGS and _PYTHON_HOST_PLATFORM, hatchling's tag inference
+# honoured both (verified locally: ARCHFLAGS='-arch x86_64' yields a `macosx_*_x86_64` tag),
+# and scripts/build_tui.py mapped the same ARCHFLAGS to `--target x86_64-apple-darwin`.
 #
-# CONSEQUENCE, stated rather than glossed: an x86_64 binary cannot be EXECUTED on an arm64
-# runner without Rosetta, so cibuildwheel skips that arch's test and only warns
-# (platforms/macos.py:659-688). The macOS x86_64 wheel is therefore BUILT but NOT executed by
-# this configuration — exactly the state SR-1 names as unacceptable for a shipped wheel. It
-# is recorded as an explicitly UNVERIFIED platform rather than assumed good; closing it needs
-# a native x86_64 runner. (#321)
+# That design was recorded here as an explicitly unverified platform, because an x86_64 binary
+# cannot be EXECUTED on an arm64 runner without Rosetta and cibuildwheel skips that arch's test
+# with only a warning (platforms/macos.py:659-688). v2.5.0 was its first real run, and the
+# outcome was worse than "untested" TWICE OVER:
 #
-# v2.5.0 UPDATE — the gap was real but it bit EARLIER than predicted. The note above assumed
-# the leg would build a wheel and merely leave it untested. It did not get that far: the
-# deployment-target mismatch described under `repair-wheel-command` killed it during repair,
-# so no x86_64 wheel existed at all. Two lessons worth keeping:
+#   1. It failed during REPAIR, before any test could be skipped — the deployment-target
+#      mismatch described under `repair-wheel-command` above.
+#   2. With that fixed, it failed inside cibuildwheel's TEST VENV, where pip had to build
+#      `cryptography` from source for x86_64 and `openssl-sys` reported `pkg-config has not
+#      been configured to support cross-compilation`.
 #
-#   * "built but not executed" was the optimistic reading. A cross-build can fail at any
-#     stage the host can still evaluate, and repair is one of those stages.
-#   * The `smoke-test` job in publish-to-pypi.yml is gated on `github.event_name == 'release'`
-#     and so is SKIPPED on a `workflow_dispatch` publish — and `publish-pypi` accepts a
-#     skipped smoke test on that path. A manual dispatch therefore ships without the
-#     TestPyPI-install-and-exec check. That remains true and is UNVERIFIED coverage, not a
-#     verified platform. Fixing it means either requiring the release event for PyPI
-#     publishes or running the smoke test on dispatch too.
+# CONSEQUENCE, stated rather than glossed: (2) is not a CI artifact. Measured over every
+# `cryptography` release on PyPI, 48.0.1 and earlier ship `macosx_10_9_universal2` and 49.0.0
+# onward ship `macosx_11_0_arm64` and nothing else for macOS. The floor above is
+# `cryptography>=50.0.0` for two HIGH CVEs, so an Intel Mac must compile it from source
+# regardless of what this project publishes. A wheel we shipped would fail on the operator's
+# machine exactly as it failed in CI, just later. So the leg was DROPPED rather than
+# `test-skip`ped, and pip now returns a clean "no matching distribution" instead.
+#
+# NET EFFECT ON HONESTY: no platform is shipped unverified any more. Every wheel published is
+# built by `build-wheels`, installed from TestPyPI by `smoke-test`, and executed there. The one
+# remaining UNVERIFIED item is a COVERAGE gap, not a platform: `smoke-test` is gated on
+# `github.event_name == 'release'` and is therefore SKIPPED on a `workflow_dispatch` publish,
+# while `publish-pypi` accepts a skipped smoke test on that path. A manual dispatch ships
+# without the install-and-exec check. Closing it means requiring the release event for PyPI
+# publishes, or running the smoke test on dispatch too. (#321)
 
 [tool.cibuildwheel.linux]
 # The manylinux CONTAINER has no Rust toolchain, and `before-build` runs inside it — so

--- a/scripts/assert_wheel_matrix.py
+++ b/scripts/assert_wheel_matrix.py
@@ -8,8 +8,8 @@ WHY A COUNT IS NOT ENOUGH, AND WHY A GREEN MATRIX IS NOT EITHER
 ---------------------------------------------------------------
 The wheel matrix runs with ``fail-fast: false`` so one platform's failure does not hide the
 others. The trade-off is that a partial result looks almost identical to a complete one in
-a run summary — three green legs and one red is easy to skim past, and the publish job would
-then upload three platforms as if that were the release.
+a run summary — a column of green with one red is easy to skim past, and the publish job
+would then upload whatever survived as if that were the release.
 
 Worse, a matrix leg can succeed while producing the WRONG artifact. The defect this unit
 fixes is precisely that: a build that reported success and emitted a ``py3-none-any`` wheel
@@ -17,9 +17,9 @@ containing a ``Mach-O 64-bit arm64`` executable. Every job was green.
 
 So this script asserts the *artifacts*, not the job outcomes:
 
-1. **Every expected platform is present.** Missing macOS x86_64 means Intel-Mac operators
-   get no wheel — pip falls back to the sdist and builds from source, which needs a Rust
-   toolchain they may not have.
+1. **Every expected platform is present.** A platform the matrix builds but fails to deliver
+   leaves its operators with no wheel — pip falls back to the sdist and builds from source,
+   which needs a Rust toolchain they may not have.
 2. **No wheel is tagged ``any``.** A single ``*-any.whl`` in ``dist/`` is the original defect
    reaching PyPI, where it OUTRANKS the platform wheels for every installer: pip prefers a
    more specific tag, but an ``any`` wheel is compatible everywhere, so any host whose
@@ -33,7 +33,7 @@ against — the same authority the installer uses.
 Usage
 -----
     python scripts/assert_wheel_matrix.py --dist dist/
-    python scripts/assert_wheel_matrix.py --dist dist/ --expect macosx_arm64 win_amd64
+    python scripts/assert_wheel_matrix.py --dist dist/ --expect macosx_11_0_arm64
 
 Exits 0 on success; non-zero with an explanatory report on failure.
 """
@@ -48,11 +48,18 @@ from typing import Dict, List, Optional, Sequence
 # The platform set this repo's wheel matrix builds, as patterns matched against the wheel
 # filename's platform tag.
 #
-# WINDOWS IS DELIBERATELY ABSENT. Interview Q2 named four platforms, but
-# `cli_agent_orchestrator` cannot be imported on Windows — four modules import `fcntl` at
-# module scope and the backend is tmux — so `win_amd64` is not built and must not be
-# required here. Requiring a platform the matrix does not build would fail every publish;
-# accepting one that cannot run would be worse. See `build-wheels` in publish-to-pypi.yml.
+# WINDOWS AND macOS x86_64 ARE DELIBERATELY ABSENT. Interview Q2 named four platforms; two of
+# them cannot be delivered as a working install:
+#
+#   * `win_amd64` — `cli_agent_orchestrator` cannot be imported on Windows at all (four
+#     modules import `fcntl` at module scope, and the backend is tmux).
+#   * `macosx_*_x86_64` — this project floors at `cryptography>=50.0.0` for two HIGH CVEs, and
+#     cryptography ships no Intel-macOS wheel at 49.0.0 or above, so an Intel Mac must compile
+#     it from source no matter what we publish.
+#
+# Neither is built, and neither may be REQUIRED here. Requiring a platform the matrix does not
+# build would fail every publish; accepting one that cannot run would be worse. See
+# `build-wheels` in publish-to-pypi.yml for the measurements behind both.
 #
 # Patterns rather than literals because the tags carry version numbers that legitimately
 # move with the runner image — `macosx_26_0_arm64` tracks the macOS SDK, and a Linux tag may
@@ -77,7 +84,6 @@ from typing import Dict, List, Optional, Sequence
 # required one makes the check unfalsifiable. (#321)
 REQUIRED_PLATFORM_PATTERNS: Dict[str, List[str]] = {
     "macOS arm64": ["macosx_*_arm64"],
-    "macOS x86_64": ["macosx_*_x86_64"],
     "Linux x86_64": ["manylinux_*_x86_64", "linux_x86_64"],
 }
 

--- a/test/scripts/test_wheel_matrix.py
+++ b/test/scripts/test_wheel_matrix.py
@@ -9,11 +9,11 @@ Every test here either (a) exercises the tag-selection logic that produces the p
 or (b) asserts a guard actually FAILS on the bad input it exists to catch. The second kind
 matters more: a guard that cannot fail is worse than no guard, because it reports success.
 
-What these tests deliberately do NOT claim: that the Linux or macOS x86_64 wheels work.
-Neither can be built or executed on the development machine (macOS arm64), and no test here
-pretends otherwise — see `test_wheel_matrix_documents_unverified_platforms`. Windows is not
-built at all; the `win_amd64` cases below exercise the tag-selection logic and the assertion
-gate on that input, not a shippable artifact.
+What these tests deliberately do NOT claim: that the Linux wheel works. It cannot be built
+or executed on the development machine (macOS arm64), and no test here pretends otherwise —
+see `test_wheel_matrix_documents_unverified_platforms`. Windows and Intel macOS are not built
+at all; their tags still appear below because the tag-selection logic and the assertion gate
+must behave correctly on any input hatchling hands them, not because either is shippable.
 """
 
 from __future__ import annotations
@@ -194,10 +194,15 @@ class TestPlatformTagSelection:
             ("cp310-cp310-win_amd64", "win_amd64"),
         ],
     )
-    def test_platform_component_is_preserved_for_every_matrix_target(
+    def test_platform_component_is_preserved_for_any_platform_hatchling_infers(
         self, tmp_path, monkeypatch, best_tag, expected_platform
     ):
-        """The platform half comes from hatchling and must pass through untouched."""
+        """The platform half comes from hatchling and must pass through untouched.
+
+        Deliberately broader than the shipped matrix: two of these platforms are not built,
+        but the hook must not special-case a platform list it cannot see, and a tag it
+        mangled would be worse than one it refused.
+        """
         _stage_binary(tmp_path)
         monkeypatch.setenv(hatch_hook.FORCE_ENV, "1")
 
@@ -632,16 +637,16 @@ class TestAutobuildStagesTheBinary:
 
 
 class TestAssertWheelMatrix:
-    def test_full_platform_set_passes_without_a_windows_wheel(self, tmp_path):
-        """The three platforms the matrix builds are the whole requirement.
+    def test_full_platform_set_passes_without_windows_or_intel_macos_wheels(self, tmp_path):
+        """The two platforms the matrix builds are the whole requirement.
 
-        Doubles as the regression test for the v2.5.0 publish gate: while `Windows AMD64` was
-        still in ``REQUIRED_PLATFORM_PATTERNS``, this exact directory — every wheel the matrix
-        can actually produce — would have been rejected as incomplete.
+        Doubles as the regression test for the v2.5.0 publish gate: while `Windows AMD64` and
+        `macOS x86_64` were still in ``REQUIRED_PLATFORM_PATTERNS``, this exact directory —
+        every wheel the matrix can actually produce — would have been rejected as incomplete,
+        blocking the publish on artifacts nothing builds.
         """
         for tag in (
             "py3-none-macosx_26_0_arm64",
-            "py3-none-macosx_26_0_x86_64",
             "py3-none-linux_x86_64",
         ):
             _wheel_with_tag(tmp_path, tag)
@@ -649,18 +654,26 @@ class TestAssertWheelMatrix:
 
     def test_missing_one_platform_fails(self, tmp_path):
         """A partial matrix must not publish. `fail-fast: false` makes this easy to miss."""
-        for tag in (
-            "py3-none-macosx_26_0_arm64",
-            "py3-none-linux_x86_64",
-        ):
-            _wheel_with_tag(tmp_path, tag)
+        _wheel_with_tag(tmp_path, "py3-none-macosx_26_0_arm64")
         assert assert_wheel_matrix.main(["--dist", str(tmp_path)]) == 1
+
+    def test_the_gate_still_fails_on_a_platform_it_is_asked_to_require(self, tmp_path):
+        """The shrunken required set must not be mistaken for a gate that cannot fail.
+
+        Two platforms were removed from ``REQUIRED_PLATFORM_PATTERNS`` for good reasons; this
+        pins that the remaining mechanism is still load-bearing by asking it, via ``--expect``,
+        for a platform the directory does not have.
+        """
+        _wheel_with_tag(tmp_path, "py3-none-macosx_26_0_arm64")
+        assert (
+            assert_wheel_matrix.main(["--dist", str(tmp_path), "--expect", "macosx_26_0_x86_64"])
+            == 1
+        )
 
     def test_an_any_wheel_in_the_set_fails(self, tmp_path):
         """An 'any' wheel OUTRANKS the platform wheels for any unmatched host."""
         for tag in (
             "py3-none-macosx_26_0_arm64",
-            "py3-none-macosx_26_0_x86_64",
             "py3-none-linux_x86_64",
             "py3-none-any",
         ):
@@ -689,7 +702,6 @@ class TestAssertWheelMatrix:
         """
         for tag in (
             "py3-none-macosx_26_0_arm64",
-            "py3-none-macosx_26_0_x86_64",
             "py3-none-manylinux_2_28_x86_64",
         ):
             _wheel_with_tag(tmp_path, tag)
@@ -705,7 +717,6 @@ class TestAssertWheelMatrix:
         """
         for tag in (
             "py3-none-macosx_26_0_arm64",
-            "py3-none-macosx_26_0_x86_64",
             "py3-none-musllinux_1_2_x86_64",
         ):
             _wheel_with_tag(tmp_path, tag)
@@ -715,7 +726,6 @@ class TestAssertWheelMatrix:
         """The suffix pins the ARCH; an aarch64 wheel must not stand in for x86_64."""
         for tag in (
             "py3-none-macosx_26_0_arm64",
-            "py3-none-macosx_26_0_x86_64",
             "py3-none-manylinux_2_28_aarch64",
         ):
             _wheel_with_tag(tmp_path, tag)
@@ -837,8 +847,14 @@ class TestReleaseToolchainInstallsEveryCrossTarget:
     ``workflow_dispatch``. (Reported by review on PR #547.)
 
     Asserted against the PARSED yaml and against ``build_tui.py``'s own arch map, not against
-    a string in the file. A grep for ``targets:`` would keep passing if a fifth leg were added
-    later without one, which is the same silence the original defect had.
+    a string in the file. A grep for ``targets:`` would keep passing if a leg were added later
+    without one, which is the same silence the original defect had.
+
+    NO LEG CROSS-COMPILES TODAY — the one that did (macOS x86_64) was dropped in v2.5.0 for a
+    dependency reason, not because cross-compiling stopped working. So the arch-map agreement
+    tests below are currently vacuous by construction, and the load-bearing assertion is
+    ``test_the_toolchain_step_installs_the_matrix_target``: it fails if the plumbing that a
+    restored leg would need is deleted as dead config.
     """
 
     WORKFLOW = PUBLISH_WORKFLOW
@@ -1032,12 +1048,11 @@ class TestConfigurationInvariants:
         )
         assert text.count("timeout-minutes:") >= 5
 
-    def test_matrix_covers_the_three_supported_platforms(self):
-        """Interview Q2 named four; Windows is not one of them. See the next test."""
+    def test_matrix_covers_the_two_shippable_platforms(self):
+        """Interview Q2 named four. Two are not shippable — see the next two tests."""
         legs = _wheel_matrix_legs()
         assert {leg["label"] for leg in legs} == {
             "macOS arm64",
-            "macOS x86_64",
             "Linux x86_64",
         }
         assert {leg["os"] for leg in legs} == {"macos-latest", "ubuntu-latest"}
@@ -1095,31 +1110,70 @@ class TestConfigurationInvariants:
             lambda s: "python scripts/build_tui.py check" in s.get("run", "")
         )
 
-    def test_macos_deployment_target_clears_the_rust_binary_floor_per_leg(self):
+    def test_macos_deployment_target_is_declared_per_leg_and_reaches_cibuildwheel(self):
         """The v2.5.0 macOS x86_64 failure, in delocate:
 
             DelocationError: Library dependencies do not satisfy target MacOS version 10.9:
               .../cao-tui has a minimum target of 10.12
 
-        cibuildwheel defaults x86_64 to 10.9, but rustc's `x86_64-apple-darwin` output
-        declares 10.12, and delocate refuses the wheel. Asserted PER LEG rather than as one
-        macOS-wide value: a blanket 10.12 would drop arm64 below its own binary's 11.0 floor
-        and break the leg that already worked, so a single shared value is itself the bug.
+        delocate compares the bundled binary's minimum-OS against the wheel's platform tag, so
+        each leg's MACOSX_DEPLOYMENT_TARGET has to clear its own binary's floor. It is declared
+        PER LEG because cibuildwheel's defaults differ by arch (10.9 x86_64, 11.0 arm64) and so
+        do the floors — one macOS-wide value is necessarily wrong for one of them.
+
+        Only the arm64 leg remains (the Intel leg is gone; see the test below), so what is
+        pinned here is the value AND the plumbing. Without the env line the matrix key would be
+        inert config that reads as if it were doing something.
         """
         targets = {leg["label"]: leg["macos-target"] for leg in _wheel_matrix_legs()}
-        assert targets["macOS x86_64"] == "10.12", (
-            "the x86_64 leg's deployment target must clear rustc's 10.12 floor or "
-            "delocate-wheel rejects the wheel during repair"
-        )
         assert (
             targets["macOS arm64"] == "11.0"
-        ), "arm64's binary floor is 11.0; lowering this leg to match x86_64 would break it"
+        ), "arm64's binary floor is 11.0; a lower value here is rejected by delocate at repair"
         assert targets["Linux x86_64"] == "", "the variable is meaningless on Linux"
+        assert all(
+            "macos-target" in leg for leg in _wheel_matrix_legs()
+        ), "every leg must declare the key, so an added platform has to make the choice"
 
         # And the value has to actually reach cibuildwheel.
         steps = _build_wheels_steps()
         cibw = next(s for s in steps if "pypa/cibuildwheel@" in s.get("uses", ""))
         assert cibw["env"]["MACOSX_DEPLOYMENT_TARGET"] == "${{ matrix.macos-target }}"
+
+    def test_no_intel_macos_wheel_is_built_or_required(self):
+        """cryptography ships no Intel-macOS wheel at the versions we are allowed to use.
+
+        Measured over every cryptography release on PyPI: 48.0.1 and earlier ship
+        `macosx_10_9_universal2`; 49.0.0 onward ship `macosx_11_0_arm64` and nothing else for
+        macOS. This project floors at `cryptography>=50.0.0` because 49.0.0 fixes
+        CVE-2026-69249 and 50.0.0 fixes CVE-2026-69247, both HIGH — so every permitted version
+        is one with no Intel wheel, and an Intel-Mac install must compile it from source.
+
+        v2.5.0's x86_64 leg died on exactly that inside cibuildwheel's test venv: pkg-config
+        cannot supply an x86_64 OpenSSL from an arm64 host. Suppressing the leg's test would
+        have shipped a wheel that fails the same way on the operator's machine, so the leg is
+        gone instead.
+
+        Pinned in three places, because restoring it in any one alone either publishes a wheel
+        that cannot install or deadlocks the publish gate on an artifact nobody builds.
+        """
+        legs = _wheel_matrix_legs()
+        intel = [
+            leg["label"]
+            for leg in legs
+            if str(leg["os"]).startswith("macos") and leg["archs"] == "x86_64"
+        ]
+        assert not intel, (
+            f"an Intel-macOS leg is back in build-wheels ({intel}); cryptography>=50 has no "
+            "Intel-macOS wheel, so the leg's test venv cannot resolve it and neither can an "
+            "operator's Intel Mac"
+        )
+        assert (
+            "macOS x86_64" not in assert_wheel_matrix.REQUIRED_PLATFORM_PATTERNS
+        ), "the publish gate would block forever on a wheel the matrix no longer builds"
+        assert "*-macosx_x86_64" in self._pyproject()["tool"]["cibuildwheel"]["skip"], (
+            "a local cibuildwheel run on an Intel Mac would otherwise emit the wheel that "
+            "CI deliberately does not"
+        )
 
     def test_wheelhouse_is_gitignored(self):
         """cibuildwheel's output dir holds multi-MB binaries; it must not enter history."""
@@ -1169,11 +1223,15 @@ class TestWindowsIsRefusedAtImport:
 def test_wheel_matrix_documents_unverified_platforms():
     """The honesty requirement, asserted rather than left to a report.
 
-    Three of the four platform wheels CANNOT be built or executed on the development machine
-    (macOS arm64), and the operator declined Docker/QEMU emulation. The configuration must
-    therefore state which platforms remain CI's to prove — a config that reads as though all
-    four were verified is exactly the "passed CI but partially worked" failure this intent
-    exists to eliminate, made worse because wheels reach operators.
+    The Linux wheel CANNOT be built or executed on the development machine (macOS arm64), and
+    the operator declined Docker/QEMU emulation. The configuration must therefore state what
+    remains CI's to prove — a config that reads as though everything were verified is exactly
+    the "passed CI but partially worked" failure this intent exists to eliminate, made worse
+    because wheels reach operators.
+
+    Since v2.5.0 the remaining admission is no longer about a PLATFORM: both unverifiable
+    platforms were dropped rather than shipped unverified, so every wheel published is built
+    and executed by CI. What is left is the smoke-test-on-dispatch coverage gap.
 
     This test fails if those admissions are removed from the config, so the caveat cannot be
     quietly dropped by a later edit.
@@ -1181,6 +1239,7 @@ def test_wheel_matrix_documents_unverified_platforms():
     text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     assert "CONSEQUENCE, stated rather than glossed" in text, (
         "the pyproject cibuildwheel section must keep naming the known gaps (the "
-        "linux_x86_64/PyPI rejection, and the untested cross-compiled macOS x86_64 binary)"
+        "linux_x86_64/PyPI rejection, why the Intel-macOS leg was dropped rather than "
+        "shipped untested, and the smoke-test-on-dispatch hole)"
     )
     assert "UNVERIFIED" in text


### PR DESCRIPTION
## Problem

#700 fixed the macOS x86_64 leg's `DelocationError` by setting `MACOSX_DEPLOYMENT_TARGET` per matrix leg. The leg then got past repair — and died one stage later, inside cibuildwheel's own **test venv**:

```
Building wheel for cryptography (pyproject.toml): finished with status 'error'
  Running `maturin pep517 build-wheel -i .../cp310-macosx_x86_64/venv-test-x86_64/bin/python`
  error: failed to run custom build command for `openssl-sys v0.9.117`
  Could not find openssl via pkg-config:
  pkg-config has not been configured to support cross-compilation.
  $HOST = aarch64-apple-darwin
  $TARGET = x86_64-apple-darwin
ERROR: Failed building wheel for cryptography
```

## Why this is not a CI artifact

pip had to build `cryptography` from source because **no Intel-macOS wheel exists at any version this project is allowed to resolve.** Measured over every `cryptography` release on PyPI:

| version | macOS wheels |
|---|---|
| ≤ 48.0.1 | `macosx_10_9_universal2` (covers Intel) |
| ≥ 49.0.0 | `macosx_11_0_arm64` only |

CAO floors at `cryptography>=50.0.0` because **49.0.0 fixes CVE-2026-69249** and **50.0.0 fixes CVE-2026-69247**, both HIGH, and the repo-wide Trivy gate is blocking. So the security floor and the Intel-wheel window do not overlap: an Intel Mac must compile `cryptography` from source (OpenSSL headers + Rust toolchain) regardless of what CAO publishes.

`test-skip` was considered and **rejected**: silencing the leg's test would ship a wheel whose install fails the same way on the operator's machine, only later and with no CI record. Dropping the leg gives an Intel Mac a clean `no matching distribution` from pip instead.

## Change

The Intel-macOS leg is dropped, mirroring the Windows leg dropped in #700. Pinned in **three** places, because restoring it in any one alone either publishes a wheel that cannot install or deadlocks the publish gate on an artifact nobody builds:

1. the `build-wheels` matrix in `publish-to-pypi.yml`
2. `REQUIRED_PLATFORM_PATTERNS` in `scripts/assert_wheel_matrix.py`
3. cibuildwheel's `skip` in `pyproject.toml` (load-bearing for a **local** `cibuildwheel` run on an Intel Mac or with `--archs x86_64`)

All three are asserted by `test_no_intel_macos_wheel_is_built_or_required`.

### Net effect on honesty

Published platforms are now **macOS arm64** and **Linux x86_64** — and each is built by `build-wheels`, then installed from TestPyPI and **executed** by `smoke-test`. The `CONSEQUENCE, stated rather than glossed` block in `pyproject.toml` no longer admits an unverified *platform*; both unverifiable ones were dropped rather than shipped. The one remaining `UNVERIFIED` item is a coverage gap, not a platform: `smoke-test` is gated on `github.event_name == 'release'` and is skipped on a `workflow_dispatch` publish, while `publish-pypi` accepts a skipped smoke test on that path.

The per-leg `MACOSX_DEPLOYMENT_TARGET` plumbing and `rust-toolchain targets:` input **stay** even though every remaining leg is host-target: `build_tui.py` still maps ARCHFLAGS to `--target <triple>`, so the day a cross-build returns, omitting either fails at release time where no PR check can see it.

## Verification

- `test/scripts/test_wheel_matrix.py` — **79 passed**
- **Mutation-tested.** Seven mutants, each caught by the suite: restore the Intel leg; restore the Windows leg; re-require Intel at the gate; un-skip Intel in cibuildwheel; drop the per-leg `MACOSX_DEPLOYMENT_TARGET`; drop the `CONSEQUENCE`/`UNVERIFIED` admission; neuter the `win32` import guard.
- Workflow YAML and `pyproject.toml` re-parsed: `build-wheels` = `[macOS arm64/arm64, Linux x86_64/x86_64]`, `smoke-test` = the same two labels, `skip = ['*-musllinux_*', '*-win*', '*-macosx_x86_64']`.
- `black`, `isort`, `mypy` clean.
- Full suite: **8406 passed / 38 skipped / 1 xfailed**. The single failure is a known machine-local environment leak (`test_launch_builtin_profile_resolves_role_defaults` reads this machine's `$CAO_HOME_DIR/agent-store/code_supervisor.md` instead of the built-in profile — same class as #684, not reproducible on a runner).

## Operator impact

Intel Macs no longer get a CAO wheel. They can install from source with a Rust toolchain and OpenSSL headers available, or run CAO in a Linux container. `CHANGELOG.md` and the 2.5.0 release notes state this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
