### PR TITLE
fix(codex): ignore account notices at startup

### DIFF
--- a/src/cli_agent_orchestrator/models/terminal.py
+++ b/src/cli_agent_orchestrator/models/terminal.py
@@ -57,6 +57,24 @@ class TerminalInputBlockedError(Exception):
     """
 
 
+class TerminalCaptureUnavailableError(Exception):
+    """Raised when a provider cannot read the terminal pane at dispatch time.
+
+    The pre-send transcript capture that establishes per-dispatch ownership
+    (see CodexProvider.mark_input_received) reads the pane before any key is
+    typed. A pane read that keeps failing is transient infrastructure, not a
+    dead terminal: nothing has been sent, so the dispatch can be retried
+    wholesale. Defined here for the same reason as
+    TerminalInputBlockedError above — providers raise it from
+    mark_input_received() while services (inbox delivery, deferred init)
+    import the concrete provider modules, so a provider importing back from
+    terminal_service would be a circular import. Consumers must treat it as
+    retryable: inbox delivery resets the message to PENDING for the
+    reconcile sweep, and deferred initialization retries the delivery and
+    leaves the initialized worker alive instead of tearing it down.
+    """
+
+
 class TerminalLimitError(Exception):
     """Raised when creating a terminal would exceed this node's tracked-terminal cap.
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -126,7 +126,6 @@ UPDATE_DIALOG_PATTERN = r"Update available!\s+\S+\s+->\s+\S+"
 UPDATE_DIALOG_MENU_PATTERN = r"Skip until next version"
 UPDATE_DIALOG_FOOTER = TRUST_PROMPT_FOOTER
 STARTUP_PROMPT_BOTTOM_LINES = 15
-STARTUP_ACTIVITY_PATTERN = r"^\s*•[^\S\n]+\S"
 # Codex's runtime approval prompt as actually rendered by codex-cli 0.147.0,
 # verified against a live tmux capture (test/providers/fixtures/
 # codex_approval_modal_raw.txt):
@@ -678,7 +677,7 @@ def _has_startup_idle_composer(clean_output: str) -> bool:
     tail_lines = all_lines[-STARTUP_PROMPT_BOTTOM_LINES:]
     tail_output = "\n".join(tail_lines)
 
-    if re.search(STARTUP_ACTIVITY_PATTERN, tail_output, re.MULTILINE):
+    if re.search(TUI_PROGRESS_PATTERN, tail_output, re.MULTILINE):
         return False
     if re.search(WAITING_PROMPT_PATTERN, tail_output, re.IGNORECASE | re.MULTILINE):
         return False
@@ -1411,12 +1410,15 @@ class CodexProvider(BaseProvider):
             # - Fresh init: no assistant content either → IDLE.
             # - Long-running response: the › user marker has been evicted from
             #   the rolling state buffer by the time the response settles, but an
-            #   assistant bullet is still visible. Without this branch we'd
-            #   return IDLE forever and ``wait_for_status(completed)`` in the
-            #   e2e tests would time out.
+            #   assistant bullet is still visible. This is only a completion
+            #   after CAO has actually dispatched a task; startup notices use the
+            #   same bullet glyph.
             # Search above the TUI footer cutoff so the › suggestion-hint and
             # status-bar lines aren't confused with a model reply.
-            if _find_assistant_marker(clean_output[:cutoff_pos]) is not None:
+            if (
+                self._task_dispatched
+                and _find_assistant_marker(clean_output[:cutoff_pos]) is not None
+            ):
                 return TerminalStatus.COMPLETED
             return TerminalStatus.IDLE
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -143,8 +143,10 @@ STARTUP_PARTIAL_ACTIVITY_PATTERN = r"^[^\S\n]*•[^\S\n]*\S[^\n]*$"
 # activity repaints carry no terminal punctuation ("• Working", "• Starting
 # MCP servers (2/3): cao-mcp-server"): the TUI redraws the whole cell once the
 # timer ticks, and a fragment with closing punctuation would be a completed
-# line, not a partial frame.
-STARTUP_STATIC_BULLET_PATTERN = r"^[^\S\n]*•[^\S\n]+\S.*[.!?…](?:\s*)$"
+# line, not a partial frame. A trailing ellipsis is NOT prose punctuation —
+# a live frame can pause on it mid-animation ("• Working…") — so it must
+# wait for the stabilization pass like any other partial frame.
+STARTUP_STATIC_BULLET_PATTERN = r"^[^\S\n]*•[^\S\n]+\S.*[.!?](?:\s*)$"
 # Codex's runtime approval prompt as actually rendered by codex-cli 0.147.0,
 # verified against a live tmux capture (test/providers/fixtures/
 # codex_approval_modal_raw.txt):
@@ -807,14 +809,35 @@ def _transcript_marker_cells(clean_output: str, cutoff_pos: Optional[int] = None
     composer line (an empty ``›``, the placeholder hint, or a draft typed
     into it) sits inside the footer region the parser already excludes, so
     a typed-but-unsubmitted draft cannot change the cells.
+
+    The same pane reaches this parser through differently produced text:
+    the pre-send baseline from a tmux capture-pane render (literal column
+    spacing, lines wrapped at the pane width) and status observations from
+    the raw stream, where cursor-forward runs collapse to single spaces and
+    lines never wrap. Cells are therefore canonicalized — horizontal
+    whitespace runs collapse to one space — and compared with truncation
+    tolerance (see ``_is_suffix``), so every view of an unchanged pane
+    parses to the same cells (issue #739 review).
+
+    When no TUI footer is detected the cutoff keeps the whole text, so a
+    partial repaint that has not drawn the status bar yet would leave the
+    composer hint as the bottom-most cell-looking line. A ``›``/``»`` line
+    that is the LAST content line of the pane is the composer in that
+    frame (a submitted user cell always has the composer or a response
+    below it), so it is dropped rather than read as a new cell that would
+    permanently disarm the ownership gate.
     """
-    if cutoff_pos is not None:
-        clean_output = clean_output[:cutoff_pos]
+    if cutoff_pos is None:
+        cutoff_pos = len(clean_output)
+    footer_detected = cutoff_pos < len(clean_output)
+    content_lines = [line for line in clean_output[:cutoff_pos].splitlines() if line.strip()]
+    if not footer_detected and content_lines and _USER_CELL_RE.match(content_lines[-1]):
+        content_lines.pop()
     cells = []
-    for line in clean_output.splitlines():
-        line = line.rstrip()
-        if _ASSISTANT_BULLET_RE.match(line) or _USER_CELL_RE.match(line):
-            cells.append(line)
+    for line in content_lines:
+        canonical = " ".join(line.split())
+        if _ASSISTANT_BULLET_RE.match(canonical) or _USER_CELL_RE.match(canonical):
+            cells.append(canonical)
     return cells
 
 
@@ -825,10 +848,20 @@ def _is_suffix(suffix: list, sequence: list) -> bool:
     cells than the pre-send baseline — genuine appended content — and is not
     a suffix. A zero-length observation is a tail of anything (a pane whose
     transcript cells scrolled out of this view is still unchanged content).
+    Cells compare equal when one is a prefix of the other: a capture-pane
+    render wraps a long cell at the pane width while the raw-stream view of
+    the same cell is unwrapped, so the wrapped fragment is a truncated view
+    of the same line, not new content. Codex never edits a printed line, so
+    a genuinely new cell cannot be a prefix of a retained one.
     """
     if len(suffix) > len(sequence):
         return False
-    return sequence[len(sequence) - len(suffix) :] == suffix
+    for observed, baseline in zip(suffix, sequence[len(sequence) - len(suffix) :], strict=True):
+        if not (
+            observed == baseline or observed.startswith(baseline) or baseline.startswith(observed)
+        ):
+            return False
+    return True
 
 
 def _find_assistant_marker(text: str) -> Optional[re.Match[str]]:
@@ -1252,6 +1285,14 @@ class CodexProvider(BaseProvider):
 
             clean_output = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", output))
 
+            # Every observed poll updates the tail signature — including
+            # dialog frames — so the stabilization comparison below is always
+            # between two immediately adjacent observations, never a stale
+            # fragment from several polls back.
+            tail_signature = "\n".join(clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+            adjacent_repeat = tail_signature == previous_tail_signature
+            previous_tail_signature = tail_signature
+
             if not trust_dismissed and re.search(TRUST_PROMPT_PATTERN, clean_output):
                 from cli_agent_orchestrator.services.status_monitor import status_monitor
 
@@ -1300,12 +1341,10 @@ class CodexProvider(BaseProvider):
             # still moving: once consecutive polls observe the identical tail,
             # the frame has settled and the pane is ready (see the signature
             # comment above).
-            tail_signature = "\n".join(clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
             has_idle = _has_startup_idle_composer(
                 clean_output,
-                allow_partial_activity_cell=(tail_signature == previous_tail_signature),
+                allow_partial_activity_cell=adjacent_repeat,
             )
-            previous_tail_signature = tail_signature
             has_dialog = (
                 re.search(TRUST_PROMPT_PATTERN, bottom_region)
                 or (
@@ -1402,10 +1441,11 @@ class CodexProvider(BaseProvider):
         The rolling byte buffer is cleared by the caller, but the pyte screen
         and pane history are not: a startup notice or a previous turn's
         completed-response bullet survives the dispatch boundary. Snapshot
-        the pane's marker cells from BOTH history bounds (viewport plus
-        scrollback) so the baseline contains every cell any observation view
-        can show; the COMPLETED decision points in ``get_status`` refuse to
-        complete while the observed cells are a tail of this baseline.
+        the pane's marker cells from the scrollback capture, falling back to
+        the visible-only viewport when the scrollback shows no cells, so the
+        baseline contains every retained cell. The COMPLETED decision points
+        in ``get_status`` refuse to complete while the observed cells are a
+        tail of this baseline.
 
         Capture happens here, strictly before send_keys: a baseline derived
         from a post-send observation would arm on a genuine fast
@@ -1434,7 +1474,10 @@ class CodexProvider(BaseProvider):
             visible = ""
 
         def _cells(raw: str) -> list:
-            clean = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", raw))
+            # Same single cleaner and same footer-cutoff rule every status
+            # observation uses, so the baseline and the views reduce the
+            # same pane to the same cells (issue #739 review).
+            clean = strip_terminal_escapes(raw)
             return _transcript_marker_cells(clean, _footer_cutoff_position(clean))
 
         cells = _cells(history)
@@ -1460,6 +1503,12 @@ class CodexProvider(BaseProvider):
         observation whose cells are NOT a tail of the baseline — genuine
         current-turn content has rendered, and the turn's own evidence
         decides from there on.
+
+        Residual gap, accepted: a genuinely new cell that byte-equals (or is
+        a truncated view of) a retained baseline cell still reads unchanged,
+        so a terse reply identical to a prior turn's last cell stays IDLE
+        until the next differing frame. Content identity cannot distinguish
+        that case; it only ever delays completion, never falsely completes.
         """
         if not self._dispatch_pending:
             return True

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1,6 +1,7 @@
 """Codex CLI provider implementation."""
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
@@ -126,6 +127,25 @@ UPDATE_DIALOG_PATTERN = r"Update available!\s+\S+\s+->\s+\S+"
 UPDATE_DIALOG_MENU_PATTERN = r"Skip until next version"
 UPDATE_DIALOG_FOOTER = TRUST_PROMPT_FOOTER
 STARTUP_PROMPT_BOTTOM_LINES = 15
+# Readiness activity is decided from the bottom-most TUI cell above the idle
+# composer, not from any match in the whole bottom region: with --no-alt-screen
+# a spinner or completed-turn bullet from an earlier turn can survive higher in
+# scrollback while the current composer renders below it (issue #739 review).
+# A live activity cell is the timed spinner ("• Working (2s • esc to
+# interrupt)"), which repaints the elapsed value every second. Before the first
+# timer tick, and on chunked redraws, that same cell renders as a bare
+# "• Working" fragment — evidence the TUI is still painting, so it vetoes
+# readiness too. A bullet that reads as a printed line (sentence punctuation,
+# or placeholder copy) is static text like an account notice, not activity.
+STARTUP_LIVE_ACTIVITY_PATTERN = TUI_PROGRESS_PATTERN
+STARTUP_PARTIAL_ACTIVITY_PATTERN = r"^[^\S\n]*•[^\S\n]*\S[^\n]*$"
+# Bullets that end like printed prose — notices, tips, and finished-turn
+# summaries — rather than a mid-paint frame of a live cell. Codex's partial
+# activity repaints carry no terminal punctuation ("• Working", "• Starting
+# MCP servers (2/3): cao-mcp-server"): the TUI redraws the whole cell once the
+# timer ticks, and a fragment with closing punctuation would be a completed
+# line, not a partial frame.
+STARTUP_STATIC_BULLET_PATTERN = r"^[^\S\n]*•[^\S\n]+\S.*[.!?…](?:\s*)$"
 # Codex's runtime approval prompt as actually rendered by codex-cli 0.147.0,
 # verified against a live tmux capture (test/providers/fixtures/
 # codex_approval_modal_raw.txt):
@@ -671,30 +691,104 @@ def _has_approval_prompt_in_bottom(clean_output: str) -> bool:
     return options >= APPROVAL_MENU_MIN_OPTIONS
 
 
-def _has_startup_idle_composer(clean_output: str) -> bool:
+def _classify_startup_activity_cell(line: str) -> str:
+    """Classify the bottom-most TUI cell above the composer, for readiness.
+
+    Returns ``"live"``, ``"partial"``, or ``"static"``. A timed spinner is
+    live activity. An unterminated bullet may be a mid-paint frame of one
+    (``• Working`` before the first timer tick), so it must settle before the
+    pane is called ready. A sentence-terminated bullet, or any line that is
+    not a bullet at all, is printed text — an account notice, a tip, a prior
+    turn — and never activity.
+    """
+    if re.search(STARTUP_LIVE_ACTIVITY_PATTERN, line):
+        return "live"
+    if re.match(STARTUP_PARTIAL_ACTIVITY_PATTERN, line) and not re.search(
+        STARTUP_STATIC_BULLET_PATTERN, line
+    ):
+        return "partial"
+    return "static"
+
+
+def _startup_cell_above_is_static(
+    tail_lines: list, anchor_index: int, allow_partial_cell: bool = False
+) -> bool:
+    """Decide readiness from the cell directly above the composer anchor.
+
+    Cells higher in the bottom region are history: with --no-alt-screen a
+    previous turn's spinner or completed-response bullet can survive in
+    scrollback while a newer composer renders below it, and a region-wide
+    veto let that stale spinner block a ready pane (issue #739 review). Only
+    the cell the current composer is actually repainting — the nearest
+    content above it — decides liveness. An unclassifiable bullet fragment
+    keeps the pane not-ready until a later poll shows the frame settled
+    (``allow_partial_cell``); that stability wait is owned by the caller's
+    poll loop, which can compare consecutive observations.
+    """
+    for index in range(anchor_index - 1, -1, -1):
+        line = tail_lines[index].rstrip()
+        if not line:
+            continue
+        kind = _classify_startup_activity_cell(line)
+        if kind == "partial":
+            return allow_partial_cell
+        return kind == "static"
+    return True
+
+
+def _has_startup_idle_composer(
+    clean_output: str, allow_partial_activity_cell: bool = False
+) -> bool:
     """Return True when the bottom of the pane shows Codex's idle composer."""
     all_lines = clean_output.splitlines()
     tail_lines = all_lines[-STARTUP_PROMPT_BOTTOM_LINES:]
     tail_output = "\n".join(tail_lines)
 
-    if re.search(TUI_PROGRESS_PATTERN, tail_output, re.MULTILINE):
-        return False
     if re.search(WAITING_PROMPT_PATTERN, tail_output, re.IGNORECASE | re.MULTILINE):
         return False
     if re.search(STARTUP_BLOCKING_INPUT_PATTERN, tail_output, re.IGNORECASE):
         return False
 
     legacy_tail = all_lines[-IDLE_PROMPT_TAIL_LINES:]
-    if any(re.match(IDLE_PROMPT_STRICT_PATTERN, line) for line in legacy_tail):
-        return True
+    for legacy_index, line in enumerate(legacy_tail):
+        if re.match(IDLE_PROMPT_STRICT_PATTERN, line):
+            anchor = len(tail_lines) - len(legacy_tail) + legacy_index
+            return _startup_cell_above_is_static(tail_lines, anchor, allow_partial_activity_cell)
 
     # Codex 0.145 renders placeholder text inside the idle composer instead of
     # an empty prompt. Match only known placeholder copy and require its status
     # footer below it so typed drafts and ordinary output are not treated as ready.
     for index in range(len(tail_lines) - 1, -1, -1):
         if re.match(STARTUP_IDLE_PLACEHOLDER_PATTERN, tail_lines[index]):
-            return any(re.search(TUI_FOOTER_PATTERN, line) for line in tail_lines[index + 1 :])
+            if not any(re.search(TUI_FOOTER_PATTERN, line) for line in tail_lines[index + 1 :]):
+                return False
+            return _startup_cell_above_is_static(tail_lines, index, allow_partial_activity_cell)
     return False
+
+
+# Transcript/notice content starts with one of these glyphs (assistant bullets,
+# user markers, composer hints). Hashing only these lines makes the dispatch
+# baseline source-independent: pane history and the pyte-composited viewport
+# of an unchanged pane reduce to the same rows.
+_CONTENT_GLYPH_RE = re.compile(r"^[^\S\n]*[•›»]")
+
+
+def _normalized_screen_hash(clean_output: str) -> str:
+    """Fingerprint the pane's turn-bearing content, ignoring volatile chrome.
+
+    Codex repaints the status bar and footer hint on a timer, so a raw tail
+    hash differs between two observations of an unchanged pane and the
+    per-dispatch staleness guard would never fire. Keep only transcript
+    lines (bullets, user markers, composer hints), normalized of trailing
+    padding, and hash the last of them: retained notices, prior responses,
+    and the idle composer survive this, while repaint-only chrome does not
+    change it. Restricting to glyph lines also keeps the fingerprint stable
+    across observation sources — pane history and the pyte viewport of the
+    same unchanged pane reduce to the same rows.
+    """
+    lines = [line.rstrip() for line in clean_output.splitlines()]
+    body = [line for line in lines if _CONTENT_GLYPH_RE.match(line)]
+    return hashlib.sha256("\n".join(body[-40:]).encode()).hexdigest()
 
 
 def _find_assistant_marker(text: str) -> Optional[re.Match[str]]:
@@ -807,6 +901,15 @@ class CodexProvider(BaseProvider):
         self._agent_profile = agent_profile
         # Explicit per-call override for profile.model, see _build_codex_command.
         self._model = model
+        # Per-dispatch screen ownership (issue #739 review): the tmux buffer is
+        # cleared at dispatch, but the pyte-composited screen (and pane history
+        # on the capture paths) is NOT — a startup notice or a prior turn's
+        # completed-response bullet survives the boundary. An ever-dispatched
+        # boolean cannot tell that retained content from this dispatch's
+        # output, so record what the pane looked like at dispatch and require
+        # the observed content to differ before COMPLETED is possible.
+        self._dispatch_screen_hash: Optional[str] = None
+        self._dispatch_pending: bool = False
 
     @property
     def blocks_orchestrated_input_while_waiting_user_answer(self) -> bool:
@@ -1083,6 +1186,12 @@ class CodexProvider(BaseProvider):
         start_time = time.time()
         trust_dismissed = False
         update_dismissed = False
+        # Readiness stabilization (issue #739 review): a partial activity cell
+        # ("• Working" before the first timer tick) is only evidence of a live
+        # repaint while it is still moving. Once a later poll shows the exact
+        # same frame, the TUI has settled and the pane is ready; a live
+        # spinner's elapsed value changes every second, so it never stabilizes.
+        previous_tail_signature = None
         while time.time() - start_time < timeout:
             output = get_backend().get_history(self.session_name, self.window_name)
             if not output:
@@ -1135,7 +1244,16 @@ class CodexProvider(BaseProvider):
             # Exit when the bottom region shows the idle composer prompt AND no
             # dialog is active. The welcome banner alone is insufficient — it
             # renders as normal startup chrome BEFORE a late update dialog appears.
-            has_idle = _has_startup_idle_composer(clean_output)
+            # A partial activity cell only keeps this loop waiting while it is
+            # still moving: once consecutive polls observe the identical tail,
+            # the frame has settled and the pane is ready (see the signature
+            # comment above).
+            tail_signature = "\n".join(clean_output.splitlines()[-STARTUP_PROMPT_BOTTOM_LINES:])
+            has_idle = _has_startup_idle_composer(
+                clean_output,
+                allow_partial_activity_cell=(tail_signature == previous_tail_signature),
+            )
+            previous_tail_signature = tail_signature
             has_dialog = (
                 re.search(TRUST_PROMPT_PATTERN, bottom_region)
                 or (
@@ -1226,6 +1344,30 @@ class CodexProvider(BaseProvider):
         self._initialized = True
         return True
 
+    def mark_input_received(self) -> None:
+        """Record the pane baseline this dispatch must own its output from.
+
+        The rolling byte buffer is cleared by the caller, but the pyte screen
+        and pane history are not: a startup notice or a previous turn's
+        completed-response bullet survives the dispatch boundary. Snapshot
+        the normalized pane content now; ``get_status`` refuses COMPLETED
+        until the observed content differs from this baseline, so retained
+        content alone can never complete the new turn.
+        """
+        output = ""
+        try:
+            output = get_backend().get_history(self.session_name, self.window_name) or ""
+        except Exception:
+            # The pane read is best-effort: on backends without a live pane
+            # (unit tests, herdr event-inbox) there is nothing to snapshot.
+            # With no baseline recorded the guard below stays inert, which is
+            # the pre-existing behaviour for those paths.
+            pass
+        clean = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", output))
+        self._dispatch_screen_hash = _normalized_screen_hash(clean) if clean else None
+        self._dispatch_pending = True
+        super().mark_input_received()
+
     def get_status(self, output: str) -> TerminalStatus:
         # Native status (herdr): trust the backend's agent state when available;
         # on herdr the buffer is never fed, so buffer parsing can't leave UNKNOWN.
@@ -1256,6 +1398,19 @@ class CodexProvider(BaseProvider):
         # idle ``›`` prompt / structural checks below misfire on the raw stream.
         clean_output = strip_terminal_escapes(output)
         tail_output = "\n".join(clean_output.splitlines()[-25:])
+
+        # Per-dispatch ownership (issue #739 review): between mark_input_received
+        # and the first observation whose content differs from the dispatch
+        # baseline, retained screen content (a startup notice, a prior turn's
+        # completed response) must not satisfy any COMPLETED branch — the
+        # visible- and evicted-user-marker paths both live below this gate.
+        # A differing observation proves current-turn content has rendered, so
+        # the guard disarms and the turn's own evidence decides as before.
+        if self._dispatch_pending:
+            observed = _normalized_screen_hash(clean_output)
+            if self._dispatch_screen_hash is not None and observed == self._dispatch_screen_hash:
+                return TerminalStatus.PROCESSING
+            self._dispatch_pending = False
 
         # Search for user messages, excluding the Codex TUI footer when present.
         # The TUI footer (idle prompt hint like "› Summarize recent commits" +
@@ -1410,9 +1565,10 @@ class CodexProvider(BaseProvider):
             # - Fresh init: no assistant content either → IDLE.
             # - Long-running response: the › user marker has been evicted from
             #   the rolling state buffer by the time the response settles, but an
-            #   assistant bullet is still visible. This is only a completion
-            #   after CAO has actually dispatched a task; startup notices use the
-            #   same bullet glyph.
+            #   assistant bullet is still visible. This is a completion only when
+            #   a dispatch owns the observed content: never-dispatched startup
+            #   notices use the same bullet glyph, and after a dispatch the
+            #   ownership gate above has already refused retained content.
             # Search above the TUI footer cutoff so the › suggestion-hint and
             # status-bar lines aren't confused with a model reply.
             if (

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 from cli_agent_orchestrator.backends.registry import get_backend
 from cli_agent_orchestrator.constants import CAO_HOME_DIR
-from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.models.terminal import TerminalCaptureUnavailableError, TerminalStatus
 from cli_agent_orchestrator.providers.base import BaseProvider
 from cli_agent_orchestrator.services.settings_service import get_server_settings
 from cli_agent_orchestrator.utils.agent_profiles import load_agent_profile
@@ -995,6 +995,10 @@ class CodexProvider(BaseProvider):
         # IDLE.
         self._dispatch_marker_baseline: Optional[list] = None
         self._dispatch_pending: bool = False
+        # Monotonic timestamp of the last full-history ownership escalation
+        # (see _full_history_owns): resets at each dispatch so the first
+        # ambiguous poll of a new dispatch always earns its escalation read.
+        self._ownership_escalation_at: float = 0.0
 
     @property
     def blocks_orchestrated_input_while_waiting_user_answer(self) -> bool:
@@ -1450,21 +1454,18 @@ class CodexProvider(BaseProvider):
         Capture happens here, strictly before send_keys: a baseline derived
         from a post-send observation would arm on a genuine fast
         completion's own settled frame and latch the turn IDLE (issue #739
-        review). When the pre-send pane read raises, the dispatch refuses
-        instead of sending unowned: ProviderError reaches
-        terminal_service.send_input's callers before any key is typed, so
-        the message is retried rather than silently accepted. A read that
-        succeeds with no marker cells (fresh pane, login menu) is a VALID
-        empty baseline — nothing is retained, so any cell observed later is
-        new content this dispatch owns.
+        review). When the pre-send pane read keeps failing after a bounded
+        retry, the dispatch refuses instead of sending unowned:
+        TerminalCaptureUnavailableError (not a generic ProviderError) reaches
+        terminal_service.send_input's callers before any key is typed, and
+        its consumers retry — inbox delivery resets the message to PENDING
+        and deferred init re-attempts the delivery, leaving the initialized
+        worker alive (issue #739 review). A read that succeeds with no
+        marker cells (fresh pane, login menu) is a VALID empty baseline —
+        nothing is retained, so any cell observed later is new content this
+        dispatch owns.
         """
-        try:
-            history = get_backend().get_history(self.session_name, self.window_name) or ""
-        except Exception as e:
-            raise ProviderError(
-                f"Codex dispatch refused: pre-send transcript capture failed for "
-                f"{self.session_name}:{self.window_name}: {e}"
-            ) from e
+        history = self._capture_presend_pane()
         try:
             visible = (
                 get_backend().get_history(self.session_name, self.window_name, visible_only=True)
@@ -1488,7 +1489,32 @@ class CodexProvider(BaseProvider):
             cells = _cells(visible)
         self._dispatch_marker_baseline = cells
         self._dispatch_pending = True
+        self._ownership_escalation_at = 0.0
         super().mark_input_received()
+
+    def _capture_presend_pane(self, attempts: int = 3, delay: float = 0.4) -> str:
+        """Read the pre-dispatch pane, retrying a transient capture failure.
+
+        A single failed ``tmux capture-pane`` is infrastructure noise, not a
+        verdict on the pane (issue #739 review): retry it bounded inside the
+        dispatch so a transient blip does not refuse an otherwise valid
+        delivery. When every attempt fails, raise the distinct retryable
+        error rather than a generic ProviderError, so consumers can route
+        the refusal back to retry instead of terminally failing the
+        message or deleting a healthy worker.
+        """
+        last_error: Optional[Exception] = None
+        for attempt in range(attempts):
+            try:
+                return get_backend().get_history(self.session_name, self.window_name) or ""
+            except Exception as e:  # noqa: BLE001 - every backend failure is retried
+                last_error = e
+                if attempt + 1 < attempts:
+                    time.sleep(delay)
+        raise TerminalCaptureUnavailableError(
+            f"Codex dispatch refused: pre-send transcript capture failed for "
+            f"{self.session_name}:{self.window_name} after {attempts} attempts: {last_error}"
+        ) from last_error
 
     def _dispatch_owns_transcript(self, clean_output: str, cutoff_pos: int) -> bool:
         """True when the observed transcript is not the dispatch baseline.
@@ -1499,16 +1525,26 @@ class CodexProvider(BaseProvider):
         every observation view — the rolling buffer and the pyte viewport
         show only the tail of a long retained transcript, and a suffix match
         recognizes that tail as unchanged instead of reading the window
-        boundary difference as new content. Cleared permanently on the first
-        observation whose cells are NOT a tail of the baseline — genuine
-        current-turn content has rendered, and the turn's own evidence
-        decides from there on.
+        boundary difference as new content.
 
-        Residual gap, accepted: a genuinely new cell that byte-equals (or is
-        a truncated view of) a retained baseline cell still reads unchanged,
-        so a terse reply identical to a prior turn's last cell stays IDLE
-        until the next differing frame. Content identity cannot distinguish
-        that case; it only ever delays completion, never falsely completes.
+        Ownership mutates only on a structurally complete observation
+        (issue #739 review). A frame whose TUI footer has not rendered yet
+        cannot tell the composer from a submitted user cell, so it carries
+        no verdict at all: the gate stays armed and the settled frame
+        decides — an incomplete frame can delay a verdict, never disarm it.
+
+        A bounded observation that matches the baseline is still ambiguous
+        when the current turn is terse: a genuinely new cell that equals
+        (or is a truncated view of) the baseline's last cell reads as a
+        tail, and such a turn used to stay IDLE forever (issue #739
+        review). Resolve exactly that case against the full pane history —
+        the one view where an appended turn is always visible as growth
+        past the baseline regardless of cell text, because transcript
+        cells only accumulate. A full view that is not a tail of the
+        baseline is a post-dispatch occurrence; a tail, however much
+        scroll truncated its head, is unchanged retained content. See
+        ``_full_history_owns`` for the read's rate limit and fail-closed
+        behavior.
         """
         if not self._dispatch_pending:
             return True
@@ -1520,11 +1556,58 @@ class CodexProvider(BaseProvider):
             # no retained marker cells — and is handled by the suffix
             # comparison below, not by this refusal.
             return False
-        observed = _transcript_marker_cells(clean_output, cutoff_pos)
-        if _is_suffix(observed, baseline):
+        if cutoff_pos >= len(clean_output):
+            # No TUI footer in this frame: the pane is mid-repaint, and the
+            # bottom-most user-looking line is the composer, not evidence.
+            # An unbounded frame never mutates ownership (issue #739
+            # review) — the footer-restored frame carries the verdict.
             return False
-        self._dispatch_pending = False
-        return True
+        observed = _transcript_marker_cells(clean_output, cutoff_pos)
+        if not _is_suffix(observed, baseline):
+            self._dispatch_pending = False
+            return True
+        if self._full_history_owns(baseline):
+            self._dispatch_pending = False
+            return True
+        return False
+
+    # Budget for the full-history ownership escalation, in seconds.
+    # get_status() is a hot path (every wait_until_status poll, every UI
+    # refresh) and the escalation forks a capture-pane subprocess — the same
+    # reasoning that rate-limits STALE_PROCESSING_CAPTURE_INTERVAL_S in
+    # status_monitor.py. While the pane is genuinely unchanged this bounds
+    # the escalation to one read per interval; a differing observation never
+    # needs the escalation at all, and the first ambiguous poll of a
+    # dispatch always escalates (the timestamp resets at mark_input_received),
+    # so an equal-content completion is only ever delayed past a PRIOR
+    # ambiguous poll by at most one interval.
+    OWNERSHIP_ESCALATION_INTERVAL_S = 3.0
+
+    def _full_history_owns(self, baseline: list) -> bool:
+        """Resolve an ambiguous suffix match against the full pane history.
+
+        The bounded observation cannot distinguish a terse new turn from
+        retained content when the new cell's text equals the baseline's
+        tail, so compare the pane's full cell sequence instead: transcript
+        cells only accumulate, so any post-dispatch turn — however terse —
+        leaves the full view no longer a tail of the pre-send baseline
+        (issue #739 review). A read that fails, comes back empty, or is
+        rate-limited is NOT ownership: the gate stays armed, so this only
+        ever delays a verdict, never falsely completes.
+        """
+        now = time.monotonic()
+        if now - self._ownership_escalation_at < self.OWNERSHIP_ESCALATION_INTERVAL_S:
+            return False
+        self._ownership_escalation_at = now
+        try:
+            raw = get_backend().get_history(self.session_name, self.window_name) or ""
+        except Exception:
+            return False
+        if not raw:
+            return False
+        clean = strip_terminal_escapes(raw)
+        full_cells = _transcript_marker_cells(clean, _footer_cutoff_position(clean))
+        return not _is_suffix(full_cells, baseline)
 
     def get_status(self, output: str) -> TerminalStatus:
         # Native status (herdr): trust the backend's agent state when available;

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -766,28 +766,50 @@ def _has_startup_idle_composer(
     return False
 
 
-# Transcript/notice content starts with one of these glyphs (assistant bullets,
-# user markers, composer hints). Hashing only these lines makes the dispatch
-# baseline source-independent: pane history and the pyte-composited viewport
-# of an unchanged pane reduce to the same rows.
-_CONTENT_GLYPH_RE = re.compile(r"^[^\S\n]*[•›»]")
+# Transcript content starts with one of these glyphs: assistant bullets (•)
+# and submitted user-cell markers (› text / » text). The composer line — an
+# empty "›", the placeholder hint, or a draft typed into it — is deliberately
+# NOT transcript: it sits inside the TUI footer region the parser already
+# excludes via the footer cutoff, and hashing it let a successful paste whose
+# Enter was swallowed disarm the dispatch gate so a retained notice completed
+# the dropped submission (issue #739 review). Applying the same cutoff on
+# both the baseline and the observation keeps the signature a property of
+# the pane's transcript, not of whatever the composer currently holds.
+_ASSISTANT_BULLET_RE = re.compile(r"^[^\S\n]*•")
+_USER_CELL_RE = re.compile(r"^[^\S\n]*(?:›|»)[^\S\n]*\S")
 
 
-def _normalized_screen_hash(clean_output: str) -> str:
-    """Fingerprint the pane's turn-bearing content, ignoring volatile chrome.
+def _footer_cutoff_position(clean_output: str) -> int:
+    """Character position where the TUI footer region starts, when detected.
+
+    Same rule ``get_status`` uses to keep the composer and status bar out of
+    transcript parsing, shared with the dispatch-baseline capture so both
+    sides of the ownership comparison exclude the same footer chrome.
+    """
+    all_lines = clean_output.splitlines()
+    if any(re.search(TUI_FOOTER_PATTERN, line) for line in all_lines[-IDLE_PROMPT_TAIL_LINES:]):
+        return _compute_tui_footer_cutoff(all_lines)
+    return len(clean_output)
+
+
+def _transcript_signature(clean_output: str, cutoff_pos: Optional[int] = None) -> str:
+    """Fingerprint the pane's turn-bearing transcript, ignoring volatile chrome.
 
     Codex repaints the status bar and footer hint on a timer, so a raw tail
     hash differs between two observations of an unchanged pane and the
     per-dispatch staleness guard would never fire. Keep only transcript
-    lines (bullets, user markers, composer hints), normalized of trailing
-    padding, and hash the last of them: retained notices, prior responses,
-    and the idle composer survive this, while repaint-only chrome does not
-    change it. Restricting to glyph lines also keeps the fingerprint stable
-    across observation sources — pane history and the pyte viewport of the
-    same unchanged pane reduce to the same rows.
+    lines above the TUI footer cutoff — assistant bullets and non-empty user
+    cells — and hash the last of them: retained notices, prior responses,
+    and a genuine new user turn all survive this, while repaint-only chrome
+    and composer drafts (typed but unsubmitted text, excluded with the whole
+    footer region) do not change it. Restricting to glyph lines also keeps
+    the fingerprint stable across observation sources — pane history and
+    the pyte viewport of the same unchanged pane reduce to the same rows.
     """
+    if cutoff_pos is not None:
+        clean_output = clean_output[:cutoff_pos]
     lines = [line.rstrip() for line in clean_output.splitlines()]
-    body = [line for line in lines if _CONTENT_GLYPH_RE.match(line)]
+    body = [line for line in lines if _ASSISTANT_BULLET_RE.match(line) or _USER_CELL_RE.match(line)]
     return hashlib.sha256("\n".join(body[-40:]).encode()).hexdigest()
 
 
@@ -901,14 +923,17 @@ class CodexProvider(BaseProvider):
         self._agent_profile = agent_profile
         # Explicit per-call override for profile.model, see _build_codex_command.
         self._model = model
-        # Per-dispatch screen ownership (issue #739 review): the tmux buffer is
-        # cleared at dispatch, but the pyte-composited screen (and pane history
+        # Per-dispatch transcript ownership (issue #739 review): the tmux buffer
+        # is cleared at dispatch, but the pyte-composited screen (and pane history
         # on the capture paths) is NOT — a startup notice or a prior turn's
         # completed-response bullet survives the boundary. An ever-dispatched
         # boolean cannot tell that retained content from this dispatch's
-        # output, so record what the pane looked like at dispatch and require
-        # the observed content to differ before COMPLETED is possible.
-        self._dispatch_screen_hash: Optional[str] = None
+        # output, so record the pane's transcript signature at dispatch and
+        # require it to differ before COMPLETED is possible. A failed pane
+        # read leaves the baseline unset: the FIRST post-dispatch observation
+        # then becomes the baseline (fail closed — retained content cannot
+        # complete), never an inert guard.
+        self._dispatch_transcript_baseline: Optional[str] = None
         self._dispatch_pending: bool = False
 
     @property
@@ -1345,28 +1370,59 @@ class CodexProvider(BaseProvider):
         return True
 
     def mark_input_received(self) -> None:
-        """Record the pane baseline this dispatch must own its output from.
+        """Record the transcript baseline this dispatch must own its output from.
 
         The rolling byte buffer is cleared by the caller, but the pyte screen
         and pane history are not: a startup notice or a previous turn's
         completed-response bullet survives the dispatch boundary. Snapshot
-        the normalized pane content now; ``get_status`` refuses COMPLETED
-        until the observed content differs from this baseline, so retained
-        content alone can never complete the new turn.
+        the pane's transcript content now; the COMPLETED decision points in
+        ``get_status`` refuse to complete on content whose signature matches
+        this baseline, so retained content alone can never complete the new
+        turn. A failed pane read leaves the baseline unset — the first
+        post-dispatch observation then becomes the baseline, so the guard
+        stays armed and still fails closed rather than going inert.
         """
         output = ""
         try:
             output = get_backend().get_history(self.session_name, self.window_name) or ""
         except Exception:
-            # The pane read is best-effort: on backends without a live pane
-            # (unit tests, herdr event-inbox) there is nothing to snapshot.
-            # With no baseline recorded the guard below stays inert, which is
-            # the pre-existing behaviour for those paths.
-            pass
+            # Fail closed: no baseline now, so the guard below arms lazily
+            # from the first observation and still refuses to complete on
+            # content the dispatch has never seen change.
+            self._dispatch_transcript_baseline = None
+            self._dispatch_pending = True
+            super().mark_input_received()
+            return
         clean = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", output))
-        self._dispatch_screen_hash = _normalized_screen_hash(clean) if clean else None
+        self._dispatch_transcript_baseline = (
+            _transcript_signature(clean, _footer_cutoff_position(clean)) if clean else None
+        )
         self._dispatch_pending = True
         super().mark_input_received()
+
+    def _dispatch_owns_transcript(self, clean_output: str, cutoff_pos: int) -> bool:
+        """True when the observed transcript is not the dispatch baseline.
+
+        Kept armed while the pane's transcript content still matches what
+        ``mark_input_received`` snapshotted (or, after a failed capture,
+        matches the first post-dispatch observation): retained notices and
+        prior-turn completions then cannot satisfy a COMPLETED branch.
+        Cleared permanently on the first observation whose transcript
+        differs — genuine current-turn content has rendered, and the turn's
+        own evidence decides from there on.
+        """
+        if not self._dispatch_pending:
+            return True
+        observed = _transcript_signature(clean_output, cutoff_pos)
+        if self._dispatch_transcript_baseline is None:
+            # Baseline capture failed: this observation becomes the baseline
+            # (fail closed), and only content that changes from it completes.
+            self._dispatch_transcript_baseline = observed
+            return False
+        if observed != self._dispatch_transcript_baseline:
+            self._dispatch_pending = False
+            return True
+        return False
 
     def get_status(self, output: str) -> TerminalStatus:
         # Native status (herdr): trust the backend's agent state when available;
@@ -1398,19 +1454,6 @@ class CodexProvider(BaseProvider):
         # idle ``›`` prompt / structural checks below misfire on the raw stream.
         clean_output = strip_terminal_escapes(output)
         tail_output = "\n".join(clean_output.splitlines()[-25:])
-
-        # Per-dispatch ownership (issue #739 review): between mark_input_received
-        # and the first observation whose content differs from the dispatch
-        # baseline, retained screen content (a startup notice, a prior turn's
-        # completed response) must not satisfy any COMPLETED branch — the
-        # visible- and evicted-user-marker paths both live below this gate.
-        # A differing observation proves current-turn content has rendered, so
-        # the guard disarms and the turn's own evidence decides as before.
-        if self._dispatch_pending:
-            observed = _normalized_screen_hash(clean_output)
-            if self._dispatch_screen_hash is not None and observed == self._dispatch_screen_hash:
-                return TerminalStatus.PROCESSING
-            self._dispatch_pending = False
 
         # Search for user messages, excluding the Codex TUI footer when present.
         # The TUI footer (idle prompt hint like "› Summarize recent commits" +
@@ -1551,12 +1594,26 @@ class CodexProvider(BaseProvider):
             if re.search(TUI_PROGRESS_PATTERN, tail_output, re.MULTILINE):
                 return TerminalStatus.PROCESSING
 
+            # Per-dispatch transcript ownership (issue #739 review): while the
+            # pane's transcript still matches the dispatch baseline, retained
+            # content — a startup notice, a prior turn's completion — cannot
+            # satisfy either COMPLETED branch. Consulted HERE, after the modal
+            # and error classifiers, so an unchanged approval/login prompt
+            # keeps its WAITING_USER_ANSWER precedence instead of collapsing
+            # to PROCESSING. The pane reports IDLE instead: the composer is
+            # visible, so a dropped submit reads "not started" to the
+            # deferred-delivery retry rather than "already done".
+            dispatch_owns_content = self._dispatch_owns_transcript(clean_output, cutoff_pos)
+
             # Consider COMPLETED only if we see an assistant marker (skipping
             # MCP tool-call markers) after the last user message. Without the
             # tool-call filter, "• Called <server>.<tool>(...)" emitted before
             # the model has actually replied would trip COMPLETED prematurely.
             if last_user is not None:
-                if _find_assistant_marker(clean_output[last_user.start() :]) is not None:
+                if (
+                    dispatch_owns_content
+                    and _find_assistant_marker(clean_output[last_user.start() :]) is not None
+                ):
                     return TerminalStatus.COMPLETED
 
                 return TerminalStatus.IDLE
@@ -1572,7 +1629,8 @@ class CodexProvider(BaseProvider):
             # Search above the TUI footer cutoff so the › suggestion-hint and
             # status-bar lines aren't confused with a model reply.
             if (
-                self._task_dispatched
+                dispatch_owns_content
+                and self._task_dispatched
                 and _find_assistant_marker(clean_output[:cutoff_pos]) is not None
             ):
                 return TerminalStatus.COMPLETED

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -1,7 +1,6 @@
 """Codex CLI provider implementation."""
 
 import asyncio
-import hashlib
 import logging
 import os
 import re
@@ -792,25 +791,44 @@ def _footer_cutoff_position(clean_output: str) -> int:
     return len(clean_output)
 
 
-def _transcript_signature(clean_output: str, cutoff_pos: Optional[int] = None) -> str:
-    """Fingerprint the pane's turn-bearing transcript, ignoring volatile chrome.
+def _transcript_marker_cells(clean_output: str, cutoff_pos: Optional[int] = None) -> list:
+    """Parsed transcript marker cells, oldest to newest.
 
-    Codex repaints the status bar and footer hint on a timer, so a raw tail
-    hash differs between two observations of an unchanged pane and the
-    per-dispatch staleness guard would never fire. Keep only transcript
-    lines above the TUI footer cutoff — assistant bullets and non-empty user
-    cells — and hash the last of them: retained notices, prior responses,
-    and a genuine new user turn all survive this, while repaint-only chrome
-    and composer drafts (typed but unsubmitted text, excluded with the whole
-    footer region) do not change it. Restricting to glyph lines also keeps
-    the fingerprint stable across observation sources — pane history and
-    the pyte viewport of the same unchanged pane reduce to the same rows.
+    Codex repaints the status bar and footer hint on a timer, so raw pane
+    text differs between two observations of an unchanged pane. Worse, the
+    tmux history window (``-S -200``) and the viewport/buffer views of the
+    SAME unchanged pane start at different lines once a transcript grows
+    past 200 rows, so even a cleaned-text hash of one view can mismatch a
+    differently bounded view of itself (issue #739 review). Reduce the pane
+    to exactly the turn-bearing marker cells — assistant bullets and
+    submitted user cells above the TUI footer cutoff — and compare parsed
+    cells by suffix (see ``_dispatch_owns_transcript``) so an observation
+    showing a tail of the baseline's cells still reads as unchanged. The
+    composer line (an empty ``›``, the placeholder hint, or a draft typed
+    into it) sits inside the footer region the parser already excludes, so
+    a typed-but-unsubmitted draft cannot change the cells.
     """
     if cutoff_pos is not None:
         clean_output = clean_output[:cutoff_pos]
-    lines = [line.rstrip() for line in clean_output.splitlines()]
-    body = [line for line in lines if _ASSISTANT_BULLET_RE.match(line) or _USER_CELL_RE.match(line)]
-    return hashlib.sha256("\n".join(body[-40:]).encode()).hexdigest()
+    cells = []
+    for line in clean_output.splitlines():
+        line = line.rstrip()
+        if _ASSISTANT_BULLET_RE.match(line) or _USER_CELL_RE.match(line):
+            cells.append(line)
+    return cells
+
+
+def _is_suffix(suffix: list, sequence: list) -> bool:
+    """True when ``suffix`` is a tail slice of ``sequence`` (or equal to it).
+
+    ``len(suffix) > len(sequence)`` means the observation shows MORE marker
+    cells than the pre-send baseline — genuine appended content — and is not
+    a suffix. A zero-length observation is a tail of anything (a pane whose
+    transcript cells scrolled out of this view is still unchanged content).
+    """
+    if len(suffix) > len(sequence):
+        return False
+    return sequence[len(sequence) - len(suffix) :] == suffix
 
 
 def _find_assistant_marker(text: str) -> Optional[re.Match[str]]:
@@ -928,12 +946,21 @@ class CodexProvider(BaseProvider):
         # on the capture paths) is NOT — a startup notice or a prior turn's
         # completed-response bullet survives the boundary. An ever-dispatched
         # boolean cannot tell that retained content from this dispatch's
-        # output, so record the pane's transcript signature at dispatch and
-        # require it to differ before COMPLETED is possible. A failed pane
-        # read leaves the baseline unset: the FIRST post-dispatch observation
-        # then becomes the baseline (fail closed — retained content cannot
-        # complete), never an inert guard.
-        self._dispatch_transcript_baseline: Optional[str] = None
+        # output, so record the pane's marker-cell baseline at dispatch and
+        # require it to differ before COMPLETED is possible. The baseline is a
+        # list of parsed marker cells (assistant bullets, submitted user cells),
+        # NOT a hash of raw pane text: history and viewport captures of the
+        # same unchanged pane cut at different line boundaries (issue #739
+        # review), so a raw-hash baseline of a long retained transcript could
+        # differ from a shorter observation of itself and read retained content
+        # as new. Marker cells are compared by suffix so an observation that
+        # shows a tail of the baseline's cells is still recognized as
+        # unchanged. Capture happens strictly BEFORE the send; when it cannot
+        # be obtained the dispatch refuses (see mark_input_received), so the
+        # baseline is never derived from a post-send observation — that would
+        # arm on a genuine fast completion's own settled frame and latch it
+        # IDLE.
+        self._dispatch_marker_baseline: Optional[list] = None
         self._dispatch_pending: bool = False
 
     @property
@@ -1370,59 +1397,85 @@ class CodexProvider(BaseProvider):
         return True
 
     def mark_input_received(self) -> None:
-        """Record the transcript baseline this dispatch must own its output from.
+        """Capture the canonical pre-send transcript baseline this dispatch owns.
 
         The rolling byte buffer is cleared by the caller, but the pyte screen
         and pane history are not: a startup notice or a previous turn's
         completed-response bullet survives the dispatch boundary. Snapshot
-        the pane's transcript content now; the COMPLETED decision points in
-        ``get_status`` refuse to complete on content whose signature matches
-        this baseline, so retained content alone can never complete the new
-        turn. A failed pane read leaves the baseline unset — the first
-        post-dispatch observation then becomes the baseline, so the guard
-        stays armed and still fails closed rather than going inert.
+        the pane's marker cells from BOTH history bounds (viewport plus
+        scrollback) so the baseline contains every cell any observation view
+        can show; the COMPLETED decision points in ``get_status`` refuse to
+        complete while the observed cells are a tail of this baseline.
+
+        Capture happens here, strictly before send_keys: a baseline derived
+        from a post-send observation would arm on a genuine fast
+        completion's own settled frame and latch the turn IDLE (issue #739
+        review). When the pre-send pane read raises, the dispatch refuses
+        instead of sending unowned: ProviderError reaches
+        terminal_service.send_input's callers before any key is typed, so
+        the message is retried rather than silently accepted. A read that
+        succeeds with no marker cells (fresh pane, login menu) is a VALID
+        empty baseline — nothing is retained, so any cell observed later is
+        new content this dispatch owns.
         """
-        output = ""
         try:
-            output = get_backend().get_history(self.session_name, self.window_name) or ""
+            history = get_backend().get_history(self.session_name, self.window_name) or ""
+        except Exception as e:
+            raise ProviderError(
+                f"Codex dispatch refused: pre-send transcript capture failed for "
+                f"{self.session_name}:{self.window_name}: {e}"
+            ) from e
+        try:
+            visible = (
+                get_backend().get_history(self.session_name, self.window_name, visible_only=True)
+                or ""
+            )
         except Exception:
-            # Fail closed: no baseline now, so the guard below arms lazily
-            # from the first observation and still refuses to complete on
-            # content the dispatch has never seen change.
-            self._dispatch_transcript_baseline = None
-            self._dispatch_pending = True
-            super().mark_input_received()
-            return
-        clean = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", output))
-        self._dispatch_transcript_baseline = (
-            _transcript_signature(clean, _footer_cutoff_position(clean)) if clean else None
-        )
+            visible = ""
+
+        def _cells(raw: str) -> list:
+            clean = strip_terminal_escapes(re.sub(ANSI_CODE_PATTERN, "", raw))
+            return _transcript_marker_cells(clean, _footer_cutoff_position(clean))
+
+        cells = _cells(history)
+        if not cells and visible:
+            # History shows no marker cells but the viewport does (e.g. a
+            # cleared scrollback): the visible cells are the retained
+            # transcript the dispatch must own from.
+            cells = _cells(visible)
+        self._dispatch_marker_baseline = cells
         self._dispatch_pending = True
         super().mark_input_received()
 
     def _dispatch_owns_transcript(self, clean_output: str, cutoff_pos: int) -> bool:
         """True when the observed transcript is not the dispatch baseline.
 
-        Kept armed while the pane's transcript content still matches what
-        ``mark_input_received`` snapshotted (or, after a failed capture,
-        matches the first post-dispatch observation): retained notices and
-        prior-turn completions then cannot satisfy a COMPLETED branch.
-        Cleared permanently on the first observation whose transcript
-        differs — genuine current-turn content has rendered, and the turn's
-        own evidence decides from there on.
+        Kept armed while the observed marker cells are a suffix of (or equal
+        to) what ``mark_input_received`` captured: retained notices and
+        prior-turn completions then cannot satisfy a COMPLETED branch, in
+        every observation view — the rolling buffer and the pyte viewport
+        show only the tail of a long retained transcript, and a suffix match
+        recognizes that tail as unchanged instead of reading the window
+        boundary difference as new content. Cleared permanently on the first
+        observation whose cells are NOT a tail of the baseline — genuine
+        current-turn content has rendered, and the turn's own evidence
+        decides from there on.
         """
         if not self._dispatch_pending:
             return True
-        observed = _transcript_signature(clean_output, cutoff_pos)
-        if self._dispatch_transcript_baseline is None:
-            # Baseline capture failed: this observation becomes the baseline
-            # (fail closed), and only content that changes from it completes.
-            self._dispatch_transcript_baseline = observed
+        baseline = self._dispatch_marker_baseline
+        if baseline is None:
+            # Unreachable while capture always records a list (possibly
+            # empty); kept as a belt-and-braces refusal rather than an
+            # inert guard. An EMPTY list is a valid baseline — a pane with
+            # no retained marker cells — and is handled by the suffix
+            # comparison below, not by this refusal.
             return False
-        if observed != self._dispatch_transcript_baseline:
-            self._dispatch_pending = False
-            return True
-        return False
+        observed = _transcript_marker_cells(clean_output, cutoff_pos)
+        if _is_suffix(observed, baseline):
+            return False
+        self._dispatch_pending = False
+        return True
 
     def get_status(self, output: str) -> TerminalStatus:
         # Native status (herdr): trust the backend's agent state when available;

--- a/src/cli_agent_orchestrator/services/inbox_service.py
+++ b/src/cli_agent_orchestrator/services/inbox_service.py
@@ -22,7 +22,7 @@ from cli_agent_orchestrator.constants import (
 )
 from cli_agent_orchestrator.models.inbox import MessageStatus, OrchestrationType
 from cli_agent_orchestrator.models.provider import ProviderType
-from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.models.terminal import TerminalCaptureUnavailableError, TerminalStatus
 from cli_agent_orchestrator.plugins import PluginRegistry
 from cli_agent_orchestrator.providers.manager import provider_manager
 from cli_agent_orchestrator.services import terminal_service
@@ -168,6 +168,18 @@ class InboxService:
                 logger.warning(
                     f"Pane not resolvable for terminal {terminal_id}; leaving "
                     f"{len(batch)} message(s) pending for retry: {e}"
+                )
+            except TerminalCaptureUnavailableError as e:
+                # The provider refused the dispatch before typing anything —
+                # its pre-send transcript capture failed after a bounded retry
+                # (issue #739 review). Nothing was sent, so the message is as
+                # retryable as an unresolvable pane: reset to PENDING for the
+                # reconcile sweep instead of terminally failing it.
+                for message in batch:
+                    update_message_status(message.id, MessageStatus.PENDING)
+                logger.warning(
+                    f"Pre-send capture unavailable for terminal {terminal_id}; "
+                    f"leaving {len(batch)} message(s) pending for retry: {e}"
                 )
             except Exception as e:
                 for message in batch:

--- a/src/cli_agent_orchestrator/services/terminal_service.py
+++ b/src/cli_agent_orchestrator/services/terminal_service.py
@@ -65,6 +65,7 @@ from cli_agent_orchestrator.models.kiro_engine import KiroEngine, resolve_kiro_e
 from cli_agent_orchestrator.models.provider import ProviderType
 from cli_agent_orchestrator.models.terminal import (
     Terminal,
+    TerminalCaptureUnavailableError,
     TerminalInputBlockedError,
     TerminalLimitError,
     TerminalStatus,
@@ -2001,15 +2002,35 @@ def _schedule_deferred_init(
                 # to ASSIGN here is always correct and cannot affect answer_user_prompt.
                 effective_orchestration_type = orchestration_type or OrchestrationType.ASSIGN
                 # send_input is blocking tmux I/O — off the loop so it can't
-                # freeze the server for concurrent requests.
-                await asyncio.to_thread(
-                    send_input,
-                    terminal_id,
-                    initial_message,
-                    registry=registry,
-                    sender_id=caller_id,
-                    orchestration_type=effective_orchestration_type,
-                )
+                # freeze the server for concurrent requests. A pre-send
+                # capture refusal (TerminalCaptureUnavailableError, raised
+                # before any key is typed) is transient infrastructure, not a
+                # dead worker: retry the delivery bounded so a blip during
+                # init doesn't tear down a healthy terminal (issue #739
+                # review).
+                delivery_attempts = 3
+                for attempt in range(delivery_attempts):
+                    try:
+                        await asyncio.to_thread(
+                            send_input,
+                            terminal_id,
+                            initial_message,
+                            registry=registry,
+                            sender_id=caller_id,
+                            orchestration_type=effective_orchestration_type,
+                        )
+                        break
+                    except TerminalCaptureUnavailableError:
+                        if attempt + 1 >= delivery_attempts:
+                            raise
+                        logger.warning(
+                            "Deferred init for %s: pre-send capture unavailable, "
+                            "retrying delivery (%d/%d)",
+                            terminal_id,
+                            attempt + 1,
+                            delivery_attempts - 1,
+                        )
+                        await asyncio.sleep(1.0)
                 # Delivery can be silently dropped (Enter swallowed / paste lost)
                 # when the TUI isn't input-ready. Confirm the worker actually
                 # started and re-submit if not; if it never starts, surface the
@@ -2064,6 +2085,32 @@ def _schedule_deferred_init(
                 f"clear the prompt, then re-send the task yourself (e.g. via "
                 f"send_message) -- it is not automatically re-delivered once the "
                 f"prompt is answered.",
+                registry,
+                delete_worker=False,
+            )
+        except TerminalCaptureUnavailableError as e:
+            # The worker initialized fine; the pre-send transcript capture
+            # refused the dispatch before any key was typed, after the
+            # bounded retry above. That is transient infrastructure, not a
+            # dead terminal: leave the worker alive (same call as
+            # TerminalInputBlockedError above) and tell the caller the task
+            # was NOT delivered, so they can re-send rather than have a
+            # healthy terminal deleted out from under them (issue #739
+            # review).
+            logger.warning(
+                "Deferred init for terminal %s: pre-send capture unavailable "
+                "after retries; task not delivered. Leaving worker alive for "
+                "re-delivery. (%s)",
+                terminal_id,
+                e,
+            )
+            await asyncio.to_thread(
+                _notify_caller_of_deferred_failure,
+                terminal_id,
+                f"Worker {terminal_id} could not be read for a pre-delivery "
+                f"capture; the assigned task has not been delivered (nothing "
+                f"was typed). Re-send the task yourself (e.g. via "
+                f"send_message) once the terminal is readable.",
                 registry,
                 delete_worker=False,
             )

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2251,15 +2251,180 @@ class TestCodexProviderTrustPrompt:
 
         assert _has_startup_idle_composer(output) is True
         assert provider.get_status(output) == TerminalStatus.IDLE
-        dispatched_output = (
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_dispatch_does_not_complete_on_retained_notice_pane(self, mock_backend):
+        """After dispatch, an unchanged retained pane is PROCESSING, not COMPLETED.
+
+        The rolling byte buffer is cleared at dispatch, but the pyte screen
+        and pane history are not (issue #739 review): a control-only redraw
+        of the startup notice pane must not satisfy the evicted-marker
+        completion branch before Codex has rendered the new user turn.
+        """
+        retained = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = retained
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider.get_status(retained) == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_dispatch_does_not_complete_on_retained_prior_turn(self, mock_backend):
+        """A prior turn's completion, retained across the dispatch boundary
+        (screen path or rolling buffer), must not complete the new dispatch."""
+        retained = (
+            "› first question\n"
+            "• First answer.\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = retained
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider.get_status(retained) == TerminalStatus.PROCESSING
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_dispatched_evicted_marker_turn_completes_after_new_content(self, mock_backend):
+        """Once current-turn content renders, the evicted-marker path completes.
+
+        The v0153 regression: the user marker rolled out of the buffer, the
+        assistant response is visible above the footer cutoff, and the pane
+        differs from the dispatch baseline, so the turn's own evidence
+        decides — COMPLETED, as before the ownership guard.
+        """
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        settled_turn = (
             "• The requested task is complete.\n\n"
             "› Ask Codex to do anything\n\n"
             "  gpt-5.6-sol default · /tmp/work\n"
         )
+        mock_backend.return_value.get_history.return_value = notice_pane
 
+        provider = CodexProvider("test1234", "test-session", "window-0")
         provider.mark_input_received()
 
-        assert provider.get_status(dispatched_output) == TerminalStatus.COMPLETED
+        assert provider.get_status(settled_turn) == TerminalStatus.COMPLETED
+        # The guard stays disarmed once the turn has been observed; a redraw
+        # of the same settled pane does not return it to PROCESSING.
+        assert provider.get_status(settled_turn) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_second_dispatch_after_completion_waits_for_new_content(self, mock_backend):
+        """Dispatch N+1 must not be completed by dispatch N's retained pane."""
+        idle_pane = (
+            "OpenAI Codex (v0.153.2)\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        first_turn = (
+            "› first question\n"
+            "• First answer.\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = idle_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+        assert provider.get_status(first_turn) == TerminalStatus.COMPLETED
+
+        # Dispatch two: the pane still shows turn one's completion.
+        mock_backend.return_value.get_history.return_value = first_turn
+        provider.mark_input_received()
+        assert provider.get_status(first_turn) == TerminalStatus.PROCESSING
+
+        second_turn = (
+            "› second question\n"
+            "• Second answer.\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        assert provider.get_status(second_turn) == TerminalStatus.COMPLETED
+
+    def test_v0153_stale_spinner_above_newer_composer_is_ready(self):
+        """Readiness comes from the bottom-most cell, not any cell in the region.
+
+        The timed spinner above belongs to an earlier turn; the current
+        composer below it is what the TUI is repainting (issue #739 review:
+        an old timed spinner above a newer notice/composer must not keep the
+        pane not-ready).
+        """
+        output = (
+            "› earlier question\n"
+            "• Working (12s • esc to interrupt)\n"
+            "\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        assert _has_startup_idle_composer(output) is True
+
+    def test_v0153_partial_activity_cell_blocks_readiness_until_stable(self):
+        """An unterminated bullet is a possible mid-paint frame: not ready on
+        first sight, ready once the frame is identical across polls."""
+        output = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• Starting MCP servers (0/3): cao-mcp-server\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        assert _has_startup_idle_composer(output) is False
+        assert _has_startup_idle_composer(output, allow_partial_activity_cell=True) is True
+
+    @pytest.mark.parametrize(
+        "notice",
+        [
+            "You have 1 usage limit reset available. Run /usage to use one.",
+            "Your plan renews on Sep 30. Visit /usage for details.",
+            "New: file uploads are available in this workspace.",
+        ],
+        ids=["usage-limit", "plan-renewal", "feature-note"],
+    )
+    def test_v0153_notice_sentence_variants_are_ready(self, notice):
+        """Sentence-terminated notices are printed lines, never activity —
+        ready on the first poll, no stabilization wait (issue #739 review)."""
+        output = (
+            "OpenAI Codex (v0.153.2)\n"
+            f"• {notice}\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        assert _has_startup_idle_composer(output) is True
+
+    def test_v0153_unterminated_notice_requires_stabilization(self):
+        """A bare non-sentence notice bullet is ambiguous with a mid-paint
+        frame, so readiness waits for a stable frame."""
+        output = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• Trying the latest stable version\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        assert _has_startup_idle_composer(output) is False
+        assert _has_startup_idle_composer(output, allow_partial_activity_cell=True) is True
 
     @pytest.mark.asyncio
     @patch(
@@ -2349,6 +2514,12 @@ class TestCodexProviderTrustPrompt:
                 "  gpt-5.6-sol medium · Context 100% left\n"
             ),
             (
+                "› Fix the failing tests\n"
+                "• Working\n"
+                "› Write tests for @filename\n"
+                "  gpt-5.6-sol medium · Context 100% left\n"
+            ),
+            (
                 "Approve this command? [y/n]\n"
                 "› Write tests for @filename\n"
                 "  gpt-5.6-sol medium · Context 100% left\n"
@@ -2370,6 +2541,7 @@ class TestCodexProviderTrustPrompt:
         ],
         ids=[
             "working",
+            "partial-working-frame",
             "approval",
             "boxed-approval",
             "typed-draft",

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2238,6 +2238,29 @@ class TestCodexProviderTrustPrompt:
 
         assert _has_startup_idle_composer(output) is True
 
+    def test_v0153_account_notice_is_idle_at_startup(self):
+        """A startup account notice is neither activity nor a completed response."""
+        output = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+
+        assert _has_startup_idle_composer(output) is True
+        assert provider.get_status(output) == TerminalStatus.IDLE
+        dispatched_output = (
+            "• The requested task is complete.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        provider.mark_input_received()
+
+        assert provider.get_status(dispatched_output) == TerminalStatus.COMPLETED
+
     @pytest.mark.asyncio
     @patch(
         "cli_agent_orchestrator.providers.codex.time.time",
@@ -2326,12 +2349,6 @@ class TestCodexProviderTrustPrompt:
                 "  gpt-5.6-sol medium · Context 100% left\n"
             ),
             (
-                "› Fix the failing tests\n"
-                "• Working\n"
-                "› Write tests for @filename\n"
-                "  gpt-5.6-sol medium · Context 100% left\n"
-            ),
-            (
                 "Approve this command? [y/n]\n"
                 "› Write tests for @filename\n"
                 "  gpt-5.6-sol medium · Context 100% left\n"
@@ -2353,7 +2370,6 @@ class TestCodexProviderTrustPrompt:
         ],
         ids=[
             "working",
-            "partial-working-frame",
             "approval",
             "boxed-approval",
             "typed-draft",

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2394,35 +2394,218 @@ class TestCodexProviderTrustPrompt:
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_baseline_capture_failure_fails_closed(self, mock_backend):
-        """A transient get_history failure at dispatch must not disarm the gate.
+        """A failed pre-send capture refuses the dispatch before any key is sent.
 
-        The first post-dispatch observation becomes the baseline, so a
-        retained notice pane still cannot complete the dropped submission
-        (issue #739 follow-up review: baseline-read failure previously
-        restored the unsafe completion behavior).
+        Issue #739 review (5126947959): the previous lazy fail-closed adopted
+        the first post-dispatch observation as the baseline, so a genuine
+        fast completion latched IDLE — deferred delivery resent the finished
+        task and synchronous dispatch timed out. A pre-send baseline that
+        cannot be obtained now raises ProviderError from
+        mark_input_received, which sits immediately before send_keys in
+        terminal_service.send_input: the message is never typed, callers
+        mark it for retry, and no baseline is ever derived post-send.
         """
+        mock_backend.return_value.get_history.side_effect = RuntimeError("capture failed")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with pytest.raises(ProviderError, match="pre-send transcript capture failed"):
+            provider.mark_input_received()
+        # Nothing was armed: the provider holds no dispatch state at all.
+        assert provider._dispatch_pending is False
+        assert provider._dispatch_marker_baseline is None
+        # No super() side effects either — the dispatch never happened.
+        assert provider._task_dispatched is False
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_empty_presend_capture_arms_empty_baseline(self, mock_backend):
+        """A successful pre-send read over a pane with no marker cells (fresh
+        session, login menu) is a VALID empty baseline — not a refusal and
+        never a None baseline the observation path would arm lazily from a
+        post-send observation (issue #739 review 5126947959). Retained-
+        content protection still holds: any cell observed later is new."""
+        mock_backend.return_value.get_history.return_value = ""
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider._dispatch_pending is True
+        assert provider._dispatch_marker_baseline == []
+        # The empty pane itself reads not-started, not completed.
+        assert provider.get_status("") == TerminalStatus.UNKNOWN
+        notice = (
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        # Content that appears after the empty baseline is owned by this
+        # dispatch and completes the turn.
+        assert provider.get_status(notice) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_fast_completion_on_first_observation_completes(self, mock_backend):
+        """A genuine fast completion visible on the FIRST post-send poll must
+        report COMPLETED immediately — the pre-send baseline is captured
+        before send_keys, so the settled turn is not its own baseline
+        (issue #739 review 5126947959: post-send-derived baselines latched
+        fast completions IDLE, causing resends and sync timeouts)."""
         notice_pane = (
             "OpenAI Codex (v0.153.2)\n"
             "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
             "› Ask Codex to do anything\n\n"
             "  gpt-5.6-sol default · /tmp/work\n"
         )
-        mock_backend.return_value.get_history.side_effect = RuntimeError("capture failed")
-
-        provider = CodexProvider("test1234", "test-session", "window-0")
-        provider.mark_input_received()
-
-        # First observation arms the baseline lazily; the same pane — with or
-        # without a typed draft — stays not-started, and genuine new content
-        # still completes.
-        assert provider.get_status(notice_pane) == TerminalStatus.IDLE
-        assert provider.get_status(notice_pane) == TerminalStatus.IDLE
         settled = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "› analyze the repo and list risks\n"
             "• The requested task is complete.\n\n"
             "› Ask Codex to do anything\n\n"
             "  gpt-5.6-sol default · /tmp/work\n"
         )
+        mock_backend.return_value.get_history.return_value = notice_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
         assert provider.get_status(settled) == TerminalStatus.COMPLETED
+        # Stable across redraws of the same settled pane.
+        assert provider.get_status(settled) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_fast_completion_after_capture_failure_retry(self, mock_backend):
+        """The dispatch refused by a failed capture is retried by the caller;
+        the retry captures normally and a fast completion on its first
+        observation completes — the refusal path leaves no state behind
+        (issue #739 review 5126947959)."""
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        settled = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "› analyze the repo and list risks\n"
+            "• The requested task is complete.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.side_effect = RuntimeError("capture failed")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        with pytest.raises(ProviderError):
+            provider.mark_input_received()
+
+        # Caller retries the dispatch; capture succeeds now.
+        mock_backend.return_value.get_history.side_effect = None
+        mock_backend.return_value.get_history.return_value = notice_pane
+        provider.mark_input_received()
+        assert provider.get_status(settled) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_completions_after_capture_failure_refusal_use_both_paths(self, mock_backend):
+        """Baseline failure followed immediately by completion: the review's
+        exact pairing (issue #739 review 5126947959). After a refused
+        dispatch, the retried capture arms normally and BOTH completion
+        branches work — the visible-user-marker path and the evicted-marker
+        path — without falsely completing, resending, or timing out."""
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        visible_settled = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "› analyze the repo and list risks\n"
+            "• The requested task is complete.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        # User marker scrolled out of the view; the assistant bullet above
+        # the footer cutoff is the only turn evidence left.
+        evicted_settled = (
+            "• The requested task is complete.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        def fresh_dispatch_then_observe(observation: str) -> TerminalStatus:
+            mock_backend.return_value.get_history.side_effect = RuntimeError("boom")
+            provider = CodexProvider("test1234", "test-session", "window-0")
+            with pytest.raises(ProviderError):
+                provider.mark_input_received()
+            mock_backend.return_value.get_history.side_effect = None
+            mock_backend.return_value.get_history.return_value = notice_pane
+            provider.mark_input_received()
+            return provider.get_status(observation)
+
+        assert fresh_dispatch_then_observe(visible_settled) == TerminalStatus.COMPLETED
+        assert fresh_dispatch_then_observe(evicted_settled) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_unchanged_long_retained_transcript_is_not_newly_owned(self, mock_backend):
+        """>200-row retained transcript: history and viewport windows cut at
+        different boundaries, so a raw-text baseline mismatched a shorter
+        observation of the SAME unchanged pane and falsely completed a
+        dropped dispatch (issue #739 review 5126947959). Marker cells are
+        compared by suffix, so the viewport's tail reads unchanged. Raw
+        string path."""
+        # 220 retained multi-line turns: alternating user/assistant cells.
+        retained_lines = ["OpenAI Codex (v0.153.2)"]
+        for i in range(110):
+            retained_lines.append(f"› question number {i} about the build")
+            retained_lines.append(f"• Answer number {i}: the build is fine.")
+            retained_lines.append("  └ details in the log")
+        retained_lines.append("")
+        retained_lines.append("› Ask Codex to do anything")
+        retained_lines.append("")
+        retained_lines.append("  gpt-5.6-sol default · /tmp/work")
+        full_history = "\n".join(retained_lines)
+
+        # The rolling buffer / pyte viewport observation holds only the last
+        # ~40 rows of that pane — a differently bounded view of the same
+        # unchanged content.
+        bounded_view = "\n".join(retained_lines[-40:])
+
+        mock_backend.return_value.get_history.return_value = full_history
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider.get_status(bounded_view) == TerminalStatus.IDLE
+        # And the full view of the same unchanged pane is not owned either.
+        assert provider.get_status(full_history) == TerminalStatus.IDLE
+
+    def test_unchanged_long_retained_transcript_pyte_view_is_not_newly_owned(self):
+        """Same differently-bounded regression through the pyte screen path:
+        get_status_from_screen strips blank rows and reuses get_status, so
+        the viewport tail of the retained transcript must read unchanged
+        (issue #739 review 5126947959 asked for raw and pyte regressions)."""
+        retained_lines = ["OpenAI Codex (v0.153.2)"]
+        for i in range(110):
+            retained_lines.append(f"› question number {i} about the build")
+            retained_lines.append(f"• Answer number {i}: the build is fine.")
+        retained_lines.append("• You have 1 usage limit reset available. Run /usage to use one.")
+        retained_lines.append("")
+        retained_lines.append("› Ask Codex to do anything")
+        retained_lines.append("")
+        retained_lines.append("  gpt-5.6-sol default · /tmp/work")
+        full_history = "\n".join(retained_lines)
+
+        # Viewport shows only the last rows (pyte 24-row screen), padded with
+        # blank rows the screen path strips.
+        viewport_rows = [row for row in retained_lines[-24:] if row.strip()]
+        viewport_rows += [""] * (24 - len(viewport_rows))
+
+        with patch("cli_agent_orchestrator.providers.codex.get_backend") as mock_backend:
+            mock_backend.return_value.get_history.return_value = full_history
+            provider = CodexProvider("test1234", "test-session", "window-0")
+            provider.mark_input_received()
+
+        assert provider.get_status_from_screen(viewport_rows) == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_unchanged_approval_prompt_keeps_waiting_after_dispatch(self, mock_backend):

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2567,7 +2567,10 @@ class TestCodexProviderTrustPrompt:
 
         # The rolling buffer / pyte viewport observation holds only the last
         # ~40 rows of that pane — a differently bounded view of the same
-        # unchanged content.
+        # unchanged content. tmux captures viewport PLUS scrollback (``-S
+        # -200``), so a 220-turn history overruns even the full 200-row
+        # window; this fixture models that overrun, not the literal boundary
+        # exactly at 200.
         bounded_view = "\n".join(retained_lines[-40:])
 
         mock_backend.return_value.get_history.return_value = full_history
@@ -2605,7 +2608,106 @@ class TestCodexProviderTrustPrompt:
             provider = CodexProvider("test1234", "test-session", "window-0")
             provider.mark_input_received()
 
-        assert provider.get_status_from_screen(viewport_rows) == TerminalStatus.IDLE
+            assert provider.get_status_from_screen(viewport_rows) == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_render_baseline_vs_raw_observation_is_not_newly_owned(self, mock_backend):
+        """One canonical representation for baseline and observation.
+
+        The pre-send baseline arrives as a tmux capture-pane render (literal
+        column spacing — double spaces where the TUI used cursor-forward
+        padding, long cells wrapped at the pane width), while status
+        observations arrive from the raw stream, where those cursor runs
+        collapse to single spaces and lines never wrap (issue #739 review:
+        exact per-cell equality between those two productions of one
+        unchanged pane disarmed the ownership gate and let a dropped
+        dispatch falsely COMPLETE). Cells canonicalize whitespace and
+        compare with wrap tolerance, so the raw view of the unchanged
+        retained turn reads unchanged.
+        """
+        rendered_history = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have  1 usage limit reset available.  Run /usage to use one.\n"
+            "› run the deployment pipeline end to end and report every step plus the\n"
+            "  timing for each stage\n"
+            "• Pipeline finished.  All stages passed.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        raw_stream_view = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "› run the deployment pipeline end to end and report every step plus the timing for each stage\n"
+            "• Pipeline finished. All stages passed.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = rendered_history
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # The differently produced view of the SAME unchanged pane must not
+        # read as newly owned content: IDLE (dropped submit retries), not
+        # COMPLETED from the retained prior turn.
+        assert provider.get_status(raw_stream_view) == TerminalStatus.IDLE
+        # The render view of the same pane reads unchanged too.
+        assert provider.get_status(rendered_history) == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_partial_repaint_without_footer_does_not_disarm_ownership(self, mock_backend):
+        """A post-clear partial repaint must not permanently disarm the gate.
+
+        The rolling buffer is cleared at dispatch, so an early poll can
+        catch the pane mid-repaint: the composer hint is drawn but the
+        status bar is not, so no TUI footer is detected and the cutoff
+        keeps the whole text (issue #739 review). The composer-looking
+        bottom line is dropped from the cells in that frame — a submitted
+        user cell always has the composer or a response below it — so the
+        unchanged notice pane keeps the gate armed and a later retained
+        notice still cannot complete the dropped dispatch.
+        """
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        partial_repaint = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+        )
+        mock_backend.return_value.get_history.return_value = notice_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # Early poll: composer present, status bar not yet drawn.
+        assert provider.get_status(partial_repaint) == TerminalStatus.IDLE
+        # The gate must still be armed: the footer-restored unchanged pane
+        # is retained content, not this dispatch's completion.
+        assert provider.get_status(notice_pane) == TerminalStatus.IDLE
+
+        # Genuine current-turn content still completes.
+        settled = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "› analyze the repo and list risks\n"
+            "• The requested task is complete.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        assert provider.get_status(settled) == TerminalStatus.COMPLETED
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_unchanged_approval_prompt_keeps_waiting_after_dispatch(self, mock_backend):
@@ -2702,6 +2804,54 @@ class TestCodexProviderTrustPrompt:
 
         assert _has_startup_idle_composer(output) is False
         assert _has_startup_idle_composer(output, allow_partial_activity_cell=True) is True
+
+    def test_v0153_ellipsis_frame_waits_for_stabilization(self):
+        """A live frame paused on an ellipsis is not printed prose: readiness
+        waits for the stabilization pass rather than declaring the pane ready
+        mid-paint."""
+        output = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• Working…\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        assert _has_startup_idle_composer(output) is False
+        assert _has_startup_idle_composer(output, allow_partial_activity_cell=True) is True
+
+    @pytest.mark.asyncio
+    @patch(
+        "cli_agent_orchestrator.providers.codex.time.time",
+        side_effect=[0.0, 0.0, 1.0, 20.0],
+    )
+    @patch("cli_agent_orchestrator.providers.codex.asyncio.sleep", new_callable=AsyncMock)
+    @patch("cli_agent_orchestrator.providers.codex.logger.error")
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    async def test_handle_trust_prompt_stabilization_exits_on_adjacent_repeat(
+        self, mock_backend, mock_error, mock_sleep, _mock_time
+    ):
+        """The stabilization loop itself, not just its helper: two identical
+        partial-activity tails on consecutive polls must exit the startup loop
+        ready (a live spinner's tail never repeats, so it keeps waiting). A
+        broken signature update would time this loop out while every helper
+        test still passed (issue #739 review)."""
+        mock_backend.return_value.get_history.return_value = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• Working\n"
+            "\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        await provider._handle_trust_prompt(timeout=20.0)
+
+        # Two polls: the first saw the partial frame moving, the second saw
+        # the identical tail and declared the pane settled.
+        assert mock_backend.return_value.get_history.call_count == 2
+        assert mock_sleep.await_count == 1
+        mock_error.assert_not_called()
 
     @pytest.mark.parametrize(
         "notice",

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -10,7 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from cli_agent_orchestrator.models.inbox import OrchestrationType
-from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.models.terminal import (
+    TerminalCaptureUnavailableError,
+    TerminalStatus,
+)
 from cli_agent_orchestrator.providers.codex import (
     APPROVAL_PROMPT_FOOTER,
     CodexProvider,
@@ -2400,15 +2403,20 @@ class TestCodexProviderTrustPrompt:
         the first post-dispatch observation as the baseline, so a genuine
         fast completion latched IDLE — deferred delivery resent the finished
         task and synchronous dispatch timed out. A pre-send baseline that
-        cannot be obtained now raises ProviderError from
+        cannot be obtained after the bounded in-dispatch retry now raises
+        the distinct retryable TerminalCaptureUnavailableError from
         mark_input_received, which sits immediately before send_keys in
-        terminal_service.send_input: the message is never typed, callers
-        mark it for retry, and no baseline is ever derived post-send.
+        terminal_service.send_input: the message is never typed, consumers
+        route it back to retry (inbox resets PENDING, deferred init retries
+        without deleting the worker), and no baseline is ever derived
+        post-send.
         """
         mock_backend.return_value.get_history.side_effect = RuntimeError("capture failed")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        with pytest.raises(ProviderError, match="pre-send transcript capture failed"):
+        with pytest.raises(
+            TerminalCaptureUnavailableError, match="pre-send transcript capture failed"
+        ):
             provider.mark_input_received()
         # Nothing was armed: the provider holds no dispatch state at all.
         assert provider._dispatch_pending is False
@@ -2494,7 +2502,7 @@ class TestCodexProviderTrustPrompt:
         mock_backend.return_value.get_history.side_effect = RuntimeError("capture failed")
 
         provider = CodexProvider("test1234", "test-session", "window-0")
-        with pytest.raises(ProviderError):
+        with pytest.raises(TerminalCaptureUnavailableError):
             provider.mark_input_received()
 
         # Caller retries the dispatch; capture succeeds now.
@@ -2535,7 +2543,7 @@ class TestCodexProviderTrustPrompt:
         def fresh_dispatch_then_observe(observation: str) -> TerminalStatus:
             mock_backend.return_value.get_history.side_effect = RuntimeError("boom")
             provider = CodexProvider("test1234", "test-session", "window-0")
-            with pytest.raises(ProviderError):
+            with pytest.raises(TerminalCaptureUnavailableError):
                 provider.mark_input_received()
             mock_backend.return_value.get_history.side_effect = None
             mock_backend.return_value.get_history.return_value = notice_pane
@@ -2708,6 +2716,229 @@ class TestCodexProviderTrustPrompt:
             "  gpt-5.6-sol default · /tmp/work\n"
         )
         assert provider.get_status(settled) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_unrecognized_partial_footer_then_settled_notice_stays_not_completed(
+        self, mock_backend
+    ):
+        """Review 5131322289 P1, first mode: a partial repaint whose composer
+        line survives (footer row not yet recognized) must not permanently
+        disarm the ownership gate. The footerless frame now carries NO
+        verdict — ownership mutates only on a structurally complete,
+        footer-bounded observation — so the later, footer-restored UNCHANGED
+        notice pane still reads IDLE for the dropped task instead of
+        COMPLETED."""
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        # Composer drawn, status-bar row present but not matching the footer
+        # pattern yet (partial repaint), so no TUI footer is detected.
+        partial_footer_repaint = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6\n"
+        )
+        mock_backend.return_value.get_history.return_value = notice_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # Ambiguous footerless frame: no verdict, gate stays armed.
+        assert provider.get_status(partial_footer_repaint) == TerminalStatus.IDLE
+        assert provider._dispatch_pending is True
+        # The footer-restored UNCHANGED pane is retained content, not this
+        # dispatch's completion.
+        assert provider.get_status(notice_pane) == TerminalStatus.IDLE
+        assert provider._dispatch_pending is True
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_equal_content_evicted_marker_turn_completes_via_full_history(self, mock_backend):
+        """Review 5131322289 P1, second mode: a fast second turn whose user
+        marker is evicted from the observation window and whose assistant
+        cell equals the prior turn's last cell must COMPLETE, not stay IDLE
+        forever. The bounded observation is an exact suffix of the baseline,
+        so the gate escalates to the full pane history, where the appended
+        turn is visible as growth past the baseline (transcript cells only
+        accumulate)."""
+        prior_pane = (
+            "› first question\n"
+            "• Done.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        # Bounded observation: the user marker of the new turn already rolled
+        # out; the only new cell, "• Done.", byte-equals the prior turn's
+        # last cell, so the window view is an exact suffix of the baseline.
+        evicted_equal_view = (
+            "• Done.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        # Full history: the appended second turn is visible — the full cell
+        # sequence is longer than the baseline, not a tail of it.
+        full_second_turn = (
+            "› first question\n"
+            "• Done.\n"
+            "› second question\n"
+            "• Done.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = prior_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # The pane history now holds the appended second turn.
+        mock_backend.return_value.get_history.return_value = full_second_turn
+        assert provider.get_status(evicted_equal_view) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_prefix_content_evicted_marker_turn_completes_via_full_history(self, mock_backend):
+        """Review 5131322289 P1, second mode, prefix variant: the terse new
+        cell is a truncated view of the retained cell (capture-pane width
+        wrap), so the window comparison alone classifies it unchanged. The
+        full-history escalation still sees the appended turn as growth."""
+        prior_pane = (
+            "› first question\n"
+            "• The requested task is complete and all checks passed.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        # New turn's cell is a prefix of the retained one; user marker
+        # evicted from the bounded view.
+        evicted_prefix_view = (
+            "• The requested task is complete\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        full_second_turn = (
+            "› first question\n"
+            "• The requested task is complete and all checks passed.\n"
+            "› second question\n"
+            "• The requested task is complete\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = prior_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        mock_backend.return_value.get_history.return_value = full_second_turn
+        assert provider.get_status(evicted_prefix_view) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_pyte_equal_content_evicted_marker_turn_completes_via_full_history(self, mock_backend):
+        """Review 5131322289 P1 through the pyte screen path: same
+        equal-content completion, driven through get_status_from_screen."""
+        prior_pane = (
+            "› first question\n"
+            "• Done.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        full_second_turn = (
+            "› first question\n"
+            "• Done.\n"
+            "› second question\n"
+            "• Done.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = prior_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        mock_backend.return_value.get_history.return_value = full_second_turn
+        screen_rows = [str(line) for line in full_second_turn.splitlines()]
+        assert provider.get_status_from_screen(screen_rows) == (TerminalStatus.COMPLETED)
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_unchanged_ambiguous_pane_does_not_escalate_unbounded(self, mock_backend):
+        """Review 5131322289 P1 rate bound: while the pane is genuinely
+        unchanged, repeated ambiguous polls escalate at most once per
+        interval — get_status stays cheap instead of forking a capture-pane
+        on every poll."""
+        prior_pane = (
+            "› first question\n"
+            "• Done.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = prior_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # The bounded view equals the baseline: ambiguous, so escalation runs
+        # on the FIRST poll and is rate-limited on the next.
+        bounded_view = "\n".join(prior_pane.splitlines()[-4:])
+        assert provider.get_status(bounded_view) == TerminalStatus.IDLE
+        reads_after_first = mock_backend.return_value.get_history.call_count
+        assert provider.get_status(bounded_view) == TerminalStatus.IDLE
+        assert provider.get_status(bounded_view) == TerminalStatus.IDLE
+        # No unbounded forking: at most one escalation read per interval. The
+        # baseline capture itself performed reads before the first poll, so
+        # compare growth across the subsequent polls only.
+        assert mock_backend.return_value.get_history.call_count - reads_after_first <= 1
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_transient_capture_failure_retries_within_dispatch(self, mock_backend):
+        """Review 5131322289 P2: a single failed capture-pane read is retried
+        bounded INSIDE the dispatch — a transient blip must not refuse an
+        otherwise valid delivery."""
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n"
+            "\n"
+            "› Ask Codex to do anything\n"
+            "\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        calls = {"n": 0}
+
+        def flaky_capture(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("capture failed")
+            return notice_pane
+
+        mock_backend.return_value.get_history.side_effect = flaky_capture
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()  # no raise: the retry recovered it
+
+        assert provider._dispatch_pending is True
+        # The retained notice pane still cannot complete the dispatch.
+        assert provider.get_status(notice_pane) == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_unchanged_approval_prompt_keeps_waiting_after_dispatch(self, mock_backend):

--- a/test/providers/test_codex_provider_unit.py
+++ b/test/providers/test_codex_provider_unit.py
@@ -2272,7 +2272,11 @@ class TestCodexProviderTrustPrompt:
         provider = CodexProvider("test1234", "test-session", "window-0")
         provider.mark_input_received()
 
-        assert provider.get_status(retained) == TerminalStatus.PROCESSING
+        # IDLE, not COMPLETED: the composer is visible, so the pane reads
+        # "not started" — exactly the signal the deferred-delivery retry
+        # loop needs to re-submit a dropped input. (PROCESSING would read
+        # as "task accepted" to that same consumer, issue #739 review.)
+        assert provider.get_status(retained) == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_dispatch_does_not_complete_on_retained_prior_turn(self, mock_backend):
@@ -2290,7 +2294,7 @@ class TestCodexProviderTrustPrompt:
         provider = CodexProvider("test1234", "test-session", "window-0")
         provider.mark_input_received()
 
-        assert provider.get_status(retained) == TerminalStatus.PROCESSING
+        assert provider.get_status(retained) == TerminalStatus.IDLE
 
     @patch("cli_agent_orchestrator.providers.codex.get_backend")
     def test_dispatched_evicted_marker_turn_completes_after_new_content(self, mock_backend):
@@ -2343,10 +2347,11 @@ class TestCodexProviderTrustPrompt:
         provider.mark_input_received()
         assert provider.get_status(first_turn) == TerminalStatus.COMPLETED
 
-        # Dispatch two: the pane still shows turn one's completion.
+        # Dispatch two: the pane still shows turn one's completion. IDLE, not
+        # COMPLETED (ownership gate), and composer-visible means "not started".
         mock_backend.return_value.get_history.return_value = first_turn
         provider.mark_input_received()
-        assert provider.get_status(first_turn) == TerminalStatus.PROCESSING
+        assert provider.get_status(first_turn) == TerminalStatus.IDLE
 
         second_turn = (
             "› second question\n"
@@ -2356,6 +2361,131 @@ class TestCodexProviderTrustPrompt:
             "  gpt-5.6-sol default · /tmp/work\n"
         )
         assert provider.get_status(second_turn) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_draft_in_composer_does_not_disarm_ownership(self, mock_backend):
+        """A successful paste with swallowed Enter must not complete the turn.
+
+        Issue #739 follow-up review: the draft changes only the composer
+        line, which the TUI footer cutoff already excludes from transcript
+        parsing — so it must not change the dispatch baseline either. With
+        the retained notice still the only transcript content, the pane
+        reads IDLE ("not started"), letting the deferred-delivery retry
+        loop re-submit instead of accepting the task as started.
+        """
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        draft_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› analyze the repo and list risks\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.return_value = notice_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider.get_status(draft_pane) == TerminalStatus.IDLE
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_baseline_capture_failure_fails_closed(self, mock_backend):
+        """A transient get_history failure at dispatch must not disarm the gate.
+
+        The first post-dispatch observation becomes the baseline, so a
+        retained notice pane still cannot complete the dropped submission
+        (issue #739 follow-up review: baseline-read failure previously
+        restored the unsafe completion behavior).
+        """
+        notice_pane = (
+            "OpenAI Codex (v0.153.2)\n"
+            "• You have 1 usage limit reset available. Run /usage to use one.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        mock_backend.return_value.get_history.side_effect = RuntimeError("capture failed")
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        # First observation arms the baseline lazily; the same pane — with or
+        # without a typed draft — stays not-started, and genuine new content
+        # still completes.
+        assert provider.get_status(notice_pane) == TerminalStatus.IDLE
+        assert provider.get_status(notice_pane) == TerminalStatus.IDLE
+        settled = (
+            "• The requested task is complete.\n\n"
+            "› Ask Codex to do anything\n\n"
+            "  gpt-5.6-sol default · /tmp/work\n"
+        )
+        assert provider.get_status(settled) == TerminalStatus.COMPLETED
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_unchanged_approval_prompt_keeps_waiting_after_dispatch(self, mock_backend):
+        """A dropped prompt answer must not flip an approval menu to PROCESSING.
+
+        Issue #739 follow-up review: the ownership gate must not mask the
+        modal classifiers. The pane is unchanged from the pre-answer
+        baseline, but the numbered approval menu keeps its
+        WAITING_USER_ANSWER precedence so another answer_user_prompt call
+        is accepted.
+        """
+        approval_pane: str = (
+            "› Run this shell command now, do not explain first: mkdir -p /tmp/x\n"
+            "• Running mkdir -p /tmp/x\n"
+            "\n"
+            "  Would you like to run the following command?\n"
+            "\n"
+            "  Environment: local\n"
+            "\n"
+            "  $ mkdir -p /tmp/x\n"
+            "\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. Yes, and don't ask again for commands that start with `mkdir -p /tmp/x` (p)\n"
+            "  3. No, and tell Codex what to do differently (n)\n"
+            "\n"
+            "  Press enter to confirm or esc to cancel\n"
+        )
+        mock_backend.return_value.get_history.return_value = approval_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider.get_status(approval_pane) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(approval_pane.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
+
+    @patch("cli_agent_orchestrator.providers.codex.get_backend")
+    def test_unchanged_login_menu_keeps_waiting_after_dispatch(self, mock_backend):
+        """Same precedence for the first-run login menu: a dropped answer must
+        keep the pane WAITING_USER_ANSWER, not PROCESSING."""
+        login_pane: str = (
+            "Welcome to Codex, OpenAI's command-line coding agent\n"
+            "Sign in with ChatGPT to use Codex as part of your paid plan\n"
+            "or connect an API key for usage-based billing\n"
+            "\n"
+            "> 1. Sign in with ChatGPT\n"
+            "  2. Sign in with Device Code\n"
+            "  3. Provide your own API key\n"
+            "\n"
+            "Press enter to continue\n"
+        )
+        mock_backend.return_value.get_history.return_value = login_pane
+
+        provider = CodexProvider("test1234", "test-session", "window-0")
+        provider.mark_input_received()
+
+        assert provider.get_status(login_pane) == TerminalStatus.WAITING_USER_ANSWER
+        assert (
+            provider.get_status_from_screen(login_pane.splitlines())
+            == TerminalStatus.WAITING_USER_ANSWER
+        )
 
     def test_v0153_stale_spinner_above_newer_composer_is_ready(self):
         """Readiness comes from the bottom-most cell, not any cell in the region.

--- a/test/services/test_inbox_service.py
+++ b/test/services/test_inbox_service.py
@@ -9,7 +9,10 @@ import pytest
 from cli_agent_orchestrator.backends.base import TerminalNotFoundError
 from cli_agent_orchestrator.constants import INBOX_RECONCILE_GRACE_SECONDS
 from cli_agent_orchestrator.models.inbox import InboxMessage, MessageStatus
-from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.models.terminal import (
+    TerminalCaptureUnavailableError,
+    TerminalStatus,
+)
 from cli_agent_orchestrator.services.inbox_service import InboxService
 
 
@@ -202,6 +205,35 @@ class TestDeliverPending:
         mock_get.return_value = [_make_message()]
         mock_monitor.get_status.return_value = TerminalStatus.IDLE
         mock_term_svc.send_input.side_effect = TerminalNotFoundError("s:w")
+
+        svc = InboxService()
+        svc.deliver_pending("term-1")
+
+        # Final status is PENDING (reset after the optimistic DELIVERED), never FAILED.
+        assert mock_update.call_args_list[-1] == call(1, MessageStatus.PENDING)
+        assert call(1, MessageStatus.FAILED) not in mock_update.call_args_list
+
+    @patch("cli_agent_orchestrator.services.inbox_service.update_message_status")
+    @patch("cli_agent_orchestrator.services.inbox_service.terminal_service")
+    @patch("cli_agent_orchestrator.services.inbox_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.inbox_service.get_pending_messages")
+    def test_capture_refusal_leaves_message_pending(
+        self, mock_get, mock_monitor, mock_term_svc, mock_update
+    ):
+        """A TerminalCaptureUnavailableError during send leaves the message
+        PENDING, not FAILED.
+
+        The provider's pre-send transcript capture refused the dispatch
+        before typing anything (issue #739 review: the generic ProviderError
+        terminally failed an otherwise valid delivery). Like an unresolvable
+        pane, nothing was sent, so the message must return to PENDING for the
+        reconcile sweep — never FAILED.
+        """
+        mock_get.return_value = [_make_message()]
+        mock_monitor.get_status.return_value = TerminalStatus.IDLE
+        mock_term_svc.send_input.side_effect = TerminalCaptureUnavailableError(
+            "pre-send transcript capture failed"
+        )
 
         svc = InboxService()
         svc.deliver_pending("term-1")

--- a/test/services/test_terminal_service_full.py
+++ b/test/services/test_terminal_service_full.py
@@ -16,7 +16,10 @@ from cli_agent_orchestrator.clients.database import (
 )
 from cli_agent_orchestrator.models.agent_profile import AgentProfile
 from cli_agent_orchestrator.models.inbox import OrchestrationType
-from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.models.terminal import (
+    TerminalCaptureUnavailableError,
+    TerminalStatus,
+)
 from cli_agent_orchestrator.providers.base import OutputExtractionError
 from cli_agent_orchestrator.services.terminal_service import (
     IdempotencyKeyConflict,
@@ -3144,5 +3147,105 @@ class TestDeferredInitWaitingUserAnswerSurvival:
         await task
 
         mock_tmux.send_keys.assert_not_called()
+        mock_notify.assert_called_once()
+        assert mock_notify.call_args.kwargs["delete_worker"] is False
+
+
+class TestDeferredInitCaptureUnavailable:
+    """Issue #739 review (5131322289) P2: the provider's pre-send transcript
+    capture refuses the dispatch before any key is typed. The deferred-init
+    path must retry the delivery bounded, and when the refusal persists it
+    must leave the initialized worker ALIVE — a capture read that keeps
+    failing is transient infrastructure, not a dead terminal — while telling
+    the caller the task was not delivered.
+    """
+
+    @pytest.mark.asyncio
+    @patch(
+        "cli_agent_orchestrator.services.terminal_service._confirm_worker_started_or_resubmit",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    @patch("cli_agent_orchestrator.services.terminal_service._notify_caller_of_deferred_failure")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.send_input")
+    async def test_transient_capture_refusal_retries_and_delivers(
+        self, mock_send, mock_pm, mock_status_monitor, mock_meta, mock_notify, mock_confirm
+    ):
+        """One capture refusal that clears on the retry: the task is
+        delivered, the confirm loop runs, and the caller is never told the
+        worker failed. (The confirm loop itself is stubbed to started — the
+        delivery retry is what this case owns.)"""
+        from cli_agent_orchestrator.services.terminal_service import (
+            _deferred_init_tasks,
+            _schedule_deferred_init,
+        )
+
+        mock_meta.return_value = {"caller_id": "super123"}
+        mock_status_monitor.get_status.return_value = TerminalStatus.IDLE
+        mock_pm.get_provider.return_value = None
+
+        calls = {"n": 0}
+
+        def send_then_succeed(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise TerminalCaptureUnavailableError("capture failed")
+            return True
+
+        mock_send.side_effect = send_then_succeed
+
+        provider_instance = AsyncMock()
+        provider_instance.initialize.return_value = True
+        provider_instance.shell_baseline = None
+
+        before_tasks = set(_deferred_init_tasks)
+        _schedule_deferred_init(
+            provider_instance, "worker99", "do the task", OrchestrationType.ASSIGN, None
+        )
+        (task,) = set(_deferred_init_tasks) - before_tasks
+        await task
+
+        # The delivery was retried and went through.
+        assert mock_send.call_count >= 2
+        mock_notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("cli_agent_orchestrator.services.terminal_service._notify_caller_of_deferred_failure")
+    @patch("cli_agent_orchestrator.services.terminal_service.get_terminal_metadata")
+    @patch("cli_agent_orchestrator.services.terminal_service.status_monitor")
+    @patch("cli_agent_orchestrator.services.terminal_service.provider_manager")
+    @patch("cli_agent_orchestrator.services.terminal_service.send_input")
+    async def test_persistent_capture_refusal_leaves_worker_alive(
+        self, mock_send, mock_pm, mock_status_monitor, mock_meta, mock_notify
+    ):
+        """The refusal never clears: after the bounded retries the caller is
+        told the task was NOT delivered and the worker is left alive
+        (delete_worker=False) instead of deleted."""
+        from cli_agent_orchestrator.services.terminal_service import (
+            _deferred_init_tasks,
+            _schedule_deferred_init,
+        )
+
+        mock_meta.return_value = {"caller_id": "super123"}
+        mock_status_monitor.get_status.return_value = TerminalStatus.IDLE
+        mock_pm.get_provider.return_value = None
+        mock_send.side_effect = TerminalCaptureUnavailableError("capture failed")
+
+        provider_instance = AsyncMock()
+        provider_instance.initialize.return_value = True
+        provider_instance.shell_baseline = None
+
+        before_tasks = set(_deferred_init_tasks)
+        _schedule_deferred_init(
+            provider_instance, "worker99", "do the task", OrchestrationType.ASSIGN, None
+        )
+        (task,) = set(_deferred_init_tasks) - before_tasks
+        await task
+
+        # Bounded retries, then the distinct alive-preserving outcome.
+        assert mock_send.call_count == 3
         mock_notify.assert_called_once()
         assert mock_notify.call_args.kwargs["delete_worker"] is False


### PR DESCRIPTION
## Summary

- Codex startup readiness and completion now classify content by per-dispatch ownership instead of by glyph.
- Readiness is decided from the bottom-most TUI cell above the composer: a live timed spinner vetoes, an unterminated bullet is a possible mid-paint frame that must stabilize across polls, older cells above (a stale spinner or finished turn) no longer block, and sentence-terminated notice bullets are static text. A frame paused on a trailing ellipsis is treated as possibly still painting, not printed prose.
- After a dispatch, the pane's transcript baseline is captured strictly before the send: parsed marker cells (assistant bullets and submitted user cells, above the TUI footer cutoff), never a hash of raw pane text and never derived from a post-send observation. The tmux history window and the buffer/viewport views of the same unchanged pane start at different lines once a transcript exceeds 200 rows, so the baseline is compared against every observation by marker-cell suffix: a differently bounded view of unchanged content still reads unchanged, and a dropped dispatch over a long retained transcript cannot falsely complete.
- Baseline and observation reduce the pane through one canonical representation. The pre-send baseline is a tmux capture-pane render (literal column spacing, cells wrapped at the pane width) while status observations come from the raw byte stream (cursor-forward runs collapsed, no wrapping), so exact string equality between the two productions of one unchanged pane read as new content and disarmed the ownership gate. Marker cells are whitespace-canonicalized and compared with wrap tolerance (a cell that is a prefix of the other is a truncated view of the same line), so every view of an unchanged pane parses to the same cells. Both sides also share the same cleaner and the same footer-cutoff rule.
- An incomplete repaint frame now carries no ownership verdict at all. A frame that has drawn the composer but not yet the status bar has no footer to bound the transcript, so it cannot tell the composer from a submitted user cell: ownership mutates only on a structurally complete, footer-bounded observation. A footerless frame can delay a verdict (the pane reads not-started), never disarm the gate; the footer-restored frame still decides, so a dropped dispatch followed by a partial repaint and the unchanged settled notice pane cannot falsely complete.
- An equal-content reply is resolved by a monotonic post-dispatch occurrence, not by cell text. A fast later turn whose user marker has been evicted from the observation window and whose response cell equals (or is a width-truncated view of) the retained cell is invisible to text comparison, so the gate escalates exactly that ambiguous suffix match to the full pane history, where an appended turn is always visible as growth past the pre-send baseline (transcript cells only accumulate). The escalation read is rate-limited and fail-closed: a read that fails or is rate-limited keeps the gate armed, so it can only delay a verdict, never fake one.
- A pre-send capture that fails is retried bounded inside the dispatch (a single failed `tmux capture-pane` is infrastructure noise, not a pane verdict). When it keeps failing, the dispatch refuses before any key is typed with a distinct retryable `TerminalCaptureUnavailableError` (not a generic `ProviderError`): inbox delivery resets the message to `PENDING` for the reconcile sweep instead of terminally failing it, and deferred initialization retries the delivery and leaves the initialized worker alive instead of deleting it. A pane with no retained marker cells (fresh session, login menu) is a valid empty baseline: nothing is retained, any cell observed later is new.
- The ownership gate is consulted only at the two COMPLETED decision points, after the modal and error classifiers: an unchanged approval prompt or first-run login menu keeps `WAITING_USER_ANSWER`, and a pane with no new transcript content reads `IDLE` ("not started"), so dropped-input redelivery retries instead of accepting the task as started.

## Why

Account notices use the same `•` glyph as activity and responses, and the rendered screen survives the rolling-buffer clear at dispatch, so glyph- and dispatch-boolean-based classification both misfire (#739, follow-up review). The tmux capture window and the status observations are differently bounded, differently produced views of the same pane, so ownership must be compared on a representation that survives both; a text comparison alone cannot tell a terse new turn from retained text, which is why the ambiguous case resolves against the full history's cell count (latest follow-up review).

## Verification

- Regressions that fail on the previously reviewed head `58519bc` and pass here: the unrecognized-footer partial repaint followed by the unchanged settled notice pane (was permanently disarming the gate, then falsely COMPLETED), the equal-content and prefix-content evicted-marker second turns on the raw and pyte paths (were staying IDLE forever: full resend or sync timeout), the persistent pre-send capture failure (was a generic `ProviderError` the consumers terminally failed), and the flaky-capture-recovered-inside-the-dispatch case (was refusing a valid delivery).
- Consumer-path coverage for the retryable refusal: inbox `deliver_pending` resets the message to `PENDING` (never `FAILED`); deferred init retries a transient refusal and delivers with no failure notification, and a persistent refusal leaves the worker alive (`delete_worker=False`) with the caller told the task was not delivered.
- The escalation read is rate-bounded: repeated ambiguous polls of an unchanged pane fork at most one capture-pane per 3s interval (loop-level bound asserted).
- The prior-round regressions (unchanged >200-row retained transcript raw and pyte views, render-baseline vs raw-observation representation, capture failure followed by visible-marker and evicted-marker completion, fast completion on first observation, retry-after-refusal, approval/login precedence, draft-in-composer, footerless partial repaint) are retained and still pass.
- `uv run pytest test/providers/test_codex_provider_unit.py --no-cov`: 299 passed, 3 skipped.
- `uv run pytest test/providers/ --no-cov`: 1557 passed, 3 skipped, 7 deselected, 1 xfailed.
- `uv run pytest test/services/ --no-cov`: full services suite numbers recorded in the thread.
- `uv run black --check src test` / `uv run isort --check-only src test`: clean. `uv run mypy` on the four changed source files: clean.

Fixes #739
