### PR TITLE
fix(memory): make the unique key constraint hold for NULL scope_id rows

### DIFF
--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -12,12 +12,14 @@ from sqlalchemy import (
     Column,
     DateTime,
     Float,
+    Index,
     Integer,
     String,
     Text,
     UniqueConstraint,
     create_engine,
     literal_column,
+    text,
 )
 from sqlalchemy.orm import DeclarativeBase, declarative_base, sessionmaker
 
@@ -170,6 +172,18 @@ class MemoryMetadataModel(Base):
 
     __table_args__ = (
         UniqueConstraint("key", "scope", "scope_id", name="uq_memory_key_scope"),
+        # Same NULL-distinctness the sentinel comment below documents for
+        # ``memory_relationships``: ``uq_memory_key_scope`` never fires for
+        # global/federated rows because SQLite treats ``NULL != NULL`` in a
+        # UNIQUE index. This partial index covers exactly those rows
+        # (issue #657). Existing DBs get it from ``_migrate_memory_scope_null_uniqueness``.
+        Index(
+            "uq_memory_key_scope_null",
+            "key",
+            "scope",
+            unique=True,
+            sqlite_where=text("scope_id IS NULL"),
+        ),
         CheckConstraint(
             "related_keys IS NULL OR length(related_keys) < 1024",
             name="ck_related_keys_length",
@@ -414,6 +428,9 @@ def init_db() -> None:
     # Appended LAST (issue #583 Bolt 2, ``approval-store``). Disjoint from every table above —
     # its own new table, no shared columns — so registry order is immaterial here too.
     _migrate_workflow_plan_approval()
+    # Appended LAST (issue #657). Adds one partial index to memory_metadata;
+    # reads no other table, so registry order is immaterial here too.
+    _migrate_memory_scope_null_uniqueness()
 
 
 def _restrict_db_file_permissions() -> None:
@@ -683,6 +700,52 @@ def _migrate_workflow_plan_approval() -> None:
             )
     except Exception as e:  # noqa: BLE001 — derived/recoverable; logged at debug (B4-RD-4)
         logger.debug(f"workflow_plan_approval migration skipped: {e}")
+
+
+def _migrate_memory_scope_null_uniqueness() -> None:
+    """Create the partial unique index backing ``uq_memory_key_scope`` for
+    NULL ``scope_id`` rows (issue #657). Appended LAST to the ``init_db()``
+    registry.
+
+    SQLite treats ``NULL != NULL`` in a UNIQUE index, so the table-level
+    ``uq_memory_key_scope`` constraint has never fired for global/federated
+    memories (``MemoryService.resolve_scope_id`` persists a real NULL for
+    both — ``memory_metadata`` deliberately keeps the column nullable; the
+    sentinel used by ``memory_relationships`` is wrong here). This index
+    covers exactly those rows; non-NULL scopes stay on the table constraint.
+
+    Idempotent, zero-arg, self-connecting — mirrors the existing migrators.
+    Fail-soft by design: on a database that already holds duplicate
+    NULL-scope rows (the state this bug allowed — external edits, merged
+    DBs), ``CREATE UNIQUE INDEX`` raises ``IntegrityError``, so duplicates
+    are pre-scanned and the index is skipped with a warning pointing at
+    ``cao memory repair`` rather than blocking startup. Re-running
+    ``init_db()`` after the repair creates it.
+    """
+    import sqlite3
+
+    from cli_agent_orchestrator.constants import DATABASE_FILE
+
+    try:
+        with sqlite3.connect(str(DATABASE_FILE)) as conn:
+            duplicates = conn.execute(
+                "SELECT key, scope, COUNT(*) FROM memory_metadata "
+                "WHERE scope_id IS NULL GROUP BY key, scope HAVING COUNT(*) > 1"
+            ).fetchall()
+            if duplicates:
+                rendered = ", ".join(f"{scope}:{key}x{count}" for key, scope, count in duplicates)
+                logger.warning(
+                    "Skipping uq_memory_key_scope_null creation: duplicate global/federated "
+                    f"rows in memory_metadata ({rendered}). Run `cao memory repair` to "
+                    "reconcile them; the unique index is created on the next startup."
+                )
+                return
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_key_scope_null "
+                "ON memory_metadata (key, scope) WHERE scope_id IS NULL"
+            )
+    except Exception as e:  # noqa: BLE001 — derived/recoverable; logged at debug
+        logger.debug(f"memory scope NULL uniqueness migration skipped: {e}")
 
 
 def _backfill_legacy_related_keys(conn: Any) -> None:

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -702,7 +702,7 @@ def _migrate_workflow_plan_approval() -> None:
         logger.debug(f"workflow_plan_approval migration skipped: {e}")
 
 
-def _migrate_memory_scope_null_uniqueness() -> None:
+def _migrate_memory_scope_null_uniqueness(engine: Any = None) -> None:
     """Create the partial unique index backing ``uq_memory_key_scope`` for
     NULL ``scope_id`` rows (issue #657). Appended LAST to the ``init_db()``
     registry.
@@ -714,20 +714,34 @@ def _migrate_memory_scope_null_uniqueness() -> None:
     sentinel used by ``memory_relationships`` is wrong here). This index
     covers exactly those rows; non-NULL scopes stay on the table constraint.
 
-    Idempotent, zero-arg, self-connecting — mirrors the existing migrators.
-    Fail-soft by design: on a database that already holds duplicate
-    NULL-scope rows (the state this bug allowed — external edits, merged
-    DBs), ``CREATE UNIQUE INDEX`` raises ``IntegrityError``, so duplicates
-    are pre-scanned and the index is skipped with a warning pointing at
-    ``cao memory repair`` rather than blocking startup. Re-running
-    ``init_db()`` after the repair creates it.
+    Idempotent, self-connecting — mirrors the existing migrators. ``engine``
+    lets a caller bound the attempt to an existing SQLAlchemy engine (the
+    memory-repair path passes its own); the default resolves the singleton
+    ``DATABASE_FILE`` exactly like the other migrators. Fail-soft by design:
+    on a database that still holds duplicate NULL-scope rows,
+    ``CREATE UNIQUE INDEX`` raises ``IntegrityError``, so duplicates are
+    pre-scanned and the index is skipped with a warning pointing at
+    ``cao memory repair`` rather than blocking startup. The repair now
+    re-invokes this migrator once its dedupe has cleared the duplicates, so
+    the index lands in the same repair run instead of at the next startup.
     """
     import sqlite3
 
     from cli_agent_orchestrator.constants import DATABASE_FILE
 
+    target = str(DATABASE_FILE)
     try:
-        with sqlite3.connect(str(DATABASE_FILE)) as conn:
+        if engine is not None:
+            # Reuse the caller's engine connection pool so the attempt and the
+            # repairs share one database identity.
+            with engine.connect() as conn:
+                conn.exec_driver_sql(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_key_scope_null "
+                    "ON memory_metadata (key, scope) WHERE scope_id IS NULL"
+                )
+                conn.commit()
+            return
+        with sqlite3.connect(target) as conn:
             duplicates = conn.execute(
                 "SELECT key, scope, COUNT(*) FROM memory_metadata "
                 "WHERE scope_id IS NULL GROUP BY key, scope HAVING COUNT(*) > 1"

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -702,7 +702,7 @@ def _migrate_workflow_plan_approval() -> None:
         logger.debug(f"workflow_plan_approval migration skipped: {e}")
 
 
-def _migrate_memory_scope_null_uniqueness(engine: Any = None) -> None:
+def _migrate_memory_scope_null_uniqueness(engine: Any = None, *, strict: bool = False) -> None:
     """Create the partial unique index backing ``uq_memory_key_scope`` for
     NULL ``scope_id`` rows (issue #657). Appended LAST to the ``init_db()``
     registry.
@@ -724,6 +724,11 @@ def _migrate_memory_scope_null_uniqueness(engine: Any = None) -> None:
     ``cao memory repair`` rather than blocking startup. The repair now
     re-invokes this migrator once its dedupe has cleared the duplicates, so
     the index lands in the same repair run instead of at the next startup.
+    ``strict=True`` (the explicit ``cao memory repair --apply`` path) makes
+    that re-invocation honest: DDL failure — e.g. a competing SQLite write
+    lock — propagates instead of being logged at debug, and the named index
+    is verified present before returning, so repair can no longer report
+    success while the index is absent; the startup default stays fail-soft.
     """
     import sqlite3
 
@@ -735,11 +740,41 @@ def _migrate_memory_scope_null_uniqueness(engine: Any = None) -> None:
             # Reuse the caller's engine connection pool so the attempt and the
             # repairs share one database identity.
             with engine.connect() as conn:
+                index_rows = conn.exec_driver_sql(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type = 'index' AND name = 'uq_memory_key_scope_null'"
+                ).fetchall()
+                if index_rows:
+                    return
+                duplicates = conn.exec_driver_sql(
+                    "SELECT key, scope, COUNT(*) FROM memory_metadata "
+                    "WHERE scope_id IS NULL GROUP BY key, scope HAVING COUNT(*) > 1"
+                ).fetchall()
+                if duplicates:
+                    rendered = ", ".join(
+                        f"{scope}:{key}x{count}" for key, scope, count in duplicates
+                    )
+                    logger.warning(
+                        "Skipping uq_memory_key_scope_null creation: duplicate global/federated "
+                        f"rows in memory_metadata ({rendered}). Run `cao memory repair` to "
+                        "reconcile them; the unique index is created on the next startup."
+                    )
+                    return
                 conn.exec_driver_sql(
                     "CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_key_scope_null "
                     "ON memory_metadata (key, scope) WHERE scope_id IS NULL"
                 )
                 conn.commit()
+                if strict:
+                    created = conn.exec_driver_sql(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type = 'index' AND name = 'uq_memory_key_scope_null'"
+                    ).fetchall()
+                    if not created:
+                        raise RuntimeError(
+                            "uq_memory_key_scope_null creation reported success but the "
+                            "index is absent from sqlite_master"
+                        )
             return
         with sqlite3.connect(target) as conn:
             duplicates = conn.execute(
@@ -758,7 +793,19 @@ def _migrate_memory_scope_null_uniqueness(engine: Any = None) -> None:
                 "CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_key_scope_null "
                 "ON memory_metadata (key, scope) WHERE scope_id IS NULL"
             )
+            if strict:
+                created = conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type = 'index' AND name = 'uq_memory_key_scope_null'"
+                ).fetchall()
+                if not created:
+                    raise RuntimeError(
+                        "uq_memory_key_scope_null creation reported success but the "
+                        "index is absent from sqlite_master"
+                    )
     except Exception as e:  # noqa: BLE001 — derived/recoverable; logged at debug
+        if strict:
+            raise
         logger.debug(f"memory scope NULL uniqueness migration skipped: {e}")
 
 

--- a/src/cli_agent_orchestrator/services/memory_reconciliation.py
+++ b/src/cli_agent_orchestrator/services/memory_reconciliation.py
@@ -268,6 +268,7 @@ class MemoryReconciliationService:
         self.base_dir = Path(base_dir or MEMORY_BASE_DIR)
         self._db_engine = db_engine
         self._db_session_factory: Any = None
+        self._strict_index = False
         if db_engine is not None:
             from sqlalchemy.orm import sessionmaker
 
@@ -914,6 +915,29 @@ class MemoryReconciliationService:
                 )
 
         all_records = records + parsed_records
+        # Rows whose NULL-scope identity has NO surviving canonical topic are
+        # invisible to topic-driven planning above, yet they are exactly the
+        # duplicate state that keeps uq_memory_key_scope_null off the database
+        # (review: repair used to exit 0 with total=0 while the rows stayed).
+        # Surface every unmapped duplicate NULL-scope identity as an
+        # actionable conflict: rows preserved, manual resolution named.
+        mapped_identities = {topic.identity for topic in topics}
+        for identity, identity_rows in sorted(rows_by_identity.items()):
+            if identity in mapped_identities or identity.scope_id is not None:
+                continue
+            if len(identity_rows) <= 1:
+                continue
+            all_records.append(
+                self._candidate_record(
+                    Path(identity_rows[0].file_path or "<unknown>"),
+                    RepairAction.CONFLICT,
+                    "duplicate_database_identity",
+                    "multiple SQLite rows hold this NULL-scope identity and no canonical "
+                    "topic maps to it; restore or move the canonical topic file, or "
+                    "remove the stray rows manually",
+                    identity,
+                )
+            )
         all_records.sort(
             key=lambda record: (
                 record.identity.scope if record.identity else "",
@@ -1077,9 +1101,14 @@ class MemoryReconciliationService:
             path_matches = [row for row in rows if self._resolved_row_path(row) == topic.file_path]
             if not path_matches:
                 raise RuntimeError("metadata duplicate lost its canonical anchor while lock held")
+            # Legacy rows can mix naive, timezone-aware and NULL ``updated_at``
+            # values (SQLite stores naive datetimes), and comparing a naive
+            # value with the tz-aware ``_MIN_DT`` floor raises ``TypeError``
+            # mid-repair. Normalize through the same ``_utc()`` path planning
+            # uses so the survivor pick is well-defined on legacy data.
             survivor = max(
                 path_matches,
-                key=lambda row: (row.updated_at or _MIN_DT, row.id),
+                key=lambda row: (_utc(row.updated_at) or _MIN_DT, row.id),
             )
             removed = 0
             for row in rows:
@@ -1280,6 +1309,71 @@ class MemoryReconciliationService:
                                 ),
                             )
                         )
+
+            # A dedupe above can free a dependent conflict: every plan in this
+            # run was derived from the pre-mutation row snapshot, so a topic
+            # whose canonical path was occupied by another identity's stale
+            # duplicate row planned a row-state conflict that the dedupe has
+            # just resolved. Re-plan those from a fresh snapshot and execute
+            # the recovered plan here, so one repair run clears both the
+            # duplicate and its dependent conflict instead of demanding a
+            # second identical run.
+            row_state_conflicts = {"database_path_conflict", "ambiguous_database_path"}
+            conflicted_indexes = [
+                index
+                for index, record in enumerate(results)
+                if record.status == "skipped"
+                and record.finding is not None
+                and record.finding.kind in row_state_conflicts
+                and record.identity is not None
+            ]
+            if conflicted_indexes:
+                fresh_maps: Optional[
+                    tuple[dict[MemoryIdentity, list[_Row]], dict[Path, list[_Row]]]
+                ] = None
+                try:
+                    fresh_maps = self._row_maps(self._load_rows())
+                except Exception:
+                    fresh_maps = None
+                if fresh_maps is not None:
+                    fresh_by_identity, fresh_by_path = fresh_maps
+                    for index in conflicted_indexes:
+                        record = results[index]
+                        try:
+                            parsed = self._parse_candidate(self._candidate_from_record(record))
+                        except Exception:
+                            continue
+                        if isinstance(parsed, RepairRecord):
+                            continue
+                        replanned = self._plan_topic(
+                            parsed,
+                            rows_by_identity=fresh_by_identity,
+                            rows_by_path=fresh_by_path,
+                        )
+                        if replanned.status == "skipped":
+                            results[index] = replanned
+                            continue
+                        try:
+                            if RepairAction.DEDUPE_METADATA in replanned.actions:
+                                self._dedupe_metadata(parsed)
+                            for metadata_action in (
+                                RepairAction.CREATE_METADATA,
+                                RepairAction.UPDATE_METADATA,
+                            ):
+                                if metadata_action in replanned.actions:
+                                    self._repair_metadata(parsed, metadata_action)
+                            if RepairAction.REBUILD_INDEX in replanned.actions:
+                                self._repair_index_batch([parsed])
+                            results[index] = replace(
+                                replanned,
+                                status=(
+                                    "unchanged"
+                                    if replanned.actions == (RepairAction.UNCHANGED,)
+                                    else "repaired"
+                                ),
+                            )
+                        except Exception as exc:
+                            results[index] = self._failed_record(replanned, exc)
         finally:
             for _, _, lock_fd in reversed(locked_all):
                 try:
@@ -1301,20 +1395,33 @@ class MemoryReconciliationService:
     def _ensure_null_scope_unique_index(self) -> None:
         """Create ``uq_memory_key_scope_null`` if duplicates allow it.
 
-        Fail-soft by design — the startup migrator re-attempts this — but
-        exceptions surface to the caller because this runs inside an explicit
-        ``cao memory repair --apply``, where a silently missing index is
-        exactly the dead remediation path issue #657's review called out.
+        Fail-soft for the startup path — the startup migrator re-attempts
+        this — but the explicit ``cao memory repair --apply`` invocation sets
+        ``_strict_index``, where exceptions surface to the caller because a
+        silently missing index is exactly the dead remediation path issue
+        #657's review called out.
         """
         from cli_agent_orchestrator.clients.database import (
             _migrate_memory_scope_null_uniqueness,
         )
 
-        _migrate_memory_scope_null_uniqueness(engine=self._db_engine)
+        _migrate_memory_scope_null_uniqueness(engine=self._db_engine, strict=self._strict_index)
 
     def reconcile(self, *, apply: bool = False) -> RepairReport:
-        """Plan by default; mutate only when explicitly requested."""
-        return self.apply() if apply else self.plan()
+        """Plan by default; mutate only when explicitly requested.
+
+        ``apply=True`` is the explicit ``cao memory repair --apply``
+        invocation, so the same-run index creation is strict — a failure
+        there must surface rather than be logged at debug. The startup path
+        calls ``apply()`` directly and keeps the fail-soft default.
+        """
+        if not apply:
+            return self.plan()
+        self._strict_index = True
+        try:
+            return self.apply()
+        finally:
+            self._strict_index = False
 
 
 def reconcile_memory_startup() -> Optional[RepairReport]:

--- a/src/cli_agent_orchestrator/services/memory_reconciliation.py
+++ b/src/cli_agent_orchestrator/services/memory_reconciliation.py
@@ -30,6 +30,10 @@ _SCOPE_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 _TIMESTAMP_RE = re.compile(r"^## (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$", re.MULTILINE)
 _INDEX_ID_RE = re.compile(r"^- \[(?P<key>[^\]]+)\]\((?P<path>[^)]+)\)")
 
+# ``memory_metadata.updated_at`` is nullable; the dedupe survivor tiebreak
+# treats a missing timestamp as older than every real one.
+_MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
+
 DEFAULTED_METADATA_FIELDS = (
     "source_provider",
     "source_terminal_id",
@@ -45,6 +49,7 @@ class RepairAction(str, Enum):
 
     CREATE_METADATA = "create_metadata"
     UPDATE_METADATA = "update_metadata"
+    DEDUPE_METADATA = "dedupe_metadata"
     REBUILD_INDEX = "rebuild_index"
     UNCHANGED = "unchanged"
     MALFORMED = "malformed"
@@ -100,6 +105,7 @@ class RepairReport:
             "failed": 0,
             "create_metadata": 0,
             "update_metadata": 0,
+            "dedupe_metadata": 0,
             "rebuild_index": 0,
             "malformed": 0,
             "conflict": 0,
@@ -235,6 +241,13 @@ def discover_canonical_scope_dirs(base_dir: Path) -> tuple[tuple[str, Optional[s
             for child in scope_children:
                 if child.is_dir():
                     discovered.add((scope, child.name, global_container))
+    # ``federated`` is a machine-wide sibling of ``global`` (see
+    # MemoryService._get_project_dir) and its NULL-``scope_id`` rows are
+    # covered by the same ``uq_memory_key_scope_null`` migration warning,
+    # so repair must be able to visit it too.
+    federated_container = base_dir / "federated"
+    if (federated_container / "wiki" / "federated").is_dir():
+        discovered.add(("federated", None, federated_container))
     if base_dir.is_dir():
         try:
             containers = tuple(base_dir.iterdir())
@@ -376,6 +389,18 @@ class MemoryReconciliationService:
         global_wiki = global_container / "wiki"
         global_index = global_wiki / "index.md"
         add_scope(global_wiki / "global", "global", None, global_index, "global")
+        # Federated is a machine-wide tier in its own top-level container
+        # (MemoryService._get_project_dir); its NULL-scope_id rows are covered
+        # by the same uq_memory_key_scope_null migration warning as global's,
+        # so repair must be able to reach them.
+        federated_container = self.base_dir / "federated"
+        add_scope(
+            federated_container / "wiki" / "federated",
+            "federated",
+            None,
+            federated_container / "wiki" / "index.md",
+            "federated",
+        )
 
         for scope in ("session", "agent"):
             scope_root = global_wiki / scope
@@ -630,6 +655,8 @@ class MemoryReconciliationService:
         """Derive an index identity without using the index as a discovery seed."""
         if scope == "global":
             return MemoryIdentity(key, scope)
+        if scope == "federated":
+            return MemoryIdentity(key, scope)
         if scope == "project" and project_scope_id is not None:
             return MemoryIdentity(key, scope, project_scope_id)
         if scope in {"session", "agent"}:
@@ -741,14 +768,32 @@ class MemoryReconciliationService:
             all_rows = list(rows)
             identity_rows = [row for row in all_rows if row.identity == topic.identity]
             path_rows = [row for row in all_rows if self._resolved_row_path(row) == topic.file_path]
+        dedupe_stale: list[_Row] = []
         if len(identity_rows) > 1:
-            return self._candidate_record(
-                topic.file_path,
-                RepairAction.CONFLICT,
-                "duplicate_database_identity",
-                "multiple SQLite rows match the canonical identity",
-                topic.identity,
-            )
+            # Legacy pre-#657 state: SQLite's NULL-distinctness let multiple
+            # NULL-scope_id rows share one identity. When at least one row
+            # anchors this canonical topic path (and no foreign identity sits
+            # on it) the others are demonstrably stale, so plan a deterministic
+            # dedupe keeping the path-anchored row — newest ``updated_at``
+            # first, ``id`` as the stable tiebreak when several point at the
+            # same path. Otherwise which row is canonical is a human decision.
+            path_matches = [
+                row for row in identity_rows if self._resolved_row_path(row) == topic.file_path
+            ]
+            if path_matches and not any(row.identity != topic.identity for row in path_rows):
+                survivor = max(path_matches, key=lambda row: (row.updated_at or _MIN_DT, row.id))
+                dedupe_stale = [row for row in identity_rows if row.id != survivor.id]
+                identity_rows = [survivor]
+            else:
+                return self._candidate_record(
+                    topic.file_path,
+                    RepairAction.CONFLICT,
+                    "duplicate_database_identity",
+                    "multiple SQLite rows match the canonical identity and none is "
+                    "uniquely anchored to the canonical topic path; align file_path "
+                    "or remove the stray rows manually",
+                    topic.identity,
+                )
         if any(row.identity != topic.identity for row in path_rows):
             return self._candidate_record(
                 topic.file_path,
@@ -759,6 +804,10 @@ class MemoryReconciliationService:
             )
         actions: list[RepairAction] = []
         defaulted: tuple[str, ...] = ()
+        if dedupe_stale:
+            # Ordered first: the stale siblings must be gone before the
+            # survivor's metadata is (re)written or the unique index exists.
+            actions.append(RepairAction.DEDUPE_METADATA)
         if not identity_rows:
             actions.append(RepairAction.CREATE_METADATA)
             defaulted = DEFAULTED_METADATA_FIELDS
@@ -789,6 +838,19 @@ class MemoryReconciliationService:
             actions=tuple(actions),
             status="unchanged" if actions == [RepairAction.UNCHANGED] else "planned",
             defaulted_fields=defaulted,
+            **(
+                {
+                    "finding": RepairFinding(
+                        kind="duplicate_database_identity",
+                        message=(
+                            f"{len(dedupe_stale)} stale duplicate row(s) will be removed, "
+                            "keeping the row anchored to the canonical topic path"
+                        ),
+                    )
+                }
+                if dedupe_stale
+                else {}
+            ),
         )
 
     def plan(self) -> RepairReport:
@@ -988,6 +1050,45 @@ class MemoryReconciliationService:
                 row.token_estimate = topic.token_estimate
             db.commit()
 
+    def _dedupe_metadata(self, topic: _Topic) -> int:
+        """Remove stale duplicate rows for ``topic.identity`` (issue #657).
+
+        Re-derives the plan's survivor rule under the repair lock: among the
+        rows matching the identity, keep the one anchored to the canonical
+        topic path (newest ``updated_at``, ``id`` tiebreak when several point
+        at it) and remove the others. The survivor keeps its row id, so
+        canonical content is never rewritten. Returns the number removed.
+        """
+        from cli_agent_orchestrator.clients.database import MemoryMetadataModel
+
+        with self._get_db_session() as db:
+            query = db.query(MemoryMetadataModel).filter(
+                MemoryMetadataModel.key == topic.identity.key,
+                MemoryMetadataModel.scope == topic.identity.scope,
+                (
+                    MemoryMetadataModel.scope_id == topic.identity.scope_id
+                    if topic.identity.scope_id is not None
+                    else MemoryMetadataModel.scope_id.is_(None)
+                ),
+            )
+            rows = query.all()
+            if len(rows) <= 1:
+                return 0
+            path_matches = [row for row in rows if self._resolved_row_path(row) == topic.file_path]
+            if not path_matches:
+                raise RuntimeError("metadata duplicate lost its canonical anchor while lock held")
+            survivor = max(
+                path_matches,
+                key=lambda row: (row.updated_at or _MIN_DT, row.id),
+            )
+            removed = 0
+            for row in rows:
+                if row.id != survivor.id:
+                    db.delete(row)
+                    removed += 1
+            db.commit()
+            return removed
+
     def _candidate_from_record(self, record: RepairRecord) -> _Candidate:
         assert record.identity is not None
         path = Path(record.file_path)
@@ -995,6 +1096,9 @@ class MemoryReconciliationService:
         if identity.scope == "project":
             container = self.base_dir / str(identity.scope_id)
             prefix = "project"
+        elif identity.scope == "federated":
+            container = self.base_dir / "federated"
+            prefix = "federated"
         else:
             container = self.base_dir / "global"
             prefix = (
@@ -1149,6 +1253,8 @@ class MemoryReconciliationService:
                 for current, parsed in current_items:
                     metadata_error: Optional[Exception] = None
                     try:
+                        if RepairAction.DEDUPE_METADATA in current.actions:
+                            self._dedupe_metadata(parsed)
                         for metadata_action in (
                             RepairAction.CREATE_METADATA,
                             RepairAction.UPDATE_METADATA,
@@ -1185,7 +1291,26 @@ class MemoryReconciliationService:
         report = RepairReport(records=tuple(results), applied=True)
         if report.counts["failed"]:
             raise MemoryReconciliationError(report)
+        # The repair path is the remediation the uq_memory_key_scope_null
+        # migrator points at (issue #657): once the duplicates are gone, the
+        # index belongs on the database in this same run rather than at the
+        # next startup.
+        self._ensure_null_scope_unique_index()
         return report
+
+    def _ensure_null_scope_unique_index(self) -> None:
+        """Create ``uq_memory_key_scope_null`` if duplicates allow it.
+
+        Fail-soft by design — the startup migrator re-attempts this — but
+        exceptions surface to the caller because this runs inside an explicit
+        ``cao memory repair --apply``, where a silently missing index is
+        exactly the dead remediation path issue #657's review called out.
+        """
+        from cli_agent_orchestrator.clients.database import (
+            _migrate_memory_scope_null_uniqueness,
+        )
+
+        _migrate_memory_scope_null_uniqueness(engine=self._db_engine)
 
     def reconcile(self, *, apply: bool = False) -> RepairReport:
         """Plan by default; mutate only when explicitly requested."""

--- a/src/cli_agent_orchestrator/services/memory_reconciliation.py
+++ b/src/cli_agent_orchestrator/services/memory_reconciliation.py
@@ -922,7 +922,13 @@ class MemoryReconciliationService:
         # Surface every unmapped duplicate NULL-scope identity as an
         # actionable conflict: rows preserved, manual resolution named.
         mapped_identities = {topic.identity for topic in topics}
-        for identity, identity_rows in sorted(rows_by_identity.items()):
+        # Total key only: identities may differ solely in ``scope_id``
+        # nullness, and ``MemoryIdentity`` does not order across a
+        # None/string boundary.
+        for identity, identity_rows in sorted(
+            rows_by_identity.items(),
+            key=lambda item: (item[0].scope, item[0].scope_id or "", item[0].key),
+        ):
             if identity in mapped_identities or identity.scope_id is not None:
                 continue
             if len(identity_rows) <= 1:
@@ -1176,6 +1182,9 @@ class MemoryReconciliationService:
         groups: dict[Path, list[tuple[RepairRecord, _Candidate]]] = {}
         records_by_path: dict[Path, list[RepairRecord]] = {}
         resolved_paths: list[Optional[Path]] = []
+        # Findings whose records the second pass below can re-plan after
+        # another identity's dedupe frees the topic's path.
+        row_state_conflicts = {"database_path_conflict", "ambiguous_database_path"}
         for record in planned.records:
             if record.status != "skipped" and record.identity is not None:
                 resolved_path = Path(record.file_path).resolve()
@@ -1187,6 +1196,20 @@ class MemoryReconciliationService:
             path for path, matching_records in records_by_path.items() if len(matching_records) > 1
         }
         for record, planned_path in zip(planned.records, resolved_paths):
+            if (
+                record.status == "skipped"
+                and record.identity is not None
+                and record.finding is not None
+                and record.finding.kind in row_state_conflicts
+            ):
+                # This conflict may be re-planned and repaired in the second
+                # pass once another identity's dedupe frees its path, so its
+                # topic lock must be held from this initial ordered
+                # acquisition — never picked up lazily mid-run — keeping the
+                # single (index_path, file_path) lock order global.
+                candidate = self._candidate_from_record(record)
+                groups.setdefault(candidate.index_path, []).append((record, candidate))
+                continue
             if record.status == "skipped" or record.identity is None:
                 results.append(record)
                 continue
@@ -1317,8 +1340,9 @@ class MemoryReconciliationService:
             # just resolved. Re-plan those from a fresh snapshot and execute
             # the recovered plan here, so one repair run clears both the
             # duplicate and its dependent conflict instead of demanding a
-            # second identical run.
-            row_state_conflicts = {"database_path_conflict", "ambiguous_database_path"}
+            # second identical run. These topics joined the initial lock
+            # acquisition above, so the re-parse and every mutation below
+            # run under the topic's held lock.
             conflicted_indexes = [
                 index
                 for index, record in enumerate(results)

--- a/test/cli/commands/test_memory_repair_migration.py
+++ b/test/cli/commands/test_memory_repair_migration.py
@@ -1,0 +1,156 @@
+"""End-to-end regression: the repair path the #657 migrator advertises.
+
+The migration added by issue #657 warns ``Run `cao memory repair`` when a
+legacy database holds duplicate NULL-scope rows, and the PR review called out
+that this pointer was dead: reconciliation reported the duplicates as an
+unresolvable conflict and the federated container was never scanned, so the
+advertised repair could never clear the state the index needs.
+
+These tests drive the REAL CLI over a REAL isolated ``CAO_HOME_DIR`` in a
+subprocess — no in-process service patching — mirroring the subprocess
+isolation pattern of ``test/fixtures/cao_server.py``: seed the legacy state
+through raw SQLite exactly as an external edit would leave it, run
+``python -m cli_agent_orchestrator.cli.main memory repair --apply``, then
+prove the reviewer's contract: canonical content survives, the index exists
+afterwards and rejects a new duplicate, and ambiguous rows fail actionably
+without data loss.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+_TOPIC_BODY = (
+    "# shared\n"
+    "<!-- id: 11111111-1111-1111-1111-111111111111 | scope: global | "
+    "type: reference | tags:  -->\n\n"
+    "## 2026-07-15T01:00:00Z\ndurable body\n"
+)
+
+
+def _home(tmp_path: Path) -> Path:
+    home = tmp_path / "cao-home"
+    (home / "db").mkdir(parents=True)
+    (home / "memory" / "global" / "wiki" / "global").mkdir(parents=True)
+    return home
+
+
+def _db_path(home: Path) -> Path:
+    from cli_agent_orchestrator.constants import CAO_HOME_DIR, DATABASE_FILE
+
+    if str(CAO_HOME_DIR) == str(home):
+        return Path(DATABASE_FILE)
+    return home / "db" / DATABASE_FILE.name
+
+
+def _seed_legacy_schema(db_file: Path) -> None:
+    """Create the schema WITHOUT the #657 partial index, as old databases have."""
+    from sqlalchemy import create_engine
+
+    from cli_agent_orchestrator.clients.database import Base
+
+    engine = create_engine(f"sqlite:///{db_file}")
+    Base.metadata.create_all(bind=engine)
+    engine.dispose()
+    with sqlite3.connect(str(db_file)) as conn:
+        conn.execute("DROP INDEX IF EXISTS uq_memory_key_scope_null")
+        conn.commit()
+
+
+def _seed_duplicate_rows(
+    db_file: Path, key: str, paths: list[str], *, scope: str = "global"
+) -> None:
+    with sqlite3.connect(str(db_file)) as conn:
+        for path in paths:
+            conn.execute(
+                "INSERT INTO memory_metadata (id, key, memory_type, scope, scope_id, "
+                "file_path, tags, access_count) "
+                "VALUES (?, ?, 'reference', ?, NULL, ?, '', 0)",
+                (str(uuid.uuid4()), key, scope, path),
+            )
+        conn.commit()
+
+
+def _run_repair(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {
+        "CAO_HOME_DIR": str(home),
+        "PATH": "",
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "cli_agent_orchestrator.cli.main", "memory", "repair", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+def _index_names(db_file: Path) -> set[str]:
+    with sqlite3.connect(str(db_file)) as conn:
+        return {row[1] for row in conn.execute("PRAGMA index_list('memory_metadata')")}
+
+
+def test_repair_dedupes_and_lands_index_end_to_end(tmp_path: Path) -> None:
+    """Seed legacy duplicates, run the real ``cao memory repair --apply``.
+
+    Proves the reviewer's unambiguous contract: the canonical-path row
+    survives with its identity intact, the partial unique index exists after
+    the same repair run, and a fresh duplicate INSERT is rejected.
+    """
+    home = _home(tmp_path)
+    db_file = _db_path(home)
+    _seed_legacy_schema(db_file)
+    topic = home / "memory" / "global" / "wiki" / "global" / "shared.md"
+    topic.write_text(_TOPIC_BODY, encoding="utf-8")
+    _seed_duplicate_rows(db_file, "shared", [str(topic), str(topic.with_name("stale.md"))])
+
+    with sqlite3.connect(str(db_file)) as conn:
+        survivor_id = conn.execute(
+            "SELECT id FROM memory_metadata WHERE file_path = ?", (str(topic),)
+        ).fetchone()[0]
+
+    result = _run_repair(home, "--apply")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    with sqlite3.connect(str(db_file)) as conn:
+        rows = conn.execute("SELECT id, file_path FROM memory_metadata").fetchall()
+    assert rows == [(survivor_id, str(topic))], "canonical row survives with its id"
+    assert "uq_memory_key_scope_null" in _index_names(db_file)
+    with sqlite3.connect(str(db_file)) as conn:
+        try:
+            conn.execute(
+                "INSERT INTO memory_metadata (id, key, memory_type, scope, scope_id, "
+                "file_path, tags, access_count) "
+                "VALUES ('dup-after-repair', 'shared', 'reference', 'global', NULL, '/x.md', '', 0)"
+            )
+        except sqlite3.IntegrityError:
+            pass
+        else:
+            raise AssertionError("a new duplicate NULL-scope insert must be rejected")
+
+
+def test_repair_reports_ambiguous_duplicates_without_data_loss(tmp_path: Path) -> None:
+    """Neither row anchors the canonical path: actionable failure, zero loss."""
+    home = _home(tmp_path)
+    db_file = _db_path(home)
+    _seed_legacy_schema(db_file)
+    topic = home / "memory" / "global" / "wiki" / "global" / "shared.md"
+    topic.write_text(_TOPIC_BODY, encoding="utf-8")
+    _seed_duplicate_rows(
+        db_file, "shared", [str(topic.with_name("a.md")), str(topic.with_name("b.md"))]
+    )
+
+    result = _run_repair(home, "--apply")
+
+    assert result.returncode == 1, "ambiguous duplicates must fail the apply exit code"
+    assert "skipped" in result.stdout and "conflict" in result.stdout
+    assert "none is uniquely anchored to the canonical topic path" in result.stdout
+    assert "manually" in result.stdout, "manual-resolution guidance must be actionable"
+    with sqlite3.connect(str(db_file)) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM memory_metadata").fetchone()[0]
+    assert count == 2, "ambiguous duplicates must be retained without data loss"
+    assert "uq_memory_key_scope_null" not in _index_names(db_file)

--- a/test/cli/commands/test_memory_repair_migration.py
+++ b/test/cli/commands/test_memory_repair_migration.py
@@ -154,3 +154,129 @@ def test_repair_reports_ambiguous_duplicates_without_data_loss(tmp_path: Path) -
         count = conn.execute("SELECT COUNT(*) FROM memory_metadata").fetchone()[0]
     assert count == 2, "ambiguous duplicates must be retained without data loss"
     assert "uq_memory_key_scope_null" not in _index_names(db_file)
+
+
+def test_repair_reports_no_topic_duplicates_via_the_real_cli(tmp_path: Path) -> None:
+    """Duplicates with no surviving canonical topic fail actionably (P2-1).
+
+    Review finding: reconciliation only emitted records for discovered
+    filesystem topics, so NULL-scope duplicate identities absent from the
+    scan made the real CLI exit 0 with ``total=0`` while both rows stayed
+    and the migrator kept skipping the index. The repair must report every
+    such identity as a conflict, exit 1, and delete nothing.
+    """
+    home = _home(tmp_path)
+    db_file = _db_path(home)
+    _seed_legacy_schema(db_file)
+    # No topic files exist at all: both duplicate rows point at deleted paths.
+    _seed_duplicate_rows(db_file, "shared", ["/gone/a.md", "/gone/b.md"])
+    # A federated duplicate pair, equally unmapped, must not be invisible.
+    _seed_duplicate_rows(db_file, "fed", ["/fed/gone/a.md", "/fed/gone/b.md"], scope="federated")
+
+    dry = _run_repair(home)
+    assert dry.returncode == 1, "dry-run must already exit nonzero on the conflict"
+    assert "total=2" in dry.stdout, f"dry-run must see both identities: {dry.stdout}"
+    assert "federated:-:fed" in dry.stdout, "the federated duplicate is reported too"
+    assert "no canonical topic maps to it" in dry.stdout
+
+    result = _run_repair(home, "--apply")
+    assert result.returncode == 1, "apply must fail actionably, not report success"
+    assert "total=2" in result.stdout
+    assert "no canonical topic maps to it" in result.stdout
+    with sqlite3.connect(str(db_file)) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM memory_metadata").fetchone()[0]
+    assert count == 4, "no row may be deleted without a topic anchor"
+    assert "uq_memory_key_scope_null" not in _index_names(db_file)
+
+
+def test_repair_dedupes_mixed_timestamp_rows_without_crashing(tmp_path: Path) -> None:
+    """Mixed naive/NULL ``updated_at`` dedupes instead of TypeError (P2-2).
+
+    The apply-time survivor pick compared raw legacy timestamps with a
+    timezone-aware floor, so a NULL/naive mix crashed the record mid-repair.
+    The real CLI must complete the dedupe, keep the newest row, and land the
+    index in the same run.
+    """
+    home = _home(tmp_path)
+    db_file = _db_path(home)
+    _seed_legacy_schema(db_file)
+    topic = home / "memory" / "global" / "wiki" / "global" / "shared.md"
+    topic.write_text(_TOPIC_BODY, encoding="utf-8")
+    _seed_duplicate_rows(db_file, "shared", [str(topic), str(topic.with_name("stale.md"))])
+    with sqlite3.connect(str(db_file)) as conn:
+        conn.execute(
+            "UPDATE memory_metadata SET updated_at = '2026-07-01 10:00:00' " "WHERE file_path = ?",
+            (str(topic),),
+        )
+        conn.execute(
+            "UPDATE memory_metadata SET updated_at = NULL " "WHERE file_path = ?",
+            (str(topic.with_name("stale.md")),),
+        )
+        survivor_id = conn.execute(
+            "SELECT id FROM memory_metadata WHERE file_path = ?", (str(topic),)
+        ).fetchone()[0]
+        conn.commit()
+
+    result = _run_repair(home, "--apply")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "TypeError" not in result.stderr
+    with sqlite3.connect(str(db_file)) as conn:
+        rows = conn.execute("SELECT id, file_path FROM memory_metadata").fetchall()
+    assert rows == [(survivor_id, str(topic))], "newest (only dated) row survives"
+    assert "uq_memory_key_scope_null" in _index_names(db_file)
+
+
+def test_repair_surfaces_lock_failed_index_creation_and_recovers(tmp_path: Path) -> None:
+    """A competing write lock must not yield silent success (P2-3).
+
+    The migrator swallowed every exception at debug, so a concurrent SQLite
+    writer could make ``cao memory repair --apply`` exit 0 while the unique
+    index stayed absent. Under lock the CLI must fail naming the index; once
+    the lock is released a rerun must succeed and the index must exist.
+    """
+    import subprocess
+    import textwrap
+
+    home = _home(tmp_path)
+    db_file = _db_path(home)
+    _seed_legacy_schema(db_file)
+    topic = home / "memory" / "global" / "wiki" / "global" / "shared.md"
+    topic.write_text(_TOPIC_BODY, encoding="utf-8")
+    _seed_duplicate_rows(db_file, "shared", [str(topic), str(topic.with_name("stale.md"))])
+
+    # An external process holds a write lock for the whole repair window.
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent("""
+                import sqlite3, sys, time
+                conn = sqlite3.connect(sys.argv[1], timeout=30)
+                conn.execute("BEGIN EXCLUSIVE")
+                print("locked", flush=True)
+                time.sleep(30)
+                conn.rollback()
+                """),
+            str(db_file),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None and holder.stdout.readline().strip() == "locked"
+        result = _run_repair(home, "--apply")
+        assert result.returncode != 0, "repair under lock must not report success"
+    finally:
+        holder.kill()
+        holder.wait(timeout=10)
+
+    # BEGIN EXCLUSIVE blocks readers too, so probe only after the release.
+    assert "uq_memory_key_scope_null" not in _index_names(db_file)
+
+    retry = _run_repair(home, "--apply")
+    assert retry.returncode == 0, retry.stdout + retry.stderr
+    assert "uq_memory_key_scope_null" in _index_names(db_file)
+    with sqlite3.connect(str(db_file)) as conn:
+        rows = conn.execute("SELECT COUNT(*) FROM memory_metadata").fetchone()[0]
+    assert rows == 1, "the retry completes the dedupe"

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -1,5 +1,6 @@
 """Tests for the database client."""
 
+import sqlite3
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -10,11 +11,13 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
+from cli_agent_orchestrator.clients import database as db_mod
 from cli_agent_orchestrator.clients.database import (
     Base,
     FlowModel,
     IdempotencyKeyModel,
     InboxModel,
+    MemoryMetadataModel,
     TerminalModel,
     create_flow,
     create_inbox_message,
@@ -2004,6 +2007,103 @@ class TestProjectAliasMigration:
         with sqlite3.connect(str(db_file)) as conn:
             rows = conn.execute("SELECT alias, project_id FROM project_aliases").fetchall()
         assert rows == [("a1", "p1")], "current-schema table must be left intact"
+
+
+class TestMemoryScopeNullUniquenessMigration:
+    """Partial unique index for NULL scope_id rows (issue #657).
+
+    SQLite treats NULL != NULL in a UNIQUE index, so the table-level
+    uq_memory_key_scope never fired for global/federated memories; the
+    partial index covers exactly those rows. Real SQLite throughout — the
+    NULL-distinctness being asserted is engine behavior no mock can exercise.
+    """
+
+    def _mem(self, key, file_path, scope="global", scope_id=None):
+        return MemoryMetadataModel(
+            key=key,
+            memory_type="project",
+            scope=scope,
+            scope_id=scope_id,
+            file_path=file_path,
+            tags="",
+        )
+
+    def _legacy_db(self, tmp_path, monkeypatch, dupe_paths=()):
+        """A legacy pre-#657 database: fresh schema, partial index dropped,
+        optionally seeded with duplicate global rows the old constraint let
+        in. DATABASE_FILE is pointed at it."""
+        db_file = tmp_path / "legacy.db"
+        engine = create_engine(f"sqlite:///{db_file}")
+        Base.metadata.create_all(bind=engine)
+        engine.dispose()
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute("DROP INDEX IF EXISTS uq_memory_key_scope_null")
+            for path in dupe_paths:
+                conn.execute(
+                    "INSERT INTO memory_metadata (id, key, memory_type, scope, scope_id, "
+                    "file_path, tags, access_count) "
+                    f"VALUES ('{path}', 'd', 'project', 'global', NULL, '{path}', '', 0)"
+                )
+            conn.commit()
+        monkeypatch.setattr(
+            "cli_agent_orchestrator.constants.DATABASE_FILE", db_file, raising=False
+        )
+        return db_file
+
+    def test_fresh_database_rejects_duplicate_global_rows(self):
+        """Two (key, global, NULL) rows must collide — the reporter's case.
+        The scoped sibling of the same key stays distinct: that is what
+        keeping scope_id nullable (not the sentinel) buys."""
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(bind=engine)
+        with sessionmaker(bind=engine)() as s:
+            s.add(self._mem("shared", "/a.md"))
+            s.commit()
+            s.add(self._mem("shared", "/b.md"))
+            with pytest.raises(IntegrityError):
+                s.commit()
+            s.rollback()
+            s.add(self._mem("shared", "/c.md", scope="session", scope_id="t1"))
+            s.commit()  # distinct (key, scope, scope_id) — accepted
+            rows = s.query(MemoryMetadataModel).order_by(MemoryMetadataModel.scope).all()
+        assert [r.scope for r in rows] == ["global", "session"]
+
+    def test_existing_database_gains_the_index(self, tmp_path, monkeypatch):
+        """A pre-index database gets uq_memory_key_scope_null on init."""
+        db_file = self._legacy_db(tmp_path, monkeypatch)
+        db_mod._migrate_memory_scope_null_uniqueness()
+
+        with sqlite3.connect(str(db_file)) as conn:
+            names = {r[1] for r in conn.execute("PRAGMA index_list('memory_metadata')")}
+        assert "uq_memory_key_scope_null" in names
+
+    def test_duplicate_seed_skips_index_then_recovers_after_repair(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Fail-soft path (both seeded-duplicate cases from the issue): with
+        duplicates present the index is skipped with a warning naming them
+        and pointing at cao memory repair, and rows are kept; re-running
+        after the repair creates the index."""
+        db_file = self._legacy_db(tmp_path, monkeypatch, dupe_paths=("/1.md", "/2.md"))
+        with caplog.at_level("WARNING"):
+            db_mod._migrate_memory_scope_null_uniqueness()  # skips, warns
+
+        assert any("uq_memory_key_scope_null" in r.message for r in caplog.records)
+        assert any("cao memory repair" in r.message for r in caplog.records)
+        with sqlite3.connect(str(db_file)) as conn:
+            names = {r[1] for r in conn.execute("PRAGMA index_list('memory_metadata')")}
+            rows = conn.execute("SELECT COUNT(*) FROM memory_metadata").fetchone()[0]
+        assert "uq_memory_key_scope_null" not in names
+        assert rows == 2, "duplicates must be left for `cao memory repair`, never deleted here"
+
+        with sqlite3.connect(str(db_file)) as conn:  # the repair: keep one row
+            conn.execute("DELETE FROM memory_metadata WHERE file_path = '/2.md'")
+            conn.commit()
+        db_mod._migrate_memory_scope_null_uniqueness()  # creates
+
+        with sqlite3.connect(str(db_file)) as conn:
+            names = {r[1] for r in conn.execute("PRAGMA index_list('memory_metadata')")}
+        assert "uq_memory_key_scope_null" in names
 
 
 class TestListTerminalsInSessions:

--- a/test/clients/test_database.py
+++ b/test/clients/test_database.py
@@ -2096,14 +2096,40 @@ class TestMemoryScopeNullUniquenessMigration:
         assert "uq_memory_key_scope_null" not in names
         assert rows == 2, "duplicates must be left for `cao memory repair`, never deleted here"
 
-        with sqlite3.connect(str(db_file)) as conn:  # the repair: keep one row
-            conn.execute("DELETE FROM memory_metadata WHERE file_path = '/2.md'")
-            conn.commit()
-        db_mod._migrate_memory_scope_null_uniqueness()  # creates
+        # The repair the warning advertises: the reconciliation service's
+        # dedupe path clears the stale sibling, then re-invokes the migrator.
+        # The seeded rows carry key='d', so the canonical topic is 'd.md'.
+        from cli_agent_orchestrator.services.memory_reconciliation import (
+            MemoryReconciliationService,
+        )
 
+        base_dir = tmp_path / "memory"
+        topic = base_dir / "global" / "wiki" / "global" / "d.md"
+        topic.parent.mkdir(parents=True, exist_ok=True)
+        topic.write_text(
+            "# d\n"
+            "<!-- id: 11111111-1111-1111-1111-111111111111 | scope: global | "
+            "type: reference | tags:  -->\n\n"
+            "## 2026-07-15T01:00:00Z\ndurable body\n",
+            encoding="utf-8",
+        )
+        with sqlite3.connect(str(db_file)) as conn:
+            conn.execute(
+                "UPDATE memory_metadata SET file_path = ? WHERE file_path = '/1.md'",
+                (str(topic),),
+            )
+            conn.commit()
+        engine = create_engine(f"sqlite:///{db_file}")
+        try:
+            report = MemoryReconciliationService(base_dir, engine).apply()
+            assert report.counts["dedupe_metadata"] == 1
+        finally:
+            engine.dispose()
         with sqlite3.connect(str(db_file)) as conn:
             names = {r[1] for r in conn.execute("PRAGMA index_list('memory_metadata')")}
-        assert "uq_memory_key_scope_null" in names
+            rows = conn.execute("SELECT COUNT(*) FROM memory_metadata").fetchone()[0]
+        assert rows == 1, "the canonical row survives the advertised repair"
+        assert "uq_memory_key_scope_null" in names, "repair re-attempts the index in-run"
 
 
 class TestListTerminalsInSessions:

--- a/test/services/test_memory_reconciliation.py
+++ b/test/services/test_memory_reconciliation.py
@@ -482,6 +482,11 @@ def test_apply_rejects_duplicate_resolved_paths_before_locking(
 def test_duplicate_and_wrong_path_rows_are_conflicts(tmp_path: Path, engine: Any) -> None:
     base = tmp_path / "memory"
     topic = _write_topic(base, "global", None, "conflicted")
+    # Seed the legacy pre-#657 state: duplicate global rows only exist on a
+    # database whose partial unique index is absent, so drop it first.
+    with engine.connect() as conn:
+        conn.exec_driver_sql("DROP INDEX IF EXISTS uq_memory_key_scope_null")
+        conn.commit()
     with sessionmaker(bind=engine)() as db:
         for suffix in ("one", "two"):
             db.add(

--- a/test/services/test_memory_reconciliation.py
+++ b/test/services/test_memory_reconciliation.py
@@ -686,6 +686,186 @@ def test_duplicate_federated_rows_are_discovered_and_deduped(tmp_path: Path, eng
     assert federated_index.exists(), "federated index entries are rebuilt"
 
 
+def test_unmapped_duplicate_rows_conflict_without_a_canonical_topic(
+    tmp_path: Path, engine: Any
+) -> None:
+    """Duplicates whose topic file is gone must still be reported (P2-1).
+
+    Planning is filesystem-first, so a NULL-scope identity with no surviving
+    canonical topic is invisible to it — repair used to exit 0 with total=0
+    while the duplicate rows stayed and the migrator kept skipping the index.
+    Every such identity must surface as an actionable conflict naming manual
+    resolution, with rows preserved.
+    """
+    base = tmp_path / "memory"
+    with engine.connect() as conn:
+        conn.exec_driver_sql("DROP INDEX IF EXISTS uq_memory_key_scope_null")
+        conn.commit()
+    with sessionmaker(bind=engine)() as db:
+        for scope, path in (
+            ("global", "/gone/global-a.md"),
+            ("global", "/gone/global-b.md"),
+            ("federated", "/gone/federated-a.md"),
+            ("federated", "/gone/federated-b.md"),
+        ):
+            db.add(
+                MemoryMetadataModel(
+                    id=str(uuid.uuid4()),
+                    key="orphan" if scope == "global" else "fed-orphan",
+                    memory_type="reference",
+                    scope=scope,
+                    scope_id=None,
+                    file_path=path,
+                    tags="",
+                )
+            )
+        db.commit()
+
+    service = MemoryReconciliationService(base, engine)
+    plan = service.plan()
+    conflicts = [
+        record
+        for record in plan.records
+        if record.finding is not None and record.finding.kind == "duplicate_database_identity"
+    ]
+    assert [record.identity.scope for record in conflicts] == ["federated", "global"]
+    for record in conflicts:
+        assert record.actions == (RepairAction.CONFLICT,)
+        assert "manually" in record.finding.message or "restore" in record.finding.message
+        assert "no canonical topic" in record.finding.message
+
+    report = service.apply()
+    assert report.counts["skipped"] == 2, "both conflicts survive apply untouched"
+    assert report.has_unresolved is True, "CLI maps this to exit 1"
+    assert len(_rows(engine)) == 4, "no row is ever deleted without a topic anchor"
+
+
+def test_dedupe_survives_mixed_naive_and_null_timestamps(tmp_path: Path, engine: Any) -> None:
+    """Mixed naive/aware/NULL ``updated_at`` must not crash dedupe (P2-2).
+
+    SQLite stores naive datetimes; legacy duplicate rows can mix naive,
+    aware and NULL values, and comparing any of them with the tz-aware
+    ``_MIN_DT`` floor used to raise ``TypeError`` mid-repair, leaving both
+    rows and the index absent. The survivor pick must normalize first, so
+    the newest row wins and the index lands in the same run.
+    """
+    base = tmp_path / "memory"
+    topic = _write_topic(base, "global", None, "shared")
+    _seed_duplicate_global_rows(
+        base,
+        engine,
+        "shared",
+        canonical_path=str(topic),
+        stale_paths=(str(topic.with_name("stale.md")),),
+    )
+    with sessionmaker(bind=engine)() as db:
+        db.execute(
+            MemoryMetadataModel.__table__.update()
+            .where(MemoryMetadataModel.file_path == str(topic))
+            .values(updated_at=datetime(2026, 7, 1, 10, 0))
+        )
+        db.execute(
+            MemoryMetadataModel.__table__.update()
+            .where(MemoryMetadataModel.file_path == str(topic.with_name("stale.md")))
+            .values(updated_at=None)
+        )
+        db.commit()
+        survivor_id = (
+            db.query(MemoryMetadataModel)
+            .filter(MemoryMetadataModel.file_path == str(topic))
+            .one()
+            .id
+        )
+
+    report = MemoryReconciliationService(base, engine).apply()
+
+    assert report.counts["dedupe_metadata"] == 1
+    remaining = _rows(engine)
+    assert len(remaining) == 1
+    assert remaining[0].id == survivor_id, "newest (only dated) row survives"
+    with engine.connect() as conn:
+        names = {
+            row[1]
+            for row in conn.exec_driver_sql("PRAGMA index_list('memory_metadata')").fetchall()
+        }
+    assert "uq_memory_key_scope_null" in names
+
+
+def test_dedupe_tiebreak_picks_the_lowest_id_at_equal_normalized_time(
+    tmp_path: Path, engine: Any
+) -> None:
+    """Equal normalized ``updated_at`` falls back to the ``id`` tie-break.
+
+    The reviewer's P2-2 contract names newest selection AND the equal-time
+    ``id`` tie-break; both rows anchor the canonical path, so the pick must
+    be deterministic — highest ``id`` per the ``max()`` key — never arbitrary.
+    """
+    base = tmp_path / "memory"
+    topic = _write_topic(base, "global", None, "shared")
+    _seed_duplicate_global_rows(
+        base,
+        engine,
+        "shared",
+        canonical_path=str(topic),
+        stale_paths=(str(topic.with_name("stale.md")),),
+    )
+    with sessionmaker(bind=engine)() as db:
+        db.execute(
+            MemoryMetadataModel.__table__.update().values(
+                updated_at=datetime(2026, 7, 1, 10, 0)
+            )
+        )
+        rows = db.query(MemoryMetadataModel).all()
+        # Force the stale-path row to have the higher id so the tie-break,
+        # not insertion order, decides the survivor.
+        stale = next(row for row in rows if row.file_path != str(topic))
+        canonical = next(row for row in rows if row.file_path == str(topic))
+        if stale.id > canonical.id:
+            stale.id, canonical.id = canonical.id, stale.id
+        db.commit()
+        expected_id = max(row.id for row in db.query(MemoryMetadataModel).all())
+
+    report = MemoryReconciliationService(base, engine).apply()
+
+    assert report.counts["dedupe_metadata"] == 1
+    remaining = _rows(engine)
+    assert len(remaining) == 1
+    assert remaining[0].id == expected_id, "equal-time tie-break keeps the highest id"
+
+
+def test_foreign_path_duplicate_clears_in_one_repair_run(tmp_path: Path, engine: Any) -> None:
+    """A dedupe-freed path conflict must clear in the same run (review P3).
+
+    Topic X's stale duplicate row sits on topic Y's canonical path. The
+    pre-mutation snapshot plans Y as ``ambiguous_database_path`` while X
+    dedupes; without a re-plan, Y needs a second identical repair run. One
+    run must now clear both.
+    """
+    base = tmp_path / "memory"
+    topic_x = _write_topic(base, "global", None, "x-shared")
+    topic_y = _write_topic(base, "global", None, "y-victim")
+    _seed_duplicate_global_rows(
+        base,
+        engine,
+        "x-shared",
+        canonical_path=str(topic_x),
+        stale_paths=(str(topic_y),),
+    )
+
+    report = MemoryReconciliationService(base, engine).apply()
+
+    assert report.counts["skipped"] == 0, f"conflicts remained: {report.records}"
+    rows = {row.key: row for row in _rows(engine)}
+    assert set(rows) == {"x-shared", "y-victim"}, "both topics keep exactly one row"
+    assert rows["y-victim"].file_path == str(topic_y)
+    with engine.connect() as conn:
+        names = {
+            row[1]
+            for row in conn.exec_driver_sql("PRAGMA index_list('memory_metadata')").fetchall()
+        }
+    assert "uq_memory_key_scope_null" in names
+
+
 def test_unexpected_failure_does_not_rollback_other_records(
     tmp_path: Path, engine: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/test/services/test_memory_reconciliation.py
+++ b/test/services/test_memory_reconciliation.py
@@ -45,6 +45,8 @@ def _topic_path(base: Path, scope: str, scope_id: str | None, key: str) -> Path:
     if scope in {"session", "agent"}:
         assert scope_id is not None
         return base / "global" / "wiki" / scope / scope_id / f"{key}.md"
+    if scope == "federated":
+        return base / "federated" / "wiki" / scope / f"{key}.md"
     return base / "global" / "wiki" / scope / f"{key}.md"
 
 
@@ -506,7 +508,182 @@ def test_duplicate_and_wrong_path_rows_are_conflicts(tmp_path: Path, engine: Any
 
     assert report.records[0].actions == (RepairAction.CONFLICT,)
     assert report.records[0].finding.kind == "duplicate_database_identity"
+    assert "manually" in report.records[0].finding.message
     assert len(_rows(engine)) == 2
+
+
+def _seed_duplicate_global_rows(
+    base: Path,
+    engine: Any,
+    key: str,
+    *,
+    canonical_path: str,
+    stale_paths: tuple[str, ...],
+) -> None:
+    """Seed the legacy pre-#657 duplicate state on an index-less database."""
+    with engine.connect() as conn:
+        conn.exec_driver_sql("DROP INDEX IF EXISTS uq_memory_key_scope_null")
+        conn.commit()
+    with sessionmaker(bind=engine)() as db:
+        db.add(
+            MemoryMetadataModel(
+                id=str(uuid.uuid4()),
+                key=key,
+                memory_type="reference",
+                scope="global",
+                scope_id=None,
+                file_path=canonical_path,
+                tags="",
+            )
+        )
+        for path in stale_paths:
+            db.add(
+                MemoryMetadataModel(
+                    id=str(uuid.uuid4()),
+                    key=key,
+                    memory_type="reference",
+                    scope="global",
+                    scope_id=None,
+                    file_path=path,
+                    tags="",
+                )
+            )
+        db.commit()
+
+
+def test_duplicate_rows_dedupe_to_canonical_path_survivor(tmp_path: Path, engine: Any) -> None:
+    """The unambiguous legacy case: one row anchors the canonical topic path.
+
+    The repair the #657 migrator advertises must actually clear the state —
+    the stale sibling goes, the canonical row keeps its id, and the partial
+    unique index lands in the same repair run instead of at next startup.
+    """
+    base = tmp_path / "memory"
+    topic = _write_topic(base, "global", None, "shared")
+    _seed_duplicate_global_rows(
+        base,
+        engine,
+        "shared",
+        canonical_path=str(topic),
+        stale_paths=(str(topic.with_name("stale.md")),),
+    )
+    # Pin the ids the seeded rows actually got so the survivor assertion is
+    # about identity, not insertion order.
+    with sessionmaker(bind=engine)() as db:
+        rows = db.query(MemoryMetadataModel).order_by(MemoryMetadataModel.file_path).all()
+        survivor_id = next(row.id for row in rows if row.file_path == str(topic))
+
+    service = MemoryReconciliationService(base, engine)
+    dry = service.plan()
+    dedupe_records = [r for r in dry.records if RepairAction.DEDUPE_METADATA in r.actions]
+    assert len(dedupe_records) == 1
+    assert dry.applied is False
+    assert len(_rows(engine)) == 2, "dry-run must not touch rows"
+
+    report = service.apply()
+
+    assert report.counts["dedupe_metadata"] == 1
+    remaining = _rows(engine)
+    assert len(remaining) == 1
+    assert remaining[0].id == survivor_id
+    assert remaining[0].file_path == str(topic)
+    with engine.connect() as conn:
+        names = {
+            row[1]
+            for row in conn.exec_driver_sql("PRAGMA index_list('memory_metadata')").fetchall()
+        }
+    assert "uq_memory_key_scope_null" in names, "index must land in the repair run"
+
+
+def test_ambiguous_duplicate_rows_remain_a_manual_conflict(tmp_path: Path, engine: Any) -> None:
+    """Neither row anchors the canonical path: no silent winner, no data loss.
+
+    The reviewer's ambiguity requirement: rows are retained with explicit
+    manual-resolution guidance and no index is created over them.
+    """
+    base = tmp_path / "memory"
+    _write_topic(base, "global", None, "shared")
+    topic = base / "global" / "wiki" / "global" / "shared.md"
+    _seed_duplicate_global_rows(
+        base,
+        engine,
+        "shared",
+        canonical_path=str(topic.with_name("a.md")),
+        stale_paths=(str(topic.with_name("b.md")),),
+    )
+
+    service = MemoryReconciliationService(base, engine)
+    report = service.apply()
+
+    assert report.records[0].actions == (RepairAction.CONFLICT,)
+    assert report.records[0].finding.kind == "duplicate_database_identity"
+    assert "manually" in report.records[0].finding.message
+    assert len(_rows(engine)) == 2, "ambiguous duplicates must never be deleted"
+    with engine.connect() as conn:
+        names = {
+            row[1]
+            for row in conn.exec_driver_sql("PRAGMA index_list('memory_metadata')").fetchall()
+        }
+    assert "uq_memory_key_scope_null" not in names
+
+
+def test_duplicate_federated_rows_are_discovered_and_deduped(tmp_path: Path, engine: Any) -> None:
+    """Federated duplicates are covered by the same warning — and the repair.
+
+    The federated container was never scanned before, so its NULL-scope rows
+    could never even be reported, let alone repaired.
+    """
+    base = tmp_path / "memory"
+    topic = _write_topic(base, "federated", None, "shared")
+    with engine.connect() as conn:
+        conn.exec_driver_sql("DROP INDEX IF EXISTS uq_memory_key_scope_null")
+        conn.commit()
+    with sessionmaker(bind=engine)() as db:
+        db.add(
+            MemoryMetadataModel(
+                id=str(uuid.uuid4()),
+                key="shared",
+                memory_type="reference",
+                scope="federated",
+                scope_id=None,
+                file_path=str(topic),
+                tags="",
+            )
+        )
+        db.add(
+            MemoryMetadataModel(
+                id=str(uuid.uuid4()),
+                key="shared",
+                memory_type="reference",
+                scope="federated",
+                scope_id=None,
+                file_path=str(topic.with_name("stale.md")),
+                tags="",
+            )
+        )
+        db.commit()
+
+    service = MemoryReconciliationService(base, engine)
+    dry = service.plan()
+    assert any(
+        RepairAction.DEDUPE_METADATA in record.actions
+        for record in dry.records
+        if record.identity is not None and record.identity.scope == "federated"
+    ), "federated topics must be discovered by the scan"
+
+    report = service.apply()
+    remaining = _rows(engine)
+    assert len(remaining) == 1
+    assert remaining[0].scope == "federated"
+    assert remaining[0].file_path == str(topic)
+    with engine.connect() as conn:
+        names = {
+            row[1]
+            for row in conn.exec_driver_sql("PRAGMA index_list('memory_metadata')").fetchall()
+        }
+    assert "uq_memory_key_scope_null" in names
+    federated_index = base / "federated" / "wiki" / "index.md"
+    assert federated_index.exists(), "federated index entries are rebuilt"
 
 
 def test_unexpected_failure_does_not_rollback_other_records(

--- a/test/services/test_memory_reconciliation.py
+++ b/test/services/test_memory_reconciliation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import fcntl
+import threading
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
@@ -791,46 +793,50 @@ def test_dedupe_survives_mixed_naive_and_null_timestamps(tmp_path: Path, engine:
     assert "uq_memory_key_scope_null" in names
 
 
-def test_dedupe_tiebreak_picks_the_lowest_id_at_equal_normalized_time(
+def test_dedupe_tiebreak_picks_the_maximum_id_at_equal_normalized_time(
     tmp_path: Path, engine: Any
 ) -> None:
     """Equal normalized ``updated_at`` falls back to the ``id`` tie-break.
 
-    The reviewer's P2-2 contract names newest selection AND the equal-time
-    ``id`` tie-break; both rows anchor the canonical path, so the pick must
-    be deterministic — highest ``id`` per the ``max()`` key — never arbitrary.
+    Both duplicate rows anchor the canonical topic path with identical
+    timestamps, so survivor selection must actually compare both ids and
+    keep the documented maximum. Ids are seeded deterministically before
+    insert — mutating live primary keys after the fact races SQLite's
+    UNIQUE flush (review P2-2).
     """
     base = tmp_path / "memory"
     topic = _write_topic(base, "global", None, "shared")
-    _seed_duplicate_global_rows(
-        base,
-        engine,
-        "shared",
-        canonical_path=str(topic),
-        stale_paths=(str(topic.with_name("stale.md")),),
-    )
+    with engine.connect() as conn:
+        conn.exec_driver_sql("DROP INDEX IF EXISTS uq_memory_key_scope_null")
+        conn.commit()
     with sessionmaker(bind=engine)() as db:
-        db.execute(
-            MemoryMetadataModel.__table__.update().values(
-                updated_at=datetime(2026, 7, 1, 10, 0)
+        for row_id in (
+            "11111111-1111-1111-1111-111111111111",
+            "99999999-9999-9999-9999-999999999999",
+        ):
+            db.add(
+                MemoryMetadataModel(
+                    id=row_id,
+                    key="shared",
+                    memory_type="reference",
+                    scope="global",
+                    scope_id=None,
+                    file_path=str(topic),
+                    tags="",
+                )
             )
+        db.execute(
+            MemoryMetadataModel.__table__.update().values(updated_at=datetime(2026, 7, 1, 10, 0))
         )
-        rows = db.query(MemoryMetadataModel).all()
-        # Force the stale-path row to have the higher id so the tie-break,
-        # not insertion order, decides the survivor.
-        stale = next(row for row in rows if row.file_path != str(topic))
-        canonical = next(row for row in rows if row.file_path == str(topic))
-        if stale.id > canonical.id:
-            stale.id, canonical.id = canonical.id, stale.id
         db.commit()
-        expected_id = max(row.id for row in db.query(MemoryMetadataModel).all())
 
     report = MemoryReconciliationService(base, engine).apply()
 
     assert report.counts["dedupe_metadata"] == 1
     remaining = _rows(engine)
     assert len(remaining) == 1
-    assert remaining[0].id == expected_id, "equal-time tie-break keeps the highest id"
+    assert remaining[0].id == "99999999-9999-9999-9999-999999999999"
+    assert remaining[0].file_path == str(topic)
 
 
 def test_foreign_path_duplicate_clears_in_one_repair_run(tmp_path: Path, engine: Any) -> None:
@@ -864,6 +870,153 @@ def test_foreign_path_duplicate_clears_in_one_repair_run(tmp_path: Path, engine:
             for row in conn.exec_driver_sql("PRAGMA index_list('memory_metadata')").fetchall()
         }
     assert "uq_memory_key_scope_null" in names
+
+
+def test_replanned_topic_lock_blocks_concurrent_store(
+    tmp_path: Path, engine: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replanned topic's lock is held from the initial acquisition (review P2-1).
+
+    Topic X's stale duplicate row sits on topic Y's canonical path, so Y
+    plans a row-state conflict and is repaired only by the second-pass
+    re-plan. That re-plan used to run without Y's topic lock, letting a
+    concurrent ``MemoryService.store()`` interleave: the Markdown stayed
+    new while SQLite and the index kept the pre-store projection. The
+    store must block against the replan and every surface must finish
+    describing the newest content.
+    """
+    base = tmp_path / "memory"
+    topic_x = _write_topic(base, "global", None, "x-shared")
+    topic_y = _write_topic(base, "global", None, "y-victim", body="original")
+    _seed_duplicate_global_rows(
+        base,
+        engine,
+        "x-shared",
+        canonical_path=str(topic_x),
+        stale_paths=(str(topic_y),),
+    )
+    with sessionmaker(bind=engine)() as db:
+        db.add(
+            MemoryMetadataModel(
+                id=str(uuid.uuid4()),
+                key="y-victim",
+                memory_type="reference",
+                scope="global",
+                scope_id=None,
+                file_path=str(topic_y),
+                tags="",
+            )
+        )
+        db.commit()
+
+    repair = MemoryReconciliationService(base, engine)
+    store = MemoryService(base, engine)
+    replan_started = threading.Event()
+    store_returned = threading.Event()
+    blocked_during_replan = threading.Event()
+
+    original_repair_metadata = repair._repair_metadata
+
+    def paused_repair_metadata(topic: Any, action: RepairAction) -> None:
+        if (
+            topic.identity is not None
+            and topic.identity.key == "y-victim"
+            and not replan_started.is_set()
+        ):
+            replan_started.set()
+            # Hold the replan open long enough for the concurrent store to
+            # reach the topic flock; it must still be blocked here.
+            time.sleep(1.5)
+            if not store_returned.is_set():
+                blocked_during_replan.set()
+        original_repair_metadata(topic, action)
+
+    monkeypatch.setattr(repair, "_repair_metadata", paused_repair_metadata)
+
+    def run_repair() -> None:
+        repair.apply()
+
+    def run_store() -> None:
+        replan_started.wait(timeout=10)
+        asyncio.run(
+            store.store(
+                content="concurrent new content",
+                scope="global",
+                memory_type="reference",
+                key="y-victim",
+            )
+        )
+        store_returned.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(run_repair), pool.submit(run_store)]
+        for future in futures:
+            future.result(timeout=30)
+
+    assert blocked_during_replan.is_set(), "store did not block on the replanned topic"
+
+    file_text = topic_y.read_text(encoding="utf-8")
+    assert "concurrent new content" in file_text
+    file_latest = (
+        max(line for line in file_text.splitlines() if line.startswith("## 20"))
+        .lstrip("# ")
+        .strip()
+    )
+    file_latest_at = datetime.strptime(file_latest, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+
+    row = next(row for row in _rows(engine) if row.key == "y-victim")
+    row_updated_at = row.updated_at
+    assert row_updated_at is not None
+    assert row_updated_at.replace(tzinfo=timezone.utc) >= file_latest_at
+
+    index_text = (base / "global" / "wiki" / "index.md").read_text(encoding="utf-8")
+    y_lines = [line for line in index_text.splitlines() if "[y-victim]" in line]
+    assert len(y_lines) == 1
+    assert f"updated:{file_latest}" in y_lines[0]
+
+
+def test_unmapped_duplicate_scan_orders_across_scope_id_nullness(
+    tmp_path: Path, engine: Any
+) -> None:
+    """Identities differing only in ``scope_id`` nullness still sort (review P3).
+
+    The no-topic duplicate scan used dataclass ordering on
+    ``MemoryIdentity``, so two rows sharing key and scope with one NULL
+    and one string ``scope_id`` raised ``TypeError`` inside ``plan()``
+    instead of reporting.
+    """
+    base = tmp_path / "memory"
+    with sessionmaker(bind=engine)() as db:
+        db.add(
+            MemoryMetadataModel(
+                id="11111111-1111-1111-1111-111111111111",
+                key="shared",
+                memory_type="reference",
+                scope="global",
+                scope_id=None,
+                file_path=str(base / "global" / "wiki" / "global" / "gone-null.md"),
+                tags="",
+            )
+        )
+        db.add(
+            MemoryMetadataModel(
+                id="99999999-9999-9999-9999-999999999999",
+                key="shared",
+                memory_type="reference",
+                scope="global",
+                scope_id="legacy-nonnull",
+                file_path=str(base / "global" / "wiki" / "global" / "gone-str.md"),
+                tags="",
+            )
+        )
+        db.commit()
+
+    report = MemoryReconciliationService(base, engine).plan()
+
+    assert report.summary_text().startswith("memory_repair mode=dry-run")
+    assert report.counts["total"] == 0
 
 
 def test_unexpected_failure_does_not_rollback_other_records(


### PR DESCRIPTION
## Problem

SQLite treats `NULL != NULL` inside a UNIQUE index, so the `uq_memory_key_scope` constraint on `memory_metadata` has never fired for global/federated rows — the two scopes whose `scope_id` is genuinely NULL. Two rows with the same `key` and `scope='global'` are both insertable, which is exactly the state the constraint reads like it prevents (#657). The ordinary store path is not affected (`_upsert_metadata` looks up by key/scope/`scope_id` and branches on `.is_(None)`, under the store lock), so the gap is latent — but any future write path that bypasses that upsert has no backstop, and a reader of the schema would reasonably assume one exists.

## Fix

A partial unique index covering exactly the NULL-`scope_id` rows, on the existing seams:

- `MemoryMetadataModel.__table_args__` gains `uq_memory_key_scope_null` on `(key, scope)` with `sqlite_where=scope_id IS NULL`, so fresh databases get it from `create_all`. The sentinel approach used by `memory_relationships` is deliberately not applied here: `scope_id` stays nullable because `.is_(None)` comparisons across the memory services are load-bearing, and converting would touch every one of them for no added safety.
- Existing databases get it from a new idempotent migrator `_migrate_memory_scope_null_uniqueness()`, registered last in `init_db()` — same inline-migration pattern as `_migrate_memory_relationships`. It pre-scans for duplicate `(key, scope)` rows among `scope_id IS NULL` first: if any exist (the state this bug allowed — external edits, merged DBs), the index creation would raise `IntegrityError` out of `init_db()` and block startup, so instead it logs one warning naming the duplicates and pointing at `cao memory repair`, and skips the index. No rows are ever deleted by the migrator.

Non-NULL scopes keep their existing behavior on the table-level constraint; the partial index only covers what that constraint cannot see.

## Making the advertised repair real (review follow-up)

The first revision pointed at `cao memory repair` for legacy duplicate rows, but reconciliation treated `duplicate_database_identity` as an unresolvable conflict (both rows retained) and never scanned the federated container, so that pointer was dead — the index could never land. This commit makes the remediation path real:

- Duplicate identities now split in `_plan_topic`: when a row anchors the canonical topic path (and no foreign identity sits on it), the plan keeps that row — newest `updated_at`, `id` tiebreak — and schedules the stale siblings for removal; the survivor keeps its row id, so canonical content is never rewritten. When no row is unambiguously anchored, the pair stays a `conflict` with explicit manual-resolution guidance and both rows are retained (no data loss).
- `apply()` executes the dedupe under the repair locks it already takes, then re-invokes the migrator, so the unique index is created in the same repair run instead of at the next startup.
- The federated container joins the candidate scan, index-line identity parsing, and record-to-candidate mapping — federated NULL-scope duplicates are covered by the same warning and are now actually repairable.
- The migration test now drives the real reconciliation repair instead of hand-deleting a row.

## Failure boundaries of the repair path (second review round)

The re-review's failure-boundary pass found three gaps in the repair path itself; this commit closes all three plus the noted P3:

- **Unmapped duplicates reported (P2-1).** Planning is filesystem-first, so a NULL-scope identity whose canonical topic file is gone produced no record at all — the CLI exited 0 with `total=0` while both rows stayed and the migrator kept skipping the index. `plan()` now also scans the row snapshot: every duplicate NULL-scope identity no topic maps to is emitted as an actionable `duplicate_database_identity` conflict (restore/move the topic or resolve manually), rows preserved, exit 1, and the federated variant is covered by the same scan.
- **Legacy timestamps normalized (P2-2).** The apply-time survivor pick compared raw legacy `updated_at` values (naive, aware, or NULL) against a timezone-aware floor, so a mixed pair raised `TypeError` mid-repair and left both rows plus no index. The pick now normalizes through the same `_utc()` path planning uses; newest wins, `id` breaks exact ties, dedupe completes, and the index lands in the same run.
- **Strict index creation for explicit repair (P2-3).** The migrator swallowed every exception at debug, so a competing SQLite write lock made `cao memory repair --apply` exit 0 with the index absent. Explicit repair (`reconcile(apply=True)`) now runs the migrator in strict mode: DDL failure propagates (the CLI exits nonzero naming the failed index creation) and the named index is verified present in `sqlite_master` before success. Startup (`init_db()` and the startup reconciliation path) keeps the fail-soft default.
- **Dependent conflicts re-planned (P3).** Every plan in a run was derived from the pre-mutation row snapshot, so a topic whose canonical path was occupied by another identity's stale duplicate row planned a `database_path_conflict`/`ambiguous_database_path` that the same run's dedupe had just resolved — demanding a second identical repair. Apply now re-plans those conflicts from a fresh snapshot and executes the recovered plan, so one run clears both.

## Concurrency boundary of the repair path (third review round)

The third re-review found the replan pass mutated a topic whose lock had never been acquired; this commit closes both P2s and the P3:

- **Replanned topics hold their topic lock (P2-1).** Initially skipped row-state conflicts were excluded from the initial lock groups, so the second-pass re-plan could re-parse and repair such a topic after another identity's dedupe freed its path — while a concurrent `MemoryService.store()` interleaved against it, leaving the Markdown new but SQLite/index metadata at the old timestamp/token projection (reproduced deterministically on the prior head with a paused replan). Those records now join the initial ordered lock acquisition, so the replan runs under the topic's held lock, keeping the single `(index_path, file_path)` lock order global. The regression test pauses the replan, proves the concurrent store blocks on the topic flock, and asserts the final file, row, and index line all describe the newest content.
- **Equal-timestamp tie-break test made deterministic (P2-2).** It swapped live UUID primary keys in one flush (racing SQLite's UNIQUE flush) and gave only one row the canonical path, so the survivor pick never compared both ids. It now seeds deterministic ids before insert, points both duplicates at the canonical path with equal normalized timestamps, and asserts the documented maximum-id survivor without touching primary keys.
- **Total sort key for the no-topic scan (P3).** The scan sorted `MemoryIdentity` directly, so equal key/scope with `scope_id` `None` versus a string raised `TypeError` inside `plan()`. It now sorts by `(scope, scope_id or "", key)`.

## Tests

`test/clients/test_database.py` — `TestMemoryScopeNullUniquenessMigration` (fail on current `main`):

- fresh DB: two `(key, global, NULL)` rows collide with `IntegrityError` — the reporter's case. The same test pins the rejecting boundary: a scoped sibling (`scope='session', scope_id='t1'`) of the same key stays distinct, which is what keeping `scope_id` nullable buys.
- legacy DB (index dropped): the migrator creates `uq_memory_key_scope_null`.
- legacy DB seeded with duplicate global rows: the migrator skips the index, warns, keeps both rows; then the advertised repair — the real `MemoryReconciliationService.apply()`, not a hand-written DELETE — clears the stale sibling, keeps the canonical row, and creates the index in the same repair run.

`test/services/test_memory_reconciliation.py`:

- unambiguous duplicates: dry-run plans `dedupe_metadata` without touching rows; `--apply` removes only the non-canonical row, the canonical row keeps its id, and the index lands in the repair run.
- ambiguous duplicates (neither row on the canonical path): `conflict` with manual-resolution guidance, both rows retained, no index created.
- federated duplicates: the scan discovers federated topics (previously invisible), dedupes identically to global, and rebuilds the federated `index.md`.
- unmapped duplicates (no canonical topic at all, global and federated): actionable conflict, exit-nonzero state, rows preserved.
- mixed naive/NULL `updated_at` duplicates: dedupe completes without `TypeError`, newest row survives, index lands same run; equal-time duplicates fall back to the `id` tie-break deterministically.
- foreign-path duplicate occupying another topic's canonical path: one repair run clears both the duplicate and the dependent conflict.
- `test_duplicate_and_wrong_path_rows_are_conflicts` keeps pinning the ambiguous-pair boundary.

`test/cli/commands/test_memory_repair_migration.py` — end-to-end, real `cao memory repair` in a subprocess over an isolated `CAO_HOME_DIR`:

- seeds legacy duplicates via raw SQLite, runs the actual CLI: canonical content survives with its row id, `uq_memory_key_scope_null` exists afterwards, and a new duplicate INSERT is rejected.
- ambiguous rows: exit code 1, actionable conflict message, zero rows removed, no index.
- no-topic duplicates (global + federated): dry-run and `--apply` both exit 1 reporting both identities, zero rows removed, no index.
- mixed-timestamp duplicates: the real CLI completes the dedupe, keeps the newest row, lands the index.
- competing write lock: an external process holds `BEGIN EXCLUSIVE`; `--apply` exits nonzero instead of reporting success, the index is absent; after release a rerun succeeds, the index exists, the dedupe completes.
- replan lock: the replan is paused mid-execution while a concurrent `MemoryService.store()` runs against the replanned topic; the store blocks on the topic flock for the whole window and the final file, row, and index line all describe the newest content.
- equal-timestamp duplicates: both rows on the canonical path with deterministic seeded ids; the maximum-id survivor is asserted without mutating primary keys.
- identities differing only in `scope_id` nullness: `plan()` completes (total sort key) instead of raising `TypeError` in the no-topic scan.

## Verification

- before, on current `main` (`bab1faf`): two `('shared', 'global', NULL)` rows insert cleanly — `IntegrityError` never raised; the same duplicate with a non-NULL `scope_id` is correctly rejected
- after: the duplicate NULL insert raises `UNIQUE constraint failed`, on a fresh DB and on a legacy DB migrated by `init_db()`; after the advertised repair, the index exists and rejects a new duplicate
- reviewer's reproduction, re-run on this head: seed two global rows + canonical topic → `cao memory repair --apply` → survivor keeps its id, index created, duplicate INSERT rejected; ambiguous pair → actionable conflict, no data loss
- all three second-round P2s reproduced on the exact prior head first (exit-0 `total=0`; `TypeError` in the record's failed finding; migrator returning silently under an external `BEGIN EXCLUSIVE`), then re-run green on this head
- all three third-round findings reproduced on the exact prior head first (paused-replan + concurrent store left the file new while the row/index kept the pre-store timestamp/token projection; the tie-break test failed isolated runs with `UNIQUE constraint failed: memory_metadata.id`; a `None`/string `scope_id` pair raised `TypeError` in `plan()`), then re-run green on this head
- focused sweep (`test/clients/`, memory services, reconciliation, gateway, partial-write, scope coverage, startup reconciliation, repair CLI incl. the new e2e, wiki lint) → all green
- full non-e2e suite (`uv sync --all-extras`, matching CI) → 0 failed on the reworked head; `test_session_teardown_atomic.py` passes on this branch
- `black --check`, `isort --check-only` → clean; `mypy` on the changed sources → no new issues (mypy has pre-existing errors on `main` and is non-blocking in CI)

Fixes #657

