### PR TITLE
docs: clarify PTY WebSocket authorization

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -296,8 +296,26 @@ Connect to:
 /terminals/{terminal_id}/ws
 ```
 
-The path must identify an existing terminal. This endpoint is unauthenticated
-and grants full read/write access to that terminal's PTY.
+The path must identify an existing terminal. An accepted connection grants
+full read/write access to that terminal's PTY, including command input.
+
+### Authentication
+
+Authentication is enabled when `CAO_AUTH_JWKS_URI` or `AUTH0_DOMAIN` is set.
+In that mode, the handshake requires a valid bearer token granting
+`cao:write` **or** `cao:admin`, matching `POST /terminals/{terminal_id}/input`.
+These are existing CAO scopes; `cao:read` alone does not permit interactive
+PTY access.
+
+Send the token in the `Authorization` bearer header, or in the `token` query
+parameter for clients that cannot set that header. An extracted header token
+takes precedence over the query parameter. Passing the Origin check does not
+supply a bearer token; the client must provide it. Keep token-bearing URLs out
+of logs and use TLS for remote connections.
+
+With neither authentication-enabling variable set, no token is required.
+The client-IP and Origin restrictions still apply in both modes. See the
+[authentication configuration](configuration.md#auth-auth--env-var-only).
 
 ### Client access boundary
 
@@ -306,9 +324,11 @@ By default, only loopback clients identified as `127.0.0.1`, `::1`, or
 IP addresses or hostnames to that allowlist. A literal `*` disables the
 client-IP restriction.
 
-Adding clients or using `*` gives those clients full PTY read/write access.
-Treat either change as a security-boundary change and do not expose the
-endpoint to untrusted networks. See the
+Adding clients or using `*` widens who can reach the PTY handshake; it does
+not bypass authentication when enabled. With authentication disabled,
+clients that also pass the Origin check receive full PTY read/write access.
+Treat either allowlist change as a security-boundary change and do not expose
+the endpoint to untrusted networks. See the
 [network configuration](configuration.md#network-network--env-var-only) for
 related server settings.
 
@@ -333,8 +353,18 @@ rows and 80 columns.
 
 ### Close outcomes
 
-- `4003`: the client is restricted, or terminal/backend target metadata is
-  invalid.
+Client-IP, Origin, and authentication refusals happen before the WebSocket
+upgrade. They reject the HTTP handshake with `403`, rather than delivering a
+WebSocket close frame. The handler uses these server-side refusal codes:
+
+- `4003`: the client is outside the allowed client-IP set.
+- `4403`: the browser Origin is not allowed.
+- `4401`: authentication is enabled and the token is missing, invalid, or
+  grants neither `cao:write` nor `cao:admin`.
+
+After the connection is accepted:
+
+- `4003`: terminal/backend target metadata is invalid.
 - `4004`: the terminal does not exist, or the backend cannot attach to it.
 - A normal viewer disconnect detaches that viewer and preserves the session.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,9 +232,19 @@ Default-off. See [../src/cli_agent_orchestrator/ext_apps/apps.py](../src/cli_age
 | `CAO_WS_ALLOWED_CLIENTS` | `WS_ALLOWED_CLIENTS` (client IPs permitted to attach to the PTY WebSocket) | Running `cao-server` inside Docker (host browser arrives via a bridge IP). |
 | `CAO_WS_ALLOWED_ORIGINS` | `WS_ALLOWED_ORIGINS` (extra browser `Origin`s permitted to attach to the PTY WebSocket) | Serving the terminal viewer from a page whose origin **differs** from the cao-server host (a separate reverse-proxy hostname or dashboard). |
 
-> **Security note:** the WebSocket PTY endpoint is unauthenticated. Only add client IPs you actually trust to `CAO_WS_ALLOWED_CLIENTS` — anyone reaching the listener at one of those IPs gets full PTY access to running agent terminals.
+> **Security note:** an accepted WebSocket PTY connection grants full
+> read/write access to a running agent terminal. When authentication is enabled
+> by `CAO_AUTH_JWKS_URI` or `AUTH0_DOMAIN`, attachment requires a valid bearer
+> token granting `cao:write` or `cao:admin`. These are existing CAO scopes;
+> `cao:read` alone is not sufficient. With neither variable set, no token is
+> required. Only add client IPs you actually trust to `CAO_WS_ALLOWED_CLIENTS`,
+> and do not expose the endpoint to untrusted networks. Authentication does
+> not replace the client-IP or Origin checks, and widening either allowlist
+> does not bypass authentication. See the [Auth settings](#auth-auth--env-var-only)
+> and [PTY WebSocket contract](api.md#pty-websocket) for configuration, token
+> transports, and refusal outcomes.
 >
-> The endpoint also enforces an **Origin** check to block cross-site WebSocket hijacking (CWE-1385): a browser page that is not same-origin with the cao-server host (and not in `CAO_WS_ALLOWED_ORIGINS`) is refused. Same-origin viewers — including the bundled UI, imported-app deployments (`uvicorn cli_agent_orchestrator.api.main:app`), and dynamic reverse-proxy / Codespaces hostnames — work with no configuration, because the check accepts any `Origin` whose authority equals the request `Host` (itself validated by `TrustedHostMiddleware`). `CAO_WS_ALLOWED_ORIGINS` is only for *genuinely cross-origin* viewers; a literal `*` disables the Origin check. Note that `CAO_CORS_ORIGINS="*"` does **not** disable it — PTY access is more sensitive than ordinary CORS reads, so the escape hatch is the dedicated `CAO_WS_ALLOWED_ORIGINS="*"`.
+> The endpoint also enforces an **Origin** check to block cross-site WebSocket hijacking (CWE-1385): a browser page that is not same-origin with the cao-server host (and not in `CAO_WS_ALLOWED_ORIGINS`) is refused. Same-origin viewers — including the bundled UI, imported-app deployments (`uvicorn cli_agent_orchestrator.api.main:app`), and dynamic reverse-proxy / Codespaces hostnames — pass this Origin check without extra Origin configuration, because the check accepts any `Origin` whose authority equals the request `Host` (itself validated by `TrustedHostMiddleware`). Passing that check does not bypass the token requirement when authentication is enabled. `CAO_WS_ALLOWED_ORIGINS` is only for *genuinely cross-origin* viewers; a literal `*` disables the Origin check. Note that `CAO_CORS_ORIGINS="*"` does **not** disable it — PTY access is more sensitive than ordinary CORS reads, so the escape hatch is the dedicated `CAO_WS_ALLOWED_ORIGINS="*"`.
 
 ### Auth (`auth`) — env-var only
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to #748. The runtime already requires `cao:write` or `cao:admin` for authenticated PTY attachment, but the public API and configuration pages still described the endpoint as unconditionally unauthenticated.

- Document the existing scopes, the real authentication-enabling variables, bearer-header/query-token transports, and unchanged authentication-disabled behavior.
- Explain that client-IP and Origin checks remain independent of authentication; same-origin access does not automatically supply a token.
- Document `4401` authorization refusals and distinguish pre-upgrade HTTP `403` responses from close frames sent after an accepted WebSocket connection.

Only `docs/api.md` and `docs/configuration.md` change. No new scopes, configuration switches, dependencies, or runtime behavior are introduced.

## Validation

- Existing Markdown-link validator: `PYTHONPATH=src python scripts/validate_markdown_links.py`.
- `git diff --check`.
- Wording matched against the current `terminal_ws` and `is_auth_enabled` implementations and Starlette's documented pre-accept denial behavior.
