### PR TITLE
fix(codex): opt into the deferred-init direct status probe (#659)

### DIFF
--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -179,6 +179,25 @@ class BaseProvider(ABC):
     # this False — their COMPLETED/IDLE split is not screen-detectable.
     supports_direct_status_probe: bool = False
 
+    def direct_probe_confirms_submission(self, output: str, message: str) -> bool:
+        """Whether a started status read from ``output`` is attributable to
+        ``message`` — the text the direct status probe is confirming.
+
+        The deferred-submit probe (``supports_direct_status_probe``) reads a
+        started status off a live capture-pane snapshot and, when it holds,
+        skips redelivery. For a TUI whose activity indicators are turn-scoped
+        that status alone is evidence the submission was accepted, and the
+        default keeps that behavior. A provider whose startup chrome shares the
+        shape of its task-activity indicators (a startup spinner or bullet
+        that ``get_status`` reads as PROCESSING/COMPLETED before any task was
+        ever submitted) must override this and bind the verdict to evidence of
+        the current submission — otherwise the probe suppresses the recovery
+        it exists to perform and a dropped task is silently lost. Return False
+        whenever attribution cannot be established: the probe then falls
+        through to the redelivery decision.
+        """
+        return True
+
     def get_status_from_screen(self, screen_lines: List[str]) -> TerminalStatus:
         """Detect status from a pyte-rendered screen (composited viewport).
 

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -179,22 +179,29 @@ class BaseProvider(ABC):
     # this False — their COMPLETED/IDLE split is not screen-detectable.
     supports_direct_status_probe: bool = False
 
-    def direct_probe_confirms_submission(self, output: str, message: str) -> bool:
-        """Whether a started status read from ``output`` is attributable to
-        ``message`` — the text the direct status probe is confirming.
+    def direct_probe_confirms_dispatch(self, post_dispatch_output: str) -> bool:
+        """Whether ``post_dispatch_output`` proves this provider's TUI actually
+        began working on the submission the direct probe is confirming.
 
-        The deferred-submit probe (``supports_direct_status_probe``) reads a
-        started status off a live capture-pane snapshot and, when it holds,
-        skips redelivery. For a TUI whose activity indicators are turn-scoped
-        that status alone is evidence the submission was accepted, and the
-        default keeps that behavior. A provider whose startup chrome shares the
-        shape of its task-activity indicators (a startup spinner or bullet
-        that ``get_status`` reads as PROCESSING/COMPLETED before any task was
-        ever submitted) must override this and bind the verdict to evidence of
-        the current submission — otherwise the probe suppresses the recovery
-        it exists to perform and a dropped task is silently lost. Return False
-        whenever attribution cannot be established: the probe then falls
-        through to the redelivery decision.
+        ``post_dispatch_output`` is the StatusMonitor rolling byte buffer, which
+        ``send_input`` empties immediately BEFORE it sends the keystrokes (see
+        ``clear_rolling_buffer``). Every byte in it therefore arrived after the
+        dispatch, by construction — it cannot contain pre-dispatch scrollback,
+        cannot be defeated by a shared message prefix, and cannot be evicted by
+        a bounded capture-pane tail.
+
+        The direct probe reads a started status off the live rendered pane
+        (``get_status``), which classifies the frame as a whole and so cannot
+        tell a running turn from leftover chrome. This hook supplies the
+        causality that status alone lacks. The default keeps the status-only
+        verdict, for TUIs whose activity indicators are turn-scoped. A provider
+        whose startup chrome renders like task activity must override it and
+        name the byte-level evidence that only a real turn produces.
+
+        Returning False is not "not started": it means unproven, and the caller
+        treats it as such — the bare-Enter recovery still runs when the message
+        is on screen, and a full re-send is withheld whenever any post-dispatch
+        output exists, because absence of proof is not proof of a dropped paste.
         """
         return True
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -801,8 +801,66 @@ class CodexProvider(BaseProvider):
     # frames the screen-detection route above feeds it in production), so a
     # live capture-pane snapshot is a valid input; there is no dispatch
     # bookkeeping that a fresh capture would bypass (the kiro_cli-style
-    # disqualifier documented on _worker_is_started_direct).
+    # disqualifier documented on _worker_is_started_direct). The status alone
+    # is NOT the verdict, though — see direct_probe_confirms_submission below.
     supports_direct_status_probe = True
+
+    def direct_probe_confirms_submission(self, output: str, message: str) -> bool:
+        """Bind a started status to the submission being confirmed.
+
+        Codex's startup chrome shares the shape of its task activity: a
+        ``• Starting MCP servers (4s • esc to interrupt)`` spinner is the
+        TUI_PROGRESS_PATTERN, and any startup ``•`` line is an assistant
+        marker. ``initialize()`` returns once the bottom
+        STARTUP_PROMPT_BOTTOM_LINES are activity-free, but ``get_status``
+        scans a wider tail for the spinner and the whole capture for a
+        marker, so a task-less pane with that residue 16+ lines above the
+        idle composer reads PROCESSING (or COMPLETED once the spinner leaves
+        the tail). Accepting that as "started" would skip the redelivery a
+        dropped paste needs and lose the task silently.
+
+        A submitted turn leaves a causal trace instead: Codex echoes the
+        message as a ``›`` transcript line and renders the turn's activity
+        (spinner, ``•`` reply/tool bullets) BELOW it, whereas startup residue
+        sits ABOVE the composer and an unsubmitted paste sits in the composer
+        with nothing but the footer beneath. So the verdict is: the message
+        is visible, and a turn-activity line follows it. Bullets that are
+        part of the message text itself do not count — a pasted, unsubmitted
+        message containing its own ``•`` lines must not attribute activity
+        to itself. Anything short of that returns False and the probe falls
+        through to the redelivery decision (fail toward recovery).
+
+        Matching collapses both sides to ``[a-z0-9]`` and uses the message's
+        leading 24 characters, the same collapse ``_message_visible_in_box``
+        applies, so pane-width wrapping, unicode punctuation, and whitespace
+        cannot defeat the match.
+        """
+        probe = re.sub(r"[^a-z0-9]", "", message.lower())[:24]
+        if len(probe) < 8:
+            return False
+        lines = strip_terminal_escapes(output).splitlines()
+        # Collapse the pane line by line, recording which line each kept
+        # character came from so the echo can be located by line.
+        collapsed: list[str] = []
+        owner: list[int] = []
+        for index, line in enumerate(lines):
+            kept = re.sub(r"[^a-z0-9]", "", line.lower())
+            collapsed.append(kept)
+            owner.extend([index] * len(kept))
+        hit = "".join(collapsed).find(probe)
+        if hit == -1:
+            return False
+        echo_line = owner[hit]
+        message_text = re.sub(r"[^a-z0-9]", "", message.lower())
+        for line in lines[echo_line + 1 :]:
+            if re.search(TUI_PROGRESS_PATTERN, line):
+                return True
+            if re.match(STARTUP_ACTIVITY_PATTERN, line):
+                kept = re.sub(r"[^a-z0-9]", "", line.lower())
+                if kept and kept in message_text:
+                    continue  # a bullet inside the pasted message, not a reply
+                return True
+        return False
 
     def __init__(
         self,

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -792,6 +792,18 @@ class CodexProvider(BaseProvider):
     # the live frame rather than stale redraw history.
     supports_screen_detection = True
 
+    # Opt-in for the deferred-init direct status probe (capture-pane bypass,
+    # #659). The event-driven cache detects only at rising-edge/quiescence, so
+    # a repainting Working spinner can leave the cached status IDLE past the
+    # whole confirm window — the retry loop then re-delivers the task into the
+    # already-working pane and eventually tears the worker down. get_status()
+    # is line-oriented text analysis of exactly this rendered shape (the same
+    # frames the screen-detection route above feeds it in production), so a
+    # live capture-pane snapshot is a valid input; there is no dispatch
+    # bookkeeping that a fresh capture would bypass (the kiro_cli-style
+    # disqualifier documented on _worker_is_started_direct).
+    supports_direct_status_probe = True
+
     def __init__(
         self,
         terminal_id: str,

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -802,65 +802,44 @@ class CodexProvider(BaseProvider):
     # live capture-pane snapshot is a valid input; there is no dispatch
     # bookkeeping that a fresh capture would bypass (the kiro_cli-style
     # disqualifier documented on _worker_is_started_direct). The status alone
-    # is NOT the verdict, though — see direct_probe_confirms_submission below.
+    # is NOT the verdict, though — see direct_probe_confirms_dispatch below.
     supports_direct_status_probe = True
 
-    def direct_probe_confirms_submission(self, output: str, message: str) -> bool:
-        """Bind a started status to the submission being confirmed.
+    def direct_probe_confirms_dispatch(self, post_dispatch_output: str) -> bool:
+        """Prove a codex turn actually started, from post-dispatch bytes alone.
 
-        Codex's startup chrome shares the shape of its task activity: a
-        ``• Starting MCP servers (4s • esc to interrupt)`` spinner is the
-        TUI_PROGRESS_PATTERN, and any startup ``•`` line is an assistant
-        marker. ``initialize()`` returns once the bottom
-        STARTUP_PROMPT_BOTTOM_LINES are activity-free, but ``get_status``
-        scans a wider tail for the spinner and the whole capture for a
-        marker, so a task-less pane with that residue 16+ lines above the
-        idle composer reads PROCESSING (or COMPLETED once the spinner leaves
-        the tail). Accepting that as "started" would skip the redelivery a
-        dropped paste needs and lose the task silently.
+        Codex's startup chrome renders like its task activity: the
+        ``Starting MCP servers (4s - esc to interrupt)`` spinner IS
+        ``TUI_PROGRESS_PATTERN`` and any startup bullet is an assistant marker.
+        On a whole-frame ``get_status`` read that residue is indistinguishable
+        from a running turn, so the probe needs evidence tied to time rather
+        than to text.
 
-        A submitted turn leaves a causal trace instead: Codex echoes the
-        message as a ``›`` transcript line and renders the turn's activity
-        (spinner, ``•`` reply/tool bullets) BELOW it, whereas startup residue
-        sits ABOVE the composer and an unsubmitted paste sits in the composer
-        with nothing but the footer beneath. So the verdict is: the message
-        is visible, and a turn-activity line follows it. Bullets that are
-        part of the message text itself do not count — a pasted, unsubmitted
-        message containing its own ``•`` lines must not attribute activity
-        to itself. Anything short of that returns False and the probe falls
-        through to the redelivery decision (fail toward recovery).
+        ``post_dispatch_output`` supplies it: ``send_input`` empties the rolling
+        buffer immediately before sending the keystrokes, so a spinner that
+        stopped BEFORE the dispatch contributes no bytes here no matter where it
+        still sits on screen, while a live one repaints its elapsed counter and
+        necessarily does. The evidence is therefore the progress spinner alone.
 
-        Matching collapses both sides to ``[a-z0-9]`` and uses the message's
-        leading 24 characters, the same collapse ``_message_visible_in_box``
-        applies, so pane-width wrapping, unicode punctuation, and whitespace
-        cannot defeat the match.
+        A bullet is deliberately NOT accepted: the composer echoes the pasted
+        message as it renders, so a multi-line paste containing its own ``.``
+        bullet would emit one without any turn having started. The spinner's
+        ``(<n>s - esc to interrupt)`` shape cannot be produced that way.
+
+        False here is "unproven", never "idle" — see the base docstring. It is
+        also the honest answer on an event-inbox backend (herdr) that never
+        feeds a byte buffer: the probe then declines to vouch for the turn and
+        the caller falls back to its pre-existing behavior.
         """
-        probe = re.sub(r"[^a-z0-9]", "", message.lower())[:24]
-        if len(probe) < 8:
+        if not post_dispatch_output:
             return False
-        lines = strip_terminal_escapes(output).splitlines()
-        # Collapse the pane line by line, recording which line each kept
-        # character came from so the echo can be located by line.
-        collapsed: list[str] = []
-        owner: list[int] = []
-        for index, line in enumerate(lines):
-            kept = re.sub(r"[^a-z0-9]", "", line.lower())
-            collapsed.append(kept)
-            owner.extend([index] * len(kept))
-        hit = "".join(collapsed).find(probe)
-        if hit == -1:
-            return False
-        echo_line = owner[hit]
-        message_text = re.sub(r"[^a-z0-9]", "", message.lower())
-        for line in lines[echo_line + 1 :]:
-            if re.search(TUI_PROGRESS_PATTERN, line):
-                return True
-            if re.match(STARTUP_ACTIVITY_PATTERN, line):
-                kept = re.sub(r"[^a-z0-9]", "", line.lower())
-                if kept and kept in message_text:
-                    continue  # a bullet inside the pasted message, not a reply
-                return True
-        return False
+        return bool(
+            re.search(
+                TUI_PROGRESS_PATTERN,
+                strip_terminal_escapes(post_dispatch_output),
+                re.MULTILINE,
+            )
+        )
 
     def __init__(
         self,

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -1178,7 +1178,7 @@ _DEFERRED_STARTED_STATUSES = {
 }
 
 
-def _worker_is_started_direct(terminal_id: str, provider) -> bool:
+def _worker_is_started_direct(terminal_id: str, provider, message: str = "") -> bool:
     """Direct visible-screen status check bypassing the event-driven status cache.
 
     The deferred-init retry loop polls ``status_monitor.get_status()`` which
@@ -1197,6 +1197,16 @@ def _worker_is_started_direct(terminal_id: str, provider) -> bool:
     providers (e.g. kiro_cli, antigravity_cli, cursor_cli) relies on
     dispatch bookkeeping and cannot distinguish IDLE from COMPLETED on a
     rendered capture-pane snapshot.
+
+    A started status is only half the verdict: the pane must also attribute it
+    to ``message``, the submission being confirmed. ``get_status`` classifies
+    the frame as a whole, so activity that predates the submission (a
+    provider's startup spinner or bullet still on screen) reads as started for
+    a pane whose task paste was dropped — and accepting it here would suppress
+    the redelivery this probe exists to gate. The provider decides attribution
+    through ``direct_probe_confirms_submission`` (default: the status alone,
+    for TUIs whose indicators are turn-scoped); a False there falls through
+    to the box check and redelivery like any other not-started read.
     """
     try:
         metadata = get_terminal_metadata(terminal_id)
@@ -1208,6 +1218,9 @@ def _worker_is_started_direct(terminal_id: str, provider) -> bool:
             return False
         output = get_backend().get_history(session_name, window_name, tail_lines=200)
         status = provider.get_status(output)
+        if status not in _DEFERRED_STARTED_STATUSES:
+            return False
+        return bool(provider.direct_probe_confirms_submission(output, message))
     except Exception:
         logger.debug(
             "Direct status probe for %s failed (falling through to cached path)",
@@ -1215,7 +1228,6 @@ def _worker_is_started_direct(terminal_id: str, provider) -> bool:
             exc_info=True,
         )
         return False
-    return status in _DEFERRED_STARTED_STATUSES
 
 
 def _message_visible_in_box(terminal_id: str, message: str) -> bool:
@@ -1301,7 +1313,7 @@ def redeliver_dropped_message(
         provider, "supports_direct_status_probe", False
     )
     if probe_capable:
-        if _worker_is_started_direct(terminal_id, provider):
+        if _worker_is_started_direct(terminal_id, provider, message):
             return True
     if _message_visible_in_box(terminal_id, message):
         logger.warning(

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -1178,7 +1178,7 @@ _DEFERRED_STARTED_STATUSES = {
 }
 
 
-def _worker_is_started_direct(terminal_id: str, provider, message: str = "") -> bool:
+def _worker_is_started_direct(terminal_id: str, provider, post_dispatch_output: str) -> bool:
     """Direct visible-screen status check bypassing the event-driven status cache.
 
     The deferred-init retry loop polls ``status_monitor.get_status()`` which
@@ -1198,15 +1198,23 @@ def _worker_is_started_direct(terminal_id: str, provider, message: str = "") -> 
     dispatch bookkeeping and cannot distinguish IDLE from COMPLETED on a
     rendered capture-pane snapshot.
 
-    A started status is only half the verdict: the pane must also attribute it
-    to ``message``, the submission being confirmed. ``get_status`` classifies
-    the frame as a whole, so activity that predates the submission (a
-    provider's startup spinner or bullet still on screen) reads as started for
-    a pane whose task paste was dropped — and accepting it here would suppress
-    the redelivery this probe exists to gate. The provider decides attribution
-    through ``direct_probe_confirms_submission`` (default: the status alone,
-    for TUIs whose indicators are turn-scoped); a False there falls through
-    to the box check and redelivery like any other not-started read.
+    A started status is only half the verdict, and the weaker half: it is read
+    from a rendered frame, which ``get_status`` classifies as a whole, so
+    activity that PREDATES the submission (a provider's startup spinner or
+    bullet still on screen) reads as started for a pane whose task paste was
+    dropped. Accepting that would suppress the very redelivery this probe
+    gates, silently losing the task.
+
+    ``post_dispatch_output`` supplies the missing causality. It is the
+    StatusMonitor rolling buffer, which ``send_input`` empties immediately
+    before sending the keystrokes, so its contents arrived after the dispatch
+    by construction — evidence that cannot be forged by a shared message
+    prefix, evicted by a bounded capture tail, or confused with leftover
+    chrome. The provider judges it through ``direct_probe_confirms_dispatch``
+    (default: the status alone, for TUIs whose indicators are turn-scoped).
+
+    False means UNPROVEN rather than idle; the caller keeps the recoveries
+    that cannot duplicate work and withholds the one that can.
     """
     try:
         metadata = get_terminal_metadata(terminal_id)
@@ -1220,7 +1228,7 @@ def _worker_is_started_direct(terminal_id: str, provider, message: str = "") -> 
         status = provider.get_status(output)
         if status not in _DEFERRED_STARTED_STATUSES:
             return False
-        return bool(provider.direct_probe_confirms_submission(output, message))
+        return bool(provider.direct_probe_confirms_dispatch(post_dispatch_output))
     except Exception:
         logger.debug(
             "Direct status probe for %s failed (falling through to cached path)",
@@ -1276,14 +1284,25 @@ def redeliver_dropped_message(
     path (#479) and the synchronous step path (#562). First, when the provider
     opts in via ``supports_direct_status_probe``, a live capture-pane check
     catches a worker that IS already running but whose cached status lags
-    behind (#496) — returns True (started) without sending anything. A caller
-    that already holds the provider instance passes it; otherwise it is
-    resolved from the registry, best-effort (a resolution failure means no
-    probe, never a failed redelivery). Then the box check picks the
-    redelivery: if the delivered text is still visible in the rendered pane
-    only the Enter was swallowed (send a bare Enter); if it is absent the
-    paste itself was dropped (re-deliver in full). See
-    ``_message_visible_in_box`` for why guessing wrong must be avoided.
+    behind (#496) — returns True (started) without sending anything. That
+    check is bound to THIS submission by the StatusMonitor rolling buffer,
+    which ``send_input`` empties at the dispatch boundary, so leftover chrome
+    from before the send can never vouch for it (see
+    ``_worker_is_started_direct``). A caller that already holds the provider
+    instance passes it; otherwise it is resolved from the registry,
+    best-effort (a resolution failure means no probe, never a failed
+    redelivery). Then the box check picks the redelivery: if the delivered
+    text is still visible in the rendered pane only the Enter was swallowed
+    (send a bare Enter); if it is absent the paste itself was dropped
+    (re-deliver in full). See ``_message_visible_in_box`` for why guessing
+    wrong must be avoided.
+
+    The full re-send is the one branch that can duplicate work, so it is also
+    withheld from a probe-capable provider whenever ANY output arrived after
+    the dispatch without proving the turn started: an accepted turn that has
+    out-scrolled its own echo presents exactly like a dropped paste to a
+    bounded capture, and absence of proof is not proof of a drop. A genuinely
+    dropped paste produces no post-dispatch output and so still re-sends.
 
     ``full_resend_requires_probe`` gates the full re-send on the provider
     being probe-capable. Reason: ``_message_visible_in_box`` scans the whole
@@ -1312,8 +1331,13 @@ def redeliver_dropped_message(
     probe_capable = provider is not None and getattr(
         provider, "supports_direct_status_probe", False
     )
+    post_dispatch_output = ""
     if probe_capable:
-        if _worker_is_started_direct(terminal_id, provider, message):
+        try:
+            post_dispatch_output = status_monitor.get_buffer(terminal_id)
+        except Exception:  # noqa: BLE001 — evidence is best-effort
+            post_dispatch_output = ""
+        if _worker_is_started_direct(terminal_id, provider, post_dispatch_output):
             return True
     if _message_visible_in_box(terminal_id, message):
         logger.warning(
@@ -1322,6 +1346,23 @@ def redeliver_dropped_message(
             attempt,
         )
         send_special_key(terminal_id, "Enter")
+        return False
+    if probe_capable and post_dispatch_output:
+        # The turn was not PROVEN started, but the terminal did emit output
+        # after the dispatch and our text is not on screen. Those are exactly
+        # the observations an ACCEPTED turn produces once its own echo has
+        # scrolled out of the captured tail, and re-pasting into it would run
+        # the task twice. Absence of proof is not proof of a dropped paste:
+        # withhold the full re-send (the only irreversible branch) and let the
+        # caller's deadline classify. A genuinely dropped paste emits nothing
+        # after the dispatch and so never reaches here.
+        logger.warning(
+            "Delivery to %s unconfirmed but the terminal emitted output after "
+            "dispatch; withholding a full re-send that could duplicate the task "
+            "(attempt %d)",
+            terminal_id,
+            attempt,
+        )
         return False
     if full_resend_requires_probe and not probe_capable:
         # No probe → cannot rule out a working worker whose prompt left the
@@ -1373,8 +1414,8 @@ async def _confirm_worker_started_or_resubmit(
 
     for attempt in range(1, _DEFERRED_SUBMIT_MAX_RESUBMITS + 1):
         # The redelivery decision (box check + #496's direct-probe guard for
-        # providers that opt in) lives in ``redeliver_dropped_message`` —
-        # shared with the synchronous step path (#562).
+        # providers that opt in, bound to post-dispatch output) lives in
+        # ``redeliver_dropped_message`` — shared with the step path (#562).
         already_started = await asyncio.to_thread(
             redeliver_dropped_message,
             terminal_id,

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -57,7 +57,8 @@ class TestRedeliverDroppedMessageHelper:
             started = ts.redeliver_dropped_message("t1", "Analyze the logs", 1)
         assert started is True
         mgr.get_provider.assert_called_once_with("t1")
-        probe.assert_called_once_with("t1", provider)
+        # The message rides along: the probe binds its verdict to it.
+        probe.assert_called_once_with("t1", provider, "Analyze the logs")
         key.assert_not_called()
         send.assert_not_called()
 
@@ -386,6 +387,8 @@ class TestCodexDirectProbeOptIn:
     this shape) goes red here — not just in a unit assert on the attribute.
     """
 
+    _MESSAGE = "[CAO Handoff] Supervisor terminal ID: sup-123. Do the task."
+
     # The shape from the issue report: handoff prompt in the transcript, live
     # Working spinner, TUI footer. Same frame family the codex provider unit
     # tests pin as PROCESSING.
@@ -398,6 +401,56 @@ class TestCodexDirectProbeOptIn:
         "\n"
         "  ? for shortcuts                     100% context left\n"
     )
+
+    # Startup chrome as Codex renders it before any task exists. The MCP
+    # startup spinner IS the TUI progress pattern, and any startup bullet is
+    # an assistant marker.
+    _STARTUP_BANNER = (
+        "╭──────────────────────────────────────────────╮\n"
+        "│ >_ OpenAI Codex (v0.145.0)                   │\n"
+        "│                                              │\n"
+        "│ model:       gpt-5.6-sol medium              │\n"
+        "│ directory:   ~/project                       │\n"
+        "│ permissions: YOLO mode                       │\n"
+        "╰──────────────────────────────────────────────╯\n"
+        "\n"
+        "• Starting MCP servers (4s • esc to interrupt)\n"
+    )
+    _IDLE_COMPOSER = (
+        "\n" "› Write tests for @filename\n" "\n" "  gpt-5.6-sol medium · Context 100% left\n"
+    )
+
+    @staticmethod
+    def _residue_frame(gap: int, composer: str) -> str:
+        """Startup spinner ``gap`` blank lines above the composer: outside the
+        bottom-15 window initialize() vetoes activity in, so the provider
+        reports ready, yet inside (or above) the wider tail get_status scans."""
+        return TestCodexDirectProbeOptIn._STARTUP_BANNER + "\n" * gap + composer
+
+    @staticmethod
+    async def _run_confirm(frame: str, message: str):
+        from cli_agent_orchestrator.providers.codex import CodexProvider
+
+        provider = CodexProvider("t1", "s1", "w0")
+        backend = MagicMock()
+        backend.get_history.return_value = frame
+        with (
+            # Cached status stays IDLE past every poll — the #496-class lag.
+            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
+            patch.object(
+                ts,
+                "get_terminal_metadata",
+                return_value={"tmux_session": "s1", "tmux_window": "w0"},
+            ),
+            patch.object(ts, "get_backend", return_value=backend),
+            patch.object(ts, "get_output", return_value=frame),
+            patch.object(ts, "send_special_key") as key,
+            patch.object(ts, "send_input") as send,
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1", message, None, "sup", None, provider=provider
+            )
+        return ok, key, send
 
     def test_codex_opts_into_direct_status_probe(self):
         from cli_agent_orchestrator.providers.codex import CodexProvider
@@ -425,7 +478,7 @@ class TestCodexDirectProbeOptIn:
         ):
             ok = await ts._confirm_worker_started_or_resubmit(
                 "t1",
-                "Do the task",
+                self._MESSAGE,
                 None,
                 "sup",
                 None,
@@ -439,3 +492,121 @@ class TestCodexDirectProbeOptIn:
         # re-delivery (which would run the task twice) and no blind Enter.
         send.assert_not_called()
         key.assert_not_called()
+
+    # --- the verdict is bound to the submission, not to the pane's status -----
+    # get_status classifies the frame as a whole, so startup residue reads as
+    # started for a pane whose task paste was dropped. The probe must not take
+    # that as acceptance: it would skip the redelivery this path exists for and
+    # the task would be silently lost with the supervisor waiting forever.
+
+    @pytest.mark.parametrize(
+        "gap, expected_status",
+        [
+            (12, "processing"),  # spinner inside get_status's 25-line spinner tail
+            (20, "processing"),  # ...at its far edge
+            (28, "completed"),  # spinner out of the tail: the bullet is an assistant marker
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_startup_residue_on_a_dropped_task_still_redelivers(self, gap, expected_status):
+        from cli_agent_orchestrator.providers.codex import CodexProvider, _has_startup_idle_composer
+
+        frame = self._residue_frame(gap, self._IDLE_COMPOSER)
+        # Precondition — this is exactly the frame the finding describes: the
+        # provider reports ready (initialize() would have returned) while the
+        # whole-frame status says started, and the message is nowhere.
+        assert _has_startup_idle_composer(frame) is True
+        assert CodexProvider("t1", "s1", "w0").get_status(frame).value == expected_status
+        assert self._MESSAGE[:12] not in frame
+
+        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
+
+        # Not started: the paste was dropped, so every attempt re-delivers the
+        # full message and the caller gets to classify the outcome.
+        assert ok is False
+        assert send.call_count == ts._DEFERRED_SUBMIT_MAX_RESUBMITS
+        key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_startup_residue_with_unsubmitted_text_sends_enter(self):
+        # Paste landed, Enter was swallowed: the message sits in the composer
+        # under the residue. The bare-Enter recovery must still fire.
+        composer = "\n› " + self._MESSAGE + "\n\n  gpt-5.6-sol medium · Context 100% left\n"
+        frame = self._residue_frame(18, composer)
+
+        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
+
+        assert ok is False
+        assert key.call_count == ts._DEFERRED_SUBMIT_MAX_RESUBMITS
+        send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_startup_residue_above_an_accepted_task_is_started(self):
+        # Residue AND a real accepted turn: the echo of our message with the
+        # turn's activity below it is the causal evidence; residue above it
+        # neither adds nor subtracts.
+        frame = self._residue_frame(18, self._WORKING_FRAME)
+
+        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
+
+        assert ok is True
+        send.assert_not_called()
+        key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_accepted_turn_on_an_approval_prompt_is_started(self):
+        # WAITING_USER_ANSWER after our turn (codex 0.147 approval menu, as in
+        # test/providers/fixtures/codex_approval_modal_raw.txt): the activity
+        # bullet below the echo binds it; the probe must not blind-Enter into
+        # the menu (that would select "Yes, proceed").
+        frame = (
+            "› " + self._MESSAGE + "\n"
+            "• Running mkdir -p /tmp/work/subdir\n"
+            "  Would you like to run the following command?\n"
+            "  $ mkdir -p /tmp/work/subdir\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. Yes, and don't ask again for commands that start with `mkdir` (p)\n"
+            "  3. No, and tell Codex what to do differently (esc)\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
+
+        assert ok is True
+        send.assert_not_called()
+        key.assert_not_called()
+
+    def test_bullets_inside_the_pasted_message_do_not_self_attribute(self):
+        from cli_agent_orchestrator.providers.codex import CodexProvider
+
+        # An unsubmitted multi-line paste whose own lines are bullets: the
+        # bullets below the echo line belong to the message, not to a reply.
+        message = "Review these findings for me:\n• first finding\n• second finding"
+        frame = self._residue_frame(
+            18,
+            "\n› Review these findings for me:\n  • first finding\n  • second finding\n"
+            "\n  gpt-5.6-sol medium · Context 100% left\n",
+        )
+        provider = CodexProvider("t1", "s1", "w0")
+        assert provider.direct_probe_confirms_submission(frame, message) is False
+        # ...while a reply bullet under the same paste does bind it.
+        assert (
+            provider.direct_probe_confirms_submission(
+                frame.replace(
+                    "  • second finding\n", "  • second finding\n• Reviewing the findings\n"
+                ),
+                message,
+            )
+            is True
+        )
+
+    def test_short_message_cannot_bind(self):
+        from cli_agent_orchestrator.providers.codex import CodexProvider
+
+        # Below the 8-character floor the collapse cannot match reliably; the
+        # hook must refuse rather than guess (same floor as the box check).
+        assert (
+            CodexProvider("t1", "s1", "w0").direct_probe_confirms_submission(
+                "› hi\n• Working (3s • esc to interrupt)\n", "hi"
+            )
+            is False
+        )

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -50,6 +50,7 @@ class TestRedeliverDroppedMessageHelper:
         with (
             patch.object(ts, "provider_manager") as mgr,
             patch.object(ts, "_worker_is_started_direct", return_value=True) as probe,
+            patch.object(ts.status_monitor, "get_buffer", return_value="• Working (1s)"),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
         ):
@@ -57,8 +58,9 @@ class TestRedeliverDroppedMessageHelper:
             started = ts.redeliver_dropped_message("t1", "Analyze the logs", 1)
         assert started is True
         mgr.get_provider.assert_called_once_with("t1")
-        # The message rides along: the probe binds its verdict to it.
-        probe.assert_called_once_with("t1", provider, "Analyze the logs")
+        # The post-dispatch bytes ride along: they are what binds the verdict
+        # to THIS submission, so the probe must receive them, not the message.
+        probe.assert_called_once_with("t1", provider, "• Working (1s)")
         key.assert_not_called()
         send.assert_not_called()
 
@@ -298,15 +300,15 @@ class TestWorkerIsStartedDirect:
 
     def test_returns_false_when_metadata_is_none(self):
         with patch.object(ts, "get_terminal_metadata", return_value=None):
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", MagicMock(), "evidence") is False
 
     def test_returns_false_when_session_key_missing(self):
         with patch.object(ts, "get_terminal_metadata", return_value={"tmux_window": "w1"}):
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", MagicMock(), "evidence") is False
 
     def test_returns_false_when_window_key_missing(self):
         with patch.object(ts, "get_terminal_metadata", return_value={"tmux_session": "s1"}):
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", MagicMock(), "evidence") is False
 
     def test_returns_false_when_get_history_raises(self):
         with (
@@ -321,7 +323,7 @@ class TestWorkerIsStartedDirect:
             patch.object(ts, "get_backend") as mock_be,
         ):
             mock_be.return_value.get_history.side_effect = Exception("capture failed")
-            assert ts._worker_is_started_direct("t1", MagicMock()) is False
+            assert ts._worker_is_started_direct("t1", MagicMock(), "evidence") is False
 
     def test_returns_false_when_get_status_raises(self):
         provider = MagicMock()
@@ -337,7 +339,7 @@ class TestWorkerIsStartedDirect:
             ),
             patch.object(ts, "get_backend") as mock_be,
         ):
-            assert ts._worker_is_started_direct("t1", provider) is False
+            assert ts._worker_is_started_direct("t1", provider, "evidence") is False
 
     def test_returns_true_when_status_is_processing(self):
         from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -355,7 +357,7 @@ class TestWorkerIsStartedDirect:
             ),
             patch.object(ts, "get_backend") as mock_be,
         ):
-            assert ts._worker_is_started_direct("t1", provider) is True
+            assert ts._worker_is_started_direct("t1", provider, "evidence") is True
 
     def test_returns_false_when_status_is_idle(self):
         from cli_agent_orchestrator.models.terminal import TerminalStatus
@@ -373,7 +375,7 @@ class TestWorkerIsStartedDirect:
             ),
             patch.object(ts, "get_backend") as mock_be,
         ):
-            assert ts._worker_is_started_direct("t1", provider) is False
+            assert ts._worker_is_started_direct("t1", provider, "evidence") is False
 
 
 class TestCodexDirectProbeOptIn:
@@ -382,16 +384,27 @@ class TestCodexDirectProbeOptIn:
     (detection fires only at rising-edge/quiescence, and a repainting spinner
     defers quiescence). Without the direct-probe opt-in the confirm loop
     re-delivers the task into the working pane up to three times and then tears
-    the worker down. These pin the opt-in end to end with the REAL provider and
-    a real rendered frame, so removing the flag (or breaking the detector on
-    this shape) goes red here — not just in a unit assert on the attribute.
+    the worker down.
+
+    The opt-in alone is not safe, though: ``get_status`` classifies a rendered
+    frame as a whole, and Codex's startup chrome renders like its task activity
+    (the ``Starting MCP servers`` spinner IS ``TUI_PROGRESS_PATTERN``; any
+    startup bullet is an assistant marker). So the verdict is bound to
+    POST-DISPATCH BYTES: ``send_input`` empties the StatusMonitor rolling buffer
+    immediately before sending keystrokes, so a spinner that stopped before the
+    dispatch contributes nothing there no matter where it still sits on screen,
+    while a live one repaints its counter and necessarily does.
+
+    These drive the REAL provider through the real redelivery decision, so a
+    regression in either half goes red here — not just in a unit assert.
     """
 
     _MESSAGE = "[CAO Handoff] Supervisor terminal ID: sup-123. Do the task."
+    _FOOTER = "  gpt-5.6-sol medium · Context 100% left\n"
+    _SPINNER = "• Working (3s • esc to interrupt)\n"
 
     # The shape from the issue report: handoff prompt in the transcript, live
-    # Working spinner, TUI footer. Same frame family the codex provider unit
-    # tests pin as PROCESSING.
+    # Working spinner, TUI footer.
     _WORKING_FRAME = (
         "› [CAO Handoff] Supervisor terminal ID: sup-123. Do the task.\n"
         "\n"
@@ -402,41 +415,38 @@ class TestCodexDirectProbeOptIn:
         "  ? for shortcuts                     100% context left\n"
     )
 
-    # Startup chrome as Codex renders it before any task exists. The MCP
-    # startup spinner IS the TUI progress pattern, and any startup bullet is
-    # an assistant marker.
+    # Startup chrome as Codex renders it before any task exists.
     _STARTUP_BANNER = (
         "╭──────────────────────────────────────────────╮\n"
         "│ >_ OpenAI Codex (v0.145.0)                   │\n"
-        "│                                              │\n"
-        "│ model:       gpt-5.6-sol medium              │\n"
-        "│ directory:   ~/project                       │\n"
         "│ permissions: YOLO mode                       │\n"
         "╰──────────────────────────────────────────────╯\n"
         "\n"
         "• Starting MCP servers (4s • esc to interrupt)\n"
     )
-    _IDLE_COMPOSER = (
-        "\n" "› Write tests for @filename\n" "\n" "  gpt-5.6-sol medium · Context 100% left\n"
-    )
+    _IDLE_COMPOSER = "\n› Write tests for @filename\n\n" + _FOOTER
 
-    @staticmethod
-    def _residue_frame(gap: int, composer: str) -> str:
+    @classmethod
+    def _residue_frame(cls, gap: int, composer: str) -> str:
         """Startup spinner ``gap`` blank lines above the composer: outside the
         bottom-15 window initialize() vetoes activity in, so the provider
         reports ready, yet inside (or above) the wider tail get_status scans."""
-        return TestCodexDirectProbeOptIn._STARTUP_BANNER + "\n" * gap + composer
+        return cls._STARTUP_BANNER + "\n" * gap + composer
 
     @staticmethod
-    async def _run_confirm(frame: str, message: str):
+    def _provider():
         from cli_agent_orchestrator.providers.codex import CodexProvider
 
-        provider = CodexProvider("t1", "s1", "w0")
+        return CodexProvider("t1", "s1", "w0")
+
+    @classmethod
+    def _redeliver(cls, frame: str, message: str, post_dispatch: str):
+        """One redelivery decision against a rendered ``frame`` and the bytes
+        that arrived since the dispatch. Returns (started, enter, full_resend)."""
+        provider = cls._provider()
         backend = MagicMock()
         backend.get_history.return_value = frame
         with (
-            # Cached status stays IDLE past every poll — the #496-class lag.
-            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
             patch.object(
                 ts,
                 "get_terminal_metadata",
@@ -444,13 +454,12 @@ class TestCodexDirectProbeOptIn:
             ),
             patch.object(ts, "get_backend", return_value=backend),
             patch.object(ts, "get_output", return_value=frame),
+            patch.object(ts.status_monitor, "get_buffer", return_value=post_dispatch),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
         ):
-            ok = await ts._confirm_worker_started_or_resubmit(
-                "t1", message, None, "sup", None, provider=provider
-            )
-        return ok, key, send
+            started = ts.redeliver_dropped_message("t1", message, 1, provider)
+        return started, key.called, send.called
 
     def test_codex_opts_into_direct_status_probe(self):
         from cli_agent_orchestrator.providers.codex import CodexProvider
@@ -459,9 +468,9 @@ class TestCodexDirectProbeOptIn:
 
     @pytest.mark.asyncio
     async def test_codex_confirm_succeeds_from_live_frame_without_redelivery(self):
-        from cli_agent_orchestrator.providers.codex import CodexProvider
-
-        provider = CodexProvider("t1", "s1", "w0")
+        """End to end through the confirm loop: cached status stays IDLE past
+        every poll, the pane shows a live turn, nothing is typed into it."""
+        provider = self._provider()
         backend = MagicMock()
         backend.get_history.return_value = self._WORKING_FRAME
         with (
@@ -473,16 +482,12 @@ class TestCodexDirectProbeOptIn:
                 return_value={"tmux_session": "s1", "tmux_window": "w0"},
             ),
             patch.object(ts, "get_backend", return_value=backend),
+            patch.object(ts.status_monitor, "get_buffer", return_value=self._SPINNER * 3),
             patch.object(ts, "send_special_key") as key,
             patch.object(ts, "send_input") as send,
         ):
             ok = await ts._confirm_worker_started_or_resubmit(
-                "t1",
-                self._MESSAGE,
-                None,
-                "sup",
-                None,
-                provider=provider,
+                "t1", self._MESSAGE, None, "sup", None, provider=provider
             )
 
         # Started: the caller must not classify this as a dropped submit, so the
@@ -493,120 +498,117 @@ class TestCodexDirectProbeOptIn:
         send.assert_not_called()
         key.assert_not_called()
 
-    # --- the verdict is bound to the submission, not to the pane's status -----
-    # get_status classifies the frame as a whole, so startup residue reads as
-    # started for a pane whose task paste was dropped. The probe must not take
-    # that as acceptance: it would skip the redelivery this path exists for and
-    # the task would be silently lost with the supervisor waiting forever.
+    # --- the verdict is bound to post-dispatch bytes, not to the frame -------
 
     @pytest.mark.parametrize(
         "gap, expected_status",
         [
-            (12, "processing"),  # spinner inside get_status's 25-line spinner tail
+            (12, "processing"),  # spinner inside get_status's 25-line tail
             (20, "processing"),  # ...at its far edge
-            (28, "completed"),  # spinner out of the tail: the bullet is an assistant marker
+            (28, "completed"),  # spinner out of the tail: the bullet is a marker
         ],
     )
-    @pytest.mark.asyncio
-    async def test_startup_residue_on_a_dropped_task_still_redelivers(self, gap, expected_status):
-        from cli_agent_orchestrator.providers.codex import CodexProvider, _has_startup_idle_composer
+    def test_startup_residue_on_a_dropped_task_still_redelivers(self, gap, expected_status):
+        """A task-less pane reads STARTED on the frame at every distance, yet
+        emitted nothing since the dispatch — so the task really was dropped."""
+        from cli_agent_orchestrator.providers.codex import _has_startup_idle_composer
 
         frame = self._residue_frame(gap, self._IDLE_COMPOSER)
-        # Precondition — this is exactly the frame the finding describes: the
-        # provider reports ready (initialize() would have returned) while the
-        # whole-frame status says started, and the message is nowhere.
+        # Precondition — the frame alone is genuinely misleading: the provider
+        # reports ready (initialize() would have returned) while the whole-frame
+        # status says started, and the message is nowhere.
         assert _has_startup_idle_composer(frame) is True
-        assert CodexProvider("t1", "s1", "w0").get_status(frame).value == expected_status
-        assert self._MESSAGE[:12] not in frame
+        assert self._provider().get_status(frame).value == expected_status
+        assert "sup-123" not in frame
 
-        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
+        started, enter, full_resend = self._redeliver(frame, self._MESSAGE, "")
 
-        # Not started: the paste was dropped, so every attempt re-delivers the
-        # full message and the caller gets to classify the outcome.
-        assert ok is False
-        assert send.call_count == ts._DEFERRED_SUBMIT_MAX_RESUBMITS
-        key.assert_not_called()
+        assert started is False
+        assert full_resend is True
+        assert enter is False
 
-    @pytest.mark.asyncio
-    async def test_startup_residue_with_unsubmitted_text_sends_enter(self):
-        # Paste landed, Enter was swallowed: the message sits in the composer
-        # under the residue. The bare-Enter recovery must still fire.
-        composer = "\n› " + self._MESSAGE + "\n\n  gpt-5.6-sol medium · Context 100% left\n"
-        frame = self._residue_frame(18, composer)
-
-        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
-
-        assert ok is False
-        assert key.call_count == ts._DEFERRED_SUBMIT_MAX_RESUBMITS
-        send.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_startup_residue_above_an_accepted_task_is_started(self):
-        # Residue AND a real accepted turn: the echo of our message with the
-        # turn's activity below it is the causal evidence; residue above it
-        # neither adds nor subtracts.
-        frame = self._residue_frame(18, self._WORKING_FRAME)
-
-        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
-
-        assert ok is True
-        send.assert_not_called()
-        key.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_accepted_turn_on_an_approval_prompt_is_started(self):
-        # WAITING_USER_ANSWER after our turn (codex 0.147 approval menu, as in
-        # test/providers/fixtures/codex_approval_modal_raw.txt): the activity
-        # bullet below the echo binds it; the probe must not blind-Enter into
-        # the menu (that would select "Yes, proceed").
+    def test_stale_activity_of_a_previous_turn_does_not_confirm_a_new_message(self):
+        """A completed EARLIER handoff, still on screen, must not vouch for a
+        message that was never delivered. Its bullet predates the dispatch, so
+        it contributes no post-dispatch bytes."""
         frame = (
-            "› " + self._MESSAGE + "\n"
-            "• Running mkdir -p /tmp/work/subdir\n"
-            "  Would you like to run the following command?\n"
-            "  $ mkdir -p /tmp/work/subdir\n"
-            "› 1. Yes, proceed (y)\n"
-            "  2. Yes, and don't ask again for commands that start with `mkdir` (p)\n"
-            "  3. No, and tell Codex what to do differently (esc)\n"
-            "  Press enter to confirm or esc to cancel\n"
+            "› [CAO Handoff] Supervisor terminal ID: OLD-999. Do the old task.\n"
+            "• Finished the old task\n"
+            "\n› Write tests for @filename\n\n" + self._FOOTER
         )
-        ok, key, send = await self._run_confirm(frame, self._MESSAGE)
+        assert self._provider().get_status(frame).value == "completed"
 
-        assert ok is True
-        send.assert_not_called()
-        key.assert_not_called()
+        provider = self._provider()
+        assert provider.direct_probe_confirms_dispatch("") is False
+        assert ts._worker_is_started_direct("t1", provider, "") is False
 
-    def test_bullets_inside_the_pasted_message_do_not_self_attribute(self):
-        from cli_agent_orchestrator.providers.codex import CodexProvider
-
-        # An unsubmitted multi-line paste whose own lines are bullets: the
-        # bullets below the echo line belong to the message, not to a reply.
-        message = "Review these findings for me:\n• first finding\n• second finding"
-        frame = self._residue_frame(
-            18,
-            "\n› Review these findings for me:\n  • first finding\n  • second finding\n"
-            "\n  gpt-5.6-sol medium · Context 100% left\n",
+    def test_accepted_turn_is_confirmed_even_after_its_echo_scrolls_away(self):
+        """An accepted turn can out-scroll its own echo while a spinner remains.
+        The frame no longer contains the message, but the live spinner is
+        post-dispatch output, so the turn is confirmed and NOT re-sent."""
+        frame = (
+            "\n".join(f"  output line {i}" for i in range(190))
+            + "\n"
+            + self._SPINNER
+            + self._FOOTER
         )
-        provider = CodexProvider("t1", "s1", "w0")
-        assert provider.direct_probe_confirms_submission(frame, message) is False
-        # ...while a reply bullet under the same paste does bind it.
-        assert (
-            provider.direct_probe_confirms_submission(
-                frame.replace(
-                    "  • second finding\n", "  • second finding\n• Reviewing the findings\n"
-                ),
-                message,
-            )
-            is True
-        )
+        assert self._provider().get_status(frame).value == "processing"
+        assert "sup-123" not in frame
 
-    def test_short_message_cannot_bind(self):
-        from cli_agent_orchestrator.providers.codex import CodexProvider
+        started, enter, full_resend = self._redeliver(frame, self._MESSAGE, self._SPINNER * 4)
 
-        # Below the 8-character floor the collapse cannot match reliably; the
-        # hook must refuse rather than guess (same floor as the box check).
-        assert (
-            CodexProvider("t1", "s1", "w0").direct_probe_confirms_submission(
-                "› hi\n• Working (3s • esc to interrupt)\n", "hi"
-            )
-            is False
-        )
+        assert started is True
+        assert full_resend is False, "re-pasting here would run the task twice"
+        assert enter is False
+
+    def test_reply_wording_that_echoes_the_prompt_still_confirms(self):
+        """A valid fast reply whose words appear in the prompt must not be
+        discarded — the verdict never inspects the message text."""
+        message = "Reply with Done"
+        frame = "› Reply with Done\n• Done\n\n› Write tests for @filename\n\n" + self._FOOTER
+        assert self._provider().get_status(frame).value == "completed"
+
+        started, enter, full_resend = self._redeliver(frame, message, self._SPINNER + "• Done\n")
+
+        assert started is True
+        assert enter is False and full_resend is False
+
+    def test_pasted_bullets_cannot_confirm_their_own_delivery(self):
+        """The composer echoes a paste as it renders, so a multi-line message
+        carrying its own bullet emits one without any turn starting. Only the
+        spinner's ``(<n>s • esc to interrupt)`` shape counts as evidence."""
+        provider = self._provider()
+        echoed_paste = "› Review these findings:\n  • first finding\n  • second finding\n"
+
+        assert provider.direct_probe_confirms_dispatch(echoed_paste) is False
+        assert provider.direct_probe_confirms_dispatch(echoed_paste + self._SPINNER) is True
+
+    def test_unicode_and_empty_post_dispatch_output_are_unproven(self):
+        provider = self._provider()
+        assert provider.direct_probe_confirms_dispatch("") is False
+        assert provider.direct_probe_confirms_dispatch("› Review this:\n  • 日本語\n") is False
+
+    def test_spinner_is_recognized_through_terminal_escapes(self):
+        """The buffer holds the RAW byte stream, so the evidence must survive
+        the SGR/cursor sequences a repainting TUI interleaves."""
+        provider = self._provider()
+        raw = "\x1b[2K\x1b[1;32m• Working (12s • esc to interrupt)\x1b[0m\r\n"
+        assert provider.direct_probe_confirms_dispatch(raw) is True
+
+    def test_unproven_delivery_with_post_dispatch_output_withholds_the_resend(self):
+        """Absence of proof is not proof of a dropped paste: when the terminal
+        emitted output after the dispatch and our text is not on screen, the
+        full re-send (the only branch that can duplicate work) is withheld."""
+        frame = "\n".join(f"  output line {i}" for i in range(190)) + "\n" + self._FOOTER
+
+        started, enter, full_resend = self._redeliver(frame, self._MESSAGE, "  a line of output\n")
+
+        assert started is False
+        assert full_resend is False
+        assert enter is False
+
+    def test_probe_declines_when_the_backend_feeds_no_buffer(self):
+        """Event-inbox backends (herdr) never push a byte buffer. The probe then
+        vouches for nothing and the caller keeps its pre-existing behavior."""
+        provider = self._provider()
+        assert ts._worker_is_started_direct("t1", provider, "") is False

--- a/test/services/test_deferred_submit_verification.py
+++ b/test/services/test_deferred_submit_verification.py
@@ -373,3 +373,69 @@ class TestWorkerIsStartedDirect:
             patch.object(ts, "get_backend") as mock_be,
         ):
             assert ts._worker_is_started_direct("t1", provider) is False
+
+
+class TestCodexDirectProbeOptIn:
+    """#659: Codex deferred assign — the cached status can sit IDLE for the whole
+    confirm window while the real pane already shows the TUI Working spinner
+    (detection fires only at rising-edge/quiescence, and a repainting spinner
+    defers quiescence). Without the direct-probe opt-in the confirm loop
+    re-delivers the task into the working pane up to three times and then tears
+    the worker down. These pin the opt-in end to end with the REAL provider and
+    a real rendered frame, so removing the flag (or breaking the detector on
+    this shape) goes red here — not just in a unit assert on the attribute.
+    """
+
+    # The shape from the issue report: handoff prompt in the transcript, live
+    # Working spinner, TUI footer. Same frame family the codex provider unit
+    # tests pin as PROCESSING.
+    _WORKING_FRAME = (
+        "› [CAO Handoff] Supervisor terminal ID: sup-123. Do the task.\n"
+        "\n"
+        "• Working (3s • esc to interrupt)\n"
+        "\n"
+        "› Use /skills to list available skills\n"
+        "\n"
+        "  ? for shortcuts                     100% context left\n"
+    )
+
+    def test_codex_opts_into_direct_status_probe(self):
+        from cli_agent_orchestrator.providers.codex import CodexProvider
+
+        assert CodexProvider.supports_direct_status_probe is True
+
+    @pytest.mark.asyncio
+    async def test_codex_confirm_succeeds_from_live_frame_without_redelivery(self):
+        from cli_agent_orchestrator.providers.codex import CodexProvider
+
+        provider = CodexProvider("t1", "s1", "w0")
+        backend = MagicMock()
+        backend.get_history.return_value = self._WORKING_FRAME
+        with (
+            # Cached status stays IDLE past every poll — the #496-class lag.
+            patch.object(ts, "wait_until_status", new=AsyncMock(return_value=False)),
+            patch.object(
+                ts,
+                "get_terminal_metadata",
+                return_value={"tmux_session": "s1", "tmux_window": "w0"},
+            ),
+            patch.object(ts, "get_backend", return_value=backend),
+            patch.object(ts, "send_special_key") as key,
+            patch.object(ts, "send_input") as send,
+        ):
+            ok = await ts._confirm_worker_started_or_resubmit(
+                "t1",
+                "Do the task",
+                None,
+                "sup",
+                None,
+                provider=provider,
+            )
+
+        # Started: the caller must not classify this as a dropped submit, so the
+        # delete_worker teardown arm never fires...
+        assert ok is True
+        # ...and nothing was typed into the already-working pane: no full
+        # re-delivery (which would run the task twice) and no blind Enter.
+        send.assert_not_called()
+        key.assert_not_called()


### PR DESCRIPTION
Fixes #659. The diagnosis and the tested fix are @karstenjakobsen's — this PR just lands their one-liner with the regression coverage the issue suggested, per the triage on the issue (2026-08-23).

## The bug

Codex workers created through deferred `assign()` can be classified as "submit dropped" while they are visibly working. The confirm loop polls the cached event-driven status, which detects only at rising-edge/quiescence — and a repainting `Working (…)` spinner defers quiescence, so the cache can sit IDLE past the whole 8s window. The loop's direct capture-pane fallback exists for exactly this (#496), but it is gated on `supports_direct_status_probe`, which `CodexProvider` never set. Outcome, verified in the issue: up to three re-deliveries of the full task into the already-working pane, then `delete_worker=True` teardown of an active worker.

## The fix

`supports_direct_status_probe = True` on `CodexProvider`, with a comment recording why the opt-in is valid: Codex's `get_status()` is line-oriented text analysis of exactly the rendered shape a capture-pane snapshot provides — the same frames `supports_screen_detection` already feeds it in production — and it has no dispatch bookkeeping a fresh capture would bypass (the kiro_cli-style disqualifier documented on `_worker_is_started_direct`). This is the per-provider opt-in the #496 review deliberately scoped for; the family so far: claude_code (#480), opencode (#496), minimax (#625), now codex.

Failure-direction check (the reason the flag is an opt-in at all): on every dropped-submit shape the probe fails toward recovery, not away from it — an empty composer reads IDLE (probe returns False → normal re-delivery), a pasted-but-unsubmitted message reads IDLE (→ box check → bare Enter), and any probe exception falls through to the cached path. The probe can only short-circuit re-delivery on frames the detector classifies as started, which is the same detector the cached path already trusts — just on live data.

## Testing

- `test_codex_confirm_succeeds_from_live_frame_without_redelivery`: the issue's suggested regression, end to end — REAL `CodexProvider`, a real rendered `Working (3s • esc to interrupt)` frame behind the mocked capture, cached status pinned IDLE for every poll → confirm returns started, nothing typed into the pane (no re-delivery, no blind Enter), so the teardown arm can't fire. Plus a direct flag pin.
- Mutation-checked: reverting the one-line flag turns both tests red — the end-to-end one at the re-delivery assertion, not just the attribute assert.
- Suites: codex provider unit tests + deferred-submit + terminal_service suites green; `black`/`isort` clean.

## Round 2 (`dca3dd34`)

The status alone is no longer the verdict. After a started read the probe asks the provider `direct_probe_confirms_submission(output, message)`; the base default keeps the status-only verdict (opencode/minimax unchanged), and Codex binds it to the trace a submitted turn leaves: the message echoed as a transcript line with the turn's activity rendered below it. Startup residue (the MCP startup spinner / any startup bullet, which `get_status` reads as PROCESSING within its 25-line tail and as COMPLETED beyond it) sits above the composer and cannot bind, so a dropped paste falls through to redelivery. Regressions cover the dropped-task residue frame at both distances, residue over an unsubmitted paste, residue over an accepted turn, an accepted turn parked on the 0.147 approval menu, a paste whose own lines are bullets, and the short-message floor.

## Round 3 (`510eea3b`) — the verdict no longer reads message text

All three findings reproduced verbatim, and they share one root cause: pane text cannot establish causality. Round 2 is withdrawn rather than patched.

The binding is now the dispatch boundary the code already maintains. `send_input` empties the StatusMonitor rolling buffer immediately BEFORE sending keystrokes (deliberately, so the turn's first bytes survive), so every byte in it arrived post-dispatch by construction — unforgeable by a shared prefix, unevictable by a bounded capture tail, indistinguishable from nothing when the pane was idle.

- `direct_probe_confirms_dispatch(post_dispatch_output)` replaces the text-matching hook and inspects no message. Base default unchanged, so opencode and minimax keep their status-only verdict.
- Codex accepts only the progress spinner, which a live turn repaints and a stopped one cannot emit. A bullet is refused, because the composer echoes a paste as it renders.
- A `False` now means UNPROVEN, so the full re-send is withheld from a probe-capable provider whenever output arrived after the dispatch without proving the turn started. That is the accepted-turn-past-its-echo shape; re-pasting there duplicates work. A dropped paste emits nothing and still re-sends.

Five mutations each redden their tests. 616 passed across the codex/opencode/minimax/omp/grok, terminal_service, status_monitor and deferred-submit suites.

The same prefix collision also affects `_message_visible_in_box` on `main`, independently of this probe — filed as #727 rather than widened into this PR, since the step path (#562) shares that helper.
