### PR TITLE
fix(deps): raise the fast-uri and qs overrides so the Security Scan passes

### DIFF
--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -16332,9 +16332,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -56,6 +56,7 @@
     "js-yaml": "^4.3.1",
     "nanoid": "^3.3.17",
     "postcss": "^8.5.23",
+    "qs": "^6.16.0",
     "serialize-javascript": "^7.0.7",
     "uuid": "^11.1.1"
   }

--- a/examples/aidlc-portfolio/bun.lock
+++ b/examples/aidlc-portfolio/bun.lock
@@ -15,7 +15,7 @@
     },
   },
   "overrides": {
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
   },
   "packages": {
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
@@ -28,7 +28,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/examples/aidlc-portfolio/package.json
+++ b/examples/aidlc-portfolio/package.json
@@ -18,6 +18,6 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "fast-uri": "^3.1.5"
+    "fast-uri": "^3.1.7"
   }
 }

--- a/examples/aidlc-portfolio/skills/aidlc-portfolio/bun.lock
+++ b/examples/aidlc-portfolio/skills/aidlc-portfolio/bun.lock
@@ -11,14 +11,14 @@
     },
   },
   "overrides": {
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
   },
   "packages": {
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/examples/aidlc-portfolio/skills/aidlc-portfolio/package.json
+++ b/examples/aidlc-portfolio/skills/aidlc-portfolio/package.json
@@ -8,6 +8,6 @@
     "yaml": "^2.8.1"
   },
   "overrides": {
-    "fast-uri": "^3.1.5"
+    "fast-uri": "^3.1.7"
   }
 }


### PR DESCRIPTION
Follow-up to @haofeif's ask on #716.

## What is broken

`Security Scan` fails on `main` at `3eafb6d` for two separate reasons. Report Summary from that run (job 100681389159):

```
docusaurus/package-lock.json                               npm     2
examples/aidlc-portfolio/bun.lock                          bun     4
examples/aidlc-portfolio/skills/aidlc-portfolio/bun.lock   bun     4
```

The other seven targets report 0. The four in each bun lock are `fast-uri` advisories against 3.1.5, all HIGH. The two in `docusaurus` are CVE-2026-82417 and CVE-2026-82562, both MEDIUM, both against `qs` 6.15.3 and both fixed in 6.16.0.

The `fast-uri` half is not caused by any recent change, since Trivy re-downloads its database on every run. All 16 Security Scan runs dated 2026-09-02 passed, and the job started failing at 02:57 UTC on 2026-09-03 on PRs touching unrelated areas.

MEDIUM findings fail this gate even though the step declares `severity: CRITICAL,HIGH`, which is the part I originally got wrong. `.github/workflows/ci.yml` lines 680-684 already document the reason. `trivy-action`'s entrypoint unsets `TRIVY_SEVERITY` when the format is `sarif`, so the gating scan runs at all severities. The failing run on this branch confirms it. The step logged `INPUT_SEVERITY: CRITICAL,HIGH`, the only findings anywhere in the repository were the two MEDIUM `qs` ones, and it still exited 1.

That also explains the bad claim in the first version of this description. The scan I ran to support it passed `--severity CRITICAL,HIGH`, so `docusaurus` reported 0 and the table looked clean while the real gate was still red. Every scan quoted below is unfiltered.

## Why it is broken

Both `aidlc-portfolio` projects hold `fast-uri` at 3.1.5 through the `package.json` override added in #552 for CVE-2026-18446. `ajv` asks for `fast-uri: ^3.0.1`, so the override decides the resolved version and nothing else can move it.

`docusaurus` is the same situation. `express` and `body-parser` both request `qs: ~6.15.1`, a range that cannot reach 6.16.0, so the `overrides` block is the only lever there too.

#726 cleared `fast-uri` from `docusaurus/package-lock.json`, but that update is scoped to `/docusaurus` and does not touch the two bun locks, so the gate stayed red after it merged.

## What this does

Raises the existing `fast-uri` override from `^3.1.5` to `^3.1.7` in both `aidlc-portfolio` projects and regenerates the locks. Same four files and the same mechanism as #552.

Adds `"qs": "^6.16.0"` to the `docusaurus` overrides and moves the lock entry to 6.16.0. The lock diff is the three lines #726 changed for `fast-uri`, since 6.16.0 declares the same dependencies, engines, license and funding as 6.15.3. The lockfile records no `overrides` object of its own, so nothing else needs to move.

Staying inside 3.x for `fast-uri` is deliberate, since `ajv`'s `^3.0.1` range would not accept 4.x. 3.1.6 is the first fixed release in that line and 3.1.7 is what #726 took.

I did not change the SARIF severity threshold. `limit-severities-for-sarif` is an input on the pinned v0.69.3 and would make the gate match the `CRITICAL,HIGH` the step already declares, but it would do that by letting these two MEDIUM advisories through, and narrowing a security gate inside a dependency bump is not a call I wanted to make on your behalf. Happy to send it as its own PR if you would rather the threshold match the stated intent.

## How it was verified

### CI has already run this combination

Branch `feat/644-obsidian-vault-knowledge-source` carries `fast-uri` 3.1.7 in both bun locks and `qs` 6.16.0 in `docusaurus`, the same three resolved versions this branch now has. Its `Security Scan` passed on 2026-09-03 at 11:58 UTC and again on 2026-09-04 at 04:54 and 04:57, and those are the only three passing runs since the job started failing. Everything else in that window is red.

### aidlc-portfolio

Lockfiles regenerated using bun 1.3.10, the version `AI-DLC Portfolio Example` pins at `ci.yml:103`, so the committed locks are what that job's `--frozen-lockfile` expects. The job's own commands, re-run on the current head:

```
$ bun --version
1.3.10

$ bun install --frozen-lockfile
Checked 11 installs across 12 packages (no changes) [49.00ms]
INSTALL_EXIT=0

$ bun run check
 29 pass
 0 fail
 134 expect() calls
Ran 29 tests across 4 files. [18.87s]
CHECK_EXIT=0

$ grep '"version"' node_modules/fast-uri/package.json | head -1
  "version": "3.1.7",
```

29 pass / 0 fail is the same result as on unmodified `main`, which was run first as a baseline.

### docusaurus

This PR now touches `docusaurus/**`, which also triggers the `Docs site` workflow. All three of its commands were run on this branch:

```
$ npm ci
added 1344 packages in 24s        # exit 0

$ npm run typecheck
> tsc                              # exit 0

$ npm run build
[SUCCESS] Generated static files in "build".   # exit 0
```

`npm ci` passing is itself the check that the edited lock and the new override agree, since it refuses to install when they do not.

The resolved version, read from disk rather than from the manifest range, and checked from the requiring packages so the override is proven to reach them instead of leaving a nested copy behind:

```
$ node -e "..."
express v4.22.2      -> qs 6.16.0 @ node_modules/qs/package.json
body-parser v1.20.6  -> qs 6.16.0 @ node_modules/qs/package.json
```

`qs` 6.16.0 parses and stringifies correctly under the option shapes `body-parser` passes:

```
parse('a[b][c]=1&d[]=2&d[]=3', {allowPrototypes:true, depth:32, parameterLimit:1000, arrayLimit:20})
  -> {"a":{"b":{"c":"1"}},"d":["2","3"]}
stringify({a:{b:'c'}, d:[1,2]}, {arrayFormat:'indices'})
  -> a%5Bb%5D=c&d%5B0%5D=1&d%5B1%5D=2
```

The integrity hash was checked against the registry rather than taken on trust. `registry.npmjs.org/qs/6.16.0` reports `sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==`, which is what is committed.

### The gate itself

Repository-wide scan on this branch with no severity filter, matching what the SARIF step actually does:

```
 cao_mcp_apps/package-lock.json                             npm     0
 docusaurus/package-lock.json                               npm     0
 examples/ag-ui/ag-ui-stock-client-live/package-lock.json   npm     0
 examples/aidlc-portfolio/bun.lock                          bun     0
 examples/aidlc-portfolio/skills/aidlc-portfolio/bun.lock   bun     0
 examples/fleet/panel/uv.lock                               uv      0
 tui/Cargo.lock                                            cargo    0
 uv.lock                                                    uv      0
 web/package-lock.json                                      npm     0

TRIVY_EXIT=0
```

That is nine targets. CI resolves ten, the tenth being the `requirements.txt` the job generates with `uv export`, which reported 0 in the failing run on this branch and is unaffected by these changes.

## Not verified

My local Trivy is 0.74.0 against the action's pinned v0.69.3, and I ran node 24 locally where `Docs site` uses node 22. The advisory database is downloaded fresh either way, and my local scan reproduced the failing CI run finding for finding, so I do not think either gap matters. The passing runs on `feat/644` are the part that does not depend on my local versions at all.
