### PR TITLE
fix(mcp): require workflow tool arguments

### DIFF
--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -2334,13 +2334,15 @@ async def workflow_return(
     output: Annotated[
         Dict[str, Any], Field(description="The structured JSON output for this workflow step")
     ],
-    output_schema: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description=(
-            "Optional JSON-Schema (Draft 2020-12) to validate the output against. "
-            "Pass the step's declared output_schema so the seam can validate it."
+    output_schema: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            description=(
+                "Optional JSON-Schema (Draft 2020-12) to validate the output against. "
+                "Pass the step's declared output_schema so the seam can validate it."
+            )
         ),
-    ),
+    ] = None,
 ) -> Dict[str, Any]:
     """Return a structured output for the current workflow step (issue #312, N4).
 
@@ -2398,17 +2400,20 @@ async def workflow_run(
     name_or_path: Annotated[
         str, Field(description="Workflow name (indexed) or path to a spec YAML file")
     ],
-    inputs: Optional[Dict[str, Any]] = Field(
-        default=None, description="Run inputs, validated against the spec's declared inputs"
-    ),
-    run_id: Optional[str] = Field(
-        default=None,
-        description=(
-            "Optional explicit run id (matches WORKFLOW_NAME_RE); the server mints "
-            "one if omitted. Validation and the uniqueness/admission gate are "
-            "server-side — a collision surfaces as the ok=False error envelope."
+    inputs: Annotated[
+        Optional[Dict[str, Any]],
+        Field(description="Run inputs, validated against the spec's declared inputs"),
+    ] = None,
+    run_id: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional explicit run id (matches WORKFLOW_NAME_RE); the server mints "
+                "one if omitted. Validation and the uniqueness/admission gate are "
+                "server-side — a collision surfaces as the ok=False error envelope."
+            )
         ),
-    ),
+    ] = None,
 ) -> Dict[str, Any]:
     """Run a workflow to completion and return the aggregated result (issue #312, N5).
 
@@ -2469,19 +2474,21 @@ async def workflow_run(
 @mcp.tool()
 async def workflow_resume(
     run_id: Annotated[str, Field(description="The run id to resume (a crashed/failed prior run)")],
-    decisions: Optional[Dict[str, str]] = Field(
-        default=None,
-        description=(
-            "Optional per-step recovery decisions for a halted script run: "
-            "{step_id: 'rerun'|'skip'}. 'rerun' authorises re-executing the step; "
-            "'skip' authorises using its stored result. Applied before the script is "
-            "spawned; an unknown step id or value applies nothing at all. Each "
-            "decision authorises exactly ONE attempt: if that attempt crashes before "
-            "it settles, the next resume asks again rather than re-executing on old "
-            "consent, so a decision is never standing authorisation for a later "
-            "resume and must not be presented to a user as one."
+    decisions: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description=(
+                "Optional per-step recovery decisions for a halted script run: "
+                "{step_id: 'rerun'|'skip'}. 'rerun' authorises re-executing the step; "
+                "'skip' authorises using its stored result. Applied before the script is "
+                "spawned; an unknown step id or value applies nothing at all. Each "
+                "decision authorises exactly ONE attempt: if that attempt crashes before "
+                "it settles, the next resume asks again rather than re-executing on old "
+                "consent, so a decision is never standing authorisation for a later "
+                "resume and must not be presented to a user as one."
+            )
         ),
-    ),
+    ] = None,
 ) -> Dict[str, Any]:
     """Resume a crashed or failed workflow run from its durable journal (issue #312, N6).
 
@@ -2591,16 +2598,19 @@ async def workflow_start(
     name_or_path: Annotated[
         str, Field(description="Workflow name (indexed) or path to a spec YAML file")
     ],
-    inputs: Optional[Dict[str, Any]] = Field(
-        default=None, description="Run inputs, validated against the spec's declared inputs"
-    ),
-    run_id: Optional[str] = Field(
-        default=None,
-        description=(
-            "Optional explicit run id (matches WORKFLOW_NAME_RE); the server mints "
-            "one if omitted. A collision surfaces as the ok=False error envelope."
+    inputs: Annotated[
+        Optional[Dict[str, Any]],
+        Field(description="Run inputs, validated against the spec's declared inputs"),
+    ] = None,
+    run_id: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional explicit run id (matches WORKFLOW_NAME_RE); the server mints "
+                "one if omitted. A collision surfaces as the ok=False error envelope."
+            )
         ),
-    ),
+    ] = None,
 ) -> Dict[str, Any]:
     """Submit a workflow run ASYNCHRONOUSLY and return its handle immediately (issue #505, U6).
 
@@ -2770,10 +2780,11 @@ async def workflow_result(
 
 @mcp.tool()
 async def workflow_list(
-    state: Optional[str] = Field(
-        default=None, description="Filter by run state (e.g. running, completed, failed, cancelled)"
-    ),
-    limit: int = Field(default=50, description="Max rows to return (server clamps to [1, 500])"),
+    state: Annotated[
+        Optional[str],
+        Field(description="Filter by run state (e.g. running, completed, failed, cancelled)"),
+    ] = None,
+    limit: Annotated[int, Field(description="Max rows to return (server clamps to [1, 500])")] = 50,
 ) -> Dict[str, Any]:
     """List journaled workflow runs newest-first (issue #505, U6; FR-3.5).
 
@@ -2909,21 +2920,25 @@ def _classify_events_404(run_id: str, detail: str) -> tuple:
 @mcp.tool()
 async def workflow_events(
     run_id: Annotated[str, Field(description="The run id whose live event stream to follow")],
-    after_seq: Optional[int] = Field(
-        default=None,
-        description=(
-            "Resume strictly after this per-run seq (exact, dedupe-free). Omit to "
-            "read from the start of the run's event stream."
+    after_seq: Annotated[
+        Optional[int],
+        Field(
+            description=(
+                "Resume strictly after this per-run seq (exact, dedupe-free). Omit to "
+                "read from the start of the run's event stream."
+            )
         ),
-    ),
-    max_events: Optional[int] = Field(
-        default=None,
-        description=(
-            "Stop after draining this many events (an MCP call cannot stream "
-            "indefinitely). Defaults to a bounded ceiling; the follower also stops "
-            "at a terminal state, whichever comes first."
+    ] = None,
+    max_events: Annotated[
+        Optional[int],
+        Field(
+            description=(
+                "Stop after draining this many events (an MCP call cannot stream "
+                "indefinitely). Defaults to a bounded ceiling; the follower also stops "
+                "at a terminal state, whichever comes first."
+            )
         ),
-    ),
+    ] = None,
 ) -> Dict[str, Any]:
     """Follow a run's live event stream, BOUNDED, and return a dict envelope (issue #505, U10).
 

--- a/src/cli_agent_orchestrator/mcp_server/server.py
+++ b/src/cli_agent_orchestrator/mcp_server/server.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 import time
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Annotated, Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import requests
 from fastmcp import FastMCP
@@ -2331,7 +2331,9 @@ async def store_lesson(
 
 @mcp.tool()
 async def workflow_return(
-    output: Dict[str, Any] = Field(description="The structured JSON output for this workflow step"),
+    output: Annotated[
+        Dict[str, Any], Field(description="The structured JSON output for this workflow step")
+    ],
     output_schema: Optional[Dict[str, Any]] = Field(
         default=None,
         description=(
@@ -2393,7 +2395,9 @@ async def workflow_return(
 
 @mcp.tool()
 async def workflow_run(
-    name_or_path: str = Field(description="Workflow name (indexed) or path to a spec YAML file"),
+    name_or_path: Annotated[
+        str, Field(description="Workflow name (indexed) or path to a spec YAML file")
+    ],
     inputs: Optional[Dict[str, Any]] = Field(
         default=None, description="Run inputs, validated against the spec's declared inputs"
     ),
@@ -2464,7 +2468,7 @@ async def workflow_run(
 
 @mcp.tool()
 async def workflow_resume(
-    run_id: str = Field(description="The run id to resume (a crashed/failed prior run)"),
+    run_id: Annotated[str, Field(description="The run id to resume (a crashed/failed prior run)")],
     decisions: Optional[Dict[str, str]] = Field(
         default=None,
         description=(
@@ -2549,7 +2553,7 @@ async def workflow_resume(
 
 @mcp.tool()
 async def workflow_cancel(
-    run_id: str = Field(description="The run id to cancel (from a prior workflow_run)"),
+    run_id: Annotated[str, Field(description="The run id to cancel (from a prior workflow_run)")],
 ) -> Dict[str, Any]:
     """Cooperatively cancel a running workflow (issue #312, N5).
 
@@ -2584,7 +2588,9 @@ async def workflow_cancel(
 # ---------------------------------------------------------------------------
 @mcp.tool()
 async def workflow_start(
-    name_or_path: str = Field(description="Workflow name (indexed) or path to a spec YAML file"),
+    name_or_path: Annotated[
+        str, Field(description="Workflow name (indexed) or path to a spec YAML file")
+    ],
     inputs: Optional[Dict[str, Any]] = Field(
         default=None, description="Run inputs, validated against the spec's declared inputs"
     ),
@@ -2642,7 +2648,9 @@ async def workflow_start(
 
 @mcp.tool()
 async def workflow_plan_approval(
-    run_id: str = Field(description="The run id to report on (from workflow_start / workflow_run)"),
+    run_id: Annotated[
+        str, Field(description="The run id to report on (from workflow_start / workflow_run)")
+    ],
 ) -> Dict[str, Any]:
     """Report a run's plan identifier and whether that plan is approved (issue #583 FR-8).
 
@@ -2695,7 +2703,9 @@ async def workflow_plan_approval(
 
 @mcp.tool()
 async def workflow_status(
-    run_id: str = Field(description="The run id to snapshot (from workflow_start / workflow_run)"),
+    run_id: Annotated[
+        str, Field(description="The run id to snapshot (from workflow_start / workflow_run)")
+    ],
 ) -> Dict[str, Any]:
     """Return a point-in-time status snapshot for a run (issue #505, U6).
 
@@ -2727,7 +2737,7 @@ async def workflow_status(
 
 @mcp.tool()
 async def workflow_result(
-    run_id: str = Field(description="The run id whose retained result to fetch"),
+    run_id: Annotated[str, Field(description="The run id whose retained result to fetch")],
 ) -> Dict[str, Any]:
     """Return the complete retained result for a run (issue #505, U6; FR-7.2).
 
@@ -2792,7 +2802,9 @@ async def workflow_list(
 
 @mcp.tool()
 async def workflow_wait(
-    run_id: str = Field(description="The run id to follow until it reaches a terminal state"),
+    run_id: Annotated[
+        str, Field(description="The run id to follow until it reaches a terminal state")
+    ],
 ) -> Dict[str, Any]:
     """Follow a submitted run to a terminal state, then return its result (issue #505, U6).
 
@@ -2896,7 +2908,7 @@ def _classify_events_404(run_id: str, detail: str) -> tuple:
 
 @mcp.tool()
 async def workflow_events(
-    run_id: str = Field(description="The run id whose live event stream to follow"),
+    run_id: Annotated[str, Field(description="The run id whose live event stream to follow")],
     after_seq: Optional[int] = Field(
         default=None,
         description=(

--- a/test/mcp_server/test_workflow_required_parameters.py
+++ b/test/mcp_server/test_workflow_required_parameters.py
@@ -1,0 +1,31 @@
+"""Regression tests for required workflow MCP tool parameters (issue #697)."""
+
+import inspect
+
+import pytest
+
+from cli_agent_orchestrator.mcp_server import server
+
+_REQUIRED_WORKFLOW_PARAMETERS = (
+    ("workflow_return", "output"),
+    ("workflow_run", "name_or_path"),
+    ("workflow_resume", "run_id"),
+    ("workflow_cancel", "run_id"),
+    ("workflow_start", "name_or_path"),
+    ("workflow_plan_approval", "run_id"),
+    ("workflow_status", "run_id"),
+    ("workflow_result", "run_id"),
+    ("workflow_wait", "run_id"),
+    ("workflow_events", "run_id"),
+)
+
+
+@pytest.mark.parametrize("tool_name, parameter_name", _REQUIRED_WORKFLOW_PARAMETERS)
+def test_required_workflow_parameters_are_required(tool_name, parameter_name):
+    """Omitted required arguments fail at the Python call boundary, not in a tool body."""
+    tool = getattr(server, tool_name)
+    parameter = inspect.signature(tool).parameters[parameter_name]
+
+    assert parameter.default is inspect.Parameter.empty
+    with pytest.raises(TypeError):
+        tool()

--- a/test/mcp_server/test_workflow_required_parameters.py
+++ b/test/mcp_server/test_workflow_required_parameters.py
@@ -45,9 +45,7 @@ def test_direct_workflow_run_call_uses_json_safe_omitted_optional_defaults():
         payloads.append(json)
         raise requests.ConnectionError("down")
 
-    with patch(
-        "cli_agent_orchestrator.mcp_server.server.requests.post", side_effect=post
-    ):
+    with patch("cli_agent_orchestrator.mcp_server.server.requests.post", side_effect=post):
         result = asyncio.run(server.workflow_run("demo"))
 
     assert inspect.signature(server.workflow_run).parameters["inputs"].default is None
@@ -69,14 +67,9 @@ def test_direct_workflow_return_call_uses_json_safe_omitted_optional_defaults(
         payloads.append(json)
         raise requests.ConnectionError("down")
 
-    with patch(
-        "cli_agent_orchestrator.mcp_server.server.requests.post", side_effect=post
-    ):
+    with patch("cli_agent_orchestrator.mcp_server.server.requests.post", side_effect=post):
         result = asyncio.run(server.workflow_return({"answer": 42}))
 
-    assert (
-        inspect.signature(server.workflow_return).parameters["output_schema"].default
-        is None
-    )
+    assert inspect.signature(server.workflow_return).parameters["output_schema"].default is None
     assert payloads == [{"output": {"answer": 42}}]
     assert result["ok"] is False

--- a/test/mcp_server/test_workflow_required_parameters.py
+++ b/test/mcp_server/test_workflow_required_parameters.py
@@ -1,8 +1,12 @@
 """Regression tests for required workflow MCP tool parameters (issue #697)."""
 
+import asyncio
 import inspect
+import json as jsonlib
+from unittest.mock import patch
 
 import pytest
+import requests
 
 from cli_agent_orchestrator.mcp_server import server
 
@@ -29,3 +33,50 @@ def test_required_workflow_parameters_are_required(tool_name, parameter_name):
     assert parameter.default is inspect.Parameter.empty
     with pytest.raises(TypeError):
         tool()
+
+
+def test_direct_workflow_run_call_uses_json_safe_omitted_optional_defaults():
+    """A required-only direct call must not send a FieldInfo input sentinel."""
+    payloads = []
+
+    def post(_url, *, json, **_kwargs):
+        # Exercise the same serialization boundary as requests' JSON handling.
+        jsonlib.dumps(json)
+        payloads.append(json)
+        raise requests.ConnectionError("down")
+
+    with patch(
+        "cli_agent_orchestrator.mcp_server.server.requests.post", side_effect=post
+    ):
+        result = asyncio.run(server.workflow_run("demo"))
+
+    assert inspect.signature(server.workflow_run).parameters["inputs"].default is None
+    assert payloads == [{"name_or_path": "demo", "inputs": {}}]
+    assert result["ok"] is False
+
+
+def test_direct_workflow_return_call_uses_json_safe_omitted_optional_defaults(
+    monkeypatch,
+):
+    """A required-only direct call must not send a FieldInfo schema sentinel."""
+    monkeypatch.setenv("CAO_WORKFLOW_RUN_ID", "run1")
+    monkeypatch.setenv("CAO_WORKFLOW_STEP_ID", "step1")
+    payloads = []
+
+    def post(_url, *, json, **_kwargs):
+        # Exercise the same serialization boundary as requests' JSON handling.
+        jsonlib.dumps(json)
+        payloads.append(json)
+        raise requests.ConnectionError("down")
+
+    with patch(
+        "cli_agent_orchestrator.mcp_server.server.requests.post", side_effect=post
+    ):
+        result = asyncio.run(server.workflow_return({"answer": 42}))
+
+    assert (
+        inspect.signature(server.workflow_return).parameters["output_schema"].default
+        is None
+    )
+    assert payloads == [{"output": {"answer": 42}}]
+    assert result["ok"] is False


### PR DESCRIPTION
## Summary

Fixes #697.

Required arguments on workflow MCP tools were declared as Python defaults with bare `Field(...)`. FastMCP still exposed them as required in the generated schema, but direct Python callers received a `FieldInfo` sentinel when omitting an argument. That allowed tools to continue with a fabricated value, producing misleading results or leaking the sentinel representation instead of failing at the call boundary.

This change:

- Uses the established `Annotated[T, Field(description=...)]` form for all affected required workflow parameters.
- Covers the nine parameters listed in #697 plus the adjacent `workflow_plan_approval.run_id` parameter, which had the same defect on current `main`.
- Preserves existing descriptions and optional argument defaults.
- Adds regression coverage for all 10 affected parameters, asserting omission raises `TypeError` before tool-body execution.

## Verification

- TDD RED: the new focused test failed for all 9 initially enumerated parameters on the baseline with the `FieldInfo` default behavior.
- TDD GREEN: focused regression test passes.
- `uv run pytest test/mcp_server/test_workflow_required_parameters.py test/mcp_server/test_workflow_return.py test/mcp_server/test_workflow_tools.py -q` - 56 passed.
- `uv run pytest test/mcp_server -q` - 259 passed, 3 pre-existing deprecation warnings.
- `uv run black --check ...` - passed.
- `uv run isort --check-only ...` - passed.
- `uv run mypy src/cli_agent_orchestrator/mcp_server/server.py` - passed.
- `git diff --check` and added-line security scan - passed.

The repository-wide test command was attempted once and timed out after 600 seconds during the run; the focused MCP suite completed successfully afterward.
