### PR TITLE
fix(workflow): distinguish approval-store faults from missing approval

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -4796,6 +4796,8 @@ async def start_workflow_run_endpoint(
                 status_code=422,
                 detail={"findings": workflow_spec_service.render_findings(e.findings)},
             )
+        except approval_gate.PlanApprovalUnavailableError as e:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e))
         except approval_gate.PlanApprovalRequiredError as e:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
         except KeyError as e:
@@ -4965,6 +4967,8 @@ async def submit_workflow_run_endpoint(
         )
         try:
             approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest_json)
+        except approval_gate.PlanApprovalUnavailableError as e:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e))
         except approval_gate.PlanApprovalRequiredError as e:
             # 403, distinct from this endpoint's 409 (run_id collision) and 422 (lint / corrupt), so a
             # caller can tell "needs approval" from "the run broke".
@@ -6353,6 +6357,8 @@ async def resume_workflow_run_endpoint(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail=f"unknown run '{run_id}'"
             )
+        except approval_gate.PlanApprovalUnavailableError as e:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e))
         except approval_gate.PlanApprovalRequiredError as e:
             # issue #583 Bolt 2, ``approval-gate``: 403, and it must be caught HERE rather than left
             # to the arms below. ``PlanApprovalRequiredError`` is deliberately not a ``ValueError``

--- a/src/cli_agent_orchestrator/services/approval_gate.py
+++ b/src/cli_agent_orchestrator/services/approval_gate.py
@@ -13,9 +13,13 @@ the right posture for a control someone deliberately switched on and the wrong o
 user of a feature that has no in-product way to grant approval until Bolt 3.
 
 THE GATE REPORTS; IT DOES NOT FORM AN OPINION ABOUT WHETHER AN APPROVAL EXISTS.
-``approval_store.is_approved`` is the sole authority, is already total, and already answers ``False``
-on a database error. A second opinion here would be the copy that drifts — and a drifted
-authorisation check is the kind that looks correct while permitting something.
+``approval_store`` is the sole authority. The gate consults it through ONE call —
+``approval_store.approval_state`` — and maps its three answers: APPROVED proceeds, ABSENT refuses as
+``PlanApprovalRequiredError`` (403), and UNKNOWN (the store faulted) refuses as
+``PlanApprovalUnavailableError`` (503, issue #696). A store fault stays fail-closed exactly as before
+— it never admits a run — but it is no longer collapsed into "not approved", because telling an
+operator whose database is unreadable to approve a plan names a remedy that cannot work. A second
+opinion here would be the copy that drifts, so the gate reads the store once and routes on that.
 
 IT SITS BEFORE THE FIRST IRREVERSIBLE ACT ON BOTH PATHS, and the two placements are not symmetric
 because what they protect is not the same thing:
@@ -72,6 +76,18 @@ class PlanApprovalRequiredError(Exception):
         self.plan_id = plan_id
 
 
+class PlanApprovalUnavailableError(Exception):
+    """Approval could not be checked because the store is unavailable.
+
+    Refuse the run with HTTP 503 so callers can distinguish a database fault from
+    a missing approval (403). Neither condition permits execution.
+    """
+
+    def __init__(self, message: str, plan_id: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.plan_id = plan_id
+
+
 def plan_id_from_manifest(manifest_json: Optional[str]) -> Optional[str]:
     """Extract ``plan_id`` from a frozen manifest, or ``None`` if it cannot be read.
 
@@ -98,7 +114,7 @@ def plan_id_from_manifest(manifest_json: Optional[str]) -> Optional[str]:
 
 
 def ensure_plan_approved(*, tier: str, manifest_json: Optional[str]) -> None:
-    """Raise :class:`PlanApprovalRequiredError` unless this run may proceed.
+    """Refuse missing approval or an unavailable approval store before execution.
 
     Returns ``None`` on every permitted path. Called from three places — the async start arm, the
     blocking start arm, and resume admission — as ONE function rather than three inline checks,
@@ -112,7 +128,7 @@ def ensure_plan_approved(*, tier: str, manifest_json: Optional[str]) -> None:
     if tier != SCRIPT_TIER:
         return
     if not is_workflow_approval_required():
-        # The default. is_approved is not called, so the disabled path cannot fail a run.
+        # The default. The approval store is not called on the disabled path.
         return
 
     plan_id = plan_id_from_manifest(manifest_json)
@@ -130,13 +146,25 @@ def ensure_plan_approved(*, tier: str, manifest_json: Optional[str]) -> None:
             "workflow.require_approval."
         )
 
-    if not approval_store.is_approved(plan_id):
-        # A control that refuses without saying which plan cannot be operated. plan_id is an opaque
-        # digest, so logging it adds nothing sensitive.
-        logger.warning("workflow approval gate: refusing unapproved plan_id %s", plan_id)
-        raise PlanApprovalRequiredError(
-            f"Plan '{plan_id}' has not been approved. Approve this plan identifier and run again. "
-            "Note that a plan_id is computed at run start, so the first run of a new or changed "
-            "plan is refused by design.",
+    state = approval_store.approval_state(plan_id)
+    if state == approval_store.APPROVED:
+        return
+
+    if state == approval_store.UNKNOWN:
+        logger.error("workflow approval store unavailable for plan_id %s", plan_id)
+        raise PlanApprovalUnavailableError(
+            f"Could not read the approval store for plan '{plan_id}'. "
+            "The run was refused. Restore database access and retry.",
             plan_id=plan_id,
         )
+
+    # state == ABSENT — a genuine absence of approval.
+    # A control that refuses without saying which plan cannot be operated. plan_id is an opaque
+    # digest, so logging it adds nothing sensitive.
+    logger.warning("workflow approval gate: refusing unapproved plan_id %s", plan_id)
+    raise PlanApprovalRequiredError(
+        f"Plan '{plan_id}' has not been approved. Approve this plan identifier and run again. "
+        "Note that a plan_id is computed at run start, so the first run of a new or changed "
+        "plan is refused by design.",
+        plan_id=plan_id,
+    )

--- a/src/cli_agent_orchestrator/services/approval_store.py
+++ b/src/cli_agent_orchestrator/services/approval_store.py
@@ -16,10 +16,9 @@ would look recent, and **work nobody reviewed would execute with a genuine appro
 of the gate, but a corruption of the thing the gate consults. ``grant`` therefore uses ``INSERT OR IGNORE``, so
 write-once is a property of the statement rather than of a caller remembering to look first.
 
-ABSENCE MEANS UNAPPROVED, AND THAT IS WHY EVERY FAULT HERE IS SAFE. A missing table, a silent migration
-failure, a database error — all converge on "no row found". Because absence answers False rather than raising or
-defaulting open, each of those becomes a REFUSED RUN rather than an authorisation bypass. Fail-closed, the same
-direction pass 2A established for an absent manifest.
+ABSENCE AND STORE FAULTS BOTH REFUSE EXECUTION. ``approval_state`` distinguishes a missing approval
+from a database error so the gate can report the appropriate remedy. ``is_approved`` retains its
+boolean contract: both absence and an unreadable store return False.
 
 ``plan_id`` IS OPAQUE: stored and compared verbatim, never parsed, never normalised. A normalisation is how two
 distinct plans could come to share one approval, and ``plan-v1:``'s versioned prefix exists precisely so a
@@ -91,28 +90,36 @@ def grant(plan_id: str, approved_by: str) -> None:
         )
 
 
-def is_approved(plan_id: str) -> bool:
-    """Does an approval exist for ``plan_id``? TOTAL — never raises, and absence answers ``False``.
+# Keep an unreadable store distinct from a plan with no approval (issue #696).
+APPROVED = "approved"
+ABSENT = "absent"
+UNKNOWN = "unknown"
 
-    The one question this module answers. It reports a fact; it does not decide whether a run may proceed.
-    """
+
+def approval_state(plan_id: str) -> str:
+    """Return APPROVED, ABSENT, or UNKNOWN when the database cannot be read."""
     try:
         with _connect() as conn:
             row = conn.execute(
                 "SELECT 1 FROM workflow_plan_approval WHERE plan_id = ?", (plan_id,)
             ).fetchone()
-        return row is not None
     except sqlite3.Error:
-        # A database fault is not permission. Answering False keeps every failure mode fail-closed:
-        # the run is refused rather than admitted on the strength of an error.
-        return False
+        # A database fault is not "no approval". UNKNOWN keeps the run fail-closed (the gate refuses)
+        # while preserving that the cause was a store the gate could not read, not a missing approval.
+        return UNKNOWN
+    return APPROVED if row is not None else ABSENT
+
+
+def is_approved(plan_id: str) -> bool:
+    """Return whether the plan is approved; absence and database faults remain False."""
+    return approval_state(plan_id) == APPROVED
 
 
 def get_approval(plan_id: str) -> Optional[PlanApproval]:
     """The approval record for ``plan_id``, or ``None``. TOTAL — never raises.
 
     FOR DIAGNOSIS, NOT FOR DECIDING. "When, and by whom" is the first question a refused operator asks;
-    ``approval-gate`` should still route on :func:`is_approved`.
+    ``approval-gate`` routes on :func:`approval_state`.
     """
     try:
         with _connect() as conn:

--- a/test/services/test_approval_gate.py
+++ b/test/services/test_approval_gate.py
@@ -35,12 +35,16 @@ def enforcement_on(monkeypatch):
 @pytest.fixture()
 def approved(monkeypatch):
     """Approve exactly ``PLAN`` and nothing else, without touching a database."""
-    monkeypatch.setattr(approval_store, "is_approved", lambda plan_id: plan_id == PLAN)
+    monkeypatch.setattr(
+        approval_store,
+        "approval_state",
+        lambda plan_id: approval_store.APPROVED if plan_id == PLAN else approval_store.ABSENT,
+    )
 
 
 @pytest.fixture()
 def nothing_approved(monkeypatch):
-    monkeypatch.setattr(approval_store, "is_approved", lambda plan_id: False)
+    monkeypatch.setattr(approval_store, "approval_state", lambda plan_id: approval_store.ABSENT)
 
 
 # ---------------------------------------------------------------------------
@@ -49,9 +53,11 @@ def nothing_approved(monkeypatch):
 
 
 def test_enforcement_is_off_by_default_so_an_unapproved_script_run_proceeds(monkeypatch):
-    """C-1 and the default. ``is_approved`` must not even be consulted."""
+    """C-1 and the default. The approval store must not even be consulted."""
     consulted = []
-    monkeypatch.setattr(approval_store, "is_approved", lambda p: consulted.append(p) or False)
+    monkeypatch.setattr(
+        approval_store, "approval_state", lambda p: consulted.append(p) or approval_store.ABSENT
+    )
     monkeypatch.setattr(approval_gate, "is_workflow_approval_required", lambda: False)
 
     ensure_plan_approved(tier="script", manifest_json=MANIFEST)  # must not raise
@@ -133,11 +139,72 @@ def test_an_unreadable_manifest_refuses(enforcement_on, approved, manifest):
     assert excinfo.value.plan_id is None
 
 
-def test_a_database_error_refuses_rather_than_permits(enforcement_on, monkeypatch):
-    """``approval_store.is_approved`` already answers False on sqlite3.Error; the gate must honour it."""
-    monkeypatch.setattr(approval_store, "is_approved", lambda p: False)
-    with pytest.raises(PlanApprovalRequiredError):
+def test_a_store_fault_is_not_reported_as_a_missing_approval(enforcement_on, monkeypatch):
+    """Issue #696 regression. A store fault must NOT reach the operator as "approve this plan".
+
+    When the approval database is unreadable, the gate cannot know whether ``plan_id`` is approved.
+    Reporting that as a missing approval hands the operator a remedy — "approve this plan identifier
+    and run again" — that cannot work, because nothing about the plan is wrong. The refusal must be
+    distinguishable from a genuine absence.
+    """
+    import sqlite3
+
+    def unreadable_store(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(approval_store, "_connect", unreadable_store)
+
+    with pytest.raises(
+        Exception
+    ) as excinfo:  # noqa: PT011 - asserting on the message, not the type
         ensure_plan_approved(tier="script", manifest_json=MANIFEST)
+
+    message = str(excinfo.value)
+    assert "has not been approved" not in message, (
+        "a store fault must not be reported as a missing approval — the operator would be told to "
+        "approve a plan that may already be approved, and the remedy cannot address a database fault"
+    )
+    assert "Approve this plan identifier" not in message
+
+
+def test_a_database_error_refuses_rather_than_permits(enforcement_on, monkeypatch):
+    """A store fault refuses rather than permits — the fail-closed posture is preserved.
+
+    The refusal is now a distinct :class:`PlanApprovalUnavailableError` (issue #696) rather than
+    :class:`PlanApprovalRequiredError`, but it is still a refusal: an unreadable store never admits
+    a run.
+    """
+    import sqlite3
+
+    def unreadable_store(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(approval_store, "_connect", unreadable_store)
+    with pytest.raises(approval_gate.PlanApprovalUnavailableError):
+        ensure_plan_approved(tier="script", manifest_json=MANIFEST)
+
+
+def test_an_unknown_store_state_is_a_distinct_refusal_carrying_the_plan_id(
+    enforcement_on, monkeypatch
+):
+    """Issue #696. UNKNOWN maps to its own refusal class, carries the plan_id, and is not a 400/absence.
+
+    The distinction is the whole point: a caller branching on the refusal must be able to tell "the
+    store is unreadable, retry" from "this plan is not approved, approve it".
+    """
+    monkeypatch.setattr(approval_store, "approval_state", lambda _plan_id: approval_store.UNKNOWN)
+
+    with pytest.raises(approval_gate.PlanApprovalUnavailableError) as excinfo:
+        ensure_plan_approved(tier="script", manifest_json=MANIFEST)
+
+    assert excinfo.value.plan_id == PLAN, "the refusal must still carry the plan_id for diagnosis"
+    assert not isinstance(excinfo.value, PlanApprovalRequiredError), (
+        "a store fault is a fact about the store, not about the plan — the two refusals must be "
+        "distinguishable so a caller does not apply the approve-this-plan remedy to a database fault"
+    )
+    assert not isinstance(
+        excinfo.value, ValueError
+    ), "transported as 503, so it must not be a ValueError the API's trailing 400 arm can claim"
 
 
 # ---------------------------------------------------------------------------

--- a/test/services/test_approval_gate_integration.py
+++ b/test/services/test_approval_gate_integration.py
@@ -172,6 +172,45 @@ def test_the_resume_endpoint_answers_403_and_not_400_or_409():
     assert PLAN_ID in json.dumps(response.json()), "the refusal must carry the plan_id"
 
 
+def test_the_resume_endpoint_answers_503_when_the_approval_store_is_unreadable(monkeypatch):
+    """Issue #696. A store fault reaches the caller as 503, distinct from the 403 of a missing approval.
+
+    503 is the transient-fault posture: retry once the database is readable. Reporting it as 403 would
+    tell the operator to approve a plan that may already be approved, against a fault approval could not
+    even be read. The two must be distinguishable at the transport, because a caller branches on it.
+    """
+    import sqlite3
+
+    from fastapi.testclient import TestClient
+
+    from cli_agent_orchestrator.api.main import app
+
+    _insert_failed_script_run("run-503")  # inserted while the store is healthy
+    before = workflow_journal.get_run("run-503")
+
+    def unreadable_store(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    # Break only the approval store's connection; the run row was already written and the journal
+    # keeps its own connection, so the admission ladder still reaches the approval gate.
+    monkeypatch.setattr(approval_store, "_connect", unreadable_store)
+
+    client = TestClient(app, base_url="http://localhost")
+    response = client.post("/workflows/runs/run-503/resume")
+
+    assert response.status_code == 503, (
+        f"expected 503, got {response.status_code}: an unreadable approval store is a transient fault "
+        "to retry, not a missing approval to grant — the two must not share a status code"
+    )
+    after = workflow_journal.get_run("run-503")
+    assert after.generation == before.generation
+    assert after.state == before.state
+    body = json.dumps(response.json())
+    assert (
+        "has not been approved" not in body
+    ), "a store fault must not be reported with the missing-approval remedy"
+
+
 # ---------------------------------------------------------------------------
 # 4. Both start arms agree
 # ---------------------------------------------------------------------------
@@ -204,3 +243,36 @@ def test_both_start_arms_reach_the_same_verdict_on_the_same_inputs():
 
     approval_store.grant(PLAN_ID, "test-account")
     approval_gate.ensure_plan_approved(tier="script", manifest_json=manifest)  # must not raise
+
+
+@pytest.mark.parametrize("endpoint", ["/workflows/runs", "/workflows/runs:submit"])
+def test_store_fault_refuses_start_before_writing_a_run(endpoint, monkeypatch):
+    """Both start endpoints must report a store fault without creating a run."""
+    import sqlite3
+
+    from fastapi.testclient import TestClient
+
+    from cli_agent_orchestrator.api.main import app
+    from cli_agent_orchestrator.models.workflow import ScriptSpec
+    from cli_agent_orchestrator.services import manifest_freeze, workflow_spec_service
+
+    spec = ScriptSpec(
+        name="store-fault",
+        path="/tmp/store-fault.py",
+        source="def main():\n    pass\n",
+        content_hash="sha256:abc",
+    )
+    monkeypatch.setattr(workflow_spec_service, "get_workflow", lambda name: spec)
+    monkeypatch.setattr(manifest_freeze, "build_manifest_json", lambda **kwargs: _manifest())
+
+    def unreadable_store():
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(approval_store, "_connect", unreadable_store)
+    response = TestClient(app, base_url="http://localhost").post(
+        endpoint, json={"name_or_path": "store-fault", "run_id": "refused-start"}
+    )
+    assert response.status_code == 503, response.text
+    assert PLAN_ID in response.json()["detail"]
+    assert "has not been approved" not in response.json()["detail"]
+    assert workflow_journal.get_run("refused-start") is None

--- a/test/services/test_approval_store.py
+++ b/test/services/test_approval_store.py
@@ -66,6 +66,37 @@ def test_an_unknown_plan_is_not_approved(db_path):
 
 
 # ---------------------------------------------------------------------------
+# The tri-state sibling (issue #696): a store FAULT is distinct from an ABSENCE
+# ---------------------------------------------------------------------------
+
+
+def test_approval_state_reports_absent_approved_and_is_consistent_with_is_approved(db_path):
+    assert approval_store.approval_state("plan-v1:missing") == approval_store.ABSENT
+    approval_store.grant("plan-v1:present", "stan")
+    assert approval_store.approval_state("plan-v1:present") == approval_store.APPROVED
+    # is_approved is the boolean view of the same fact.
+    assert approval_store.is_approved("plan-v1:present") is True
+    assert approval_store.is_approved("plan-v1:missing") is False
+
+
+def test_a_store_fault_is_unknown_not_absent(db_path, monkeypatch):
+    """A database error must answer UNKNOWN, not ABSENT — the whole point of #696.
+
+    ``is_approved`` still collapses the fault to False (fail-closed), but ``approval_state`` preserves
+    that CAO could not read the store, so the gate can refuse without calling it a missing approval.
+    """
+
+    def unreadable_store(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(approval_store, "_connect", unreadable_store)
+
+    assert approval_store.approval_state("plan-v1:anything") == approval_store.UNKNOWN
+    # The boolean view stays fail-closed: a fault is not permission.
+    assert approval_store.is_approved("plan-v1:anything") is False
+
+
+# ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
 

--- a/test/services/test_manifest_freeze.py
+++ b/test/services/test_manifest_freeze.py
@@ -181,7 +181,13 @@ def test_an_unavailable_snapshot_reaches_the_gate_without_a_plan_id(monkeypatch)
     approved_manifest = manifest_freeze.build_manifest_json(source_hash="abc123", inputs={"k": "v"})
     assert approved_manifest is not None
     approved_plan_id = json.loads(approved_manifest)["plan_id"]
-    monkeypatch.setattr(approval_store, "is_approved", lambda plan_id: plan_id == approved_plan_id)
+    monkeypatch.setattr(
+        approval_store,
+        "approval_state",
+        lambda plan_id: (
+            approval_store.APPROVED if plan_id == approved_plan_id else approval_store.ABSENT
+        ),
+    )
     approval_gate.ensure_plan_approved(tier="script", manifest_json=approved_manifest)
 
     unavailable_manifest = manifest_freeze.build_manifest_json(


### PR DESCRIPTION
Fixes #696.

When the approval database cannot be read, starting or resuming a script workflow currently returns 403 and tells the caller to approve the plan. The plan may already be approved; the database fault is what needs attention.

This adds a three-state lookup in `approval_store` and a distinct `PlanApprovalUnavailableError`. Blocking start, background submission, and resume return 503 for that failure. Missing approval still returns 403. `is_approved()` keeps its boolean behavior and shares the same lookup, returning `False` on a database fault.

Regression tests inject a SQLite connection error through the real gate and all three API endpoints. They check that a refused start creates no run and a refused resume preserves its state and generation. All three endpoint cases fail against unchanged `main` with 403 instead of 503.

Verification:

- Full CI test selection with four workers: upstream `ce18db2` has 8,821 passing tests; this branch has 8,828. Both have the same two failures by test identity: the default-data-directory assertion with `CAO_HOME_DIR` redirected to a temporary location, and the Rust dependency-graph check because rustup has no configured toolchain. The directory assertion passes separately without that override. Both runs also have 30 skips and one expected failure.
- `black --check src/ test/`, `isort --check-only src/ test/`, Markdown link validation, and `git diff --check` pass.
- `mypy src/` reports the same 110 errors in 14 files on upstream and this branch, with no new diagnostics.

Best Regards, Tarik
