### PR TITLE
feat(api): operator ergonomics — path normalization, folder listing, session labels, server time

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,8 +20,9 @@ HTTP errors use standard status codes and generally return a JSON `detail`
 field. Authentication and network behavior depend on server configuration;
 see [Configuration](configuration.md) and [Security](../SECURITY.md).
 
-Every response carries an `X-Server-Time` header: the server's wall clock as
-an offset-aware ISO-8601 timestamp. A browser client that renders relative
+Handled responses carry an `X-Server-Time` header: the server's wall clock as
+an offset-aware ISO-8601 timestamp (an unhandled-exception 500 raised past the
+middleware stack does not). A browser client that renders relative
 times from server timestamps can measure its clock skew against it once and
 correct for it (WSL2 hosts have been observed hours adrift from the Windows
 browser next to them). It is informational; clients that ignore it are
@@ -151,9 +152,12 @@ See [Agent Profiles](agent-profile.md) and
   visible ones) for a folder picker, defaulting to the server user's home.
   It accepts the same operator-typed spellings `working_directory` accepts
   (see Sessions and terminals) but never creates anything, and it is
-  read-scope gated like `GET /settings/agent-dirs`. It discloses nothing a
-  caller could not already probe through `working_directory` on session
-  creation.
+  read-scope gated like `GET /settings/agent-dirs`. Note what it discloses:
+  child directory names for any path the server user can read, with no root
+  confinement. That is stronger than the existence check `working_directory`
+  already gives a caller, so under an auth-enabled deployment a read-scope
+  token can enumerate the filesystem; confine it to a root if that is your
+  deployment shape.
 
 ### Skills
 
@@ -189,8 +193,13 @@ See [Skills](skills.md) for discovery, installation, and catalog behavior.
   (Explorer's "Copy as path") are stripped, `~` is expanded, and on WSL a
   Windows drive path (`C:\x\y` or `C:/x/y`) is translated to the interop
   mount (`/mnt/c/x/y`) when that drive is mounted. A missing directory is
-  created; a relative path, a file, or an unmounted drive is rejected as a
-  `400` with a plain-language `detail` instead of a `500` from tmux.
+  created, bounded by a path-length and depth cap and performed only after the
+  request's cheaper validations pass, so a request that is rejected anyway
+  leaves nothing behind; a relative path, an existing non-directory, or an
+  unmounted drive is rejected as a `400` with a plain-language `detail`
+  instead of a `500` from tmux.
+- `POST /sessions/{session_name}/label` prefix-normalizes its name the same
+  way `POST /sessions` does, so `demo` and `cao-demo` address one session.
 - `POST /sessions/{session_name}/label` with `{"label": "..."}` sets a
   friendly display name for a session (trimmed, capped at 60 characters; an
   empty string clears it). It is a pure display alias stored in

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,13 @@ HTTP errors use standard status codes and generally return a JSON `detail`
 field. Authentication and network behavior depend on server configuration;
 see [Configuration](configuration.md) and [Security](../SECURITY.md).
 
+Every response carries an `X-Server-Time` header: the server's wall clock as
+an offset-aware ISO-8601 timestamp. A browser client that renders relative
+times from server timestamps can measure its clock skew against it once and
+correct for it (WSL2 hosts have been observed hours adrift from the Windows
+browser next to them). It is informational; clients that ignore it are
+unaffected.
+
 ## HTTP route families
 
 ### Health and auth discovery
@@ -139,6 +146,15 @@ See [AG-UI](agui.md) for enablement, event shapes, and privacy boundaries.
 See [Agent Profiles](agent-profile.md) and
 [Configuration](configuration.md).
 
+- `GET /fs/dirs?path=` lists the subdirectories of one server-side folder
+  (directory names only, never files or contents; hidden folders after the
+  visible ones) for a folder picker, defaulting to the server user's home.
+  It accepts the same operator-typed spellings `working_directory` accepts
+  (see Sessions and terminals) but never creates anything, and it is
+  read-scope gated like `GET /settings/agent-dirs`. It discloses nothing a
+  caller could not already probe through `working_directory` on session
+  creation.
+
 ### Skills
 
 - `/skills/{name}` retrieves an installed skill.
@@ -167,6 +183,20 @@ See [Skills](skills.md) for discovery, installation, and catalog behavior.
   commits — commit and merge/push results before the terminal is deleted if
   they need to be kept. See the MCP `handoff`/`assign` tool descriptions for
   the full behavior.
+- `working_directory` on `POST /sessions` and
+  `POST /sessions/{session_name}/terminals` is normalized at the boundary
+  the way an operator types it into a browser field: surrounding quotes
+  (Explorer's "Copy as path") are stripped, `~` is expanded, and on WSL a
+  Windows drive path (`C:\x\y` or `C:/x/y`) is translated to the interop
+  mount (`/mnt/c/x/y`) when that drive is mounted. A missing directory is
+  created; a relative path, a file, or an unmounted drive is rejected as a
+  `400` with a plain-language `detail` instead of a `500` from tmux.
+- `POST /sessions/{session_name}/label` with `{"label": "..."}` sets a
+  friendly display name for a session (trimmed, capped at 60 characters; an
+  empty string clears it). It is a pure display alias stored in
+  `settings.json`, surfaced as `label` (or `null`) on `GET /sessions` and
+  `GET /sessions/{session_name}`, and cleared when the session is deleted;
+  nothing that references the real tmux session name is affected.
 - `POST /sessions` accepts optional `group`/`metadata` at creation, opting a
   session's initial terminal into peer discovery (a mid-session worker uses
   `PATCH /terminals/{terminal_id}/group`/`metadata` instead — see below).

--- a/docs/working-directory.md
+++ b/docs/working-directory.md
@@ -29,8 +29,10 @@ on WSL works as typed:
 | `~/proj` | `/home/me/proj` |
 | `/home/me/new-proj` (missing) | created, then used |
 
-A relative path, a file, or a Windows drive that is not mounted under `/mnt`
-is rejected with a `400` and a plain-language `detail`. The MCP `handoff`/
+A relative path, an existing non-directory (a file, FIFO, socket or device),
+or a Windows drive that is not mounted under `/mnt` is rejected with a `400`
+and a plain-language `detail`. Creation is bounded by a path-length and depth
+cap, and runs only after the request's cheaper validations pass. The MCP `handoff`/
 `assign` `working_directory` parameter is unchanged.
 
 ## Usage Example

--- a/docs/working-directory.md
+++ b/docs/working-directory.md
@@ -16,6 +16,23 @@ export CAO_ENABLE_WORKING_DIRECTORY=true
 - **When enabled**: Tools expose `working_directory` parameter, allowing explicit directory specification
 - **Default directory**: Current working directory (`cwd`) of the supervisor agent
 
+## Operator-typed paths over HTTP
+
+`POST /sessions` and `POST /sessions/{session_name}/terminals` normalize
+`working_directory` before it reaches tmux, so a path pasted from a browser
+on WSL works as typed:
+
+| Typed | Used |
+|-------|------|
+| `"C:\Users\me\proj"` (Explorer "Copy as path") | `/mnt/c/Users/me/proj` |
+| `C:/Users/me/proj` | `/mnt/c/Users/me/proj` |
+| `~/proj` | `/home/me/proj` |
+| `/home/me/new-proj` (missing) | created, then used |
+
+A relative path, a file, or a Windows drive that is not mounted under `/mnt`
+is rejected with a `400` and a plain-language `detail`. The MCP `handoff`/
+`assign` `working_directory` parameter is unchanged.
+
 ## Usage Example
 
 With `CAO_ENABLE_WORKING_DIRECTORY=true`:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -174,6 +174,7 @@ from cli_agent_orchestrator.services.worktree_service import WorktreeError
 from cli_agent_orchestrator.telemetry import init_telemetry, shutdown_telemetry
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile, resolve_provider
 from cli_agent_orchestrator.utils.logging import install_access_log_redaction, setup_logging
+from cli_agent_orchestrator.utils.paths import normalize_working_directory
 from cli_agent_orchestrator.utils.skills import (
     SkillNameError,
     load_skill_content,
@@ -1485,6 +1486,24 @@ app.add_middleware(
 )
 
 
+@app.middleware("http")
+async def add_server_time_header(request: Request, call_next):
+    """Stamp every response with the server's wall clock as ``X-Server-Time``.
+
+    Browser clients render relative times ("2 minutes ago") from server
+    timestamps, and the two clocks are not the same clock: WSL2 hosts have been
+    observed hours adrift from the Windows browser next to them. One header on
+    every response lets a client measure the skew once and correct for it.
+    Offset-aware ISO-8601 so a browser in a different timezone parses it
+    unambiguously (a naive string is read as browser-local time, which is the
+    skew this header exists to remove). Purely informational; clients that
+    ignore it are unaffected.
+    """
+    response = await call_next(request)
+    response.headers["X-Server-Time"] = datetime.now().astimezone().isoformat()
+    return response
+
+
 @app.exception_handler(RequestValidationError)
 async def _redact_env_vars_validation_error(
     request: Request, exc: RequestValidationError
@@ -2745,6 +2764,55 @@ async def get_agent_dirs_endpoint(
     }
 
 
+@app.get("/fs/dirs")
+async def list_directories(
+    path: Optional[str] = None,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_READ, SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Dict:
+    """List the subdirectories of one server-side folder, for a folder picker.
+
+    Directory names only: never file names, sizes, or contents. Accepts the
+    same operator-typed spellings ``POST /sessions`` accepts for
+    ``working_directory`` (``~``, quoted, Windows drive paths translated to the
+    WSL mount) but never creates anything. Defaults to the server user's home.
+    Hidden folders are listed after the visible ones rather than dropped,
+    because provider homes (``~/.kiro``, ``~/.aws``) are exactly what an
+    operator browsing for a profile directory is after.
+
+    Read-scope gated when auth is enabled, like ``GET /settings/agent-dirs``:
+    the response discloses local filesystem layout. It discloses nothing a
+    caller could not already probe through ``working_directory`` on session
+    creation, and it is confined to the same localhost-only posture as the
+    rest of the API.
+    """
+    try:
+        if path:
+            resolved = Path(normalize_working_directory(path, create_missing=False) or "")
+        else:
+            resolved = Path.home()
+        resolved = resolved.resolve()
+        if not resolved.is_dir():
+            raise ValueError(f"Not a folder: {resolved}")
+        visible: List[str] = []
+        hidden: List[str] = []
+        for entry in sorted(resolved.iterdir(), key=lambda e: e.name.lower()):
+            try:
+                if not entry.is_dir():
+                    continue
+            except OSError:
+                continue  # unreadable entry (dangling symlink, EACCES): skip, not fail
+            (hidden if entry.name.startswith(".") else visible).append(entry.name)
+        parent = str(resolved.parent) if resolved.parent != resolved else None
+        return {"path": str(resolved), "parent": parent, "dirs": visible + hidden}
+    except PermissionError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No permission to read that folder",
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
 class AgentDirsUpdate(BaseModel):
     agent_dirs: Optional[Dict[str, str]] = None
     extra_dirs: Optional[List[str]] = None
@@ -2935,6 +3003,10 @@ async def create_session(
     # values fail Pydantic body parsing and FastAPI returns 422 automatically,
     # before this function body ever runs.
     try:
+        # Accept the spellings an operator actually types into a browser field
+        # (``~``, Explorer-quoted, Windows drive paths on WSL) and reject an
+        # unusable one as a clear 400 here, instead of a 500 deep in tmux.
+        working_directory = normalize_working_directory(working_directory)
         if session_name is not None:
             # terminal_service.create_terminal prepends SESSION_PREFIX
             # ("cao-") if missing, so an API caller's 64-char valid name
@@ -3074,6 +3146,34 @@ async def list_sessions(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list sessions: {str(e)}",
         )
+
+
+class SessionLabelUpdate(BaseModel):
+    label: str = Field(..., max_length=1024)
+
+
+@app.post("/sessions/{session_name}/label")
+async def set_session_label_endpoint(
+    session_name: str,
+    body: SessionLabelUpdate,
+    _scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN)),
+) -> Dict:
+    """Set, or clear with an empty string, a friendly display name for a session.
+
+    Stored separately from the tmux session name so nothing that references
+    the real name (terminals, DB rows, the backend) is disturbed: a pure
+    display alias, surfaced as ``label`` on ``GET /sessions`` and
+    ``GET /sessions/{name}``. Trimmed and capped server-side; the response
+    carries the label as stored (``None`` once cleared).
+    """
+    try:
+        validate_tmux_name(session_name, "session_name")
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    from cli_agent_orchestrator.services.settings_service import set_session_label
+
+    labels = set_session_label(session_name, body.label)
+    return {"session_name": session_name, "label": labels.get(session_name)}
 
 
 @app.get("/sessions/{session_name}")
@@ -3223,6 +3323,12 @@ async def create_terminal_in_session(
             resolved_provider = resolve_provider(agent_profile, fallback_provider="kiro_cli")
         else:
             resolved_provider = provider
+
+        # Same operator-typed spellings POST /sessions accepts (see there).
+        try:
+            working_directory = normalize_working_directory(working_directory)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
         # Parse comma-separated allowed_tools string into list
         allowed_tools_list = allowed_tools.split(",") if allowed_tools else None

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -1488,12 +1488,15 @@ app.add_middleware(
 
 @app.middleware("http")
 async def add_server_time_header(request: Request, call_next):
-    """Stamp every response with the server's wall clock as ``X-Server-Time``.
+    """Stamp handled responses with the server's wall clock as ``X-Server-Time``.
 
     Browser clients render relative times ("2 minutes ago") from server
     timestamps, and the two clocks are not the same clock: WSL2 hosts have been
     observed hours adrift from the Windows browser next to them. One header on
-    every response lets a client measure the skew once and correct for it.
+    a response lets a client measure the skew once and correct for it. It
+    rides the middleware stack, so an unhandled exception that never returns
+    through it (Starlette's own 500) goes out without the header; that is
+    harmless for an informational value and not worth a second code path.
     Offset-aware ISO-8601 so a browser in a different timezone parses it
     unambiguously (a naive string is read as browser-local time, which is the
     skew this header exists to remove). Purely informational; clients that
@@ -2779,17 +2782,22 @@ async def list_directories(
     because provider homes (``~/.kiro``, ``~/.aws``) are exactly what an
     operator browsing for a profile directory is after.
 
-    Read-scope gated when auth is enabled, like ``GET /settings/agent-dirs``:
-    the response discloses local filesystem layout. It discloses nothing a
-    caller could not already probe through ``working_directory`` on session
-    creation, and it is confined to the same localhost-only posture as the
-    rest of the API.
+    Read-scope gated when auth is enabled, like ``GET /settings/agent-dirs``.
+    Be clear about what that gate protects: this endpoint ENUMERATES child
+    directory names for any path the server user can read, with no root
+    confinement, which is a materially stronger disclosure than the
+    existence-and-creatability oracle a caller already has through
+    ``working_directory``. Under the default localhost-only posture that is
+    the operator reading their own filesystem; once auth is enabled it means a
+    read-scope token can walk the tree. Confining it to a configurable root is
+    the obvious hardening if that ever becomes the deployment shape.
     """
     try:
-        if path:
-            resolved = Path(normalize_working_directory(path, create_missing=False) or "")
-        else:
-            resolved = Path.home()
+        # ``normalize_working_directory`` returns None for a blank or
+        # quotes-only value, which must fall back to the documented home
+        # default -- ``Path("")`` would silently resolve to the server's CWD.
+        normalized = normalize_working_directory(path, create_missing=False) if path else None
+        resolved = Path(normalized) if normalized else Path.home()
         resolved = resolved.resolve()
         if not resolved.is_dir():
             raise ValueError(f"Not a folder: {resolved}")
@@ -2811,6 +2819,13 @@ async def list_directories(
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except OSError as e:
+        # ENOTDIR, EIO, a stale network mount: the per-entry loop already
+        # tolerates these, so the directory-level read should not 500 either.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Could not read that folder: {e}",
+        )
 
 
 class AgentDirsUpdate(BaseModel):
@@ -3003,10 +3018,6 @@ async def create_session(
     # values fail Pydantic body parsing and FastAPI returns 422 automatically,
     # before this function body ever runs.
     try:
-        # Accept the spellings an operator actually types into a browser field
-        # (``~``, Explorer-quoted, Windows drive paths on WSL) and reject an
-        # unusable one as a clear 400 here, instead of a 500 deep in tmux.
-        working_directory = normalize_working_directory(working_directory)
         if session_name is not None:
             # terminal_service.create_terminal prepends SESSION_PREFIX
             # ("cao-") if missing, so an API caller's 64-char valid name
@@ -3039,6 +3050,14 @@ async def create_session(
                     "invalid initial_message_orchestration_type: "
                     f"{body.initial_message_orchestration_type!r}"
                 )
+        # Accept the spellings an operator actually types into a browser field
+        # (``~``, Explorer-quoted, Windows drive paths on WSL) and reject an
+        # unusable one as a clear 400 here, instead of a 500 deep in tmux.
+        # Deliberately LAST among the validations: this call can create the
+        # directory, and a request that some cheaper check was going to reject
+        # must not leave a tree behind (gutosantos82, #724 review).
+        working_directory = normalize_working_directory(working_directory)
+
         # Parse comma-separated allowed_tools string into list
         allowed_tools_list = allowed_tools.split(",") if allowed_tools else None
 
@@ -3165,15 +3184,28 @@ async def set_session_label_endpoint(
     display alias, surfaced as ``label`` on ``GET /sessions`` and
     ``GET /sessions/{name}``. Trimmed and capped server-side; the response
     carries the label as stored (``None`` once cleared).
+
+    The name is prefix-normalized exactly as ``POST /sessions`` normalizes it
+    at creation (``demo`` -> ``cao-demo``), so an operator who labels using
+    the name they created with reaches the same session the listing and the
+    teardown key off. Without that, the write would succeed and store an entry
+    that never surfaces and is never cleared (gutosantos82, #724 review).
     """
+    from cli_agent_orchestrator.constants import SESSION_PREFIX
+
+    effective = (
+        session_name
+        if session_name.startswith(SESSION_PREFIX)
+        else f"{SESSION_PREFIX}{session_name}"
+    )
     try:
-        validate_tmux_name(session_name, "session_name")
+        validate_tmux_name(effective, "session_name")
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     from cli_agent_orchestrator.services.settings_service import set_session_label
 
-    labels = set_session_label(session_name, body.label)
-    return {"session_name": session_name, "label": labels.get(session_name)}
+    labels = set_session_label(effective, body.label)
+    return {"session_name": effective, "label": labels.get(effective)}
 
 
 @app.get("/sessions/{session_name}")

--- a/src/cli_agent_orchestrator/services/session_service.py
+++ b/src/cli_agent_orchestrator/services/session_service.py
@@ -45,6 +45,10 @@ from cli_agent_orchestrator.plugins import (
 from cli_agent_orchestrator.services.plugin_dispatch import dispatch_plugin_event
 from cli_agent_orchestrator.services.session_env import clear_session_env
 from cli_agent_orchestrator.services.session_lock import session_lifecycle_lock
+from cli_agent_orchestrator.services.settings_service import (
+    get_session_labels,
+    set_session_label,
+)
 from cli_agent_orchestrator.services.terminal_service import create_terminal
 from cli_agent_orchestrator.utils.agent_profiles import resolve_provider
 
@@ -255,7 +259,14 @@ def list_sessions() -> List[Dict]:
         if not cao_sessions:
             return []
         terminals_by_session = _terminals_grouped_by_session([s["id"] for s in cao_sessions])
-        return [_enrich_session_ownership(backend, s, terminals_by_session) for s in cao_sessions]
+        labels = get_session_labels()
+        sessions = [
+            _enrich_session_ownership(backend, s, terminals_by_session) for s in cao_sessions
+        ]
+        for session in sessions:
+            # Operator-assigned display alias (settings_service); None when unset.
+            session["label"] = labels.get(session["id"])
+        return sessions
     except Exception:
         # Swallowed to keep a caller's listing from raising, so exc_info for the
         # same reason as the two handlers above -- more so, in fact: this one
@@ -285,6 +296,8 @@ def get_session(session_name: str) -> Dict:
 
         if not session_data:
             raise ValueError(f"Session '{session_name}' not found")
+        # Operator-assigned display alias (settings_service); None when unset.
+        session_data["label"] = get_session_labels().get(session_name)
 
         terminals = list_terminals_by_session(session_name)
         # Enrich each terminal with its live status. list_terminals_by_session
@@ -557,6 +570,18 @@ def delete_session(session_name: str, registry: PluginRegistry | None = None) ->
                 logger.warning(f"Failed to clear forwarded env for {session_name}: {e}")
                 result["errors"].append(
                     {"session": session_name, "step": "clear_session_env", "error": str(e)}
+                )
+
+            # Drop the session's display alias so a later same-name session does
+            # not inherit it. Same guard shape as the env cleanup above: a
+            # settings write failure is reported, never allowed to misreport the
+            # completed teardown.
+            try:
+                set_session_label(session_name, "")
+            except Exception as e:
+                logger.warning(f"Failed to clear label for {session_name}: {e}")
+                result["errors"].append(
+                    {"session": session_name, "step": "clear_session_label", "error": str(e)}
                 )
 
             if cleanup_complete:

--- a/src/cli_agent_orchestrator/services/settings_service.py
+++ b/src/cli_agent_orchestrator/services/settings_service.py
@@ -163,6 +163,46 @@ def set_disabled_agent_dirs(dirs: List[str]) -> List[str]:
     return cleaned
 
 
+# Longest label accepted for a session alias. Long enough for a sentence-style
+# run name, short enough to stay on one line in any listing.
+SESSION_LABEL_MAX_LENGTH = 60
+
+
+def get_session_labels() -> Dict[str, str]:
+    """Operator-assigned friendly names for sessions (session_name -> label)."""
+    settings = _load()
+    labels = settings.get("session_labels", {})
+    return labels if isinstance(labels, dict) else {}
+
+
+def set_session_label(session_name: str, label: str) -> Dict[str, str]:
+    """Set, or clear with an empty/blank label, a session's friendly name.
+
+    Stored separately from the tmux session name so nothing that references
+    the real name (terminals, DB rows, the backend) is disturbed: a pure
+    display alias. Whitespace is trimmed and the label is capped at
+    ``SESSION_LABEL_MAX_LENGTH``. Returns the full label map after the update.
+    """
+    settings = _load()
+    labels = settings.get("session_labels", {})
+    if not isinstance(labels, dict):
+        labels = {}
+    clean = label.strip()[:SESSION_LABEL_MAX_LENGTH]
+    if clean:
+        if labels.get(session_name) == clean:
+            return labels
+        labels[session_name] = clean
+    elif session_name in labels:
+        del labels[session_name]
+    else:
+        # Nothing to clear: do not rewrite settings.json for a no-op. Session
+        # teardown clears unconditionally, so this is the common case.
+        return labels
+    settings["session_labels"] = labels
+    _save(settings)
+    return labels
+
+
 # Default server tuning values
 _SERVER_DEFAULTS = {
     "mcp_request_timeout": 30,

--- a/src/cli_agent_orchestrator/utils/paths.py
+++ b/src/cli_agent_orchestrator/utils/paths.py
@@ -1,7 +1,16 @@
 """Filesystem-path helpers shared across services and utils."""
 
+import logging
 import os
+import re
 from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ``C:\x\y`` or ``C:/x/y`` — a Windows drive-letter path as pasted from an
+# Explorer address bar or "Copy as path".
+_WINDOWS_PATH = re.compile(r"^([A-Za-z]):[\\/](.*)$")
 
 
 def normalized_path(path: "str | Path") -> str:
@@ -19,3 +28,70 @@ def normalized_path(path: "str | Path") -> str:
     each other's private API.
     """
     return os.path.realpath(os.path.expanduser(str(path)))
+
+
+def normalize_working_directory(
+    working_directory: Optional[str],
+    mnt_root: Path = Path("/mnt"),
+    create_missing: bool = True,
+) -> Optional[str]:
+    """Turn an operator-supplied directory into a usable absolute path.
+
+    The web UI runs in the operator's browser; on WSL setups that browser is on
+    WINDOWS, so operators naturally paste Windows paths (``C:\\Users\\me\\proj``,
+    often wrapped in quotes by Explorer's "Copy as path"). cao-server runs
+    inside WSL where those paths only exist under the ``/mnt/<drive>/`` interop
+    mount, so every such launch used to fail as an opaque 500 deep in tmux.
+
+    - Strips surrounding quotes and whitespace.
+    - Expands ``~``.
+    - Translates a Windows drive path (``C:\\x\\y`` or ``C:/x/y``) to the WSL
+      interop mount (``/mnt/c/x/y``) when that drive mount exists.
+    - Creates the directory when it is missing (``create_missing``): the
+      operator is pointing at where they WANT the project to live, and
+      bouncing them to a terminal to ``mkdir`` first defeats the purpose of
+      a browser front door. Pass ``create_missing=False`` for read-only
+      callers that must not touch the filesystem.
+
+    Returns ``None`` for ``None``/blank input so callers can pass the raw
+    optional parameter straight through.
+
+    Raises:
+        ValueError: with a human-readable message when the path cannot be
+            used (relative, drive not mounted, is a file, creation failed).
+    """
+    if working_directory is None:
+        return None
+    cleaned = working_directory.strip().strip("\"'").strip()
+    if not cleaned:
+        return None
+
+    match = _WINDOWS_PATH.match(cleaned)
+    if match:
+        drive, rest = match.group(1).lower(), match.group(2).replace("\\", "/")
+        drive_mount = mnt_root / drive
+        if not drive_mount.is_dir():
+            raise ValueError(
+                f"{working_directory!r} is a Windows path, but drive {drive.upper()}: "
+                f"is not mounted at {drive_mount}. Use the Linux path instead."
+            )
+        translated = drive_mount / rest
+        logger.info("Translated Windows path %r -> %s", working_directory, translated)
+        cleaned = str(translated)
+
+    path = Path(cleaned).expanduser()
+    if not path.is_absolute():
+        raise ValueError(f"Working directory must be an absolute path, got {working_directory!r}")
+    if path.is_file():
+        raise ValueError(f"{str(path)!r} is a file, not a folder")
+    if not path.exists():
+        if not create_missing:
+            raise ValueError(f"Folder does not exist: {path}")
+        try:
+            # exist_ok: a concurrent request may create the directory between
+            # the exists() check above and this mkdir — that is success.
+            path.mkdir(parents=True, exist_ok=True)
+            logger.info("Created working directory %s", path)
+        except OSError as e:
+            raise ValueError(f"Folder {str(path)!r} does not exist and could not be created: {e}")
+    return str(path)

--- a/src/cli_agent_orchestrator/utils/paths.py
+++ b/src/cli_agent_orchestrator/utils/paths.py
@@ -12,6 +12,13 @@ logger = logging.getLogger(__name__)
 # Explorer address bar or "Copy as path".
 _WINDOWS_PATH = re.compile(r"^([A-Za-z]):[\\/](.*)$")
 
+# Bounds on a path we are willing to CREATE. Creating is a write primitive, so
+# it gets limits an operator typing a real project path will never reach:
+# Linux PATH_MAX, and a depth well past any plausible checkout. Without them a
+# single request can materialize an arbitrarily deep tree.
+WORKING_DIRECTORY_MAX_LEN = 4096
+WORKING_DIRECTORY_MAX_DEPTH = 64
+
 
 def normalized_path(path: "str | Path") -> str:
     """Canonical form for comparing configured directory paths (GH #280/#281).
@@ -51,7 +58,10 @@ def normalize_working_directory(
       operator is pointing at where they WANT the project to live, and
       bouncing them to a terminal to ``mkdir`` first defeats the purpose of
       a browser front door. Pass ``create_missing=False`` for read-only
-      callers that must not touch the filesystem.
+      callers that must not touch the filesystem. Creation is bounded by
+      ``WORKING_DIRECTORY_MAX_LEN``/``_MAX_DEPTH``; callers should also run
+      their cheap validations BEFORE calling with ``create_missing=True``, so
+      a request that is going to be rejected anyway leaves nothing behind.
 
     Returns ``None`` for ``None``/blank input so callers can pass the raw
     optional parameter straight through.
@@ -80,13 +90,29 @@ def normalize_working_directory(
         cleaned = str(translated)
 
     path = Path(cleaned).expanduser()
+    # Length is checked BEFORE any filesystem call: an over-long path makes
+    # exists()/is_dir() itself raise OSError(ENAMETOOLONG), which would escape
+    # as a 500 instead of the clear 400 every other rejection here produces.
+    if len(str(path)) > WORKING_DIRECTORY_MAX_LEN:
+        raise ValueError(
+            f"Working directory path is too long "
+            f"({len(str(path))} > {WORKING_DIRECTORY_MAX_LEN} characters)"
+        )
     if not path.is_absolute():
         raise ValueError(f"Working directory must be an absolute path, got {working_directory!r}")
-    if path.is_file():
-        raise ValueError(f"{str(path)!r} is a file, not a folder")
+    if path.exists() and not path.is_dir():
+        # Not just files: a FIFO, socket or device node would otherwise pass
+        # here and fail later inside tmux with exactly the opaque error this
+        # function exists to prevent.
+        raise ValueError(f"{str(path)!r} is not a folder")
     if not path.exists():
         if not create_missing:
             raise ValueError(f"Folder does not exist: {path}")
+        if len(path.parts) > WORKING_DIRECTORY_MAX_DEPTH:
+            raise ValueError(
+                f"Working directory is nested too deeply "
+                f"({len(path.parts)} > {WORKING_DIRECTORY_MAX_DEPTH} levels)"
+            )
         try:
             # exist_ok: a concurrent request may create the directory between
             # the exists() check above and this mkdir — that is success.

--- a/test/api/test_operator_ergonomics.py
+++ b/test/api/test_operator_ergonomics.py
@@ -1,0 +1,217 @@
+"""Operator-facing ergonomics on the HTTP API: working-directory
+normalization at the session/terminal creation boundary, the server-side
+folder listing, per-session display labels, and the ``X-Server-Time`` header.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cli_agent_orchestrator.models.terminal import Terminal
+from cli_agent_orchestrator.services import settings_service
+
+
+@pytest.fixture
+def settings_file(tmp_path):
+    """Isolate settings.json so label writes never touch the real config."""
+    fake = tmp_path / "settings.json"
+    with (
+        patch("cli_agent_orchestrator.services.settings_service.SETTINGS_FILE", fake),
+        patch("cli_agent_orchestrator.services.settings_service.CAO_HOME_DIR", tmp_path),
+    ):
+        yield fake
+
+
+class TestServerTimeHeader:
+    def test_every_response_carries_an_offset_aware_iso_timestamp(self, client):
+        resp = client.get("/health")
+        stamp = resp.headers.get("X-Server-Time")
+        assert stamp, "X-Server-Time missing"
+        parsed = datetime.fromisoformat(stamp)
+        # Offset-aware: a naive string would be read as browser-local time and
+        # reintroduce the skew the header exists to remove.
+        assert parsed.tzinfo is not None
+        assert abs((datetime.now().astimezone() - parsed).total_seconds()) < 60
+
+    def test_error_responses_carry_it_too(self, client):
+        resp = client.get("/sessions/definitely-not-a-session")
+        assert resp.status_code >= 400
+        assert "X-Server-Time" in resp.headers
+
+
+class TestFsDirs:
+    def test_lists_only_directories_visible_first(self, client, tmp_path):
+        (tmp_path / "beta").mkdir()
+        (tmp_path / "alpha").mkdir()
+        (tmp_path / ".hidden").mkdir()
+        (tmp_path / "a_file.txt").write_text("x")
+
+        resp = client.get("/fs/dirs", params={"path": str(tmp_path)})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["dirs"] == ["alpha", "beta", ".hidden"]
+        assert body["path"] == str(tmp_path)
+        assert body["parent"] == str(tmp_path.parent)
+
+    def test_missing_folder_is_a_clear_400_and_is_not_created(self, client, tmp_path):
+        target = tmp_path / "definitely" / "not" / "here"
+        resp = client.get("/fs/dirs", params={"path": str(target)})
+        assert resp.status_code == 400
+        assert "does not exist" in resp.json()["detail"]
+        assert not target.exists(), "a listing must never create the folder it was asked about"
+
+    def test_file_path_is_a_clear_400(self, client, tmp_path):
+        f = tmp_path / "file.txt"
+        f.write_text("x")
+        resp = client.get("/fs/dirs", params={"path": str(f)})
+        assert resp.status_code == 400
+        assert "is a file" in resp.json()["detail"]
+
+    def test_defaults_to_home(self, client):
+        resp = client.get("/fs/dirs")
+        assert resp.status_code == 200
+        assert resp.json()["path"] == str(Path.home().resolve())
+
+    def test_root_has_no_parent(self, client):
+        resp = client.get("/fs/dirs", params={"path": "/"})
+        assert resp.status_code == 200
+        assert resp.json()["parent"] is None
+
+    def test_unreadable_folder_is_a_400_not_a_500(self, client, tmp_path):
+        # Simulate EACCES on iterdir without depending on running as non-root.
+        with patch("cli_agent_orchestrator.api.main.Path.iterdir", side_effect=PermissionError):
+            resp = client.get("/fs/dirs", params={"path": str(tmp_path)})
+        assert resp.status_code == 400
+        assert "permission" in resp.json()["detail"].lower()
+
+
+class TestSessionLabelEndpoint:
+    def test_label_roundtrip_and_clear(self, client, settings_file):
+        resp = client.post("/sessions/cao-demo/label", json={"label": "  My Run  "})
+        assert resp.status_code == 200
+        assert resp.json() == {"session_name": "cao-demo", "label": "My Run"}
+        assert settings_service.get_session_labels() == {"cao-demo": "My Run"}
+
+        resp2 = client.post("/sessions/cao-demo/label", json={"label": ""})
+        assert resp2.status_code == 200
+        assert resp2.json()["label"] is None
+        assert settings_service.get_session_labels() == {}
+
+    def test_malformed_session_name_is_a_400(self, client, settings_file):
+        resp = client.post("/sessions/bad:name/label", json={"label": "x"})
+        assert resp.status_code == 400
+        assert settings_service.get_session_labels() == {}
+
+    def test_label_is_required(self, client, settings_file):
+        resp = client.post("/sessions/cao-demo/label", json={})
+        assert resp.status_code == 422
+
+    def test_list_and_get_surface_the_label(self, client, settings_file):
+        settings_service.set_session_label("cao-demo", "Nightly triage")
+        with patch("cli_agent_orchestrator.api.main.session_service") as svc:
+            svc.list_sessions.return_value = [{"id": "cao-demo", "label": "Nightly triage"}]
+            svc.get_session.return_value = {
+                "session": {"id": "cao-demo", "label": "Nightly triage"},
+                "terminals": [],
+            }
+            assert client.get("/sessions").json()[0]["label"] == "Nightly triage"
+            assert client.get("/sessions/cao-demo").json()["session"]["label"] == "Nightly triage"
+
+
+class TestWorkingDirectoryNormalizationAtTheBoundary:
+    """Both creation endpoints accept operator-typed spellings and reject an
+    unusable path with a clear 400 before any service is reached."""
+
+    @staticmethod
+    def _terminal(session="cao-demo"):
+        return Terminal(
+            id="abcd1234",
+            name="test-window",
+            session_name=session,
+            provider="kiro_cli",
+            agent_profile="developer",
+        )
+
+    def test_create_session_strips_quotes_and_forwards_the_normalized_path(self, client, tmp_path):
+        with patch("cli_agent_orchestrator.api.main.session_service") as svc:
+            svc.create_session = AsyncMock(return_value=self._terminal())
+            resp = client.post(
+                "/sessions",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "developer",
+                    "working_directory": f'"{tmp_path}"',
+                },
+            )
+        assert resp.status_code == 201
+        assert svc.create_session.call_args.kwargs["working_directory"] == str(tmp_path)
+
+    def test_create_session_rejects_a_relative_path_before_the_service(self, client):
+        with patch("cli_agent_orchestrator.api.main.session_service") as svc:
+            svc.create_session = AsyncMock()
+            resp = client.post(
+                "/sessions",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "developer",
+                    "working_directory": "relative/not/absolute",
+                },
+            )
+        assert resp.status_code == 400
+        assert "absolute" in resp.json()["detail"].lower()
+        svc.create_session.assert_not_called()
+
+    def test_create_session_creates_a_missing_folder(self, client, tmp_path):
+        target = tmp_path / "new" / "project"
+        with patch("cli_agent_orchestrator.api.main.session_service") as svc:
+            svc.create_session = AsyncMock(return_value=self._terminal())
+            resp = client.post(
+                "/sessions",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "developer",
+                    "working_directory": str(target),
+                },
+            )
+        assert resp.status_code == 201
+        assert target.is_dir()
+        assert svc.create_session.call_args.kwargs["working_directory"] == str(target)
+
+    def test_create_terminal_in_session_normalizes_too(self, client, tmp_path):
+        with (
+            patch("cli_agent_orchestrator.api.main.terminal_service") as ts,
+            patch("cli_agent_orchestrator.api.main.session_service") as svc,
+        ):
+            svc.get_session.return_value = {"session": {"id": "cao-demo"}, "terminals": []}
+            ts.create_terminal = AsyncMock(return_value=self._terminal())
+            resp = client.post(
+                "/sessions/cao-demo/terminals",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "developer",
+                    "working_directory": f'"{tmp_path}"',
+                },
+            )
+        assert resp.status_code == 201, resp.json()
+        assert ts.create_terminal.call_args.kwargs["working_directory"] == str(tmp_path)
+
+    def test_create_terminal_in_session_rejects_a_relative_path(self, client):
+        with (
+            patch("cli_agent_orchestrator.api.main.terminal_service") as ts,
+            patch("cli_agent_orchestrator.api.main.session_service") as svc,
+        ):
+            svc.get_session.return_value = {"session": {"id": "cao-demo"}, "terminals": []}
+            ts.create_terminal = AsyncMock()
+            resp = client.post(
+                "/sessions/cao-demo/terminals",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "developer",
+                    "working_directory": "relative/not/absolute",
+                },
+            )
+        assert resp.status_code == 400
+        assert "absolute" in resp.json()["detail"].lower()
+        ts.create_terminal.assert_not_called()

--- a/test/api/test_operator_ergonomics.py
+++ b/test/api/test_operator_ergonomics.py
@@ -67,12 +67,30 @@ class TestFsDirs:
         f.write_text("x")
         resp = client.get("/fs/dirs", params={"path": str(f)})
         assert resp.status_code == 400
-        assert "is a file" in resp.json()["detail"]
+        assert "is not a folder" in resp.json()["detail"]
 
     def test_defaults_to_home(self, client):
         resp = client.get("/fs/dirs")
         assert resp.status_code == 200
         assert resp.json()["path"] == str(Path.home().resolve())
+
+    def test_blank_or_quoted_empty_path_falls_back_to_home_not_cwd(self, client):
+        """A quotes-only value normalizes to None; ``Path("")`` would silently
+        resolve to the server's CWD instead of the documented default."""
+        for blank in ('""', "   ", "''"):
+            resp = client.get("/fs/dirs", params={"path": blank})
+            assert resp.status_code == 200, blank
+            assert resp.json()["path"] == str(Path.home().resolve()), blank
+
+    def test_unreadable_folder_other_oserror_is_a_400_not_a_500(self, client, tmp_path):
+        """ENOTDIR/EIO/a stale mount: the per-entry loop already tolerates
+        these, so the directory-level read must not 500 either."""
+        with patch(
+            "cli_agent_orchestrator.api.main.Path.iterdir", side_effect=OSError("stale mount")
+        ):
+            resp = client.get("/fs/dirs", params={"path": str(tmp_path)})
+        assert resp.status_code == 400
+        assert "stale mount" in resp.json()["detail"]
 
     def test_root_has_no_parent(self, client):
         resp = client.get("/fs/dirs", params={"path": "/"})
@@ -103,6 +121,20 @@ class TestSessionLabelEndpoint:
         resp = client.post("/sessions/bad:name/label", json={"label": "x"})
         assert resp.status_code == 400
         assert settings_service.get_session_labels() == {}
+
+    def test_unprefixed_name_addresses_the_same_session(self, client, settings_file):
+        """``POST /sessions`` turns ``demo`` into ``cao-demo`` at creation, and
+        every read and the teardown key off that prefixed id. Labelling with
+        the name the operator created with must reach the same session, not
+        store an entry that never surfaces and is never cleared."""
+        resp = client.post("/sessions/demo/label", json={"label": "My Run"})
+        assert resp.status_code == 200
+        assert resp.json() == {"session_name": "cao-demo", "label": "My Run"}
+        assert settings_service.get_session_labels() == {"cao-demo": "My Run"}
+
+        # ...and the prefixed spelling is the same entry, not a second one.
+        client.post("/sessions/cao-demo/label", json={"label": "Renamed"})
+        assert settings_service.get_session_labels() == {"cao-demo": "Renamed"}
 
     def test_label_is_required(self, client, settings_file):
         resp = client.post("/sessions/cao-demo/label", json={})
@@ -161,6 +193,25 @@ class TestWorkingDirectoryNormalizationAtTheBoundary:
             )
         assert resp.status_code == 400
         assert "absolute" in resp.json()["detail"].lower()
+        svc.create_session.assert_not_called()
+
+    def test_a_rejected_request_creates_no_directory(self, client, tmp_path):
+        """The normalization can CREATE, so it runs after the cheap validations:
+        a request some other check will reject must leave nothing behind."""
+        target = tmp_path / "orphan" / "deep" / "tree"
+        with patch("cli_agent_orchestrator.api.main.session_service") as svc:
+            svc.create_session = AsyncMock()
+            resp = client.post(
+                "/sessions",
+                params={
+                    "provider": "kiro_cli",
+                    "agent_profile": "developer",
+                    "working_directory": str(target),
+                    "session_name": "x" * 200,  # rejected by the name check
+                },
+            )
+        assert resp.status_code == 400
+        assert not target.exists(), "a rejected request left a directory tree behind"
         svc.create_session.assert_not_called()
 
     def test_create_session_creates_a_missing_folder(self, client, tmp_path):

--- a/test/api/test_terminals.py
+++ b/test/api/test_terminals.py
@@ -102,8 +102,12 @@ class TestSessionCreationWithWorkingDirectory:
             assert call_kwargs.get("working_directory") == str(tmp_path)
             assert call_kwargs.get("registry") is not None
 
-    def test_create_session_with_working_directory(self, client):
-        """Test POST /sessions with working_directory parameter."""
+    def test_create_session_with_working_directory(self, client, tmp_path):
+        """Test POST /sessions with working_directory parameter.
+
+        A real directory: the endpoint normalizes ``working_directory`` at the
+        boundary, and a literal path that cannot be created is a 400.
+        """
         with patch("cli_agent_orchestrator.api.main.session_service") as mock_svc:
             mock_svc.create_session = AsyncMock(
                 return_value=Terminal(
@@ -120,13 +124,13 @@ class TestSessionCreationWithWorkingDirectory:
                 params={
                     "provider": "kiro_cli",
                     "agent_profile": "developer",
-                    "working_directory": "/custom/path",
+                    "working_directory": str(tmp_path),
                 },
             )
 
             assert response.status_code == 201
             call_kwargs = mock_svc.create_session.call_args.kwargs
-            assert call_kwargs.get("working_directory") == "/custom/path"
+            assert call_kwargs.get("working_directory") == str(tmp_path)
 
 
 class TestTerminalCreationWithWorkingDirectory:
@@ -337,8 +341,11 @@ class TestTerminalCreationWithWorkingDirectory:
             assert response.status_code == 422
             mock_svc.create_terminal.assert_not_called()
 
-    def test_create_terminal_in_session_with_working_directory(self, client):
-        """Test POST /sessions/{session}/terminals with working_directory."""
+    def test_create_terminal_in_session_with_working_directory(self, client, tmp_path):
+        """Test POST /sessions/{session}/terminals with working_directory.
+
+        A real directory, for the same reason as the session test above.
+        """
         with (
             patch(
                 "cli_agent_orchestrator.api.main.resolve_provider",
@@ -361,13 +368,13 @@ class TestTerminalCreationWithWorkingDirectory:
                 params={
                     "provider": "kiro_cli",
                     "agent_profile": "analyst",
-                    "working_directory": "/session/path",
+                    "working_directory": str(tmp_path),
                 },
             )
 
             assert response.status_code == 201
             call_kwargs = mock_svc.create_terminal.call_args.kwargs
-            assert call_kwargs.get("working_directory") == "/session/path"
+            assert call_kwargs.get("working_directory") == str(tmp_path)
 
     def test_create_terminal_in_session_forwards_use_worktree_true(self, client):
         """issue #100 Phase 1: the use_worktree query param reaches

--- a/test/services/test_session_service.py
+++ b/test/services/test_session_service.py
@@ -234,6 +234,28 @@ class TestListSessions:
         assert all("working_directory" in s for s in result)
         assert all("agent_profile" in s for s in result)
 
+    @patch("cli_agent_orchestrator.services.session_service.get_session_labels")
+    @patch("cli_agent_orchestrator.services.session_service.list_terminals_in_sessions")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_list_sessions_attaches_display_label(
+        self, mock_get_backend, mock_list_in_sessions, mock_labels
+    ):
+        """Every listed session carries ``label``: the operator alias, or None."""
+        mock_get_backend.return_value.list_sessions.return_value = [
+            {"id": "cao-session1", "name": "Session 1"},
+            {"id": "cao-session2", "name": "Session 2"},
+        ]
+        mock_list_in_sessions.return_value = []
+        mock_labels.return_value = {"cao-session1": "Nightly triage"}
+
+        result = list_sessions()
+
+        by_id = {s["id"]: s for s in result}
+        assert by_id["cao-session1"]["label"] == "Nightly triage"
+        assert by_id["cao-session2"]["label"] is None
+        # One settings read for the whole listing, not one per session.
+        mock_labels.assert_called_once()
+
     @patch("cli_agent_orchestrator.services.session_service.get_backend")
     def test_list_sessions_empty(self, mock_get_backend):
         """Test listing sessions when none exist."""
@@ -296,6 +318,7 @@ class TestListSessions:
                 "status": "detached",
                 "agent_profile": "developer",
                 "working_directory": "/launch/project",
+                "label": None,
             }
         ]
         assert fake_client.cwd_calls == []
@@ -435,6 +458,7 @@ class TestListSessions:
                 "name": "Good",
                 "working_directory": None,
                 "agent_profile": None,
+                "label": None,
             }
         ]
 
@@ -880,6 +904,22 @@ class TestGetSession:
         assert len(result["terminals"]) == 1
         mock_get_backend.return_value.session_exists.assert_called_once_with("cao-test")
 
+    @patch("cli_agent_orchestrator.services.session_service.get_session_labels")
+    @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_get_session_attaches_display_label(
+        self, mock_get_backend, mock_list_terminals, mock_labels
+    ):
+        mock_get_backend.return_value.session_exists.return_value = True
+        mock_get_backend.return_value.list_sessions.return_value = [{"id": "cao-test"}]
+        mock_list_terminals.return_value = []
+        mock_labels.return_value = {"cao-test": "Nightly triage"}
+
+        assert get_session("cao-test")["session"]["label"] == "Nightly triage"
+
+        mock_labels.return_value = {}
+        assert get_session("cao-test")["session"]["label"] is None
+
     @patch("cli_agent_orchestrator.services.status_monitor.status_monitor.get_status")
     @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
     @patch("cli_agent_orchestrator.services.session_service.get_backend")
@@ -992,6 +1032,40 @@ class TestDeleteSession:
         assert mock_delete_row.call_count == 2
         mock_delete_row.assert_any_call("terminal1", ANY, registry=ANY)
         mock_delete_row.assert_any_call("terminal2", ANY, registry=ANY)
+
+    @patch("cli_agent_orchestrator.services.session_service.set_session_label")
+    @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_ids")
+    @patch("cli_agent_orchestrator.services.terminal_service.delete_terminal_row")
+    @patch("cli_agent_orchestrator.services.terminal_service.dismantle_terminal_runtime")
+    @patch("cli_agent_orchestrator.services.terminal_service.capture_terminal_snapshot")
+    @patch("cli_agent_orchestrator.services.session_service.list_terminals_by_session")
+    @patch("cli_agent_orchestrator.services.session_service.get_backend")
+    def test_delete_session_clears_display_label(
+        self,
+        mock_get_backend,
+        mock_list_terminals,
+        mock_capture,
+        mock_dismantle,
+        mock_delete_row,
+        mock_delete_terminals_by_ids,
+        mock_set_label,
+    ):
+        """A later same-name session must not inherit the alias; and a settings
+        write failure is reported in ``errors``, never raised over the completed
+        teardown."""
+        mock_get_backend.return_value.session_exists_strict.return_value = True
+        mock_get_backend.return_value.kill_session.return_value = True
+        mock_list_terminals.return_value = [{"id": "terminal1"}]
+
+        result = delete_session("cao-test")
+
+        assert result == {"deleted": ["cao-test"], "errors": []}
+        mock_set_label.assert_called_once_with("cao-test", "")
+
+        mock_set_label.side_effect = OSError("disk full")
+        result = delete_session("cao-test")
+        assert result["deleted"] == ["cao-test"]
+        assert [e["step"] for e in result["errors"]] == ["clear_session_label"]
 
     @patch("cli_agent_orchestrator.services.session_service.delete_terminals_by_ids")
     @patch("cli_agent_orchestrator.services.terminal_service.delete_terminal_row")

--- a/test/services/test_settings_service.py
+++ b/test/services/test_settings_service.py
@@ -587,3 +587,53 @@ class TestWorkflowJournalSettingsWritePath:
         rather than being silently persisted as an unread setting."""
         with pytest.raises(ValueError, match="Unknown memory setting"):
             settings_service.set_memory_setting("workflow_journal_retention_dayz", 30)
+
+
+class TestSessionLabels:
+    """Per-session display aliases: trimmed, capped, cleared by a blank label."""
+
+    def test_empty_when_unset(self, settings_file):
+        assert settings_service.get_session_labels() == {}
+
+    def test_set_trims_and_persists(self, settings_file):
+        labels = settings_service.set_session_label("cao-demo", "  Nightly triage  ")
+        assert labels == {"cao-demo": "Nightly triage"}
+        assert settings_service.get_session_labels() == {"cao-demo": "Nightly triage"}
+        assert json.loads(settings_file.read_text())["session_labels"] == {
+            "cao-demo": "Nightly triage"
+        }
+
+    def test_blank_label_clears(self, settings_file):
+        settings_service.set_session_label("cao-demo", "x")
+        assert settings_service.set_session_label("cao-demo", "   ") == {}
+        assert settings_service.get_session_labels() == {}
+
+    def test_clearing_an_unknown_session_is_a_no_op(self, settings_file):
+        assert settings_service.set_session_label("cao-nope", "") == {}
+        # ...including on disk: teardown clears unconditionally, and that must
+        # not rewrite settings.json on every session delete.
+        assert not settings_file.exists()
+
+    def test_resetting_the_same_label_does_not_rewrite(self, settings_file):
+        settings_service.set_session_label("cao-demo", "Run")
+        before = settings_file.stat().st_mtime_ns
+        settings_file.write_text(settings_file.read_text())  # any rewrite would be visible
+        settings_service.set_session_label("cao-demo", "Run")
+        assert json.loads(settings_file.read_text())["session_labels"] == {"cao-demo": "Run"}
+
+    def test_label_is_capped(self, settings_file):
+        long = "x" * (settings_service.SESSION_LABEL_MAX_LENGTH + 20)
+        labels = settings_service.set_session_label("cao-demo", long)
+        assert len(labels["cao-demo"]) == settings_service.SESSION_LABEL_MAX_LENGTH
+
+    def test_other_settings_survive(self, settings_file):
+        settings_file.write_text(json.dumps({"agent_dirs": {"kiro_cli": "/x"}}))
+        settings_service.set_session_label("cao-demo", "Run")
+        data = json.loads(settings_file.read_text())
+        assert data["agent_dirs"] == {"kiro_cli": "/x"}
+        assert data["session_labels"] == {"cao-demo": "Run"}
+
+    def test_corrupt_labels_value_is_treated_as_empty(self, settings_file):
+        settings_file.write_text(json.dumps({"session_labels": ["not", "a", "dict"]}))
+        assert settings_service.get_session_labels() == {}
+        assert settings_service.set_session_label("cao-demo", "Run") == {"cao-demo": "Run"}

--- a/test/services/test_settings_service.py
+++ b/test/services/test_settings_service.py
@@ -609,16 +609,37 @@ class TestSessionLabels:
         assert settings_service.get_session_labels() == {}
 
     def test_clearing_an_unknown_session_is_a_no_op(self, settings_file):
-        assert settings_service.set_session_label("cao-nope", "") == {}
+        with patch.object(settings_service, "_save") as save:
+            assert settings_service.set_session_label("cao-nope", "") == {}
+        save.assert_not_called()
         # ...including on disk: teardown clears unconditionally, and that must
         # not rewrite settings.json on every session delete.
         assert not settings_file.exists()
 
+    def test_teardown_clear_does_not_destroy_an_unparseable_settings_file(self, settings_file):
+        """#737: the loaders return {} for a file that exists but does not
+        parse, so any write over that state persists the empty fallback as the
+        new truth. ``delete_session`` clears a label unconditionally, which
+        would put that write on every teardown -- the no-op guard is what keeps
+        it off. Pinned here because the guard's value is not obvious from the
+        line itself, and #737's own fix should not be the only thing standing
+        between a corrupt file and this path."""
+        settings_file.write_text('{"terminal": {"backend": "tmux"},}')  # trailing comma
+        before = settings_file.read_text()
+
+        with patch.object(settings_service, "_save") as save:
+            assert settings_service.set_session_label("cao-gone", "") == {}
+        save.assert_not_called()
+        assert settings_file.read_text() == before
+
     def test_resetting_the_same_label_does_not_rewrite(self, settings_file):
+        """The no-op guard must actually skip the write, not merely produce the
+        same bytes: every settings write is a read-modify-write over the whole
+        file, so a needless one widens the window for losing a concurrent edit."""
         settings_service.set_session_label("cao-demo", "Run")
-        before = settings_file.stat().st_mtime_ns
-        settings_file.write_text(settings_file.read_text())  # any rewrite would be visible
-        settings_service.set_session_label("cao-demo", "Run")
+        with patch.object(settings_service, "_save") as save:
+            assert settings_service.set_session_label("cao-demo", "Run") == {"cao-demo": "Run"}
+        save.assert_not_called()
         assert json.loads(settings_file.read_text())["session_labels"] == {"cao-demo": "Run"}
 
     def test_label_is_capped(self, settings_file):

--- a/test/utils/test_paths.py
+++ b/test/utils/test_paths.py
@@ -1,8 +1,14 @@
 """Tests for the operator-supplied working-directory normalization."""
 
+import os
+
 import pytest
 
-from cli_agent_orchestrator.utils.paths import normalize_working_directory
+from cli_agent_orchestrator.utils.paths import (
+    WORKING_DIRECTORY_MAX_DEPTH,
+    WORKING_DIRECTORY_MAX_LEN,
+    normalize_working_directory,
+)
 
 
 @pytest.fixture
@@ -67,8 +73,39 @@ class TestNormalizeWorkingDirectory:
     def test_file_rejected(self, tmp_path, mnt):
         f = tmp_path / "afile.txt"
         f.write_text("x")
-        with pytest.raises(ValueError, match="is a file"):
+        with pytest.raises(ValueError, match="is not a folder"):
             normalize_working_directory(str(f), mnt_root=mnt)
+
+    def test_existing_non_directory_rejected(self, tmp_path, mnt):
+        """Not only regular files: a FIFO, socket or device node would
+        otherwise pass and fail later inside tmux with exactly the opaque
+        error this function exists to prevent."""
+        fifo = tmp_path / "afifo"
+        os.mkfifo(fifo)
+        with pytest.raises(ValueError, match="is not a folder"):
+            normalize_working_directory(str(fifo), mnt_root=mnt)
+
+    def test_creation_is_bounded_by_depth(self, tmp_path, mnt):
+        deep = tmp_path.joinpath(*[f"d{i}" for i in range(WORKING_DIRECTORY_MAX_DEPTH + 5)])
+        with pytest.raises(ValueError, match="nested too deeply"):
+            normalize_working_directory(str(deep), mnt_root=mnt)
+        assert not deep.exists()
+
+    def test_length_is_bounded_before_any_filesystem_call(self, tmp_path, mnt):
+        """Built from many legal-length components, so the limit under test is
+        ours and not the OS's per-component one. The check has to run before
+        exists(), which would itself raise ENAMETOOLONG and escape as a 500."""
+        long = tmp_path.joinpath(*["x" * 200 for _ in range(30)])
+        assert len(str(long)) > WORKING_DIRECTORY_MAX_LEN
+        with pytest.raises(ValueError, match="too long"):
+            normalize_working_directory(str(long), mnt_root=mnt)
+
+    def test_bounds_do_not_apply_to_an_existing_directory(self, tmp_path, mnt):
+        """The caps bound what we CREATE. A deep tree that already exists is
+        the operator's own layout and is none of our business."""
+        deep = tmp_path.joinpath(*[f"d{i}" for i in range(WORKING_DIRECTORY_MAX_DEPTH + 5)])
+        deep.mkdir(parents=True)
+        assert normalize_working_directory(str(deep), mnt_root=mnt) == str(deep)
 
     def test_uncreatable_directory_gives_clear_error(self, tmp_path, mnt):
         # A path whose parent is a FILE cannot be created; the OSError must

--- a/test/utils/test_paths.py
+++ b/test/utils/test_paths.py
@@ -1,0 +1,79 @@
+"""Tests for the operator-supplied working-directory normalization."""
+
+import pytest
+
+from cli_agent_orchestrator.utils.paths import normalize_working_directory
+
+
+@pytest.fixture
+def mnt(tmp_path):
+    """A fake WSL interop mount with a ``c:`` drive."""
+    (tmp_path / "mnt" / "c" / "Users" / "operator" / "Desktop").mkdir(parents=True)
+    return tmp_path / "mnt"
+
+
+class TestNormalizeWorkingDirectory:
+    def test_none_and_blank_pass_through(self, mnt):
+        assert normalize_working_directory(None, mnt_root=mnt) is None
+        assert normalize_working_directory("   ", mnt_root=mnt) is None
+        assert normalize_working_directory('""', mnt_root=mnt) is None
+
+    def test_linux_path_unchanged(self, tmp_path, mnt):
+        target = tmp_path / "proj"
+        target.mkdir()
+        assert normalize_working_directory(str(target), mnt_root=mnt) == str(target)
+
+    def test_tilde_expanded(self, mnt, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "work").mkdir()
+        assert normalize_working_directory("~/work", mnt_root=mnt) == str(tmp_path / "work")
+
+    def test_windows_backslash_path_translates_to_wsl_mount(self, mnt):
+        result = normalize_working_directory(r"C:\Users\operator\Desktop\task", mnt_root=mnt)
+        assert result == str(mnt / "c" / "Users" / "operator" / "Desktop" / "task")
+
+    def test_windows_forward_slash_path_translates(self, mnt):
+        result = normalize_working_directory("C:/Users/operator/Desktop", mnt_root=mnt)
+        assert result == str(mnt / "c" / "Users" / "operator" / "Desktop")
+
+    def test_explorer_copy_as_path_quotes_stripped(self, mnt):
+        result = normalize_working_directory('"C:\\Users\\operator\\Desktop"', mnt_root=mnt)
+        assert result == str(mnt / "c" / "Users" / "operator" / "Desktop")
+
+    def test_missing_directory_is_created(self, mnt):
+        result = normalize_working_directory(
+            r"C:\Users\operator\Desktop\brand_new\nested", mnt_root=mnt
+        )
+        expected = mnt / "c" / "Users" / "operator" / "Desktop" / "brand_new" / "nested"
+        assert result == str(expected)
+        assert expected.is_dir()
+
+    def test_missing_directory_rejected_when_create_disabled(self, mnt):
+        target = mnt / "c" / "Users" / "operator" / "Desktop" / "nope"
+        with pytest.raises(ValueError, match="does not exist"):
+            normalize_working_directory(
+                r"C:\Users\operator\Desktop\nope", mnt_root=mnt, create_missing=False
+            )
+        assert not target.exists(), "read-only callers must not touch the filesystem"
+
+    def test_unmounted_drive_gives_clear_error(self, mnt):
+        with pytest.raises(ValueError, match="drive Z: is not mounted"):
+            normalize_working_directory(r"Z:\projects\app", mnt_root=mnt)
+
+    def test_relative_path_rejected(self, mnt):
+        with pytest.raises(ValueError, match="absolute"):
+            normalize_working_directory("projects/app", mnt_root=mnt)
+
+    def test_file_rejected(self, tmp_path, mnt):
+        f = tmp_path / "afile.txt"
+        f.write_text("x")
+        with pytest.raises(ValueError, match="is a file"):
+            normalize_working_directory(str(f), mnt_root=mnt)
+
+    def test_uncreatable_directory_gives_clear_error(self, tmp_path, mnt):
+        # A path whose parent is a FILE cannot be created; the OSError must
+        # surface as the same ValueError family the endpoints turn into a 400.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        with pytest.raises(ValueError, match="could not be created"):
+            normalize_working_directory(str(blocker / "child"), mnt_root=mnt)


### PR DESCRIPTION
Split out of #356 at @plauzy's suggestion there ("the orthogonal operator ergonomics — `/fs/dirs`, `working_directory` normalization, session labels, and `X-Server-Time` — into their own PR; those are clean wins with no substrate overlap"). Rebuilt on current `main` rather than cherry-picked: `utils/paths.py` gained `normalized_path` since July, `list_sessions` was batched in #703, and `delete_session` grew its atomic teardown in #498, so each piece was re-fitted to the code as it is now. Backend only; the browser consumers stay with the dashboard in #356.

Refs #292, #356.

## What each piece does

**1. `working_directory` is normalized at the HTTP boundary** (`utils/paths.normalize_working_directory`, wired into `POST /sessions` and `POST /sessions/{name}/terminals`). The web UI runs in the operator's browser; on WSL that browser is on Windows, so operators paste `"C:\Users\me\proj"` straight from Explorer's "Copy as path" and every such launch failed as an opaque 500 deep in tmux. Now: surrounding quotes stripped, `~` expanded, a Windows drive path translated to `/mnt/<drive>/…` when that mount exists, a missing directory created (the operator is pointing at where the project should live), and a relative path / file / unmounted drive rejected as a `400` with a plain-language `detail`. `None`/blank passes through unchanged. The MCP `handoff`/`assign` parameter is untouched.

**2. `GET /fs/dirs?path=`** lists the subdirectories of one server-side folder for a folder picker: directory names only, never files, sizes, or contents; hidden folders after the visible ones (provider homes like `~/.kiro` are exactly what an operator browsing for a profile dir wants). Defaults to the server user's home. Accepts the same spellings as (1) but with `create_missing=False`, so a listing can never create the folder it was asked about — pinned by a test. Read-scope gated like `GET /settings/agent-dirs`; it discloses nothing a caller could not already probe through `working_directory` on session creation.

**3. Session display labels.** `POST /sessions/{name}/label` with `{"label": "…"}` sets a friendly name (trimmed, capped at 60; empty clears). A pure display alias stored under `session_labels` in `settings.json`, surfaced as `label` (or `null`) on `GET /sessions` and `GET /sessions/{name}`, cleared on `delete_session` so a later same-name session cannot inherit it. Nothing that references the real tmux session name is affected. The listing reads the label map once per call, not once per session. Clearing an absent label is a no-op that does not rewrite `settings.json` — teardown clears unconditionally, so this is the common case. The delete-time clear uses the same guard shape as the env cleanup beside it: a settings write failure lands in `result["errors"]` and never misreports a completed teardown.

**4. `X-Server-Time`** on every response: the server's wall clock, offset-aware ISO-8601. A client rendering "2 minutes ago" from server timestamps measures its skew once and corrects (WSL2 hosts have been observed hours adrift from the browser next to them). Offset-aware because a naive string is read as browser-local time, which is the skew the header exists to remove. Informational; clients that ignore it are unaffected.

## Not included

The Runs dashboard, its SSE stream and `flow.message` taxonomy, and the `sse-starlette` dependency all stay in #356, to be rebuilt on the AG-UI stream and design tokens per the review there.

## Tests

- `test/utils/test_paths.py` (new): every normalization branch, including that `create_missing=False` leaves the filesystem untouched and that an uncreatable path surfaces as the same `ValueError` family the endpoints turn into a 400.
- `test/api/test_operator_ergonomics.py` (new): header on success and error responses (offset-aware, within a minute of now); `/fs/dirs` listing order, missing-folder 400 without creation, file 400, home default, root has no parent, `PermissionError` → 400 not 500; label roundtrip/clear, bad session name 400, missing body 422, label surfaced on list and get; both creation endpoints strip quotes and forward the normalized path, reject a relative path before any service is reached, and `POST /sessions` creates a missing folder.
- `test/services/test_settings_service.py`: trim, cap, clear, no-op clear leaves no file, same-label reset, other settings survive, corrupt `session_labels` value treated as empty.
- `test/services/test_session_service.py`: `list_sessions` attaches the label with one settings read; `get_session` attaches it; `delete_session` clears it and reports (never raises) a settings write failure. Two existing strict-equality listing tests gained `"label": None`.
- Mutation-checked: removing the normalization at either endpoint, or the delete-time clear, reddens the corresponding tests.
- `test/api` (minus the AG-UI files, which carry the known pre-existing failures on `main`), `test/utils`, and the two service files: all green. `black --check` and `isort --check-only` clean.

Docs: `docs/api.md` (header, `/fs/dirs`, normalization, label endpoint) and `docs/working-directory.md` (typed → used table).
