### PR TITLE
feat(ops-mcp): forward env_vars when launching sessions

### DIFF
--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -52,6 +52,29 @@ Rejected at the CLI boundary:
 
 Forwarded vars are held in process memory on cao-server and dropped when the session is deleted; restarting cao-server wipes them.
 
+### From the ops-MCP `launch_session` tool
+
+An external agent driving CAO through the `cao-ops` MCP server forwards the same
+vars via an `env_vars` mapping on `launch_session` — the identical mechanism,
+validation, and request-body delivery as `cao launch --env`:
+
+```python
+launch_session(
+    agent_profile="code_supervisor",
+    env_vars={
+        "MNEMOSYNE_DIR": "/root/mnemosyne",
+        "ISAAC_CHANNEL": "room:engineering",
+    },
+)
+```
+
+The same three rules are enforced at the tool boundary — blocked
+`CLAUDE` / `CODEX_` / `__MISE_` prefixes (with the 6 `CLAUDE_CODE_USE_*` /
+`CLAUDE_CODE_SKIP_*` flags allowlisted), non-POSIX keys, and values ≥ 2048 bytes
+— so an entry the server would silently drop fails the tool call loudly instead
+of vanishing. The CLI and the ops-MCP tool share one validator
+(`utils/forwarded_env.py`) so the two paths cannot drift.
+
 ## Notes
 
 - CAO session names are automatically prefixed with `cao-`. Use the prefixed name (e.g. `cao-my-task`) when referencing a session in `tmux attach`, `cao session send`, or `cao shutdown`.

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -17,13 +17,8 @@ from cli_agent_orchestrator.constants import (
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.forwarded_env import (
-    FORWARDED_ENV_BLOCKED_PREFIXES as _FORWARDED_ENV_BLOCKED_PREFIXES,
-)
-from cli_agent_orchestrator.utils.forwarded_env import (
-    FORWARDED_ENV_MAX_VALUE_BYTES as _FORWARDED_ENV_MAX_VALUE_BYTES,
-)
-from cli_agent_orchestrator.utils.forwarded_env import (
-    FORWARDED_ENV_PREFIX_ALLOWLIST as _FORWARDED_ENV_PREFIX_ALLOWLIST,
+    ForwardedEnvError,
+    validate_forwarded_env,
 )
 from cli_agent_orchestrator.utils.terminal import (
     poll_until_done,
@@ -50,47 +45,30 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
 # Validation constraints for ``--env`` forwarded vars live in
 # ``utils.forwarded_env`` (shared with the ops-MCP ``launch_session`` tool so
 # the two client paths cannot drift) and are mirrored server-side in
-# ``TmuxClient._merge_extra_env``. See issue #248. Imported above under the
-# historical private names ``_parse_env_pairs`` uses.
+# ``TmuxClient._merge_extra_env``. See issue #248.
 
 
 def _parse_env_pairs(pairs):
-    """Parse repeated ``KEY=VALUE`` entries into a dict, validating each.
+    """Parse repeated ``KEY=VALUE`` entries into a validated dict.
 
-    Mirrors the constraints applied to inherited env in TmuxClient so a
-    forwarded var that would be silently dropped server-side is rejected at
-    the CLI boundary with a clear error message instead.
+    Splitting each ``KEY=VALUE`` string (and the last-wins duplicate handling)
+    is CLI-specific, but every validation rule is delegated to the shared
+    ``validate_forwarded_env`` so ``--env`` and the ops-MCP ``launch_session``
+    tool can never drift. Each shared message begins with ``env ``; prefixing
+    with ``--`` reproduces the historical ``--env ...`` CLI messages exactly.
     """
-    result: dict[str, str] = {}
+    parsed: dict[str, str] = {}
     for raw in pairs:
         if "=" not in raw:
             raise click.ClickException(
                 f"--env expects KEY=VALUE (got {raw!r}); did you forget the '='?"
             )
         key, value = raw.split("=", 1)
-        # POSIX env names: leading letter/underscore, then alnum/underscore.
-        # Stricter than ``str.isidentifier`` only in that it forbids non-ASCII.
-        if (
-            not key
-            or not (key[0].isalpha() or key[0] == "_")
-            or not all(c.isalnum() or c == "_" for c in key)
-            or not key.isascii()
-        ):
-            raise click.ClickException(f"--env key must match [A-Za-z_][A-Za-z0-9_]* (got {key!r})")
-        if key not in _FORWARDED_ENV_PREFIX_ALLOWLIST and any(
-            key.startswith(p) for p in _FORWARDED_ENV_BLOCKED_PREFIXES
-        ):
-            raise click.ClickException(
-                f"--env key {key!r} uses a blocked prefix "
-                f"({', '.join(_FORWARDED_ENV_BLOCKED_PREFIXES)}) reserved for provider env"
-            )
-        if len(value.encode("utf-8")) >= _FORWARDED_ENV_MAX_VALUE_BYTES:
-            raise click.ClickException(
-                f"--env value for {key!r} exceeds {_FORWARDED_ENV_MAX_VALUE_BYTES} bytes "
-                "(tmux argv limit, PR #246)"
-            )
-        result[key] = value
-    return result
+        parsed[key] = value  # last-wins on a duplicate key
+    try:
+        return validate_forwarded_env(parsed)
+    except ForwardedEnvError as exc:
+        raise click.ClickException(f"--{exc}") from exc
 
 
 @click.command()

--- a/src/cli_agent_orchestrator/cli/commands/launch.py
+++ b/src/cli_agent_orchestrator/cli/commands/launch.py
@@ -16,6 +16,15 @@ from cli_agent_orchestrator.constants import (
 )
 from cli_agent_orchestrator.models.terminal import TerminalStatus
 from cli_agent_orchestrator.services.settings_service import get_server_settings
+from cli_agent_orchestrator.utils.forwarded_env import (
+    FORWARDED_ENV_BLOCKED_PREFIXES as _FORWARDED_ENV_BLOCKED_PREFIXES,
+)
+from cli_agent_orchestrator.utils.forwarded_env import (
+    FORWARDED_ENV_MAX_VALUE_BYTES as _FORWARDED_ENV_MAX_VALUE_BYTES,
+)
+from cli_agent_orchestrator.utils.forwarded_env import (
+    FORWARDED_ENV_PREFIX_ALLOWLIST as _FORWARDED_ENV_PREFIX_ALLOWLIST,
+)
 from cli_agent_orchestrator.utils.terminal import (
     poll_until_done,
     sync_backend_from_server,
@@ -38,20 +47,11 @@ PROVIDERS_REQUIRING_WORKSPACE_ACCESS = {
     "omp",
 }
 
-# Validation constraints for ``--env`` forwarded vars (mirrored server-side
-# in ``TmuxClient._merge_extra_env``). See issue #248.
-_FORWARDED_ENV_BLOCKED_PREFIXES = ("CLAUDE", "CODEX_", "__MISE_")
-_FORWARDED_ENV_PREFIX_ALLOWLIST = frozenset(
-    {
-        "CLAUDE_CODE_USE_BEDROCK",
-        "CLAUDE_CODE_USE_VERTEX",
-        "CLAUDE_CODE_USE_FOUNDRY",
-        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
-        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
-        "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
-    }
-)
-_FORWARDED_ENV_MAX_VALUE_BYTES = 2048
+# Validation constraints for ``--env`` forwarded vars live in
+# ``utils.forwarded_env`` (shared with the ops-MCP ``launch_session`` tool so
+# the two client paths cannot drift) and are mirrored server-side in
+# ``TmuxClient._merge_extra_env``. See issue #248. Imported above under the
+# historical private names ``_parse_env_pairs`` uses.
 
 
 def _parse_env_pairs(pairs):

--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -14,6 +14,10 @@ from cli_agent_orchestrator.ops_mcp_server.models import (
     SendMessageResult,
     SessionListResult,
 )
+from cli_agent_orchestrator.utils.forwarded_env import (
+    ForwardedEnvError,
+    validate_forwarded_env,
+)
 from cli_agent_orchestrator.utils.terminal import generate_session_name
 
 JsonDict = Dict[str, Any]
@@ -101,9 +105,25 @@ async def _launch_session_impl(
     allowed_tools: Optional[List[str]] = None,
     model: Optional[str] = None,
     initial_message: Optional[str] = None,
+    env_vars: Optional[Dict[str, str]] = None,
 ) -> LaunchResult:
     """Create a new CAO session and return the session identifiers."""
     resolved_session_name = session_name or generate_session_name()
+
+    # Validate forwarded env at this boundary: the server silently drops a var
+    # that breaks the rules, so mirror `cao launch --env` and fail loudly here.
+    validated_env: Optional[Dict[str, str]] = None
+    if env_vars:
+        try:
+            validated_env = validate_forwarded_env(env_vars)
+        except ForwardedEnvError as exc:
+            return LaunchResult(
+                success=False,
+                message=f"Launch session failed: {exc}",
+                session_name=resolved_session_name,
+                terminal_id=None,
+            )
+
     params: Dict[str, Any] = {
         "agent_profile": agent_profile,
         "session_name": resolved_session_name,
@@ -119,7 +139,16 @@ async def _launch_session_impl(
     if serialized_allowed_tools:
         params["allowed_tools"] = serialized_allowed_tools
 
-    body = {"initial_message": initial_message} if initial_message is not None else None
+    # initial_message and env_vars both travel in the JSON body (never the URL,
+    # so a forwarded secret does not land in the server access log).
+    body: Optional[Dict[str, Any]] = None
+    if initial_message is not None or validated_env:
+        body = {}
+        if initial_message is not None:
+            body["initial_message"] = initial_message
+        if validated_env:
+            body["env_vars"] = validated_env
+
     session_data, error = _request_json(
         "post", "/sessions", params=params, json=body, operation="Launch session"
     )
@@ -303,6 +332,20 @@ async def launch_session(
             )
         ),
     ] = None,
+    env_vars: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description=(
+                "Optional environment variables forwarded into the launched "
+                "session -- the supervisor terminal and every worker it later "
+                "spawns -- the same mechanism as `cao launch --env`. Delivered "
+                "in the JSON request body (never the URL, so a forwarded secret "
+                "stays out of the server access log). Keys must be POSIX "
+                "identifiers; the CLAUDE/CODEX_/__MISE_ prefixes are reserved "
+                "for provider env and >=2048-byte values are rejected."
+            )
+        ),
+    ] = None,
 ) -> LaunchResult:
     """Create a new CAO session with the given provider and agent profile.
 
@@ -320,6 +363,8 @@ async def launch_session(
         allowed_tools: Optional list of tool restrictions
         model: Optional per-launch model override
         initial_message: Optional first task, carried in the JSON request body
+        env_vars: Optional env vars forwarded into the session, validated the
+            same way as ``cao launch --env`` and carried in the JSON body
 
     Returns:
         LaunchResult with success status, session_name, and terminal_id
@@ -332,6 +377,7 @@ async def launch_session(
         allowed_tools=allowed_tools,
         model=model,
         initial_message=initial_message,
+        env_vars=env_vars,
     )
 
 

--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -342,7 +342,10 @@ async def launch_session(
                 "in the JSON request body (never the URL, so a forwarded secret "
                 "stays out of the server access log). Keys must be POSIX "
                 "identifiers; the CLAUDE/CODEX_/__MISE_ prefixes are reserved "
-                "for provider env and >=2048-byte values are rejected."
+                "for provider env. Values must be UTF-8 with no NUL byte and "
+                "<2048 bytes each; at most 256 vars totalling <128 KiB are "
+                "accepted (tmux argv limits). Invalid input returns "
+                "success=False, it does not raise."
             )
         ),
     ] = None,

--- a/src/cli_agent_orchestrator/utils/forwarded_env.py
+++ b/src/cli_agent_orchestrator/utils/forwarded_env.py
@@ -11,6 +11,11 @@ The server silently *drops* a var that violates these rules
 (``SessionEnvStore._merge_extra_env``), so each client validates at its own
 boundary and surfaces a clear error instead of letting a forwarded var vanish.
 
+The validator also rejects inputs that would survive the schema but break the
+launch downstream -- NUL bytes, non-UTF-8 values, and mappings whose aggregate
+size would overflow the tmux argv (E2BIG). Those failures make libtmux log the
+full command, so rejecting them here keeps forwarded secrets out of the log.
+
 Error messages name the offending KEY and the violated rule only; they never
 echo the VALUE, so a secret passed as a value cannot leak into an error string.
 """
@@ -38,6 +43,27 @@ FORWARDED_ENV_PREFIX_ALLOWLIST = frozenset(
 # Per-value byte cap. Forwarded vars ride the ``tmux new-session -e`` argv, so an
 # oversized value risks the kernel "command too long" limit (see PR #246).
 FORWARDED_ENV_MAX_VALUE_BYTES = 2048
+
+# Per-key byte cap. Keys are ASCII identifiers (see ``_is_valid_env_key``), so
+# bytes == chars; this bounds a single pathological key on the argv.
+FORWARDED_ENV_MAX_KEY_BYTES = 128
+
+# Max number of forwarded entries. Guards the argv against a mapping with a
+# huge entry count (each entry becomes one ``-eKEY=VALUE`` argument).
+FORWARDED_ENV_MAX_ENTRIES = 256
+
+# Aggregate argv budget for the whole forwarded set. Each entry rides tmux argv
+# as ``-eKEY=VALUE``; the kernel rejects an over-long argv with E2BIG, and
+# libtmux logs the full command (values included) on that failure -- so a set
+# that would blow the argv limit is rejected here, before launch, both to keep
+# the launch working and to keep forwarded secrets out of the server log. Set
+# well under the ~2 MiB kernel ARG_MAX to leave room for the rest of argv and
+# the ambient environment.
+FORWARDED_ENV_MAX_TOTAL_BYTES = 128 * 1024
+
+# Per-entry argv overhead: the ``-e`` flag plus the ``=`` separator in
+# ``-eKEY=VALUE``. Added to each entry's key+value bytes for the aggregate.
+_ARGV_ENTRY_OVERHEAD = 3
 
 
 class ForwardedEnvError(ValueError):
@@ -70,24 +96,66 @@ def _uses_blocked_prefix(key: str) -> bool:
 def validate_forwarded_env(mapping: Mapping[str, str]) -> Dict[str, str]:
     """Validate an already-parsed env mapping; return it as a plain dict.
 
-    Raises ``ForwardedEnvError`` on the first offending entry:
+    Every message starts with ``env `` so a caller can prefix it (the CLI turns
+    it into a ``--env `` message) without re-implementing the rules.
+
+    Raises ``ForwardedEnvError`` on the first violation:
+      * more than ``FORWARDED_ENV_MAX_ENTRIES`` entries,
       * a key that is not a ``[A-Za-z_][A-Za-z0-9_]*`` ASCII identifier,
+      * a key longer than ``FORWARDED_ENV_MAX_KEY_BYTES`` bytes,
       * a key using a blocked provider prefix (outside the allowlist),
-      * a value whose UTF-8 encoding is >= ``FORWARDED_ENV_MAX_VALUE_BYTES``.
+      * a value containing a NUL byte (breaks ``Popen`` with "embedded null
+        byte" and leaks the argv into logs),
+      * a value that is not encodable as UTF-8 (e.g. a lone surrogate that
+        JSON/FastMCP accepts as a str),
+      * a value whose UTF-8 encoding is >= ``FORWARDED_ENV_MAX_VALUE_BYTES``,
+      * a set whose aggregate argv size exceeds ``FORWARDED_ENV_MAX_TOTAL_BYTES``.
     """
+    if len(mapping) > FORWARDED_ENV_MAX_ENTRIES:
+        raise ForwardedEnvError(
+            f"env var count {len(mapping)} exceeds the limit of {FORWARDED_ENV_MAX_ENTRIES}"
+        )
+
     validated: Dict[str, str] = {}
+    total_argv_bytes = 0
     for key, value in mapping.items():
         if not _is_valid_env_key(key):
             raise ForwardedEnvError(f"env key must match [A-Za-z_][A-Za-z0-9_]* (got {key!r})")
+        # Keys are guaranteed ASCII here, so byte length == character length.
+        key_bytes = len(key)
+        if key_bytes > FORWARDED_ENV_MAX_KEY_BYTES:
+            raise ForwardedEnvError(f"env key {key!r} exceeds {FORWARDED_ENV_MAX_KEY_BYTES} bytes")
         if _uses_blocked_prefix(key):
             raise ForwardedEnvError(
                 f"env key {key!r} uses a blocked prefix "
                 f"({', '.join(FORWARDED_ENV_BLOCKED_PREFIXES)}) reserved for provider env"
             )
-        if len(value.encode("utf-8")) >= FORWARDED_ENV_MAX_VALUE_BYTES:
+        # A NUL passes the byte-length check but makes ``Popen`` raise
+        # "embedded null byte"; libtmux logs the whole argv (values included)
+        # on that failure, so reject it here before launch.
+        if "\x00" in value:
+            raise ForwardedEnvError(
+                f"env value for {key!r} contains a NUL byte and cannot be forwarded"
+            )
+        # JSON/FastMCP accept a lone surrogate as a str, but ``str.encode`` then
+        # raises before any downstream use -- treat it as invalid input so the
+        # caller returns a clean error instead of crashing.
+        try:
+            value_bytes = len(value.encode("utf-8"))
+        except UnicodeEncodeError:
+            raise ForwardedEnvError(
+                f"env value for {key!r} is not valid UTF-8 and cannot be forwarded"
+            ) from None
+        if value_bytes >= FORWARDED_ENV_MAX_VALUE_BYTES:
             raise ForwardedEnvError(
                 f"env value for {key!r} exceeds {FORWARDED_ENV_MAX_VALUE_BYTES} bytes "
                 "(tmux argv limit, PR #246)"
+            )
+        total_argv_bytes += key_bytes + value_bytes + _ARGV_ENTRY_OVERHEAD
+        if total_argv_bytes > FORWARDED_ENV_MAX_TOTAL_BYTES:
+            raise ForwardedEnvError(
+                f"env vars exceed the total argv budget of {FORWARDED_ENV_MAX_TOTAL_BYTES} "
+                "bytes (tmux argv limit)"
             )
         validated[key] = value
     return validated

--- a/src/cli_agent_orchestrator/utils/forwarded_env.py
+++ b/src/cli_agent_orchestrator/utils/forwarded_env.py
@@ -1,0 +1,93 @@
+"""Validation for operator-forwarded session environment variables.
+
+The same constraints are enforced by every client entry point that forwards
+env vars into a launched session -- ``cao launch --env``
+(``cli/commands/launch.py``) and the ops-MCP ``launch_session`` tool -- and
+mirror the server-side filtering in ``TmuxClient._merge_extra_env``. Keeping the
+canonical constants and the validator here stops the two client paths from
+drifting apart. See issue #248.
+
+The server silently *drops* a var that violates these rules
+(``SessionEnvStore._merge_extra_env``), so each client validates at its own
+boundary and surfaces a clear error instead of letting a forwarded var vanish.
+
+Error messages name the offending KEY and the violated rule only; they never
+echo the VALUE, so a secret passed as a value cannot leak into an error string.
+"""
+
+from typing import Dict, Mapping
+
+# Prefixes reserved for provider-managed env; forwarding them is rejected so an
+# operator cannot clobber the provider's own auth/config vars. Mirrored in
+# ``TmuxClient._merge_extra_env`` server-side.
+FORWARDED_ENV_BLOCKED_PREFIXES = ("CLAUDE", "CODEX_", "__MISE_")
+
+# Explicit exceptions to the blocked prefixes: the documented Claude Code
+# auth-routing flags an operator legitimately needs to forward.
+FORWARDED_ENV_PREFIX_ALLOWLIST = frozenset(
+    {
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+        "CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+    }
+)
+
+# Per-value byte cap. Forwarded vars ride the ``tmux new-session -e`` argv, so an
+# oversized value risks the kernel "command too long" limit (see PR #246).
+FORWARDED_ENV_MAX_VALUE_BYTES = 2048
+
+
+class ForwardedEnvError(ValueError):
+    """A forwarded env var violates the forwarding constraints.
+
+    Subclasses ``ValueError`` so callers that only catch ``ValueError`` still
+    work; the message names the key and rule but never the value.
+    """
+
+
+def _is_valid_env_key(key: str) -> bool:
+    """POSIX env-name shape: leading letter/underscore, then ASCII alnum/underscore.
+
+    Stricter than ``str.isidentifier`` only in forbidding non-ASCII.
+    """
+    return bool(
+        key
+        and (key[0].isalpha() or key[0] == "_")
+        and all(c.isalnum() or c == "_" for c in key)
+        and key.isascii()
+    )
+
+
+def _uses_blocked_prefix(key: str) -> bool:
+    if key in FORWARDED_ENV_PREFIX_ALLOWLIST:
+        return False
+    return any(key.startswith(p) for p in FORWARDED_ENV_BLOCKED_PREFIXES)
+
+
+def validate_forwarded_env(mapping: Mapping[str, str]) -> Dict[str, str]:
+    """Validate an already-parsed env mapping; return it as a plain dict.
+
+    Raises ``ForwardedEnvError`` on the first offending entry:
+      * a key that is not a ``[A-Za-z_][A-Za-z0-9_]*`` ASCII identifier,
+      * a key using a blocked provider prefix (outside the allowlist),
+      * a value whose UTF-8 encoding is >= ``FORWARDED_ENV_MAX_VALUE_BYTES``.
+    """
+    validated: Dict[str, str] = {}
+    for key, value in mapping.items():
+        if not _is_valid_env_key(key):
+            raise ForwardedEnvError(f"env key must match [A-Za-z_][A-Za-z0-9_]* (got {key!r})")
+        if _uses_blocked_prefix(key):
+            raise ForwardedEnvError(
+                f"env key {key!r} uses a blocked prefix "
+                f"({', '.join(FORWARDED_ENV_BLOCKED_PREFIXES)}) reserved for provider env"
+            )
+        if len(value.encode("utf-8")) >= FORWARDED_ENV_MAX_VALUE_BYTES:
+            raise ForwardedEnvError(
+                f"env value for {key!r} exceeds {FORWARDED_ENV_MAX_VALUE_BYTES} bytes "
+                "(tmux argv limit, PR #246)"
+            )
+        validated[key] = value
+    return validated

--- a/test/cli/commands/test_launch.py
+++ b/test/cli/commands/test_launch.py
@@ -877,6 +877,27 @@ class TestParseEnvPairs:
     def test_value_under_cap_accepted(self):
         assert _parse_env_pairs(["SMALL=" + ("x" * 2047)]) == {"SMALL": "x" * 2047}
 
+    def test_nul_byte_value_rejected(self):
+        # Shared-validator rule now protects --env too (no drift): a NUL value
+        # is rejected at the CLI boundary as a --env error.
+        import click as _click
+
+        with pytest.raises(_click.ClickException, match="NUL byte"):
+            _parse_env_pairs(["TOKEN=bad\x00value"])
+
+    def test_non_utf8_value_rejected(self):
+        import click as _click
+
+        with pytest.raises(_click.ClickException, match="not valid UTF-8"):
+            _parse_env_pairs(["X=\ud800"])
+
+    def test_too_many_entries_rejected(self):
+        import click as _click
+
+        pairs = [f"K{i}=x" for i in range(257)]
+        with pytest.raises(_click.ClickException, match="exceeds the limit"):
+            _parse_env_pairs(pairs)
+
 
 def test_launch_forwards_env_in_json_body_not_url():
     """``--env`` values travel in the request body so secrets do not leak

--- a/test/ops_mcp_server/test_server.py
+++ b/test/ops_mcp_server/test_server.py
@@ -457,6 +457,44 @@ class TestSessionLifecycleTools:
         assert result.terminal_id is None
         mock_request.assert_not_called()
 
+    async def test_launch_session_rejects_non_utf8_env_without_crashing(self) -> None:
+        """A lone surrogate is a valid JSON/FastMCP str but is not UTF-8
+        encodable. It must return success=False (not raise a ToolError wrapping
+        UnicodeEncodeError) and make no HTTP request. Regression for the P2
+        review finding on PR #729."""
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+        ) as mock_request:
+            result = await launch_session(
+                agent_profile="developer",
+                session_name="bad-utf8",
+                env_vars={"X": "\ud800"},  # lone surrogate, not UTF-8 encodable
+            )
+
+        assert result.success is False
+        assert "not valid UTF-8" in result.message
+        assert result.terminal_id is None
+        mock_request.assert_not_called()
+
+    async def test_launch_session_rejects_nul_byte_env_without_crashing(self) -> None:
+        """A NUL byte in a value passes the length check but breaks Popen and
+        leaks the argv into logs. It must return success=False before any HTTP
+        request. Regression for the P1 review finding on PR #729."""
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+        ) as mock_request:
+            result = await launch_session(
+                agent_profile="developer",
+                session_name="bad-nul",
+                env_vars={"TOKEN": "secret\x00value"},
+            )
+
+        assert result.success is False
+        assert "NUL byte" in result.message
+        assert "secret" not in result.message  # value must not leak
+        assert result.terminal_id is None
+        mock_request.assert_not_called()
+
     async def test_launch_session_returns_invalid_model_error(self) -> None:
         """Request-boundary model errors are returned instead of ignored."""
         with patch(

--- a/test/ops_mcp_server/test_server.py
+++ b/test/ops_mcp_server/test_server.py
@@ -385,6 +385,78 @@ class TestSessionLifecycleTools:
         assert initial_message not in request_url
         assert initial_message not in str(request_params)
 
+    async def test_launch_session_forwards_env_vars(self) -> None:
+        """Forwarded env vars ride the JSON body (never the URL/params), the
+        same wire shape as ``cao launch --env``."""
+        env_vars = {"DEV_ACCOUNT": "123456789012", "BASE_URL": "http://localhost:8080"}
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(json_data={"id": "term-env"}),
+        ) as mock_request:
+            result = await launch_session(
+                agent_profile="developer",
+                session_name="env-session",
+                env_vars=env_vars,
+            )
+
+        assert result == LaunchResult(
+            success=True,
+            message="Session 'env-session' launched successfully",
+            session_name="env-session",
+            terminal_id="term-env",
+        )
+        mock_request.assert_called_once_with(
+            "post",
+            "http://127.0.0.1:9889/sessions",
+            params={
+                "agent_profile": "developer",
+                "session_name": "env-session",
+            },
+            json={"env_vars": env_vars},
+        )
+        # A forwarded value must not leak into the URL or query params.
+        request_url = mock_request.call_args.args[1]
+        request_params = mock_request.call_args.kwargs["params"]
+        assert "env_vars" not in request_params
+        assert "123456789012" not in request_url
+        assert "123456789012" not in str(request_params)
+
+    async def test_launch_session_forwards_env_vars_with_initial_message(self) -> None:
+        """env_vars and initial_message coexist in the JSON body."""
+        env_vars = {"REGION": "us-west-2"}
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(json_data={"id": "term-both"}),
+        ) as mock_request:
+            await launch_session(
+                agent_profile="developer",
+                session_name="both-session",
+                initial_message="do the thing",
+                env_vars=env_vars,
+            )
+
+        assert mock_request.call_args.kwargs["json"] == {
+            "initial_message": "do the thing",
+            "env_vars": env_vars,
+        }
+
+    async def test_launch_session_rejects_invalid_env_before_api_call(self) -> None:
+        """A forwarded env var breaking the forwarding rules fails at the MCP
+        boundary (mirroring ``cao launch --env``) with no HTTP request made."""
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+        ) as mock_request:
+            result = await launch_session(
+                agent_profile="developer",
+                session_name="bad-env",
+                env_vars={"CLAUDE_SESSION_ID": "abc"},  # blocked provider prefix
+            )
+
+        assert result.success is False
+        assert "blocked prefix" in result.message
+        assert result.terminal_id is None
+        mock_request.assert_not_called()
+
     async def test_launch_session_returns_invalid_model_error(self) -> None:
         """Request-boundary model errors are returned instead of ignored."""
         with patch(

--- a/test/utils/test_forwarded_env.py
+++ b/test/utils/test_forwarded_env.py
@@ -3,6 +3,9 @@
 import pytest
 
 from cli_agent_orchestrator.utils.forwarded_env import (
+    FORWARDED_ENV_MAX_ENTRIES,
+    FORWARDED_ENV_MAX_KEY_BYTES,
+    FORWARDED_ENV_MAX_TOTAL_BYTES,
     FORWARDED_ENV_MAX_VALUE_BYTES,
     ForwardedEnvError,
     validate_forwarded_env,
@@ -65,3 +68,102 @@ def test_error_message_never_echoes_value():
         # Blocked prefix triggers before any value check; value must not appear.
         validate_forwarded_env({"CLAUDE_LEAK": secret})
     assert secret not in str(excinfo.value)
+
+
+def test_nul_byte_in_value_rejected():
+    """A NUL byte passes the length check but breaks Popen ("embedded null
+    byte") and leaks the argv into logs -- reject it up front (P1)."""
+    with pytest.raises(ForwardedEnvError, match="NUL byte"):
+        validate_forwarded_env({"TOKEN": "bad\x00value"})
+
+
+def test_nul_byte_error_never_echoes_value():
+    """The NUL-byte rejection must not leak the secret value it rejected."""
+    secret = "TOP-SECRET-729"
+    with pytest.raises(ForwardedEnvError) as excinfo:
+        validate_forwarded_env({"TOKEN": f"{secret}\x00tail"})
+    assert secret not in str(excinfo.value)
+
+
+def test_nul_in_one_var_does_not_leak_a_separate_secret():
+    """haofeif's exact repro: {"TOKEN": "TOP-SECRET-729", "BROKEN": "bad\\0value"}.
+
+    A NUL in one var must be rejected before launch, and the *other* var's
+    secret value (the one that would ride the argv into libtmux's error log)
+    must not appear in the raised error.
+    """
+    with pytest.raises(ForwardedEnvError) as excinfo:
+        validate_forwarded_env({"TOKEN": "TOP-SECRET-729", "BROKEN": "bad\x00value"})
+    message = str(excinfo.value)
+    assert "NUL byte" in message
+    assert "TOP-SECRET-729" not in message
+
+
+def test_lone_surrogate_value_rejected():
+    """A lone surrogate is a valid str (JSON/FastMCP accept it) but is not
+    UTF-8 encodable; it must become a ForwardedEnvError, not a raw
+    UnicodeEncodeError (P2)."""
+    with pytest.raises(ForwardedEnvError, match="not valid UTF-8"):
+        validate_forwarded_env({"X": "\ud800"})
+
+
+def test_lone_surrogate_error_never_echoes_value():
+    """The non-UTF-8 rejection names the key only, never the value."""
+    with pytest.raises(ForwardedEnvError) as excinfo:
+        validate_forwarded_env({"X": "secret-\ud800-suffix"})
+    assert "\ud800" not in str(excinfo.value)
+
+
+def test_valid_multibyte_utf8_value_allowed():
+    """Brackets the non-UTF-8 rejection: a legitimate multibyte UTF-8 value
+    (accented Latin, CJK, emoji) is valid input and passes unchanged."""
+    value = "cafe\u0301 - \u4f60\u597d - \u2615"
+    assert validate_forwarded_env({"GREETING": value}) == {"GREETING": value}
+
+
+def test_oversized_key_rejected():
+    with pytest.raises(ForwardedEnvError, match="exceeds"):
+        validate_forwarded_env({"K" * (FORWARDED_ENV_MAX_KEY_BYTES + 1): "x"})
+
+
+def test_key_at_cap_allowed():
+    key = "K" * FORWARDED_ENV_MAX_KEY_BYTES
+    assert validate_forwarded_env({key: "x"}) == {key: "x"}
+
+
+def test_too_many_entries_rejected():
+    mapping = {f"K{i}": "x" for i in range(FORWARDED_ENV_MAX_ENTRIES + 1)}
+    with pytest.raises(ForwardedEnvError, match="exceeds the limit"):
+        validate_forwarded_env(mapping)
+
+
+def test_max_entries_allowed():
+    mapping = {f"K{i}": "x" for i in range(FORWARDED_ENV_MAX_ENTRIES)}
+    assert validate_forwarded_env(mapping) == mapping
+
+
+def test_aggregate_argv_budget_rejected():
+    """A set that stays under the per-entry caps can still overflow the argv
+    in aggregate; the total-bytes budget must reject it (P1)."""
+    # Each value is just under the per-value cap, so only the aggregate budget
+    # can catch the set. Enough entries to exceed the total but stay within the
+    # entry-count limit.
+    per_value = FORWARDED_ENV_MAX_VALUE_BYTES - 1
+    n_entries = (FORWARDED_ENV_MAX_TOTAL_BYTES // per_value) + 2
+    assert n_entries <= FORWARDED_ENV_MAX_ENTRIES  # isolate the aggregate rule
+    mapping = {f"K{i}": "x" * per_value for i in range(n_entries)}
+    with pytest.raises(ForwardedEnvError, match="total argv budget"):
+        validate_forwarded_env(mapping)
+
+
+def test_aggregate_argv_budget_just_under_allowed():
+    """Brackets the aggregate rule: a set whose total argv size lands at or
+    just below the budget is accepted. Fixed-width keys (``K0000``..) make the
+    per-entry cost exact: 5 (key) + value_bytes + 3 (``-e`` and ``=``)."""
+    value_bytes = FORWARDED_ENV_MAX_VALUE_BYTES - 9  # each value well under the per-value cap
+    per_entry = 5 + value_bytes + 3
+    n_entries = FORWARDED_ENV_MAX_TOTAL_BYTES // per_entry  # largest set that still fits
+    assert n_entries <= FORWARDED_ENV_MAX_ENTRIES  # aggregate, not entry-count, is the binding rule
+    mapping = {f"K{i:04d}": "x" * value_bytes for i in range(n_entries)}
+    assert n_entries * per_entry <= FORWARDED_ENV_MAX_TOTAL_BYTES  # confirm we are under budget
+    assert validate_forwarded_env(mapping) == mapping

--- a/test/utils/test_forwarded_env.py
+++ b/test/utils/test_forwarded_env.py
@@ -1,0 +1,67 @@
+"""Tests for the shared forwarded-env validator (issue #248)."""
+
+import pytest
+
+from cli_agent_orchestrator.utils.forwarded_env import (
+    FORWARDED_ENV_MAX_VALUE_BYTES,
+    ForwardedEnvError,
+    validate_forwarded_env,
+)
+
+
+def test_valid_mapping_returned_unchanged():
+    """A well-formed mapping is returned as a plain dict, values intact."""
+    result = validate_forwarded_env({"FOO": "bar", "AWS_REGION": "us-west-2"})
+    assert result == {"FOO": "bar", "AWS_REGION": "us-west-2"}
+
+
+def test_empty_value_is_allowed():
+    assert validate_forwarded_env({"EMPTY": ""}) == {"EMPTY": ""}
+
+
+def test_value_with_url_query_is_preserved():
+    """Values are opaque; '=' and '&' in a value are not re-parsed."""
+    assert validate_forwarded_env({"URL": "https://x?a=1&b=2"}) == {"URL": "https://x?a=1&b=2"}
+
+
+@pytest.mark.parametrize("bad_key", ["1FOO", "FOO-BAR", "FOO BAR", "föö", ""])
+def test_invalid_key_rejected(bad_key):
+    with pytest.raises(ForwardedEnvError, match="must match"):
+        validate_forwarded_env({bad_key: "x"})
+
+
+@pytest.mark.parametrize("blocked_key", ["CLAUDE_SECRET", "CODEX_TOKEN", "__MISE_X"])
+def test_blocked_prefix_rejected(blocked_key):
+    with pytest.raises(ForwardedEnvError, match="blocked prefix"):
+        validate_forwarded_env({blocked_key: "x"})
+
+
+@pytest.mark.parametrize(
+    "allowed_key",
+    [
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+    ],
+)
+def test_allowlisted_claude_flags_permitted(allowed_key):
+    """The documented Claude Code auth flags are exempt from the block."""
+    assert validate_forwarded_env({allowed_key: "1"}) == {allowed_key: "1"}
+
+
+def test_oversized_value_rejected():
+    with pytest.raises(ForwardedEnvError, match="exceeds"):
+        validate_forwarded_env({"BIG": "x" * FORWARDED_ENV_MAX_VALUE_BYTES})
+
+
+def test_value_just_under_cap_allowed():
+    value = "x" * (FORWARDED_ENV_MAX_VALUE_BYTES - 1)
+    assert validate_forwarded_env({"SMALL": value}) == {"SMALL": value}
+
+
+def test_error_message_never_echoes_value():
+    """A rejected value must not leak into the error string (secret safety)."""
+    secret = "super-secret-token-value"
+    with pytest.raises(ForwardedEnvError) as excinfo:
+        # Blocked prefix triggers before any value check; value must not appear.
+        validate_forwarded_env({"CLAUDE_LEAK": secret})
+    assert secret not in str(excinfo.value)


### PR DESCRIPTION
The ops-MCP launch_session tool could not forward session environment variables, so an agent driving CAO through cao-ops had to drop to the raw HTTP API to do what `cao launch --env` already does. #513 carried model and initial_message through launch_session for parity but left env_vars behind.

Add an optional env_vars mapping to launch_session (and _launch_session_impl), delivered in the POST /sessions JSON body next to initial_message (never the URL, so a forwarded secret stays out of the access log). The server already accepts and applies CreateSessionBody.env_vars via SessionEnvStore, silently dropping entries that break the forwarding rules, so the tool validates at its boundary and returns a failed LaunchResult before any request -- matching how `cao launch --env` fails loudly.

Extract the forwarding constraints (blocked CLAUDE/CODEX_/__MISE_ prefixes with the CLAUDE_CODE_* allowlist, POSIX key shape, 2048-byte value cap) into utils/forwarded_env.py so the CLI and the ops-MCP tool share one validator and cannot drift. cli/commands/launch.py now sources the constants from there; its _parse_env_pairs messages are unchanged.

Relates to #248, #259 (env forwarding); #513 (launch_session parity).

*Issue #, if available:*

*Description of changes:*
## Summary

Adds an optional `env_vars` mapping to the ops-MCP `launch_session` tool so an
external agent driving CAO through `cao-ops` can forward session environment
variables at launch -- the same capability `cao launch --env` already gives the
CLI. The forwarding rules are extracted into one shared validator so the CLI and
the ops-MCP tool cannot drift.

## Motivation

CAO already forwards session env vars end to end: `cao launch --env` validates at
the CLI boundary and POSTs `{"env_vars": {...}}` to `/sessions`, and the server
(`CreateSessionBody.env_vars` -> `SessionEnvStore._merge_extra_env`) applies them
to the supervisor terminal and every worker spawned in the session (#248, #259).
PR #513 carried `model` and `initial_message` through `launch_session` for
parity with the CLI, but `env_vars` was left out -- so an agent using the
`cao-ops` control plane (the agentic launcher path) could not forward env vars
without dropping to the raw HTTP API.

The server accepts `env_vars` in the `/sessions` body but has no API-boundary
validator for it; `SessionEnvStore._merge_extra_env` silently *drops* an entry
that breaks the forwarding rules. That is exactly why the CLI validates at its
own boundary and errors loudly. The ops-MCP tool needs to do the same, or a
forwarded var would vanish with no signal.

## What changed

- **`utils/forwarded_env.py` (new)** -- canonical forwarding constraints
  (blocked `CLAUDE` / `CODEX_` / `__MISE_` prefixes with the six documented
  `CLAUDE_CODE_USE_*` / `CLAUDE_CODE_SKIP_*` auth-flag exceptions, POSIX key
  shape, 2048-byte value cap), plus `ForwardedEnvError` and
  `validate_forwarded_env(mapping)`. Error messages name the offending key and
  rule but never echo the value, so a secret passed as a value cannot leak into
  an error string.
- **`ops_mcp_server/server.py`** -- `launch_session` and `_launch_session_impl`
  gain an optional `env_vars` param. It is validated at the tool boundary before
  any HTTP request (a violation returns `LaunchResult(success=False, ...)` with
  no request made), then delivered in the `POST /sessions` JSON body alongside
  `initial_message` (in the body, never the URL, so a forwarded secret stays out
  of the server access log).
- **`cli/commands/launch.py`** -- sources the three forwarding constants from
  `utils/forwarded_env` instead of defining its own copies, so the CLI and the
  ops-MCP tool share one definition. `_parse_env_pairs` and its exact
  `--env ...` error messages are unchanged.
- **`docs/tmux.md`** -- new "From the ops-MCP `launch_session` tool" subsection
  documenting the parity.

## Consistency with `cao launch --env`

Same rules (blocked prefixes + allowlist, POSIX keys, 2048-byte cap), same
JSON-body delivery, same server-side enforcement -- and now one shared validator
(`utils/forwarded_env.py`) that both client paths import, so they cannot drift.

## Testing

Unit (`uv run pytest ... --no-cov` -> 108 passed; `black --check`,
`isort --check-only`, `mypy` clean on touched files):

- `test/utils/test_forwarded_env.py` (new) -- valid passthrough, empty value,
  `=`/`&` in a value not re-parsed, invalid POSIX keys, blocked prefixes,
  allowlisted `CLAUDE_CODE_*` flags, oversized value rejected, under-cap allowed,
  and a check that a rejected value never appears in the error message.
- `test/ops_mcp_server/test_server.py` -- three added: env_vars ride the JSON
  body (not the URL/params); env_vars and initial_message compose in the body;
  a blocked-prefix var is rejected at the tool boundary with no HTTP call.
- `test/cli/commands/test_launch.py` -- unchanged and still green, confirming
  the shared-constants refactor did not alter CLI behavior or messages.

End-to-end (a real MCP stdio round-trip through the modified server against a
live `cao-server`, via a throwaway `cao-ops` client):

- schema: `launch_session` exposes `env_vars`.
- validation: a blocked-prefix var returns `success=False` with no cao-server
  call and no session created.
- happy path: forwarded `CAO_E2E_PROBE=hello-123` and `AWS_REGION=us-west-2`
  reached the launched session's tmux environment
  (`tmux show-environment`); the test session was then torn down.

## Non-goals

No server-side change -- `env_vars` is already accepted and applied server-side.
No change to CLI behavior or messages. No new session-creation logic; the
ops-MCP tool remains a thin client of `POST /sessions`.

Relates to #248, #259 (session env forwarding) and #513 (`launch_session`
parity).

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license.

---

## Proposed commit message

feat(ops-mcp): forward env_vars when launching sessions

The ops-MCP launch_session tool could not forward session environment
variables, so an agent driving CAO through cao-ops had to drop to the raw
HTTP API to do what `cao launch --env` already does. #513 carried model
and initial_message through launch_session for parity but left env_vars
behind.

Add an optional env_vars mapping to launch_session (and
_launch_session_impl), delivered in the POST /sessions JSON body next to
initial_message (never the URL, so a forwarded secret stays out of the
access log). The server already accepts and applies CreateSessionBody
.env_vars via SessionEnvStore, silently dropping entries that break the
forwarding rules, so the tool validates at its boundary and returns a
failed LaunchResult before any request -- matching how `cao launch --env`
fails loudly.

Extract the forwarding constraints (blocked CLAUDE/CODEX_/__MISE_ prefixes
with the CLAUDE_CODE_* allowlist, POSIX key shape, 2048-byte value cap)
into utils/forwarded_env.py so the CLI and the ops-MCP tool share one
validator and cannot drift. cli/commands/launch.py now sources the
constants from there; its _parse_env_pairs messages are unchanged.

Relates to #248, #259 (env forwarding); #513 (launch_session parity).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
