### PR TITLE
fix(status): self-heal a stuck-PROCESSING terminal from a bounded, detector-routed pane capture

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -3023,7 +3023,13 @@ async def get_session(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     try:
-        return session_service.get_session(session_name)
+        # session_service.get_session() calls status_monitor.get_status() once per
+        # terminal in the session, which for a PROCESSING terminal can shell out to a
+        # real tmux capture-pane subprocess (the stale-PROCESSING fallback). A session
+        # with N processing terminals would otherwise fork N times inline on the event
+        # loop per request — and the web UI polls this endpoint. Run it off the loop,
+        # matching GET /terminals/{id}'s established pattern for the identical hazard.
+        return await asyncio.to_thread(session_service.get_session, session_name)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:
@@ -6504,7 +6510,12 @@ async def create_inbox_message_endpoint(
     # Attempt immediate delivery if terminal is already IDLE.
     # If not, InboxService will deliver on next IDLE status event.
     try:
-        inbox_service.deliver_pending(receiver_id, registry=get_plugin_registry(request))
+        # deliver_pending reads status_monitor.get_status() (which can fork a tmux
+        # capture-pane via the stale-PROCESSING fallback) and, on delivery, paste-bombs
+        # the pane — blocking I/O either way, so keep it off the event loop.
+        await asyncio.to_thread(
+            inbox_service.deliver_pending, receiver_id, registry=get_plugin_registry(request)
+        )
     except Exception as e:
         logger.warning(f"Immediate delivery attempt failed for {receiver_id}: {e}")
 

--- a/src/cli_agent_orchestrator/backends/base.py
+++ b/src/cli_agent_orchestrator/backends/base.py
@@ -228,15 +228,22 @@ class TerminalBackend(ABC):
         tail_lines: Optional[int] = None,
         strip_escapes: bool = False,
         full_history: bool = False,
+        visible_only: bool = False,
     ) -> str:
         """Get terminal output/history from a window.
 
         Args:
             session_name: Target session
             window_name: Target window
-            tail_lines: Number of lines from the end (None = backend default)
+            tail_lines: Number of lines from the end (None = backend default).
+                On tmux this INCLUDES the visible pane plus N lines of scrollback
+                above it — it is not a viewport bounded to N rows.
             strip_escapes: If True, strip ANSI escape sequences
             full_history: If True, capture entire scrollback
+            visible_only: If True, capture only the currently rendered viewport,
+                nothing from scrollback (overrides tail_lines/full_history). A
+                backend without a viewport concept may approximate with its
+                closest bounded recent read.
 
         Returns:
             Terminal output as a string

--- a/src/cli_agent_orchestrator/backends/herdr_backend.py
+++ b/src/cli_agent_orchestrator/backends/herdr_backend.py
@@ -538,12 +538,20 @@ class HerdrBackend(TerminalBackend):
         tail_lines: Optional[int] = None,
         strip_escapes: bool = False,
         full_history: bool = False,
+        visible_only: bool = False,
     ) -> str:
         """Read pane output via herdr pane read."""
         pane_id = self._resolve_pane_id_from_window(session_name, window_name)
 
         args = ["pane", "read", pane_id]
-        if full_history:
+        if visible_only:
+            # herdr has no viewport/scrollback split; approximate the "current
+            # screen" contract with a small bounded recent read. In practice this
+            # arm is unreachable from the one visible_only caller (the stale-
+            # PROCESSING capture fallback): event-inbox backends return from
+            # get_status() before that fallback is reached.
+            args.extend(["--source", "recent", "--lines", "50"])
+        elif full_history:
             pass  # no flags — returns full scrollback
         elif tail_lines:
             args.extend(["--source", "recent", "--lines", str(tail_lines)])

--- a/src/cli_agent_orchestrator/backends/tmux_backend.py
+++ b/src/cli_agent_orchestrator/backends/tmux_backend.py
@@ -114,6 +114,7 @@ class TmuxBackend(TerminalBackend):
         tail_lines: Optional[int] = None,
         strip_escapes: bool = False,
         full_history: bool = False,
+        visible_only: bool = False,
     ) -> str:
         return self._client.get_history(
             session_name,
@@ -121,6 +122,7 @@ class TmuxBackend(TerminalBackend):
             tail_lines=tail_lines,
             strip_escapes=strip_escapes,
             full_history=full_history,
+            visible_only=visible_only,
         )
 
     def get_pane_working_directory(self, session_name: str, window_name: str) -> Optional[str]:

--- a/src/cli_agent_orchestrator/clients/tmux.py
+++ b/src/cli_agent_orchestrator/clients/tmux.py
@@ -1169,15 +1169,21 @@ class TmuxClient:
         tail_lines: Optional[int] = None,
         strip_escapes: bool = False,
         full_history: bool = False,
+        visible_only: bool = False,
     ) -> str:
         """Get window history.
 
         Args:
             session_name: Name of tmux session
             window_name: Name of window in session
-            tail_lines: Number of lines to capture from end (default: TMUX_HISTORY_LINES)
+            tail_lines: Number of lines to capture from end (default: TMUX_HISTORY_LINES).
+                NOTE this maps to capture-pane ``-S -N``, which starts N lines of
+                HISTORY above the viewport and then includes the viewport — it is
+                "viewport plus N lines of scrollback", not a viewport bounded to N rows.
             strip_escapes: If True, capture plain text without ANSI escape sequences
             full_history: If True, capture entire scrollback buffer (overrides tail_lines)
+            visible_only: If True, capture exactly the currently rendered viewport
+                (``-S 0``) and nothing from scrollback (overrides tail_lines/full_history)
 
         Raises:
             ValueError: The session or window is genuinely gone.
@@ -1200,7 +1206,11 @@ class TmuxClient:
 
             # Use cmd to run capture-pane with -e (escape sequences) and -p (print) flags
             pane = self._find_first_pane(window, session_name, window_name)
-            if full_history:
+            if visible_only:
+                # "-S 0" starts at the first line of the visible pane (default -E
+                # already ends at its last line): the rendered viewport, no scrollback.
+                flags = ["-p", "-S", "0"]
+            elif full_history:
                 # "-S -" captures from the start of the scrollback buffer
                 flags = ["-p", "-S", "-"]
             else:

--- a/src/cli_agent_orchestrator/providers/copilot_cli.py
+++ b/src/cli_agent_orchestrator/providers/copilot_cli.py
@@ -287,7 +287,15 @@ class CopilotCliProvider(BaseProvider):
         likewise blocking. All three are offloaded via ``asyncio.to_thread``
         so building and sending the launch command can't block the shared
         event loop under concurrent session creation. ``status_monitor.
-        get_status`` stays inline -- it is in-memory only, no blocking I/O.
+        get_status`` is offloaded too: it is NOT in-memory only -- for a
+        terminal stuck in PROCESSING it can fork a real tmux capture-pane
+        subprocess (status_monitor.py's stale-PROCESSING fallback), and this
+        provider's own get_status falls back to ``self._history()`` (another
+        capture-pane) when the buffer has no visible text. Copilot init is
+        exactly the regime that trips the fallback -- cached status PROCESSING
+        while the CLI boots, pane quiet during auth/MCP startup -- and this
+        loop polls every second for up to 60s, multiplied by concurrent
+        session creations.
         """
         from cli_agent_orchestrator.services.status_monitor import status_monitor
 
@@ -315,7 +323,7 @@ class CopilotCliProvider(BaseProvider):
         deadline = time.time() + 60.0
         await self._accept_trust_prompts(timeout=10.0)
         while time.time() < deadline:
-            status = status_monitor.get_status(self.terminal_id)
+            status = await asyncio.to_thread(status_monitor.get_status, self.terminal_id)
             if status == TerminalStatus.WAITING_USER_ANSWER:
                 await self._accept_trust_prompts(timeout=5.0)
                 await asyncio.sleep(1.0)

--- a/src/cli_agent_orchestrator/providers/grok_cli.py
+++ b/src/cli_agent_orchestrator/providers/grok_cli.py
@@ -531,7 +531,10 @@ class GrokCliProvider(BaseProvider):
                     "project-local configuration (for example .mcp.json or .grok/) before "
                     "launching this CAO terminal."
                 )
-            if status_monitor.get_status(self.terminal_id) in {
+            # Off the loop: get_status() can fork a tmux capture-pane for a PROCESSING
+            # terminal (status_monitor.py's stale-PROCESSING fallback) and this polls
+            # every second on the shared event loop during init.
+            if (await asyncio.to_thread(status_monitor.get_status, self.terminal_id)) in {
                 TerminalStatus.IDLE,
                 TerminalStatus.COMPLETED,
             }:

--- a/src/cli_agent_orchestrator/providers/kiro_cli.py
+++ b/src/cli_agent_orchestrator/providers/kiro_cli.py
@@ -17,6 +17,7 @@ The provider detects the following terminal states:
 - ERROR: Agent encountered an error during processing
 """
 
+import asyncio
 import logging
 import re
 import shlex
@@ -409,7 +410,10 @@ class KiroCliProvider(BaseProvider):
         # has since flapped to IDLE/COMPLETED, treat the terminal as ready and do
         # NOT send dialog keys (a blind Down+Enter into a live prompt would be a
         # stray message). Low probability given the sticky latch, but explicit.
-        if status_monitor.get_status(self.terminal_id) != TerminalStatus.WAITING_USER_ANSWER:
+        # Off the loop: get_status() can fork a tmux capture-pane for a PROCESSING
+        # terminal (status_monitor.py's stale-PROCESSING fallback).
+        current = await asyncio.to_thread(status_monitor.get_status, self.terminal_id)
+        if current != TerminalStatus.WAITING_USER_ANSWER:
             return True
 
         # WAITING_USER_ANSWER is classified from TUI_TRUST_ALL_TOOLS_FOOTER,

--- a/src/cli_agent_orchestrator/services/agent_step.py
+++ b/src/cli_agent_orchestrator/services/agent_step.py
@@ -222,7 +222,9 @@ async def _wait_for_completion(
         if cancel_event is not None and cancel_event.is_set():
             raise StepCancelledError(terminal_id=terminal_id)
 
-        current = status_monitor.get_status(terminal_id)
+        # Off the event loop — get_status() can shell out to a real tmux capture-pane
+        # subprocess (status_monitor.py's stale-PROCESSING fallback) or a herdr CLI call.
+        current = await asyncio.to_thread(status_monitor.get_status, terminal_id)
         if current == TerminalStatus.ERROR:
             raise StepExecutionError(
                 f"terminal {terminal_id} reached ERROR status",
@@ -256,7 +258,9 @@ async def _wait_for_completion(
         if time.monotonic() >= deadline:
             # Defensive: a terminal that flipped to ERROR right at the deadline is
             # a crash, not a slow run (preserve the kind="error" vs "timeout" split).
-            if status_monitor.get_status(terminal_id) == TerminalStatus.ERROR:
+            if (
+                await asyncio.to_thread(status_monitor.get_status, terminal_id)
+            ) == TerminalStatus.ERROR:
                 raise StepExecutionError(
                     f"terminal {terminal_id} reached ERROR status",
                     kind="error",

--- a/src/cli_agent_orchestrator/services/flow_service.py
+++ b/src/cli_agent_orchestrator/services/flow_service.py
@@ -291,7 +291,10 @@ async def execute_flow(name: str) -> bool:
             # own row was deleted, or a row was inserted during flow recycling,
             # which does not hold ``session_lifecycle_lock``.
             conductor = terminals[0] if terminals else None
-            if conductor and _is_terminal_busy(conductor["id"]):
+            # Off the loop: get_status() can fork a tmux capture-pane for a
+            # PROCESSING terminal (status_monitor.py's stale-PROCESSING
+            # fallback), and execute_flow runs on the shared event loop.
+            if conductor and await asyncio.to_thread(_is_terminal_busy, conductor["id"]):
                 logger.info(f"Flow {name}: session {session_name} is busy, skipping")
                 return False
             for t in terminals:

--- a/src/cli_agent_orchestrator/services/inbox_service.py
+++ b/src/cli_agent_orchestrator/services/inbox_service.py
@@ -5,7 +5,9 @@ Consumer: terminal.{id}.status
 
 import asyncio
 import logging
+import threading
 from itertools import groupby
+from typing import Dict
 
 from cli_agent_orchestrator.backends.base import TerminalNotFoundError
 from cli_agent_orchestrator.clients.database import (
@@ -33,6 +35,28 @@ logger = logging.getLogger(__name__)
 
 class InboxService:
     """Delivers one pending message per terminal per IDLE cycle."""
+
+    def __init__(self) -> None:
+        # deliver_pending is read(PENDING) → status check → mark DELIVERED → send,
+        # with no atomic claim at the DB layer, so two concurrent calls for the
+        # SAME terminal can both read the same oldest row before either marks it
+        # and deliver one task twice. Concurrent callers are real: the status-event
+        # consumer and the immediate POST path both dispatch to worker threads, and
+        # the OpenCode poller and the reconcile sweep add more. Serialize the whole
+        # read→mark→send sequence per terminal; as a side effect this also keeps
+        # two pastes from ever interleaving in one pane. The lock map is tiny
+        # (one Lock per terminal id ever delivered to in this process) and is not
+        # reaped — terminal ids are bounded by session lifecycle.
+        self._delivery_locks_guard = threading.Lock()
+        self._delivery_locks: Dict[str, threading.Lock] = {}
+
+    def _delivery_lock(self, terminal_id: str) -> threading.Lock:
+        with self._delivery_locks_guard:
+            lock = self._delivery_locks.get(terminal_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._delivery_locks[terminal_id] = lock
+            return lock
 
     async def run(self, registry: PluginRegistry | None = None) -> None:
         queue = bus.subscribe("terminal.*.status")
@@ -70,7 +94,19 @@ class InboxService:
         When a plugin registry is supplied, the originating sender and a
         ``send_message`` orchestration type are threaded to ``terminal_service``
         so ``PostSendMessageEvent`` hooks fire with correct attribution.
+
+        Safe to call from any thread: the whole read→mark→send sequence is
+        serialized per terminal (see __init__ for why that is load-bearing).
         """
+        with self._delivery_lock(terminal_id):
+            self._deliver_pending_locked(terminal_id, num_messages, registry)
+
+    def _deliver_pending_locked(
+        self,
+        terminal_id: str,
+        num_messages: int,
+        registry: PluginRegistry | None,
+    ) -> None:
         limit = num_messages if num_messages > 0 else 100
         messages = get_pending_messages(terminal_id, limit=limit)
         if not messages:

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -117,14 +117,18 @@ class StatusMonitor:
         # appended a chunk (i.e. the buffer changed) — the STALE_PROCESSING_BUFFER_QUIET_S
         # quiet gate reads this. Same None-vs-0.0 sentinel rule as above.
         self._buffer_changed_at: Dict[str, Optional[float]] = {}
-        # Per-terminal (status, monotonic) candidate from a stale-PROCESSING capture,
-        # awaiting a second confirming read before being honored (see
-        # _fresh_capture_pane_status). Cleared on confirm, on an intervening
-        # PROCESSING/UNKNOWN read, on expiry past STALE_PROCESSING_CONFIRM_TTL_S, by
-        # a real chunk landing in _process_chunk, and by notify_input_sent — new
-        # input or new output means whatever the pane showed before no longer
-        # describes the terminal.
-        self._pending_stale_capture: Dict[str, Tuple[TerminalStatus, float]] = {}
+        # Per-terminal (status, monotonic, generation) candidate from a
+        # stale-PROCESSING capture, awaiting a second confirming read before being
+        # honored (see _fresh_capture_pane_status). Cleared on confirm, on an
+        # intervening PROCESSING/UNKNOWN read, on expiry past
+        # STALE_PROCESSING_CONFIRM_TTL_S, by a real chunk landing in
+        # _process_chunk, and by notify_input_sent — new input or new output means
+        # whatever the pane showed before no longer describes the terminal. The
+        # third element is the generation sampled BEFORE the candidate's pane
+        # read: every mutation of this map is rejected unless that generation is
+        # still current, so a read that straddled a turn/output boundary can never
+        # seed (or confirm) a candidate — see _fresh_capture_pane_status.
+        self._pending_stale_capture: Dict[str, Tuple[TerminalStatus, float, int]] = {}
         # Per-terminal turn/output generation. Bumped under the lock by
         # notify_input_sent (a new turn began) and by _process_chunk (real output
         # arrived). A capture-pane verdict is only applied if the generation it was
@@ -726,7 +730,7 @@ class StatusMonitor:
                 and time.monotonic() - changed_at >= STALE_PROCESSING_BUFFER_QUIET_S
             )
             if buffer_is_quiet:
-                fresh_capture = self._fresh_capture_pane_status(terminal_id)
+                fresh_capture = self._fresh_capture_pane_status(terminal_id, generation)
                 if fresh_capture is not None:
                     logger.debug(
                         f"get_status [{terminal_id}]: cached=PROCESSING stale-buffer re-check "
@@ -781,8 +785,22 @@ class StatusMonitor:
                             return current_last_status
         return cached
 
-    def _fresh_capture_pane_status(self, terminal_id: str) -> Optional[TerminalStatus]:
+    def _fresh_capture_pane_status(
+        self, terminal_id: str, generation: int
+    ) -> Optional[TerminalStatus]:
         """Re-detect a stuck-PROCESSING terminal from a fresh pane capture (#558).
+
+        ``generation`` is the turn/output generation the caller pinned BEFORE
+        deciding to capture. The pane read below runs unlocked, so
+        notify_input_sent or _process_chunk can bump the generation (and clear the
+        candidate map) while it is in flight; a verdict from such a read describes
+        the pane from BEFORE that boundary. The caller's apply-time check cannot
+        see this alone: it only rejects CONFIRMED verdicts, while a straddling
+        first read would re-seed the candidate map AFTER the boundary cleared it,
+        and the next poll — pinning the new, by-then-stable generation — would
+        treat that pre-boundary entry as its matching first read and confirm it.
+        So every candidate-map mutation here (seed, confirm-pop, busy-pop) is
+        performed only if ``generation`` is still current under the lock.
 
         Reads the pane directly via ``get_backend().get_history()`` (a real ``tmux
         capture-pane``, not the FIFO-fed rolling buffer) and re-runs provider detection
@@ -889,27 +907,46 @@ class StatusMonitor:
         if detected == TerminalStatus.PROCESSING or detected == TerminalStatus.UNKNOWN:
             # Not a ready candidate — nothing to confirm. Clear any pending one: a busy
             # read BETWEEN two ready reads means the terminal is genuinely still working,
-            # so the earlier candidate no longer describes a settled pane.
+            # so the earlier candidate no longer describes a settled pane. Only if this
+            # read didn't straddle a boundary, though — a busy verdict from BEFORE a
+            # notify_input_sent/_process_chunk bump says nothing about a candidate
+            # legitimately seeded after it.
             with self._lock:
-                self._pending_stale_capture.pop(terminal_id, None)
+                if self._capture_generation.get(terminal_id, 0) == generation:
+                    self._pending_stale_capture.pop(terminal_id, None)
             return detected
 
         now = time.monotonic()
         with self._lock:
+            if self._capture_generation.get(terminal_id, 0) != generation:
+                # The pane read straddled a turn/output boundary: the boundary already
+                # cleared the candidate map, and this verdict describes the pane from
+                # before it. Seeding it anyway would hand the NEXT poll (which pins the
+                # new generation before its read) a pre-boundary first read to "confirm"
+                # against — the exact single-frame latch the two-read confirm exists to
+                # prevent. No mutation, no verdict.
+                logger.debug(
+                    f"_fresh_capture_pane_status [{terminal_id}]: candidate "
+                    f"{detected.value} discarded — the terminal moved on (new input or "
+                    "new output) while the capture-pane read was in flight"
+                )
+                return None
             pending = self._pending_stale_capture.get(terminal_id)
             if (
                 pending is not None
                 and pending[0] == detected
+                and pending[2] == generation
                 and now - pending[1] <= STALE_PROCESSING_CONFIRM_TTL_S
             ):
-                # Second consecutive matching read, in time — honor it.
+                # Second consecutive matching read, in time and within the same
+                # turn/output generation — honor it.
                 self._pending_stale_capture.pop(terminal_id, None)
                 confirmed = True
             else:
                 # First sighting, a different candidate than the pending one, or a
                 # candidate that aged out — (re)record with a fresh timestamp and wait
                 # for the next read to agree.
-                self._pending_stale_capture[terminal_id] = (detected, now)
+                self._pending_stale_capture[terminal_id] = (detected, now, generation)
                 confirmed = False
         if not confirmed:
             logger.debug(

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -7,6 +7,7 @@ Publisher: terminal.{id}.status
 import asyncio
 import logging
 import threading
+import time
 from typing import Dict, List, Optional, Tuple
 
 from cli_agent_orchestrator.constants import (
@@ -45,6 +46,38 @@ _STICKY_READY_STATUSES = frozenset(
     }
 )
 
+# Stale-PROCESSING self-heal (#558). get_status()'s cheap re-check re-derives from the SAME
+# rolling buffer the FIFO pipeline feeds — and the moment a process goes genuinely idle it also
+# stops emitting output, so that buffer stops changing. If its final content never happened to
+# parse as a ready state (the idle marker rotated out of the bounded window, or a truncated
+# escape corrupted the tail), re-running detection on the unchanging buffer returns
+# PROCESSING/UNKNOWN forever: the pane already shows the finished response while every poller
+# sees PROCESSING. The #397 pipe-liveness watchdog cannot see this either — the FIFO delivered
+# its bytes, so the pipe looks healthy. Observed live: a queued message sat undelivered for
+# ~10 minutes until a manual tmux resize forced a redraw. The self-heal reads the pane directly
+# via get_backend().get_history() (a real ``tmux capture-pane``, NOT the FIFO-fed buffer — tmux
+# always holds the current rendered state regardless of output volume) and re-detects from that.
+# This constant rate-limits those reads: get_status() is a hot path (every wait_until_status
+# poll, every UI refresh, fleet-wide) and a capture-pane is a real subprocess fork — unbounded,
+# it would recreate the fork-storm class run()'s own docstring documents.
+STALE_PROCESSING_CAPTURE_INTERVAL_S = 3.0
+
+# The interval above bounds how OFTEN the fallback re-runs; this gates WHETHER it runs at all.
+# Without it, every genuinely busy terminal would eat a capture-pane subprocess every ~3s for
+# the entire duration of every ordinary turn, on top of the fifo watchdog's own probing. The
+# wedge's actual signature is "the rolling buffer stopped changing", so require exactly that:
+# only attempt a capture once no new chunk has been appended for this long. A terminal
+# mid-burst never reaches the fallback at all.
+STALE_PROCESSING_BUFFER_QUIET_S = 3.0
+
+# A ready verdict from a single capture is never honored on its own — it must repeat on the
+# next eligible read (see _fresh_capture_pane_status). This bounds how far apart those two
+# reads may be: a candidate older than this is dropped and confirmation starts over. Without
+# the bound, a candidate recorded during one turn could sit in the map indefinitely and be
+# "confirmed" by one lone mid-repaint frame much later — exactly the single-frame latch the
+# two-read confirm exists to prevent.
+STALE_PROCESSING_CONFIRM_TTL_S = 2 * STALE_PROCESSING_CAPTURE_INTERVAL_S
+
 
 class StatusMonitor:
     """Accumulates terminal output into rolling buffers and detects status changes."""
@@ -74,6 +107,22 @@ class StatusMonitor:
         # IDLE/COMPLETED would freeze the terminal forever even when the
         # agent is genuinely processing new work.
         self._allow_processing_revert: Dict[str, bool] = {}
+        # Per-terminal monotonic timestamp of the last stale-PROCESSING capture-pane
+        # attempt — the STALE_PROCESSING_CAPTURE_INTERVAL_S rate limit. Absence is None,
+        # deliberately NOT 0.0: time.monotonic()'s reference point is arbitrary, so a 0.0
+        # sentinel is indistinguishable from a genuine reading and could rate-limit the
+        # very first check before it ever runs.
+        self._last_stale_capture_check: Dict[str, Optional[float]] = {}
+        # Per-terminal monotonic timestamp of the last time _process_chunk actually
+        # appended a chunk (i.e. the buffer changed) — the STALE_PROCESSING_BUFFER_QUIET_S
+        # quiet gate reads this. Same None-vs-0.0 sentinel rule as above.
+        self._buffer_changed_at: Dict[str, Optional[float]] = {}
+        # Per-terminal (status, monotonic) candidate from a stale-PROCESSING capture,
+        # awaiting a second confirming read before being honored (see
+        # _fresh_capture_pane_status). Cleared on confirm, on an intervening
+        # PROCESSING/UNKNOWN read, on expiry past STALE_PROCESSING_CONFIRM_TTL_S, and by
+        # notify_input_sent — a new turn invalidates whatever the pane showed before it.
+        self._pending_stale_capture: Dict[str, Tuple[TerminalStatus, float]] = {}
         # --- pyte rendered-screen detection state (only used when CAO_PYTE_STATUS
         # is on AND the provider opts in via supports_screen_detection) ---
         # Per-terminal pyte Screen+Stream that composites the raw byte stream
@@ -154,6 +203,9 @@ class StatusMonitor:
             if len(buffer) > state_buffer_max:
                 buffer = buffer[-state_buffer_max:]
             self._buffers[terminal_id] = buffer
+            # Real new output just landed — the stale-PROCESSING quiet gate keys off this
+            # (see STALE_PROCESSING_BUFFER_QUIET_S).
+            self._buffer_changed_at[terminal_id] = time.monotonic()
             if use_screen:
                 self._feed_screen_locked(terminal_id, chunk)
 
@@ -481,6 +533,11 @@ class StatusMonitor:
         """
         with self._lock:
             self._allow_processing_revert[terminal_id] = True
+            # A new turn is starting: whatever ready state a stale-PROCESSING capture saw
+            # before this input no longer describes the terminal. Left armed, that candidate
+            # could be "confirmed" by a single post-input read and latch ready against the
+            # new turn's genuine PROCESSING.
+            self._pending_stale_capture.pop(terminal_id, None)
         if assume_processing:
             self._apply_detection(terminal_id, TerminalStatus.PROCESSING)
 
@@ -529,6 +586,9 @@ class StatusMonitor:
             self._allow_processing_revert.pop(terminal_id, None)
             self._screens.pop(terminal_id, None)
             self._bursting.pop(terminal_id, None)
+            self._last_stale_capture_check.pop(terminal_id, None)
+            self._buffer_changed_at.pop(terminal_id, None)
+            self._pending_stale_capture.pop(terminal_id, None)
             handle = self._quiesce_handle.pop(terminal_id, None)
         self._cancel_quiesce_handle(handle)
 
@@ -549,6 +609,9 @@ class StatusMonitor:
             # detected against a fresh viewport, not the failed attempt's.
             self._screens.pop(terminal_id, None)
             self._bursting.pop(terminal_id, None)
+            self._last_stale_capture_check.pop(terminal_id, None)
+            self._buffer_changed_at.pop(terminal_id, None)
+            self._pending_stale_capture.pop(terminal_id, None)
             handle = self._quiesce_handle.pop(terminal_id, None)
         self._cancel_quiesce_handle(handle)
 
@@ -606,7 +669,186 @@ class StatusMonitor:
             if fresh != TerminalStatus.PROCESSING and fresh != TerminalStatus.UNKNOWN:
                 self._apply_detection(terminal_id, fresh)
                 return fresh
+
+        if cached == TerminalStatus.PROCESSING:
+            # The cheap re-check above re-derives from the SAME rolling buffer the FIFO
+            # pipeline feeds — once the process stops emitting output, that buffer stops
+            # changing too, so the re-check can return PROCESSING/UNKNOWN forever while
+            # the real pane already shows the finished response (#558; the module
+            # constants above carry the full incident rationale). Consult the quiet gate
+            # BEFORE anything that could fork: a terminal still streaming chunks is busy,
+            # not wedged, and must not cost a subprocess call.
+            with self._lock:
+                changed_at = self._buffer_changed_at.get(terminal_id)
+            buffer_is_quiet = (
+                changed_at is not None
+                and time.monotonic() - changed_at >= STALE_PROCESSING_BUFFER_QUIET_S
+            )
+            if buffer_is_quiet:
+                fresh_capture = self._fresh_capture_pane_status(terminal_id)
+                if fresh_capture is not None:
+                    logger.debug(
+                        f"get_status [{terminal_id}]: cached=PROCESSING stale-buffer re-check "
+                        f"still PROCESSING/UNKNOWN, fresh capture-pane={fresh_capture.value}"
+                    )
+                    if (
+                        fresh_capture != TerminalStatus.PROCESSING
+                        and fresh_capture != TerminalStatus.UNKNOWN
+                    ):
+                        # The capture-pane read above ran OUTSIDE the lock — a real
+                        # subprocess call, tens of milliseconds rather than microseconds —
+                        # so real new output can have arrived and genuinely resumed
+                        # PROCESSING in the meantime. Re-validate under the lock that this
+                        # is STILL the same stale-PROCESSING terminal before applying: a
+                        # capture taken against a since-superseded state must never
+                        # downgrade a terminal that is, right now, processing again.
+                        with self._lock:
+                            current_last_status = self._last_status.get(terminal_id)
+                        if current_last_status == TerminalStatus.PROCESSING:
+                            self._apply_detection(terminal_id, fresh_capture)
+                            return fresh_capture
+                        logger.debug(
+                            f"get_status [{terminal_id}]: fresh capture-pane result "
+                            "discarded — terminal status changed while the capture-pane "
+                            "read was in flight"
+                        )
+                        # The pipeline got there first: hand back ITS status rather than
+                        # the `cached` value snapshotted at entry, which is now one step
+                        # stale.
+                        if current_last_status is not None:
+                            return current_last_status
         return cached
+
+    def _fresh_capture_pane_status(self, terminal_id: str) -> Optional[TerminalStatus]:
+        """Re-detect a stuck-PROCESSING terminal from a fresh pane capture (#558).
+
+        Reads the pane directly via ``get_backend().get_history()`` (a real ``tmux
+        capture-pane``, not the FIFO-fed rolling buffer) and re-runs provider detection
+        against it. tmux always holds the correct, current rendered pane state regardless
+        of output volume, so this can see the ready state a stale buffer cannot.
+
+        Detector routing: a capture-pane snapshot is RENDERED content — cursor moves
+        resolved, lines in on-screen order — a different input shape from the raw byte
+        stream most ``get_status()`` detectors are tuned against (see BaseProvider.
+        get_status's input contract). Feeding a rendered frame to a raw-stream detector
+        produces systematic misreads, not noise: in a rendered busy kiro frame the
+        always-drawn composer placeholder sits physically BELOW the working line and the
+        credits line, which its raw-stream ordering checks parse as COMPLETED — and a
+        deterministic misread sails straight through the two-read confirm below, because
+        both reads see the same bytes. Applied, that false ready sticky-latches, disarms
+        _allow_processing_revert, and blocks the agent's genuine PROCESSING for the rest
+        of the turn. So the capture is routed through the two existing opt-in predicates:
+        ``supports_screen_detection`` providers get their purpose-built
+        ``get_status_from_screen()`` (calibrated for exactly this composited-viewport
+        shape), ``supports_direct_status_probe`` providers get ``get_status()`` (declared
+        safe on rendered snapshots — the same contract terminal_service's deferred-init
+        direct probe relies on), and providers with neither flag fail CLOSED: no capture,
+        no verdict, the terminal stays PROCESSING until the pipeline resolves it.
+        Bounding the read to PYTE_SCREEN_ROWS also keeps stale scrollback from an earlier
+        turn out of whole-text matches (kiro's ERROR indicator is one such match).
+
+        A single capture is still not trusted even on a routed detector: Ink-style TUIs
+        repaint by clear-then-rewrite, and a sample caught between those two steps can
+        miss the spinner while the previous response box parses ready. The screen path
+        never samples mid-burst for exactly this reason (_schedule_screen_detection);
+        since this read fires at an arbitrary moment instead, it requires the SAME ready
+        status on two consecutive reads — the confirming read arriving within
+        STALE_PROCESSING_CONFIRM_TTL_S — before honoring it. The same confirm-don't-trust
+        pattern claude_code's wait_until_input_ready uses. The confirm still earns its
+        keep despite the quiet gate: the gate watches the FIFO-fed buffer, so a pane that
+        repaints without reaching the wedged FIFO can differ between reads.
+
+        Returns ``None`` when skipped (rate-limited, no provider, unroutable detector,
+        unconfirmed candidate, or any read/detection failure) — the caller treats that
+        identically to "still PROCESSING", never as a signal to change status. Only ever
+        called when cached status is already PROCESSING, so every failure path degrades
+        to today's behavior, never past it.
+        """
+        now = time.monotonic()
+        with self._lock:
+            last_check = self._last_stale_capture_check.get(terminal_id)
+            if last_check is not None and now - last_check < STALE_PROCESSING_CAPTURE_INTERVAL_S:
+                return None
+            self._last_stale_capture_check[terminal_id] = now
+
+        try:
+            provider = provider_manager.get_provider(terminal_id)
+        except Exception as e:
+            # get_provider() raises (not returns None) for a terminal it doesn't
+            # recognize (not yet / no longer in the DB) — same defensive shape as
+            # get_status()'s own event-inbox branch.
+            logger.debug(f"_fresh_capture_pane_status [{terminal_id}]: get_provider failed: {e}")
+            return None
+        if provider is None:
+            return None
+
+        use_screen = getattr(provider, "supports_screen_detection", False)
+        if not use_screen and not getattr(provider, "supports_direct_status_probe", False):
+            # Raw-stream-tuned detector with no snapshot-safe alternative (kiro_cli,
+            # cursor_cli): a rendered frame cannot be trusted as its input — see the
+            # docstring — so don't capture at all. Self-heal is opt-in via either flag,
+            # never a guess; these providers stay PROCESSING until the pipeline resolves
+            # them.
+            return None
+
+        try:
+            from cli_agent_orchestrator.backends.registry import get_backend
+
+            fresh_output = get_backend().get_history(
+                provider.session_name,
+                provider.window_name,
+                tail_lines=PYTE_SCREEN_ROWS,
+                strip_escapes=True,
+            )
+        except Exception as e:
+            logger.debug(
+                f"_fresh_capture_pane_status [{terminal_id}]: capture-pane read failed: {e}"
+            )
+            return None
+        if not fresh_output:
+            return None
+
+        try:
+            if use_screen:
+                detected = provider.get_status_from_screen(fresh_output.splitlines())
+            else:
+                detected = provider.get_status(fresh_output)
+        except Exception as e:
+            logger.debug(f"_fresh_capture_pane_status [{terminal_id}]: detection failed: {e}")
+            return None
+
+        if detected == TerminalStatus.PROCESSING or detected == TerminalStatus.UNKNOWN:
+            # Not a ready candidate — nothing to confirm. Clear any pending one: a busy
+            # read BETWEEN two ready reads means the terminal is genuinely still working,
+            # so the earlier candidate no longer describes a settled pane.
+            with self._lock:
+                self._pending_stale_capture.pop(terminal_id, None)
+            return detected
+
+        now = time.monotonic()
+        with self._lock:
+            pending = self._pending_stale_capture.get(terminal_id)
+            if (
+                pending is not None
+                and pending[0] == detected
+                and now - pending[1] <= STALE_PROCESSING_CONFIRM_TTL_S
+            ):
+                # Second consecutive matching read, in time — honor it.
+                self._pending_stale_capture.pop(terminal_id, None)
+                confirmed = True
+            else:
+                # First sighting, a different candidate than the pending one, or a
+                # candidate that aged out — (re)record with a fresh timestamp and wait
+                # for the next read to agree.
+                self._pending_stale_capture[terminal_id] = (detected, now)
+                confirmed = False
+        if not confirmed:
+            logger.debug(
+                f"_fresh_capture_pane_status [{terminal_id}]: candidate {detected.value} "
+                "recorded, awaiting a second confirming read before honoring it"
+            )
+            return None
+        return detected
 
     def get_buffer(self, terminal_id: str) -> str:
         """Get accumulated output buffer for a terminal."""

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -120,9 +120,20 @@ class StatusMonitor:
         # Per-terminal (status, monotonic) candidate from a stale-PROCESSING capture,
         # awaiting a second confirming read before being honored (see
         # _fresh_capture_pane_status). Cleared on confirm, on an intervening
-        # PROCESSING/UNKNOWN read, on expiry past STALE_PROCESSING_CONFIRM_TTL_S, and by
-        # notify_input_sent — a new turn invalidates whatever the pane showed before it.
+        # PROCESSING/UNKNOWN read, on expiry past STALE_PROCESSING_CONFIRM_TTL_S, by
+        # a real chunk landing in _process_chunk, and by notify_input_sent — new
+        # input or new output means whatever the pane showed before no longer
+        # describes the terminal.
         self._pending_stale_capture: Dict[str, Tuple[TerminalStatus, float]] = {}
+        # Per-terminal turn/output generation. Bumped under the lock by
+        # notify_input_sent (a new turn began) and by _process_chunk (real output
+        # arrived). A capture-pane verdict is only applied if the generation it was
+        # sampled under is still current at apply time: checking _last_status alone
+        # cannot see a new turn, because notify_input_sent deliberately leaves
+        # _last_status == PROCESSING while arming the revert — a stale ready verdict
+        # applied across that boundary would consume the arm and latch-block the new
+        # turn's genuine PROCESSING.
+        self._capture_generation: Dict[str, int] = {}
         # --- pyte rendered-screen detection state (only used when CAO_PYTE_STATUS
         # is on AND the provider opts in via supports_screen_detection) ---
         # Per-terminal pyte Screen+Stream that composites the raw byte stream
@@ -204,8 +215,14 @@ class StatusMonitor:
                 buffer = buffer[-state_buffer_max:]
             self._buffers[terminal_id] = buffer
             # Real new output just landed — the stale-PROCESSING quiet gate keys off this
-            # (see STALE_PROCESSING_BUFFER_QUIET_S).
+            # (see STALE_PROCESSING_BUFFER_QUIET_S). It also advances the capture
+            # generation and kills any pending capture candidate: output arriving
+            # means the terminal is demonstrably alive, so a ready verdict sampled
+            # before this chunk no longer describes it and must not be confirmable
+            # by a later read.
             self._buffer_changed_at[terminal_id] = time.monotonic()
+            self._capture_generation[terminal_id] = self._capture_generation.get(terminal_id, 0) + 1
+            self._pending_stale_capture.pop(terminal_id, None)
             if use_screen:
                 self._feed_screen_locked(terminal_id, chunk)
 
@@ -234,53 +251,67 @@ class StatusMonitor:
         paste into a busy agent).
         """
         with self._lock:
-            last = self._last_status.get(terminal_id)
+            changed = self._apply_detection_locked(terminal_id, detected)
+        if changed:
+            # Publish outside the lock — subscribers must never be able to
+            # re-enter StatusMonitor while the latch state is mid-update.
+            bus.publish(f"terminal.{terminal_id}.status", {"status": detected.value})
+            logger.info(f"Terminal {terminal_id} status changed: {detected.value}")
 
-            # UNKNOWN is "no signal", not a state: never let it overwrite a known
-            # status. Mid-turn the screen can momentarily show neither a spinner
-            # nor the prompt (e.g. while a tool runs), which the detector reports
-            # as UNKNOWN; downgrading a known PROCESSING to UNKNOWN there is a
-            # spurious transition (observed live as processing->unknown->completed).
-            #
-            # Do NOT narrow this to "suppress only when not armed" (to let an
-            # armed new turn clear a stale ready status). It does not actually
-            # close that window — the rising-edge frame right after a paste still
-            # composites the PREVIOUS turn's COMPLETED box, so get_status() reports
-            # ready whether or not UNKNOWN is let through — and it opens a worse
-            # one: an armed ready->UNKNOWN->ready re-render (torn paste frame, then
-            # the prior turn repainted before the new spinner draws) makes the
-            # bounce back to COMPLETED a non-ready->ready upgrade that CONSUMES the
-            # revert arm. The genuine PROCESSING that follows is then latch-blocked
-            # and the terminal reads ready for the entire busy turn — exactly what
-            # InboxService must never paste into. See
-            # test_armed_unknown_then_ready_rerender_keeps_processing. The initial
-            # UNKNOWN (last is None, nothing detected yet) is still allowed through.
-            if detected == TerminalStatus.UNKNOWN and last is not None:
-                return
+    def _apply_detection_locked(self, terminal_id: str, detected: TerminalStatus) -> bool:
+        """Sticky-latch core of _apply_detection. Caller MUST hold self._lock.
 
-            armed = self._allow_processing_revert.get(terminal_id, False)
-            if not armed:
-                if last in _STICKY_READY_STATUSES and detected in (
-                    TerminalStatus.PROCESSING,
-                    TerminalStatus.UNKNOWN,
-                ):
-                    return
-                if last == TerminalStatus.COMPLETED and detected == TerminalStatus.IDLE:
-                    return
+        Split out so callers that need to validate a precondition and apply in
+        ONE critical section (the stale-PROCESSING capture path revalidating its
+        generation) can do so without a check-then-apply gap for
+        notify_input_sent to slip through. Returns True when the status changed;
+        the caller must then publish the change on the bus AFTER releasing the
+        lock (see _apply_detection for why).
+        """
+        last = self._last_status.get(terminal_id)
 
-            if detected == last:
-                return
+        # UNKNOWN is "no signal", not a state: never let it overwrite a known
+        # status. Mid-turn the screen can momentarily show neither a spinner
+        # nor the prompt (e.g. while a tool runs), which the detector reports
+        # as UNKNOWN; downgrading a known PROCESSING to UNKNOWN there is a
+        # spurious transition (observed live as processing->unknown->completed).
+        #
+        # Do NOT narrow this to "suppress only when not armed" (to let an
+        # armed new turn clear a stale ready status). It does not actually
+        # close that window — the rising-edge frame right after a paste still
+        # composites the PREVIOUS turn's COMPLETED box, so get_status() reports
+        # ready whether or not UNKNOWN is let through — and it opens a worse
+        # one: an armed ready->UNKNOWN->ready re-render (torn paste frame, then
+        # the prior turn repainted before the new spinner draws) makes the
+        # bounce back to COMPLETED a non-ready->ready upgrade that CONSUMES the
+        # revert arm. The genuine PROCESSING that follows is then latch-blocked
+        # and the terminal reads ready for the entire busy turn — exactly what
+        # InboxService must never paste into. See
+        # test_armed_unknown_then_ready_rerender_keeps_processing. The initial
+        # UNKNOWN (last is None, nothing detected yet) is still allowed through.
+        if detected == TerminalStatus.UNKNOWN and last is not None:
+            return False
 
-            self._last_status[terminal_id] = detected
-            if detected == TerminalStatus.PROCESSING:
-                self._allow_processing_revert[terminal_id] = False
-            elif detected in _STICKY_READY_STATUSES and last not in _STICKY_READY_STATUSES:
-                self._allow_processing_revert[terminal_id] = False
+        armed = self._allow_processing_revert.get(terminal_id, False)
+        if not armed:
+            if last in _STICKY_READY_STATUSES and detected in (
+                TerminalStatus.PROCESSING,
+                TerminalStatus.UNKNOWN,
+            ):
+                return False
+            if last == TerminalStatus.COMPLETED and detected == TerminalStatus.IDLE:
+                return False
 
-        # Publish outside the lock — subscribers must never be able to
-        # re-enter StatusMonitor while the latch state is mid-update.
-        bus.publish(f"terminal.{terminal_id}.status", {"status": detected.value})
-        logger.info(f"Terminal {terminal_id} status changed: {detected.value}")
+        if detected == last:
+            return False
+
+        self._last_status[terminal_id] = detected
+        if detected == TerminalStatus.PROCESSING:
+            self._allow_processing_revert[terminal_id] = False
+        elif detected in _STICKY_READY_STATUSES and last not in _STICKY_READY_STATUSES:
+            self._allow_processing_revert[terminal_id] = False
+
+        return True
 
     # ----- pyte rendered-screen detection (edge-debounced) -------------------
 
@@ -536,8 +567,12 @@ class StatusMonitor:
             # A new turn is starting: whatever ready state a stale-PROCESSING capture saw
             # before this input no longer describes the terminal. Left armed, that candidate
             # could be "confirmed" by a single post-input read and latch ready against the
-            # new turn's genuine PROCESSING.
+            # new turn's genuine PROCESSING. The generation bump additionally invalidates
+            # any capture verdict already CONFIRMED but not yet applied — an in-flight
+            # get_status() that sampled the pane before this input must not stamp its
+            # stale verdict over the new turn (and consume the revert arm just set).
             self._pending_stale_capture.pop(terminal_id, None)
+            self._capture_generation[terminal_id] = self._capture_generation.get(terminal_id, 0) + 1
         if assume_processing:
             self._apply_detection(terminal_id, TerminalStatus.PROCESSING)
 
@@ -589,6 +624,7 @@ class StatusMonitor:
             self._last_stale_capture_check.pop(terminal_id, None)
             self._buffer_changed_at.pop(terminal_id, None)
             self._pending_stale_capture.pop(terminal_id, None)
+            self._capture_generation.pop(terminal_id, None)
             handle = self._quiesce_handle.pop(terminal_id, None)
         self._cancel_quiesce_handle(handle)
 
@@ -612,6 +648,7 @@ class StatusMonitor:
             self._last_stale_capture_check.pop(terminal_id, None)
             self._buffer_changed_at.pop(terminal_id, None)
             self._pending_stale_capture.pop(terminal_id, None)
+            self._capture_generation.pop(terminal_id, None)
             handle = self._quiesce_handle.pop(terminal_id, None)
         self._cancel_quiesce_handle(handle)
 
@@ -680,6 +717,10 @@ class StatusMonitor:
             # not wedged, and must not cost a subprocess call.
             with self._lock:
                 changed_at = self._buffer_changed_at.get(terminal_id)
+                # Pin the turn/output generation BEFORE the capture read. The pane
+                # is sampled outside the lock; only a verdict whose generation is
+                # still current at apply time may be applied (see below).
+                generation = self._capture_generation.get(terminal_id, 0)
             buffer_is_quiet = (
                 changed_at is not None
                 and time.monotonic() - changed_at >= STALE_PROCESSING_BUFFER_QUIET_S
@@ -697,20 +738,41 @@ class StatusMonitor:
                     ):
                         # The capture-pane read above ran OUTSIDE the lock — a real
                         # subprocess call, tens of milliseconds rather than microseconds —
-                        # so real new output can have arrived and genuinely resumed
-                        # PROCESSING in the meantime. Re-validate under the lock that this
-                        # is STILL the same stale-PROCESSING terminal before applying: a
-                        # capture taken against a since-superseded state must never
-                        # downgrade a terminal that is, right now, processing again.
+                        # so the world can have moved: real new output can have resumed
+                        # PROCESSING, or notify_input_sent can have started a whole new
+                        # turn. The latter is invisible to a _last_status check (a new
+                        # turn deliberately KEEPS _last_status == PROCESSING while arming
+                        # the revert), which is why the generation pinned before the read
+                        # is the authority here. Validate and apply in ONE critical
+                        # section — a check-then-apply gap would let notify_input_sent
+                        # slip between them, and the stale verdict would consume the arm
+                        # it just set, latch-blocking the new turn's genuine PROCESSING.
                         with self._lock:
                             current_last_status = self._last_status.get(terminal_id)
-                        if current_last_status == TerminalStatus.PROCESSING:
-                            self._apply_detection(terminal_id, fresh_capture)
+                            generation_current = (
+                                self._capture_generation.get(terminal_id, 0) == generation
+                            )
+                            apply_ok = (
+                                generation_current
+                                and current_last_status == TerminalStatus.PROCESSING
+                            )
+                            if apply_ok:
+                                changed = self._apply_detection_locked(terminal_id, fresh_capture)
+                        if apply_ok:
+                            if changed:
+                                bus.publish(
+                                    f"terminal.{terminal_id}.status",
+                                    {"status": fresh_capture.value},
+                                )
+                                logger.info(
+                                    f"Terminal {terminal_id} status changed: "
+                                    f"{fresh_capture.value}"
+                                )
                             return fresh_capture
                         logger.debug(
                             f"get_status [{terminal_id}]: fresh capture-pane result "
-                            "discarded — terminal status changed while the capture-pane "
-                            "read was in flight"
+                            "discarded — the terminal moved on (new input or new "
+                            "output) while the capture-pane read was in flight"
                         )
                         # The pipeline got there first: hand back ITS status rather than
                         # the `cached` value snapshotted at entry, which is now one step
@@ -744,8 +806,10 @@ class StatusMonitor:
         safe on rendered snapshots — the same contract terminal_service's deferred-init
         direct probe relies on), and providers with neither flag fail CLOSED: no capture,
         no verdict, the terminal stays PROCESSING until the pipeline resolves it.
-        Bounding the read to PYTE_SCREEN_ROWS also keeps stale scrollback from an earlier
-        turn out of whole-text matches (kiro's ERROR indicator is one such match).
+        The read is viewport-only (``visible_only=True`` — capture-pane ``-S 0``): a
+        ``tail_lines`` read would include scrollback ABOVE the viewport, and detectors
+        that match anywhere in their input (kimi/kiro ERROR indicators) would resurrect
+        text from finished turns. Only the currently rendered screen is evidence.
 
         A single capture is still not trusted even on a routed detector: Ink-style TUIs
         repaint by clear-then-rewrite, and a sample caught between those two steps can
@@ -794,11 +858,16 @@ class StatusMonitor:
         try:
             from cli_agent_orchestrator.backends.registry import get_backend
 
+            # visible_only, NOT tail_lines: capture-pane's -S -N means "N history
+            # lines ABOVE the viewport, plus the viewport" — a tail_lines read
+            # includes scrollback, and detectors that match anywhere in their input
+            # (kiro/kimi ERROR indicators) would resurrect text from finished turns.
+            # Only the currently rendered screen is evidence about the current turn.
             fresh_output = get_backend().get_history(
                 provider.session_name,
                 provider.window_name,
-                tail_lines=PYTE_SCREEN_ROWS,
                 strip_escapes=True,
+                visible_only=True,
             )
         except Exception as e:
             logger.debug(

--- a/src/cli_agent_orchestrator/utils/terminal.py
+++ b/src/cli_agent_orchestrator/utils/terminal.py
@@ -169,6 +169,12 @@ async def wait_until_status(
     it returns the pushed pipeline status, and for event-inbox backends (herdr)
     it derives status on demand from the provider's native status. So this poll
     works for both backends without special-casing here.
+
+    get_status() is no longer purely in-memory: for a terminal stuck in PROCESSING it can
+    shell out to a real tmux capture-pane subprocess (the stale-PROCESSING fallback in
+    status_monitor.py), and on herdr it shells out to the herdr CLI. Offload each poll via
+    asyncio.to_thread so that blocking I/O can't fork/exec on the shared event loop —
+    matches the pattern GET /terminals/{id} (api/main.py) uses for the identical hazard.
     """
     from cli_agent_orchestrator.services.status_monitor import status_monitor
 
@@ -179,7 +185,7 @@ async def wait_until_status(
     )
     start = time.time()
     while time.time() - start < timeout:
-        current = status_monitor.get_status(terminal_id)
+        current = await asyncio.to_thread(status_monitor.get_status, terminal_id)
         if current in targets:
             logger.info(f"wait_until_status [{terminal_id}]: reached {current.value}")
             return True

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -746,6 +746,31 @@ class TestGetSession:
         assert response.status_code == 500
         assert "Failed to get session" in response.json()["detail"]
 
+    def test_get_session_dispatches_via_to_thread(self, client):
+        """#558: session_service.get_session() calls status_monitor.get_status() once per
+        terminal in the session, which for a PROCESSING terminal can shell out to a real
+        tmux capture-pane subprocess (the stale-PROCESSING fallback) -- a session with N
+        processing terminals would fork N times inline on the event loop per request
+        otherwise, and the web UI polls this endpoint. Pin the asyncio.to_thread wrapping
+        directly: the tests above mock session_service entirely and cannot see HOW it was
+        called, so a regression back to a bare synchronous call would stay green."""
+        mock_session = {"id": "test-session", "windows": []}
+        with (
+            patch("cli_agent_orchestrator.api.main.session_service") as mock_svc,
+            patch(
+                "cli_agent_orchestrator.api.main.asyncio.to_thread", wraps=asyncio.to_thread
+            ) as mock_to_thread,
+        ):
+            mock_svc.get_session.return_value = mock_session
+            response = client.get("/sessions/test-session")
+            get_session_calls = [
+                c for c in mock_to_thread.call_args_list if c.args[0] == mock_svc.get_session
+            ]
+
+        assert response.status_code == 200
+        assert get_session_calls, "session_service.get_session was never dispatched via to_thread"
+        assert get_session_calls[0].args[1] == "test-session"
+
 
 class TestDeleteSession:
     """Tests for DELETE /sessions/{session_name} endpoint."""

--- a/test/backends/test_tmux_backend.py
+++ b/test/backends/test_tmux_backend.py
@@ -130,8 +130,22 @@ class TestTmuxBackendDelegation:
             tail_lines=50,
             strip_escapes=False,
             full_history=False,
+            visible_only=False,
         )
         assert result == "output text"
+
+    def test_get_history_delegates_visible_only(self, backend, mock_client):
+        mock_client.get_history.return_value = "viewport text"
+        result = backend.get_history("cao-test", "window-0", visible_only=True)
+        mock_client.get_history.assert_called_once_with(
+            "cao-test",
+            "window-0",
+            tail_lines=None,
+            strip_escapes=False,
+            full_history=False,
+            visible_only=True,
+        )
+        assert result == "viewport text"
 
     def test_get_pane_working_directory_delegates(self, backend, mock_client):
         mock_client.get_pane_working_directory.return_value = "/home/user"

--- a/test/providers/test_copilot_cli_unit.py
+++ b/test/providers/test_copilot_cli_unit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import shlex
 from unittest.mock import patch
@@ -264,6 +265,46 @@ class TestCopilotCliProviderInitialization:
         assert result is True
         # Initial trust handling + the in-loop WAITING_USER_ANSWER handling.
         assert mock_accept.call_count >= 2
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.status_monitor.status_monitor")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.wait_for_shell")
+    @patch("cli_agent_orchestrator.providers.copilot_cli.get_backend")
+    @patch.object(CopilotCliProvider, "_accept_trust_prompts")
+    async def test_initialize_polls_get_status_via_to_thread(
+        self,
+        mock_accept,
+        mock_tmux,
+        mock_wait_shell,
+        mock_status_monitor,
+    ):
+        """#558: status_monitor.get_status() is no longer in-memory only -- for a
+        PROCESSING terminal it can fork a real tmux capture-pane subprocess (the
+        stale-PROCESSING fallback), and copilot init is exactly the regime that trips it
+        (cached PROCESSING, pane quiet during auth/MCP boot). Pin the asyncio.to_thread
+        dispatch of the init poll -- the other init tests mock the status monitor and
+        cannot see HOW it was called."""
+        mock_wait_shell.return_value = True
+        mock_status_monitor.get_status.return_value = TerminalStatus.IDLE
+
+        provider = CopilotCliProvider("test1234", "test-session", "window-0")
+
+        with patch(
+            "cli_agent_orchestrator.providers.copilot_cli.asyncio.to_thread",
+            wraps=asyncio.to_thread,
+        ) as mock_to_thread:
+            result = await provider.initialize()
+            # initialize() also offloads _command and send_keys -- count only the
+            # get_status dispatches.
+            get_status_calls = [
+                c
+                for c in mock_to_thread.call_args_list
+                if c.args[0] == mock_status_monitor.get_status
+            ]
+
+        assert result is True
+        assert get_status_calls, "status_monitor.get_status was never dispatched via to_thread"
+        assert all(c.args[1] == "test1234" for c in get_status_calls)
 
 
 class TestCopilotCliProviderTrustPrompts:

--- a/test/services/test_agent_step.py
+++ b/test/services/test_agent_step.py
@@ -700,6 +700,40 @@ class TestIdleCompletionSignal:
                 asyncio.run(run_agent_step("kiro_cli", "dev", "x"))
         assert exc_info.value.kind == "error"
 
+    def test_completion_poll_dispatches_get_status_via_to_thread(self):
+        """#558: status_monitor.get_status() can shell out to a real tmux capture-pane
+        subprocess (the stale-PROCESSING fallback); calling it inline in
+        _wait_for_completion's poll loop would fork tmux ON the event loop every poll.
+        Pin the asyncio.to_thread wrapping directly -- every other test here mocks
+        status_monitor.get_status itself, which cannot see HOW it was called, so a
+        regression back to a bare synchronous call would stay green."""
+        create, send, delete, get_output, exit_cli, get_wd, wait, status = _patch_terminal_layer(
+            final_status=TerminalStatus.COMPLETED,
+        )
+        with (
+            create,
+            send,
+            delete,
+            get_output,
+            exit_cli,
+            wait,
+            status,
+            patch(f"{_MODULE}.asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread,
+        ):
+            from cli_agent_orchestrator.services.agent_step import status_monitor
+
+            asyncio.run(run_agent_step("kiro_cli", "dev", "x"))
+
+            # Captured while still inside the patch context -- status_monitor.get_status
+            # is the active mock here (patched by `status` above); comparing against it
+            # after the patches unwind would compare against the restored, unpatched
+            # method instead.
+            get_status_calls = [
+                c for c in mock_to_thread.call_args_list if c.args[0] == status_monitor.get_status
+            ]
+        assert get_status_calls, "status_monitor.get_status was never dispatched via to_thread"
+        assert all(c.args[1] == "abc12345" for c in get_status_calls)
+
 
 class TestPromptDeliveryVerification:
     """#562: a prompt dropped at send (worker idle, never picked up) is

--- a/test/services/test_flow_service.py
+++ b/test/services/test_flow_service.py
@@ -1,5 +1,6 @@
 """Tests for flow service."""
 
+import asyncio
 import json
 import tempfile
 from datetime import datetime
@@ -919,6 +920,66 @@ Prompt.
         # first (conductor) terminal", which an index into call_args_list would
         # miss, and it does not break if the call ever becomes keyword-style.
         mock_status_monitor.get_status.assert_called_once_with("conductor")
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.flow_service.send_input")
+    @patch("cli_agent_orchestrator.services.flow_service.create_terminal")
+    @patch("cli_agent_orchestrator.services.flow_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.flow_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.flow_service.get_backend")
+    @patch("cli_agent_orchestrator.services.flow_service.db_update_flow_run_times")
+    @patch("cli_agent_orchestrator.services.flow_service.db_get_flow")
+    async def test_execute_flow_busy_check_dispatches_via_to_thread(
+        self,
+        mock_db_get,
+        mock_update_times,
+        mock_get_backend,
+        mock_list_terminals,
+        mock_status_monitor,
+        mock_create_terminal,
+        mock_send_input,
+    ):
+        """#558: the conductor busy check reads status_monitor.get_status(), which for a
+        PROCESSING terminal can fork a real tmux capture-pane subprocess (the
+        stale-PROCESSING fallback), and execute_flow runs on the shared event loop. Pin
+        the asyncio.to_thread dispatch -- the busy tests above mock the status monitor
+        and cannot see HOW the check was called."""
+        from cli_agent_orchestrator.services import flow_service
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(
+                "---\nname: pin-flow\nschedule: '* * * * *'\nagent_profile: developer\n---\nPrompt.\n"
+            )
+            f.flush()
+            mock_flow = Flow(
+                name="pin-flow",
+                file_path=f.name,
+                schedule="* * * * *",
+                agent_profile="developer",
+                provider="kiro_cli",
+                script="",
+                enabled=True,
+                next_run=datetime.now(),
+            )
+        mock_db_get.return_value = mock_flow
+        mock_get_backend.return_value.session_exists.return_value = True
+        mock_list_terminals.return_value = [{"id": "t1", "agent_profile": "developer"}]
+        mock_status_monitor.get_status.return_value = TerminalStatus.PROCESSING
+
+        with patch(
+            "cli_agent_orchestrator.services.flow_service.asyncio.to_thread",
+            wraps=asyncio.to_thread,
+        ) as mock_to_thread:
+            result = await execute_flow("pin-flow")
+            busy_calls = [
+                c
+                for c in mock_to_thread.call_args_list
+                if c.args[0] == flow_service._is_terminal_busy
+            ]
+
+        assert result is False
+        assert busy_calls, "_is_terminal_busy was never dispatched via to_thread"
+        assert busy_calls[0].args[1] == "t1"
 
     @pytest.mark.asyncio
     @patch("cli_agent_orchestrator.services.flow_service.delete_terminals_by_session")

--- a/test/services/test_inbox_service.py
+++ b/test/services/test_inbox_service.py
@@ -210,6 +210,58 @@ class TestDeliverPending:
         assert mock_update.call_args_list[-1] == call(1, MessageStatus.PENDING)
         assert call(1, MessageStatus.FAILED) not in mock_update.call_args_list
 
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_concurrent_delivery_for_one_terminal_sends_exactly_once(
+        self, mock_get, mock_monitor, mock_term_svc, mock_update
+    ):
+        """deliver_pending is read(PENDING) -> status check -> mark DELIVERED -> send,
+        with no atomic claim at the DB layer. Its callers genuinely overlap on worker
+        threads (the status-event consumer, the immediate POST path, the OpenCode poller,
+        the reconcile sweep), and two calls both reading the same oldest row before
+        either marks it would execute one agent task twice. The per-terminal lock must
+        serialize the whole sequence: with the mark artificially slowed to hold the
+        read->mark window open, two racing threads must produce exactly one send."""
+        import threading
+        import time
+
+        mock_monitor.get_status.return_value = TerminalStatus.IDLE
+        message = _make_message()
+        store = {"status": MessageStatus.PENDING}
+        store_guard = threading.Lock()
+
+        def read_pending(terminal_id, limit=1):
+            with store_guard:
+                return [message] if store["status"] == MessageStatus.PENDING else []
+
+        def slow_mark(message_id, status):
+            # Hold the read->mark window open long enough that an unserialized second
+            # thread would re-read the row as PENDING.
+            time.sleep(0.15)
+            with store_guard:
+                store["status"] = status
+
+        mock_get.side_effect = read_pending
+        mock_update.side_effect = slow_mark
+
+        svc = InboxService()
+        start = threading.Barrier(2)
+
+        def race():
+            start.wait(timeout=5)
+            svc.deliver_pending("term-1")
+
+        threads = [threading.Thread(target=race) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert mock_term_svc.send_input.call_count == 1
+        assert store["status"] == MessageStatus.DELIVERED
+
 
 class TestEagerInboxDelivery:
     """Tests for eager inbox delivery (CAO_EAGER_INBOX_DELIVERY).

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -170,14 +170,13 @@ class TestStaleProcessingCapturePane:
 
     @patch("cli_agent_orchestrator.backends.registry.get_backend")
     @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
-    def test_capture_is_bounded_to_viewport_and_escape_free(self, mock_pm, mock_get_backend):
-        """The pane read must be bounded to the rendered viewport (PYTE_SCREEN_ROWS) and
-        escape-free -- the input shape the routed detectors are calibrated for. An
-        unbounded read drags scrollback from earlier turns into whole-text matches (a
-        stale kiro error string surviving in scrollback would parse as ERROR, which is
-        sticky and makes agent_step raise)."""
-        from cli_agent_orchestrator.constants import PYTE_SCREEN_ROWS
-
+    def test_capture_is_viewport_only_and_escape_free(self, mock_pm, mock_get_backend):
+        """The pane read must be exactly the rendered viewport, escape-free -- the input
+        shape the routed detectors are calibrated for. A tail_lines read is NOT that:
+        capture-pane's ``-S -N`` starts N lines of scrollback ABOVE the viewport, so text
+        from finished turns rides along, and detectors that match anywhere in their input
+        resurrect it (a stale kimi/kiro error string in scrollback parses as ERROR, which
+        is sticky and makes agent_step raise -- while the actual visible pane is IDLE)."""
         provider = self._probe_provider(TerminalStatus.IDLE)
         mock_pm.get_provider.return_value = provider
         backend = _backend(event_inbox=False)
@@ -192,7 +191,7 @@ class TestStaleProcessingCapturePane:
         sm.get_status("t1")
 
         backend.get_history.assert_called_once_with(
-            "s1", "w1", tail_lines=PYTE_SCREEN_ROWS, strip_escapes=True
+            "s1", "w1", strip_escapes=True, visible_only=True
         )
 
     @patch("cli_agent_orchestrator.backends.registry.get_backend")
@@ -435,6 +434,95 @@ class TestStaleProcessingCapturePane:
         )
         assert sm.get_status("t1") == TerminalStatus.PROCESSING
         assert backend.get_history.call_count == 1
+
+    @patch("cli_agent_orchestrator.services.status_monitor.get_server_settings")
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_real_chunk_between_reads_invalidates_the_candidate(
+        self, mock_pm, mock_get_backend, mock_settings
+    ):
+        """Real output arriving between the candidate read and the confirming read means
+        the terminal is demonstrably alive -- the earlier ready verdict no longer
+        describes it, and it must not be confirmable even after the buffer goes quiet
+        again. Otherwise a candidate from before the burst pairs with a read from after
+        it, and the two-read confirm degrades back to a single-frame latch."""
+        mock_settings.return_value = {"state_buffer_max": 32768}
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "idle-looking pane"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        # Read 1 records the IDLE candidate.
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert sm._pending_stale_capture["t1"][0] == TerminalStatus.IDLE
+
+        # A real chunk lands via the real ingestion path -- provider reports PROCESSING
+        # for the buffer-driven detection so only the candidate bookkeeping is exercised.
+        provider.get_status.return_value = TerminalStatus.PROCESSING
+        sm._process_chunk("t1", "fresh spinner frame")
+        assert "t1" not in sm._pending_stale_capture
+
+        # Quiet returns, rate limit reset, and the pane reads IDLE again: this must be a
+        # FRESH candidate (returns PROCESSING), never a confirmation of the pre-chunk one.
+        # Empty the rolling buffer again so the cheap buffer re-check can't resolve the
+        # status on its own -- this test is about the capture path's candidate bookkeeping.
+        provider.get_status.return_value = TerminalStatus.IDLE
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_new_turn_during_the_confirming_read_discards_the_verdict(
+        self, mock_pm, mock_get_backend
+    ):
+        """notify_input_sent deliberately leaves _last_status == PROCESSING while arming
+        the revert, so a status re-check alone cannot see a new turn. If new input lands
+        while the confirming capture is in flight, the confirmed-but-stale verdict must
+        be discarded: applying it would stamp a pre-turn IDLE over the new turn AND
+        consume the revert arm it just set, latch-blocking the new turn's genuine
+        PROCESSING -- the exact failure the self-heal must never introduce."""
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "idle-looking pane"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        # Land the new input in the EXACT window: after _fresh_capture_pane_status has
+        # confirmed and popped the candidate, before get_status applies the verdict.
+        # (Input during the capture read itself is covered separately -- the candidate
+        # pop handles that; this pins the later, narrower window.)
+        real_probe = sm._fresh_capture_pane_status
+
+        def probe_then_new_turn(terminal_id):
+            verdict = real_probe(terminal_id)
+            if verdict == TerminalStatus.IDLE:
+                sm.notify_input_sent("t1")
+            return verdict
+
+        sm._fresh_capture_pane_status = probe_then_new_turn  # type: ignore[method-assign]
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING  # read 1: candidate only
+        sm._last_stale_capture_check["t1"] = None
+        result = sm.get_status("t1")  # read 2: confirmed, then the new turn intervenes
+
+        assert result == TerminalStatus.PROCESSING
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+        # The arm set by notify_input_sent must survive untouched for the new turn.
+        assert sm._allow_processing_revert["t1"] is True
 
     @patch("cli_agent_orchestrator.backends.registry.get_backend")
     @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -503,12 +503,13 @@ class TestStaleProcessingCapturePane:
 
         # Land the new input in the EXACT window: after _fresh_capture_pane_status has
         # confirmed and popped the candidate, before get_status applies the verdict.
-        # (Input during the capture read itself is covered separately -- the candidate
-        # pop handles that; this pins the later, narrower window.)
+        # (Input during the capture read itself is pinned separately by
+        # test_new_turn_during_the_seeding_read_rejects_the_candidate; this pins the
+        # later, narrower window.)
         real_probe = sm._fresh_capture_pane_status
 
-        def probe_then_new_turn(terminal_id):
-            verdict = real_probe(terminal_id)
+        def probe_then_new_turn(terminal_id, generation):
+            verdict = real_probe(terminal_id, generation)
             if verdict == TerminalStatus.IDLE:
                 sm.notify_input_sent("t1")
             return verdict
@@ -523,6 +524,95 @@ class TestStaleProcessingCapturePane:
         assert sm._last_status["t1"] == TerminalStatus.PROCESSING
         # The arm set by notify_input_sent must survive untouched for the new turn.
         assert sm._allow_processing_revert["t1"] is True
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_new_turn_during_the_seeding_read_rejects_the_candidate(
+        self, mock_pm, mock_get_backend
+    ):
+        """New input landing while the FIRST (candidate-seeding) capture is in flight
+        must reject that candidate outright, not merely fail to confirm it.
+        notify_input_sent's own candidate pop cannot help here -- the pop runs while the
+        read is still in flight, and the seeding write lands AFTER it. If that
+        pre-boundary IDLE were seeded anyway, the next poll would pin the new (by then
+        stable) generation, take its own IDLE read as the "second" of the pair, confirm,
+        and apply -- consuming the revert arm the new turn just set and latch-blocking
+        its genuine PROCESSING. The seeding mutation itself must be generation-gated."""
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        # New input arrives DURING the first pane read -- inside the unlocked
+        # subprocess window, after the caller pinned its generation.
+        def new_turn_then_return_history(*args, **kwargs):
+            sm.notify_input_sent("t1")
+            return "idle-looking pane"
+
+        backend.get_history.side_effect = new_turn_then_return_history
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        # The straddling read must not have (re)seeded the candidate map.
+        assert "t1" not in sm._pending_stale_capture
+
+        # Next poll reads the same idle-looking pane cleanly: with the stale candidate
+        # correctly rejected this is a FIRST sighting, so nothing confirms, nothing is
+        # applied, and the new turn's revert arm is still intact.
+        backend.get_history.side_effect = None
+        backend.get_history.return_value = "idle-looking pane"
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+        assert sm._allow_processing_revert["t1"] is True
+
+    @patch("cli_agent_orchestrator.services.status_monitor.get_server_settings")
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_real_chunk_during_the_seeding_read_rejects_the_candidate(
+        self, mock_pm, mock_get_backend, mock_settings
+    ):
+        """Same straddling window as above, other boundary source: a real chunk through
+        _process_chunk while the seeding capture is in flight. The chunk's candidate pop
+        runs before the seeding write lands, so without the generation gate the
+        pre-burst IDLE would be seeded after it and confirmable by the next quiet
+        poll."""
+        mock_settings.return_value = {"state_buffer_max": 32768}
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        def chunk_then_return_history(*args, **kwargs):
+            # The buffer-driven detection must keep reporting busy so only the
+            # capture path's candidate bookkeeping is exercised.
+            provider.get_status.return_value = TerminalStatus.PROCESSING
+            sm._process_chunk("t1", "fresh spinner frame")
+            provider.get_status.return_value = TerminalStatus.IDLE
+            return "idle-looking pane"
+
+        backend.get_history.side_effect = chunk_then_return_history
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert "t1" not in sm._pending_stale_capture
+
+        # Quiet again; the next clean read is a FIRST sighting, never a confirmation.
+        backend.get_history.side_effect = None
+        backend.get_history.return_value = "idle-looking pane"
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
 
     @patch("cli_agent_orchestrator.backends.registry.get_backend")
     @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
@@ -640,10 +730,11 @@ class TestStaleProcessingCapturePane:
         assert sm.get_status("t1") == TerminalStatus.PROCESSING  # candidate recorded
 
         # Age the candidate past the TTL, as if the confirming read never arrived on time.
-        pending_status, pending_ts = sm._pending_stale_capture["t1"]
+        pending_status, pending_ts, pending_gen = sm._pending_stale_capture["t1"]
         sm._pending_stale_capture["t1"] = (
             pending_status,
             pending_ts - (STALE_PROCESSING_CONFIRM_TTL_S + 0.5),
+            pending_gen,
         )
 
         # The next matching read must NOT confirm the expired candidate -- it starts a

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -7,10 +7,15 @@ provider's native status. These tests pin both paths.
 """
 
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 from cli_agent_orchestrator.models.terminal import TerminalStatus
-from cli_agent_orchestrator.services.status_monitor import StatusMonitor
+from cli_agent_orchestrator.services.status_monitor import (
+    STALE_PROCESSING_BUFFER_QUIET_S,
+    STALE_PROCESSING_CONFIRM_TTL_S,
+    StatusMonitor,
+)
 
 
 def _backend(event_inbox):
@@ -83,6 +88,553 @@ class TestGetStatusEventInbox:
 
         sm = StatusMonitor()
         assert sm.get_status("t1") == TerminalStatus.UNKNOWN
+
+
+class TestStaleProcessingCapturePane:
+    """Stuck-PROCESSING self-heal (#558): a terminal that goes genuinely idle can leave
+    get_status() reporting PROCESSING forever, because the cheap re-check re-derives from
+    the SAME rolling buffer that stopped changing the moment the process stopped emitting
+    output. These pin the fresh capture-pane fallback that self-heals this without waiting
+    for a manual nudge, and the gates that keep it from firing during ordinary turns:
+
+    1. Buffer-quiet gate: the fallback only even attempts once no new chunk has landed for
+       STALE_PROCESSING_BUFFER_QUIET_S. Most tests set _buffer_changed_at directly rather
+       than mocking the ``time`` module wholesale — real time.monotonic() is always far
+       past its arbitrary reference point, so a large negative value is unconditionally
+       quiet.
+    2. Detector routing: a capture-pane snapshot is rendered content, so it only feeds a
+       detector declared safe for that shape — get_status_from_screen() for
+       supports_screen_detection providers, get_status() for supports_direct_status_probe
+       providers, and NOTHING for providers with neither flag (fail closed).
+    3. Two-read confirm with expiry: a ready verdict must repeat on the next eligible read
+       within STALE_PROCESSING_CONFIRM_TTL_S, and a new turn (notify_input_sent) drops the
+       pending candidate.
+    """
+
+    @staticmethod
+    def _quiet_since():
+        """A _buffer_changed_at value old enough to satisfy the quiet gate unconditionally."""
+        return -1000.0
+
+    @staticmethod
+    def _probe_provider(status=TerminalStatus.IDLE):
+        """A provider stub routed through get_status(): direct-status-probe capable.
+
+        Flags are set explicitly — a bare MagicMock's auto-attributes are truthy, which
+        would silently route through the screen path instead.
+        """
+        provider = MagicMock()
+        provider.session_name = "s1"
+        provider.window_name = "w1"
+        provider.supports_screen_detection = False
+        provider.supports_direct_status_probe = True
+        provider.get_status.return_value = status
+        return provider
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_stale_processing_self_heals_via_capture_pane_after_two_confirming_reads(
+        self, mock_pm, mock_get_backend
+    ):
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "the real pane -- idle composer, fully rendered"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        # Empty buffer -- as if the process stopped emitting output entirely, exactly the
+        # shape that leaves the cheap re-check (which requires a truthy buffer) unable to
+        # help at all.
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        # First read: a genuine ready candidate, but a single sample is never trusted --
+        # must NOT self-heal yet (a lone capture can catch an Ink repaint mid-clear/rewrite
+        # and read the wrong turn's response box).
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+        assert backend.get_history.call_count == 1
+
+        # Second, matching read confirms it. Reset the internal rate-limit gate directly
+        # instead of waiting out STALE_PROCESSING_CAPTURE_INTERVAL_S for real.
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.IDLE
+        assert backend.get_history.call_count == 2
+        provider.get_status.assert_called_with("the real pane -- idle composer, fully rendered")
+        # Self-healing must actually update the latched status, not just this one return
+        # value -- otherwise the very next poll would go right back through the same stale
+        # path.
+        assert sm._last_status["t1"] == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_capture_is_bounded_to_viewport_and_escape_free(self, mock_pm, mock_get_backend):
+        """The pane read must be bounded to the rendered viewport (PYTE_SCREEN_ROWS) and
+        escape-free -- the input shape the routed detectors are calibrated for. An
+        unbounded read drags scrollback from earlier turns into whole-text matches (a
+        stale kiro error string surviving in scrollback would parse as ERROR, which is
+        sticky and makes agent_step raise)."""
+        from cli_agent_orchestrator.constants import PYTE_SCREEN_ROWS
+
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "pane"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        sm.get_status("t1")
+
+        backend.get_history.assert_called_once_with(
+            "s1", "w1", tail_lines=PYTE_SCREEN_ROWS, strip_escapes=True
+        )
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_differing_second_read_never_confirms(self, mock_pm, mock_get_backend):
+        """Two DIFFERENT ready candidates in a row must never be honored -- only two
+        IDENTICAL consecutive reads count as confirmed."""
+        provider = self._probe_provider()
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "some pane content"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        provider.get_status.return_value = TerminalStatus.IDLE
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING  # 1st read: pending=IDLE
+
+        sm._last_stale_capture_check["t1"] = None
+        provider.get_status.return_value = TerminalStatus.COMPLETED
+        # 2nd read differs -> not confirmed; pending is now COMPLETED, not IDLE.
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+        assert backend.get_history.call_count == 2
+
+        # A THIRD read matching the second (COMPLETED) now confirms it.
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.COMPLETED
+        assert sm._last_status["t1"] == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_capture_pane_still_processing_stays_processing_no_crash(
+        self, mock_pm, mock_get_backend
+    ):
+        provider = self._probe_provider(TerminalStatus.PROCESSING)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "• Working (12s • esc to interrupt)"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_capture_pane_read_failure_stays_processing_no_crash(self, mock_pm, mock_get_backend):
+        provider = self._probe_provider()
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.side_effect = RuntimeError("tmux not reachable")
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        provider.get_status.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_no_provider_stays_processing_and_skips_capture_pane_entirely(
+        self, mock_pm, mock_get_backend
+    ):
+        mock_pm.get_provider.return_value = None
+        backend = _backend(event_inbox=False)
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_get_provider_raising_stays_processing_no_crash(self, mock_pm, mock_get_backend):
+        # get_provider() raises (not returns None) for a terminal it no longer recognizes
+        # -- matches get_status()'s own event-inbox branch, which already defends against
+        # this.
+        mock_pm.get_provider.side_effect = ValueError("terminal not in db")
+        backend = _backend(event_inbox=False)
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_capture_pane_fallback_is_rate_limited(self, mock_pm, mock_get_backend):
+        # get_status() is a hot path (every poll, across the whole fleet) -- the
+        # capture-pane fallback is a real tmux subprocess call and must not fire on every
+        # single poll while a terminal is stuck. Two calls back-to-back (real
+        # time.monotonic(), so well within the rate-limit window) must only shell out once.
+        provider = self._probe_provider(TerminalStatus.PROCESSING)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "still working"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        sm.get_status("t1")
+        sm.get_status("t1")
+
+        backend.get_history.assert_called_once()
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_capture_pane_fallback_retried_after_rate_limit_window(self, mock_pm, mock_get_backend):
+        provider = self._probe_provider(TerminalStatus.PROCESSING)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "still working"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        sm.get_status("t1")
+        # Simulate the rate-limit window having elapsed, without a real sleep.
+        sm._last_stale_capture_check["t1"] = None
+        sm.get_status("t1")
+
+        assert backend.get_history.call_count == 2
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_buffer_recheck_resolving_skips_capture_pane_entirely(self, mock_pm, mock_get_backend):
+        # When the existing cheap buffer re-check already resolves the status, the (more
+        # expensive) capture-pane fallback must not run at all -- no regression in the
+        # common case where the original mechanism already worked.
+        provider = self._probe_provider(TerminalStatus.COMPLETED)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = "a real, non-empty buffer that resolves cleanly"
+
+        assert sm.get_status("t1") == TerminalStatus.COMPLETED
+        backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_recently_changed_buffer_skips_capture_pane_entirely(self, mock_pm, mock_get_backend):
+        """A terminal mid-burst -- new chunks still actively arriving -- is not the stuck
+        case this fallback exists for. Without the buffer-quiet gate, every ordinary busy
+        turn would eat a real tmux subprocess call every ~3s for its entire duration."""
+        provider = self._probe_provider()
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "some content"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        # A chunk "just arrived" -- well within STALE_PROCESSING_BUFFER_QUIET_S.
+        sm._buffer_changed_at["t1"] = time.monotonic()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_no_buffer_changed_at_recorded_skips_capture_pane_entirely(
+        self, mock_pm, mock_get_backend
+    ):
+        """A terminal that has never had _process_chunk record a change must not be
+        treated as "quiet since forever" -- the gate requires a real recorded quiet
+        duration, not the absence of one."""
+        provider = self._probe_provider()
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        # _buffer_changed_at deliberately left unset.
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        backend.get_history.assert_not_called()
+
+    @patch("cli_agent_orchestrator.services.status_monitor.get_server_settings")
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_quiet_gate_tracks_real_chunk_arrivals(self, mock_pm, mock_get_backend, mock_settings):
+        """The quiet gate must be driven by _process_chunk's own timestamp bump -- its
+        real write site -- not by state the tests hand-set. Chunks streaming in keep the
+        gate closed (no capture mid-burst); once the last recorded arrival ages past the
+        window, exactly one capture fires. If _process_chunk ever stops recording
+        arrivals, the aging step here has nothing to age and this fails."""
+        mock_settings.return_value = {"state_buffer_max": 32768}
+        provider = self._probe_provider(TerminalStatus.PROCESSING)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "pane content"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        # Drive the REAL ingestion path: each chunk lands in the rolling buffer and (with
+        # no event loop) detects inline -- provider reports PROCESSING throughout.
+        for chunk in ("spinner ", "frame ", "spinner ", "frame ", "spinner"):
+            sm._process_chunk("t1", chunk)
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+
+        # Mid-burst: the last chunk just landed, so the gate must hold the fallback shut.
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert backend.get_history.call_count == 0
+
+        # Age the recorded arrival past the quiet window (KeyError here means the bump
+        # never happened) and poll again: exactly one capture.
+        sm._buffer_changed_at["t1"] = sm._buffer_changed_at["t1"] - (
+            STALE_PROCESSING_BUFFER_QUIET_S + 0.5
+        )
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert backend.get_history.call_count == 1
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_screen_provider_routes_through_get_status_from_screen(self, mock_pm, mock_get_backend):
+        """A supports_screen_detection provider owns a detector calibrated for rendered
+        viewport lines -- the fallback must feed the capture to THAT, never to the
+        raw-stream get_status() (whose ordering heuristics invert on rendered frames)."""
+        provider = MagicMock()
+        provider.session_name = "s1"
+        provider.window_name = "w1"
+        provider.supports_screen_detection = True
+        provider.get_status_from_screen.return_value = TerminalStatus.IDLE
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "line one\nline two\nline three"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING  # 1st read: candidate
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.IDLE  # 2nd read: confirmed
+
+        provider.get_status_from_screen.assert_called_with(["line one", "line two", "line three"])
+        provider.get_status.assert_not_called()
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_unroutable_provider_fails_closed_busy_kiro_frame_never_latches_completed(
+        self, mock_pm, mock_get_backend
+    ):
+        """The regression pin for the detector routing. kiro_cli sets neither
+        supports_screen_detection nor supports_direct_status_probe: its raw-stream
+        detector misreads a RENDERED busy frame as COMPLETED, because on screen the
+        always-drawn composer placeholder sits physically below the working line and the
+        credits line -- the opposite of the byte-stream ordering its checks were tuned
+        against. Fed through the fallback, that deterministic misread would confirm
+        itself (both reads see the same bytes), sticky-latch COMPLETED, disarm
+        _allow_processing_revert, and block the agent's genuine PROCESSING for the rest
+        of the turn. The fallback must therefore not consult a capture for this provider
+        at all."""
+        from cli_agent_orchestrator.providers.kiro_cli import KiroCliProvider
+
+        # A plausible rendered pane of a BUSY kiro: finished previous turn (credits) with
+        # the live working indicator, and the composer placeholder drawn at the bottom as
+        # always.
+        busy_pane = "\n".join(
+            [
+                "> summarize the repo layout",
+                "",
+                "────────────────────────────────",
+                "The repository is organised into providers, services and backends.",
+                "────────────────────────────────",
+                "",
+                "▸ Credits: 0.42 • Time: 12s",
+                "",
+                "⠧ Kiro is working... (esc to interrupt)",
+                "",
+                "Ask a question or describe a task ↵",
+            ]
+        )
+
+        provider = KiroCliProvider("test1234", "s1", "w1", "developer")
+        provider._initialized = True
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_native_status.return_value = None
+        backend.get_history.return_value = busy_pane
+        mock_get_backend.return_value = backend
+
+        # Canary: the raw detector really does misread this rendered busy frame as
+        # COMPLETED. If kiro's detector ever changes and this stops holding, the fixture
+        # no longer exercises the hazard and needs refreshing.
+        assert provider.get_status(busy_pane) == TerminalStatus.COMPLETED
+        backend.get_history.reset_mock()
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        # Two eligible polls (rate limit reset in between): the fallback must not
+        # capture, must not apply, and the terminal must still read PROCESSING.
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        backend.get_history.assert_not_called()
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+        # The revert arm is untouched -- a later genuine ready detection from the real
+        # pipeline is still free to land.
+        assert sm._allow_processing_revert.get("t1") is None
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_stale_pending_candidate_expires_instead_of_confirming(self, mock_pm, mock_get_backend):
+        """A pending candidate must be confirmed within STALE_PROCESSING_CONFIRM_TTL_S or
+        dropped. Without the expiry, a candidate recorded long ago -- e.g. during a
+        different phase of the same turn -- could be "confirmed" by one lone mid-repaint
+        read much later, which is exactly the single-frame latch the confirm exists to
+        prevent."""
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "idle pane"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING  # candidate recorded
+
+        # Age the candidate past the TTL, as if the confirming read never arrived on time.
+        pending_status, pending_ts = sm._pending_stale_capture["t1"]
+        sm._pending_stale_capture["t1"] = (
+            pending_status,
+            pending_ts - (STALE_PROCESSING_CONFIRM_TTL_S + 0.5),
+        )
+
+        # The next matching read must NOT confirm the expired candidate -- it starts a
+        # fresh one instead.
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+
+        # The fresh candidate confirms normally on the read after that.
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_notify_input_sent_invalidates_pending_candidate(self, mock_pm, mock_get_backend):
+        """A new turn invalidates whatever the pane showed before it: after
+        notify_input_sent, one lone ready read must NOT be honored off the pre-turn
+        candidate -- confirmation starts over."""
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "idle pane"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING  # candidate recorded
+
+        # Turn boundary: new input goes to the terminal.
+        sm.notify_input_sent("t1")
+
+        # One post-input ready read is a FIRST sighting again, not a confirmation.
+        sm._last_stale_capture_check["t1"] = None
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.backends.registry.get_backend")
+    @patch("cli_agent_orchestrator.services.status_monitor.provider_manager")
+    def test_toctou_stale_capture_discarded_if_status_changed_meanwhile(
+        self, mock_pm, mock_get_backend
+    ):
+        """The capture-pane read runs OUTSIDE the lock (a real subprocess call). If the
+        real pipeline independently resolves the terminal to something else WHILE that
+        read is in flight, the stale capture result must be discarded rather than applied
+        over the fresher, real status."""
+        provider = self._probe_provider(TerminalStatus.IDLE)
+        mock_pm.get_provider.return_value = provider
+        backend = _backend(event_inbox=False)
+        backend.get_history.return_value = "idle pane"
+        mock_get_backend.return_value = backend
+
+        sm = StatusMonitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        sm._buffers["t1"] = ""
+        sm._buffer_changed_at["t1"] = self._quiet_since()
+
+        # First read establishes the pending candidate.
+        assert sm.get_status("t1") == TerminalStatus.PROCESSING
+        sm._last_stale_capture_check["t1"] = None
+
+        # Simulate the real pipeline resolving this terminal to ERROR WHILE the second,
+        # confirming capture-pane read is "in flight" -- mutate _last_status from inside
+        # the mocked backend call, which is where the real (slow, unlocked) subprocess
+        # call happens.
+        def mutate_then_return_history(*args, **kwargs):
+            sm._last_status["t1"] = TerminalStatus.ERROR
+            return "idle pane"
+
+        backend.get_history.side_effect = mutate_then_return_history
+
+        result = sm.get_status("t1")
+
+        # The stale IDLE confirmation must be discarded, not applied over the real ERROR
+        # that arrived while the capture-pane read was in flight.
+        assert result == TerminalStatus.ERROR
+        assert sm._last_status["t1"] == TerminalStatus.ERROR
 
 
 class TestScreenDetection:

--- a/test/utils/test_terminal.py
+++ b/test/utils/test_terminal.py
@@ -318,6 +318,25 @@ class TestWaitUntilStatus:
 
         assert result is True
 
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.utils.terminal.asyncio.to_thread")
+    async def test_wait_until_status_dispatches_get_status_via_to_thread(self, mock_to_thread):
+        """#558: status_monitor.get_status() can shell out to a real tmux capture-pane
+        subprocess (the stale-PROCESSING fallback); calling it inline here would fork
+        tmux ON the event loop every poll. Pin the asyncio.to_thread wrapping directly --
+        the other tests in this class mock status_monitor itself and cannot see HOW it
+        was called, so a regression back to a bare synchronous call would stay green."""
+        mock_to_thread.return_value = TerminalStatus.IDLE
+
+        result = await wait_until_status(
+            "test-terminal", TerminalStatus.IDLE, timeout=1.0, polling_interval=0.1
+        )
+
+        assert result is True
+        from cli_agent_orchestrator.services.status_monitor import status_monitor
+
+        mock_to_thread.assert_called_once_with(status_monitor.get_status, "test-terminal")
+
 
 class TestWaitUntilTerminalStatus:
     """Tests for wait_until_terminal_status function."""


### PR DESCRIPTION
Adopts and completes #558. The incident, the diagnosis, and the quiet-gate design are @klabulan's — full credit for finding a wedge the #397 watchdog structurally cannot see. That PR has been quiet since 08-06 and the pick-up offer from 08-23 got no response, so per the disposition deadline this rebuilds it on current main with the three outstanding review items closed. If @klabulan resurfaces, happy to hand it back or co-credit however they prefer.

## The bug

The status pipeline's cheap re-check re-derives from the same rolling buffer the FIFO feeds. A process that finishes also stops emitting output, so when the ready marker rotated out of the bounded window (or a truncated escape corrupted the tail), the re-check returns PROCESSING forever while the pane already shows the finished response. The #397 watchdog treats "FIFO delivered bytes" as healthy, so it can't see it either — the original report had a queued message sitting undelivered ~10 minutes until a manual tmux resize forced a redraw.

## What's different from the original PR

The original fed the capture-pane snapshot to `provider.get_status()` for **every** provider. A capture is *rendered* content — a different input shape from the raw byte stream most detectors are tuned against — and for kiro that produces a deterministic misread: in a rendered busy frame the always-drawn composer placeholder sits physically below the working line, which its raw-stream ordering checks parse as COMPLETED. A deterministic misread also sails through any repeat-read confirm (both reads see the same bytes), then sticky-latches, disarms `_allow_processing_revert`, and blocks the agent's genuine PROCESSING for the rest of the turn. So:

- **Detector routing through the two existing opt-in predicates**: `supports_screen_detection` providers get their purpose-built `get_status_from_screen()` (calibrated for exactly this composited-viewport shape); `supports_direct_status_probe` providers get `get_status()` (the same contract the deferred-init direct probe relies on); providers with neither flag fail closed — no capture, no verdict. Same routing the rest of the codebase already promises for this operation.
- **Candidate TTL + turn invalidation**: the two-read confirm now requires the confirming read within 2× the capture interval, and `notify_input_sent` drops any pending candidate. Previously a stale ready candidate could survive a full turn boundary and be "confirmed" by one lone mid-repaint frame much later.
- **Complete event-loop offload**: with this feature, `get_status()` can fork a real subprocess, so every call site reachable from async goes through `asyncio.to_thread`. That's the four sites from the original PR plus copilot's init poll (whose docstring claimed get_status is in-memory only — now corrected), `execute_flow`'s busy check, and three sites that appeared on main since: grok's startup poll, kiro's trust-dialog re-read, and the inbox POST's `deliver_pending` (which was already doing blocking sends inline on the loop — flagging that scope addition explicitly in case it's preferred as a separate change).
- **Bounded reads**: `tail_lines=PYTE_SCREEN_ROWS` + escapes stripped, which also keeps stale scrollback out of whole-text matches (kiro's ERROR indicator is one such match).

Kept from the original because they were right: the buffer-quiet gate keyed off the one place output actually lands (a mid-burst terminal never pays for a subprocess), routing results through `_apply_detection`, the TOCTOU re-validation under the lock (extended to hand back the fresher pipeline status when the capture loses the race), fail-soft on every error path, and cleanup in `clear_terminal`/`reset_buffer`.

## Testing

- 23 new tests. `TestStaleProcessingCapturePane` (18) includes: the quiet gate driven through the real `_process_chunk` write site (deleting the timestamp bump fails the test — the gate can no longer be silently disabled); a screen-provider routing pin; a fail-closed regression pin using the **real** `KiroCliProvider` and a rendered busy frame, with a canary assert that the raw detector still misreads that frame as COMPLETED (so detector drift surfaces as a fixture refresh, not a silently vacuous test); candidate-TTL expiry and `notify_input_sent` invalidation; capture bounding. Five `to_thread` dispatch pins across the offloaded call sites.
- Every guard mutation-tested: 9 targeted reverts (drop the routing, drop the gate, drop the TTL, drop the confirm, drop the TOCTOU check, inline the offloads, unbound the read…), each kills at least one specific test on a real assertion.
- Full suite: failure set is byte-identical to clean main at 231de7a4 (same command, side-by-side worktrees) — nothing introduced. With `--all-extras` matching CI, 8345 passed with 5 pre-existing fifo-reader timing flakes that pass standalone.
- Live end-to-end: real tmux pane running the real claude TUI; wedged a real StatusMonitor at PROCESSING with a stale buffer while the on-screen turn completed; first eligible read records the candidate and stays PROCESSING, second read confirms and self-heals to IDLE through `get_status_from_screen`; control with both flags off stays PROCESSING across both reads.

Closes #558's incident; related: #659/#496/#480 are the same family in the opposite direction (stale ready), which is why the routing predicate matters in both.
