### PR TITLE
Expose current MiniMax Code model catalog

### DIFF
--- a/docs/minimax-code.md
+++ b/docs/minimax-code.md
@@ -53,6 +53,12 @@ only in the terminal-local copy of `config.yaml`; the explicit launch override
 wins over the profile value. The user's normal MiniMax Code configuration is
 not modified.
 
+The current MiniMax model IDs are `MiniMax-M3` and `MiniMax-M2.7`. For example:
+
+```bash
+cao launch --agents developer --provider mcode --model MiniMax-M3
+```
+
 ## Runtime behavior
 
 CAO launches a command equivalent to:

--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -2702,6 +2702,8 @@ async def list_providers_endpoint() -> List[Dict]:
     """List available providers with installation status."""
     import shutil
 
+    from cli_agent_orchestrator.providers.minimax_code import MINIMAX_CODE_MODEL_IDS
+
     provider_binaries = {
         "kiro_cli": "kiro-cli",
         "claude_code": "claude",
@@ -2719,7 +2721,10 @@ async def list_providers_endpoint() -> List[Dict]:
     result = []
     for provider, binary in provider_binaries.items():
         installed = shutil.which(binary) is not None
-        result.append({"name": provider, "binary": binary, "installed": installed})
+        item = {"name": provider, "binary": binary, "installed": installed}
+        if provider == "mcode":
+            item["models"] = list(MINIMAX_CODE_MODEL_IDS)
+        result.append(item)
     return result
 
 

--- a/src/cli_agent_orchestrator/providers/minimax_code.py
+++ b/src/cli_agent_orchestrator/providers/minimax_code.py
@@ -26,6 +26,7 @@ from cli_agent_orchestrator.utils.text import strip_terminal_escapes
 
 _PLUGIN_NAME = "cao-orchestrator"
 _PLUGIN_SERVER_NAME = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+MINIMAX_CODE_MODEL_IDS = ("MiniMax-M3", "MiniMax-M2.7")
 _USER_LINE_PATTERN = re.compile(r"^\s*›[^\S\n]+(.*)$")
 _COMPLETION_LINE_PATTERN = re.compile(r"^\s*└\s+Completed in\s+\d", re.IGNORECASE)
 _COMPLETION_PATTERN = re.compile(r"(?:^|\n)\s*└\s+Completed in\s+\d", re.IGNORECASE)

--- a/test/api/test_api_endpoints.py
+++ b/test/api/test_api_endpoints.py
@@ -192,6 +192,7 @@ class TestAgentProviders:
         assert providers_dict["omp"]["binary"] == "omp"
         assert providers_dict["grok_cli"]["binary"] == "grok"
         assert providers_dict["mcode"]["binary"] == "mcode"
+        assert providers_dict["mcode"]["models"] == ["MiniMax-M3", "MiniMax-M2.7"]
 
 
 # ── Skills endpoint ──────────────────────────────────────────────────

--- a/test/providers/test_minimax_code_unit.py
+++ b/test/providers/test_minimax_code_unit.py
@@ -13,7 +13,11 @@ import yaml
 
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.models.terminal import TerminalStatus
-from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider, ProviderError
+from cli_agent_orchestrator.providers.minimax_code import (
+    MINIMAX_CODE_MODEL_IDS,
+    MiniMaxCodeProvider,
+    ProviderError,
+)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -30,6 +34,10 @@ def make_provider(**kwargs) -> MiniMaxCodeProvider:
         agent_profile=kwargs.pop("agent_profile", "developer"),
         **kwargs,
     )
+
+
+def test_current_model_catalog():
+    assert MINIMAX_CODE_MODEL_IDS == ("MiniMax-M3", "MiniMax-M2.7")
 
 
 def test_prepare_runtime_isolates_auth_and_generates_private_mcp_plugin(


### PR DESCRIPTION
Reason: Publish the current MiniMax Code model catalog through the provider API.

## Summary

- define the current MiniMax Code model IDs in the provider implementation
- expose the catalog in the provider availability response
- document model selection and cover the catalog with focused tests

## Checks

- `uv run --frozen pytest test/providers/test_minimax_code_unit.py test/api/test_api_endpoints.py::TestAgentProviders -q -o 'addopts='`
- `uv run --frozen black --check src/cli_agent_orchestrator/providers/minimax_code.py src/cli_agent_orchestrator/api/main.py test/api/test_api_endpoints.py test/providers/test_minimax_code_unit.py`
- `uv run --frozen isort --check-only src/cli_agent_orchestrator/providers/minimax_code.py src/cli_agent_orchestrator/api/main.py test/api/test_api_endpoints.py test/providers/test_minimax_code_unit.py`
- `PYTHONPATH=src uv run --frozen mypy src/cli_agent_orchestrator/providers/minimax_code.py`
- `PYTHONPATH=src uv run --frozen python scripts/validate_markdown_links.py`
