### PR TITLE
fix(codex): say so when --yolo discards a profile's codexProfile (#707)

### DIFF
--- a/docs/codex-cli.md
+++ b/docs/codex-cli.md
@@ -128,6 +128,24 @@ The Codex provider automatically adds these flags for tmux compatibility:
 
 By default, CAO also passes `--yolo` (alias for `--dangerously-bypass-approvals-and-sandbox`) because CAO agents run in non-interactive tmux sessions where approval prompts block handoff/assign flows. Profiles can opt out via `codexProfile`; see [Custom Codex Profile](#custom-codex-profile). Any unrestricted allowed-tools configuration (`allowedTools: ["*"]`, `--allowed-tools '*'`, or `cao launch --yolo`) forces `--yolo` regardless of the profile setting.
 
+> **`--yolo` makes your Codex sandbox settings inert — do not rely on them as containment.**
+> Because `--yolo` bypasses the sandbox entirely, nothing in your `~/.codex/config.toml`
+> `[sandbox_*]` tables applies to a default CAO worker. That includes
+> `[sandbox_workspace_write].network_access = false`: setting it does not stop a worker reaching
+> the network, and it does not restrict Codex's built-in backend web tool, which runs server-side
+> rather than as a sandboxed shell command (reported in
+> [#707](https://github.com/awslabs/cli-agent-orchestrator/issues/707)). A worker that reads
+> untrusted web content can carry prompt-injected instructions into the working tree with no
+> human in the loop.
+>
+> To actually contain a Codex worker:
+>
+> - **`codexProfile`** drops `--yolo`, so your named `[profiles.<name>]` block governs sandbox and
+>   approvals. Note that `allowedTools: ["*"]` overrides it and forces `--yolo`; CAO logs a
+>   warning when that happens, so the discard is not silent.
+> - **`use_worktree=true`** puts writes in a throwaway git worktree behind review instead of the
+>   live tree. That bounds the damage; it does not stop the network access.
+
 ### Custom Codex Profile
 
 The `codexProfile` field on an agent profile names a `[profiles.<name>]` block in your `~/.codex/config.toml`. When set, CAO drops `--yolo` and passes `--profile <name>` instead, letting the user's named profile govern sandbox and approval behavior. Unrestricted allowed tools (`allowedTools: ["*"]`, `--allowed-tools '*'`, or `cao launch --yolo`) override this field and always force `--yolo`.

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -858,6 +858,36 @@ class CodexProvider(BaseProvider):
         if profile and profile.codexProfile and not yolo:
             command_parts = ["codex", "--profile", profile.codexProfile]
         else:
+            if profile and profile.codexProfile:
+                # The operator asked for containment and is not getting it. Naming a
+                # codexProfile is the ONLY way to keep Codex's sandbox and approval
+                # policy in effect under CAO, and allowed_tools containing "*"
+                # discards it. Silently dropping an explicit safety setting is worse
+                # than not offering one, so say so at the point it happens (#707).
+                logger.warning(
+                    "Terminal %s: profile '%s' sets codexProfile=%r, but allowed_tools "
+                    "contains '*', which forces --yolo and discards it. This worker "
+                    "runs with Codex approvals AND sandbox bypassed. Remove '*' from "
+                    "allowed_tools to keep codexProfile in effect.",
+                    self.terminal_id,
+                    self._agent_profile,
+                    profile.codexProfile,
+                )
+            else:
+                # --yolo is --dangerously-bypass-approvals-and-sandbox, so NOTHING in
+                # ~/.codex/config.toml's [sandbox_*] tables applies to this worker --
+                # including network_access. Operators have relied on that setting as a
+                # containment control (#707); it is inert here. Logged on every default
+                # codex launch because that is exactly when the expectation is set.
+                logger.info(
+                    "Terminal %s: launching codex with --yolo "
+                    "(--dangerously-bypass-approvals-and-sandbox). Codex sandbox "
+                    "settings in ~/.codex/config.toml, including "
+                    "[sandbox_workspace_write].network_access, do NOT apply. Set "
+                    "codexProfile on the agent profile to launch under a named "
+                    "[profiles.<name>] block instead.",
+                    self.terminal_id,
+                )
             command_parts = ["codex", "--yolo"]
         command_parts.extend(["--no-alt-screen", "--disable", "shell_snapshot"])
 

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -1,5 +1,6 @@
 """Unit tests for Codex provider."""
 
+import logging
 import os
 import re
 import shlex
@@ -704,6 +705,68 @@ class TestCodexProviderCodexProfile:
 
         assert "--yolo" in command
         assert "--profile" not in command
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_discarded_codex_profile_is_warned_not_silent(self, mock_load, caplog):
+        """#707: dropping an explicit containment setting must not be silent.
+
+        Naming a ``codexProfile`` is the only way to keep Codex's sandbox and
+        approval policy in effect under CAO. ``allowed_tools`` containing ``"*"``
+        discards it and launches --yolo, so an operator who set both gets no
+        sandbox. The launch still proceeds -- the point is that it says so.
+        """
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = "cao_reviewer"
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent", allowed_tools=["*"])
+        with caplog.at_level(logging.WARNING):
+            command = provider._build_codex_command()
+
+        assert "--yolo" in command
+        assert "--profile" not in command
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "discarding codexProfile logged nothing at WARNING"
+        text = warnings[0].getMessage()
+        assert "cao_reviewer" in text, "the discarded profile is not named"
+        assert "allowed_tools" in text and "*" in text, "the cause is not named"
+
+    @patch("cli_agent_orchestrator.providers.codex.load_agent_profile")
+    def test_no_warning_when_codex_profile_is_honored(self, mock_load, caplog):
+        """The warning must be specific to the discard, not to codexProfile itself."""
+        mock_profile = MagicMock()
+        mock_profile.model = None
+        mock_profile.system_prompt = None
+        mock_profile.mcpServers = None
+        mock_profile.codexProfile = "cao_reviewer"
+        mock_load.return_value = mock_profile
+
+        provider = CodexProvider("tid", "sess", "win", "agent", allowed_tools=["fs_read"])
+        with caplog.at_level(logging.WARNING):
+            command = provider._build_codex_command()
+
+        assert "--profile cao_reviewer" in command
+        assert "--yolo" not in command
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_default_yolo_launch_records_that_sandbox_settings_do_not_apply(self, caplog):
+        """#707: operators relied on ~/.codex sandbox settings that --yolo makes inert.
+
+        Logged at INFO rather than WARNING because it is the documented default for
+        every codex worker, so warning on it would be noise; the point is that the
+        record names ``network_access`` where someone grepping for it will find it.
+        """
+        provider = CodexProvider("tid", "sess", "win", None)
+        with caplog.at_level(logging.INFO):
+            command = provider._build_codex_command()
+
+        assert "--yolo" in command
+        text = " ".join(r.getMessage() for r in caplog.records)
+        assert "network_access" in text, "the inert setting is not named"
+        assert "do NOT apply" in text or "not apply" in text
 
 
 class TestTomlScalar:


### PR DESCRIPTION
Addresses the visibility half of #707. Does not change any default.

## What #707 found, and what's actually going on

The reporter set `[sandbox_workspace_write].network_access = false` and found a Codex write seat still reaching the network via Codex's built-in backend web tool, verified by live probe. The diagnosis is right, but the cause is broader than the web tool.

CAO passes `--yolo` by default, which is `--dangerously-bypass-approvals-and-sandbox`, so **nothing in `~/.codex/config.toml`'s `[sandbox_*]` tables applies to a default worker**. `network_access` is not circumvented for one tool — it is inert. CAO never sets it itself (no hits in `src/` or `docs/`), so the expectation comes from Codex's own config and our launch flags override it.

## Changes

**1. Warn when `codexProfile` is discarded.** Naming a `codexProfile` is the only way to keep Codex's sandbox and approval policy in effect under CAO. `allowed_tools` containing `"*"` forces `--yolo` and discards it — and there was no logging at that decision at all. An explicit safety setting was being dropped with no signal. Now logged at `WARNING`, naming the discarded profile and the cause.

**2. Record that sandbox settings don't apply on an ordinary `--yolo` launch**, naming `network_access` so it's greppable by anyone who went looking for it. `INFO` rather than `WARNING` because it's the documented default for every codex worker and warning on it would be noise — happy to raise it if reviewers disagree.

**3. Docs.** `docs/codex-cli.md` already documented the `--yolo` default and the `"*"` override, but not that the sandbox tables become inert, which is the expectation the reporter had. Added that, plus what `codexProfile` and `use_worktree` each do and don't cover.

## Deliberately not included

The reporter also proposed defaulting `use_worktree=true` for the codex provider. That's a behaviour change for one provider rather than a visibility fix; `use_worktree` defaults to `False` everywhere today (`api/main.py:3102`, `mcp_server/server.py:386`), and there's existing handling for `use_worktree=true` against a non-git working directory that would need to keep holding. Worth its own discussion.

## One note for whoever takes that up

The existing soft-enforcement warning at `services/terminal_service.py:609` can't serve this purpose as written:

```python
if provider in SOFT_ENFORCEMENT_PROVIDERS and allowed_tools and "*" not in allowed_tools:
```

It's gated on `allowed_tools` being set and not containing `"*"`, so it never fires for a profile with no `allowed_tools` or one with `"*"` — the two shapes that actually get `--yolo`. Extending it needs the gate moved, not just the message reworded.

## Verification

- `test_codex_provider_unit.py`: 266 passed, 3 skipped.
- Both new tests are mutation-tested: removing either log call fails them.
- `black --check` and `isort --check-only` clean.

@gutosantos82 has the issue assigned — this is offered as a starting point rather than a claim on it, so redirect or close it if you'd rather take a different shape.
