### PR TITLE
fix(security): require cao:write for the PTY WebSocket

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -6691,16 +6691,18 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
       hijacking guard);
     * when the HTTP auth layer is enabled (``AUTH0_DOMAIN`` /
       ``CAO_AUTH_JWKS_URI`` set — see :func:`is_auth_enabled`), the handshake
-      must carry a valid bearer token granting at least the ``cao:read``
-      scope.
+      must carry a valid bearer token granting ``cao:write`` or ``cao:admin``.
+      Keystroke injection is RCE; ``cao:read`` is not enough. HTTP
+      ``POST /terminals/{id}/input`` already requires write.
 
     Token scheme: browsers cannot set request headers on a WebSocket
     handshake, so the token is accepted from either ``Authorization: Bearer
     <token>`` (native clients) or a ``?token=<token>`` query parameter (the
     bundled web viewer). The token is verified exactly like the HTTP layer —
     RS256 signature, issuer, audience and expiry via the JWKS cache — and a
-    missing/invalid token or one lacking ``cao:read`` closes the handshake
-    with code 4401 before accept. This closes the bypass where widening
+    missing/invalid token or one lacking ``cao:write`` (or ``cao:admin``)
+    closes the handshake with code 4401 before accept. This closes the bypass
+    where widening
     ``CAO_WS_ALLOWED_CLIENTS`` / ``CAO_WS_ALLOWED_ORIGINS`` for containers,
     devcontainers or Codespaces exposed full PTY control with no credential.
     Do NOT expose the server to untrusted networks (e.g. --host 0.0.0.0)
@@ -6754,9 +6756,10 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
     # identity: browsers cannot set request headers on a WebSocket handshake,
     # so the token is accepted from the Authorization header or a ``?token=``
     # query parameter. The token is verified with the same JWKS/issuer/
-    # audience/expiry logic as the HTTP layer and must grant at least
-    # ``SCOPE_READ``. Default-off (auth disabled): no token is required and
-    # behavior is byte-for-byte unchanged.
+    # audience/expiry logic as the HTTP layer and must grant ``SCOPE_WRITE``
+    # or ``SCOPE_ADMIN``. ``SCOPE_READ`` is enough to watch HTTP output, not
+    # to type into the PTY. Default-off (auth disabled): no token is required
+    # and behavior is byte-for-byte unchanged.
     if is_auth_enabled():
         token = _extract_bearer(websocket.headers.get("authorization"))
         if not token:
@@ -6777,11 +6780,12 @@ async def terminal_ws(websocket: WebSocket, terminal_id: str):
             )
             await websocket.close(code=4401, reason="Unauthorized")
             return
-        if SCOPE_READ not in scopes:
+        if SCOPE_WRITE not in scopes and SCOPE_ADMIN not in scopes:
             logger.warning(
-                "Rejected WebSocket attach for terminal %r: token lacks %r scope",
+                "Rejected WebSocket attach for terminal %r: token lacks %r/%r scope",
                 terminal_id,
-                SCOPE_READ,
+                SCOPE_WRITE,
+                SCOPE_ADMIN,
             )
             await websocket.close(code=4401, reason="Unauthorized")
             return

--- a/test/api/test_ws_auth.py
+++ b/test/api/test_ws_auth.py
@@ -3,7 +3,8 @@
 Covers the security fix that closes the auth bypass on
 ``/terminals/{terminal_id}/ws``: when the HTTP auth layer is enabled the
 handshake must carry a valid JWT (``Authorization: Bearer`` header or
-``?token=`` query parameter) granting at least ``cao:read``. Default-off —
+``?token=`` query parameter) granting ``cao:write`` or ``cao:admin``.
+Keystroke injection is RCE; ``cao:read`` is not enough. Default-off —
 auth disabled — the attach must behave exactly as before (no token needed).
 
 The tests drive ``terminal_ws`` directly with a mock ``WebSocket`` (the same
@@ -166,7 +167,7 @@ async def test_ws_auth_enabled_valid_bearer_header_attaches(monkeypatch, jwt_fac
     from cli_agent_orchestrator.api.main import terminal_ws
 
     _enable_auth(monkeypatch, jwt_factory)
-    ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint_viewer()}"})
+    ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint_operator()}"})
     with _admitted_patches():
         await terminal_ws(ws, "abcd1234")
 
@@ -182,7 +183,7 @@ async def test_ws_auth_enabled_valid_token_query_param_attaches(monkeypatch, jwt
     from cli_agent_orchestrator.api.main import terminal_ws
 
     _enable_auth(monkeypatch, jwt_factory)
-    ws = _make_ws(query_params={"token": jwt_factory.mint_viewer()})
+    ws = _make_ws(query_params={"token": jwt_factory.mint_operator()})
     with _admitted_patches():
         await terminal_ws(ws, "abcd1234")
 
@@ -191,13 +192,28 @@ async def test_ws_auth_enabled_valid_token_query_param_attaches(monkeypatch, jwt
 
 
 @pytest.mark.asyncio
-async def test_ws_auth_enabled_write_only_token_rejected(monkeypatch, jwt_factory):
-    """Auth on + a valid token WITHOUT ``cao:read`` → closed 4401 (attach
-    requires at least the read scope)."""
+async def test_ws_auth_enabled_write_only_token_attaches(monkeypatch, jwt_factory):
+    """Auth on + a valid token with ``cao:write`` (no read) → proceeds past
+    the gate. Matches HTTP ``POST /terminals/{id}/input``."""
     from cli_agent_orchestrator.api.main import terminal_ws
 
     _enable_auth(monkeypatch, jwt_factory)
     ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint(scopes='cao:write')}"})
+    with _admitted_patches():
+        await terminal_ws(ws, "abcd1234")
+
+    ws.accept.assert_awaited_once()
+    assert ws.close.call_args.kwargs.get("code") == 4004
+
+
+@pytest.mark.asyncio
+async def test_ws_auth_enabled_read_only_token_rejected(monkeypatch, jwt_factory):
+    """Auth on + a valid ``cao:read``-only token → closed 4401. The PTY is
+    write/RCE; read is not enough."""
+    from cli_agent_orchestrator.api.main import terminal_ws
+
+    _enable_auth(monkeypatch, jwt_factory)
+    ws = _make_ws(headers={"authorization": f"Bearer {jwt_factory.mint_viewer()}"})
     with _admitted_patches():
         await terminal_ws(ws, "abcd1234")
 


### PR DESCRIPTION
## What
The PTY WebSocket already 4401s when the token lacks `cao:read`. HTTP `POST /terminals/{id}/input` requires `cao:write`. The socket is keystroke injection (the handler docstring calls it RCE) and still admitted a read-only JWT.

On main at 79befd0:

```python
# api/main.py — POST /terminals/{id}/input
_scopes: List[str] = Depends(require_any_scope(SCOPE_WRITE, SCOPE_ADMIN))

# api/main.py — /terminals/{id}/ws
if SCOPE_READ not in scopes:
    await websocket.close(code=4401, reason="Unauthorized")
    return
```

A `cao:read` token therefore cannot POST input and can still attach the live PTY. Default-off auth is unchanged (no token required).

## Why
I was comparing the HTTP input gate with the WebSocket handshake. The tests even encoded the mismatch: `test_ws_auth_enabled_write_only_token_rejected` required `cao:read`, and the happy path used `mint_viewer()` (`cao:read` only). I flipped that: read-only must 4401, write may attach.

## How
Require `SCOPE_WRITE` or `SCOPE_ADMIN` before `accept()`, same membership test as the HTTP input route. Update the handler docstring and the WS auth tests.

## Testing
```
uv run pytest test/api/test_ws_auth.py -q --no-cov
```
`test_ws_auth_enabled_read_only_token_rejected` fails on 79befd0 (viewer attaches) and passes with this patch. Write-only and operator tokens still attach. Default-off and the IP/Origin checks are unchanged.
