### PR TITLE
fix(grok): classify the weekly-limit picker as ERROR instead of stale PROCESSING

### DIFF
--- a/docs/grok-cli.md
+++ b/docs/grok-cli.md
@@ -110,6 +110,17 @@ env GROK_SUBAGENTS=0 GROK_WORKFLOWS=0 GROK_GOAL=0 \
   combination was verified against Grok Build 1.0.0; recheck it after a Grok
   upgrade because these controls are not all shown by `grok --help`.
 - A single Enter submits bracketed-paste input. `/quit` exits the session.
+- A usage-limit picker (`You hit your weekly limit.` drawn inside the picker box,
+  with `Upgrade tier` / `Buy more credits` / `Try Again` options and a
+  `Tab:next answer` footer) is classified as ERROR instead of leaving the
+  terminal on the stale PROCESSING marker of the turn that hit the limit. A
+  waiting `handoff` then fails as soon as the picker is seen, with the generic
+  "worker errored"/terminal-ERROR message; the picker's own text is not
+  propagated to the caller. Other pickers of the same shape (`Tab:next answer`,
+  `Enter:submit`) read as WAITING_USER_ANSWER. Both classifications require the
+  picker to be the newest thing on screen: status is read from an append-only
+  raw buffer, so a picker a later frame erased or a transcript that quotes one
+  loses to the newer processing frame and the turn keeps running.
 
 ### Native workflow opt-in
 
@@ -210,8 +221,9 @@ restrictions. Do not substitute `--yolo` when validating supervisor safety.
 
 - The provider targets Grok Build's interactive TUI and currently requires the
   tmux backend. Headless `-p` and ACP modes are not CAO transports.
-- TUI parsing is calibrated against Grok Build 1.0.0. A future layout change
-  may require updated status and extraction fixtures.
+- TUI parsing is calibrated against Grok Build 1.0.0; the usage-limit picker
+  fixture was captured on 1.0.13. A future layout change may require updated
+  status and extraction fixtures.
 - CAO reuses existing Grok authentication. Complete interactive login first;
   CAO does not drive account or device-code login screens.
 - Per-tool MCP gating is not available. `@cao-mcp-server` does not selectively

--- a/src/cli_agent_orchestrator/providers/grok_cli.py
+++ b/src/cli_agent_orchestrator/providers/grok_cli.py
@@ -97,6 +97,33 @@ ERROR_PATTERN = re.compile(
     r"Unknown model|Model .* (?:not found|unavailable))",
     re.IGNORECASE | re.MULTILINE,
 )
+# Footers grok 1.0.13 draws beneath a selectable picker.  Deliberately kept out
+# of ``WAITING_USER_PATTERN``: that branch is ordered only against completion
+# and ready evidence, and these shapes are also what the usage-limit picker
+# prints, so a picker an erase/redraw already replaced could report
+# WAITING_USER_ANSWER over a live turn.  ``get_status`` classifies them through
+# its own check, ordered against newer processing evidence too.
+PICKER_ANSWER_FOOTER_PATTERN = re.compile(r"(?:Tab:next answer|Enter:submit)", re.IGNORECASE)
+# Any footer that proves a picker was drawn in the frame -- the 1.0.13 shapes
+# plus the ``n/m:select`` footer ``WAITING_USER_PATTERN`` already knows.  Used
+# below only as the structural companion of the usage-limit refusal line.
+PICKER_FOOTER_PATTERN = re.compile(
+    r"(?:Tab:next answer|Enter:submit|\d+/\d+:select)", re.IGNORECASE
+)
+# Usage-limit refusal (grok 1.0.13).  It is not an ``Error:`` line; it is drawn
+# inside the picker box that offers "Upgrade tier" / "Buy more credits" /
+# "Try Again":
+#
+#     ┃  You hit your weekly limit.
+#     ┃  1 (○) Upgrade tier      Upgrade to a higher tier for more usage
+#     ┃  ↑/↓ navigate · y copy                                    Enter:submit
+#     Tab:next answer  │  Esc:scrollback  │  Shift+x:dismiss
+#
+# Requiring the box glyph on the refusal line keeps ordinary assistant prose
+# that quotes the sentence from matching; ``get_status`` additionally requires
+# a ``PICKER_FOOTER_PATTERN`` footer after the line, so only a drawn picker is
+# classified, and orders the whole structure against every newer status signal.
+USAGE_LIMIT_PATTERN = re.compile(r"┃[ \t]*You hit your weekly limit", re.IGNORECASE)
 
 _STATUS_TAIL_CHARS = 8192
 _COMPLETION_TO_READY_MAX_CHARS = 4096
@@ -709,9 +736,50 @@ class GrokCliProvider(BaseProvider):
         last_completion = completion_matches[-1].start() if completion_matches else -1
         last_error = max((match.start() for match in ERROR_PATTERN.finditer(tail)), default=-1)
 
+        # The usage-limit refusal counts only as part of a picker that is still
+        # drawn: the boxed refusal line must be followed by one of the picker's
+        # own footers in the same frame.
+        last_picker_footer = max(
+            (match.start() for match in PICKER_FOOTER_PATTERN.finditer(tail)), default=-1
+        )
+        last_limit_picker = max(
+            (
+                match.start()
+                for match in USAGE_LIMIT_PATTERN.finditer(tail)
+                if match.end() <= last_picker_footer
+            ),
+            default=-1,
+        )
+        last_picker_answer = max(
+            (match.start() for match in PICKER_ANSWER_FOOTER_PATTERN.finditer(tail)), default=-1
+        )
+
         # Pickers/login are bottom-of-screen blocking surfaces. Position guards
         # keep a dismissed prompt retained in scrollback from pinning status.
+        #
+        # The limit picker is checked ahead of WAITING and PROCESSING, but only
+        # while it is the newest evidence in the tail. Grok reads an append-only
+        # raw FIFO buffer and ``strip_terminal_escapes`` drops erase sequences
+        # without removing the text they erased, so a picker that ``ESC[2J``,
+        # ``ESC[H ESC[J`` or an ordinary redraw has already replaced still reads
+        # as a full picker here -- as does a transcript that quotes one. Only
+        # position tells the two apart, so this is ordered against
+        # last_processing as well as last_completion/last_ready. The real
+        # refusal still wins: the stale "Waiting for response…"/"Esc:cancel"
+        # marker belongs to the turn that hit the limit and therefore sits
+        # BEFORE the picker in the buffer.
+        if last_limit_picker > max(last_completion, last_ready, last_processing):
+            return TerminalStatus.ERROR
+
         if last_waiting > max(last_completion, last_ready):
+            return TerminalStatus.WAITING_USER_ANSWER
+
+        # The footer shapes 1.0.13 added, classified separately from the branch
+        # above so upstream's footers keep their existing ordering. A picker is
+        # only waiting on the user while nothing newer has been drawn over it,
+        # so these are ordered against last_processing for the same append-only
+        # reason as the limit picker.
+        if last_picker_answer > max(last_completion, last_ready, last_processing):
             return TerminalStatus.WAITING_USER_ANSWER
 
         if last_processing > last_completion:

--- a/test/providers/test_grok_cli_unit.py
+++ b/test/providers/test_grok_cli_unit.py
@@ -120,6 +120,206 @@ def test_stale_permission_and_error_before_current_ready_are_ignored():
     assert make_provider().get_status(output) == TerminalStatus.IDLE
 
 
+def _limit_picker() -> str:
+    """Build the boxed usage-limit picker as captured on grok 1.0.13."""
+
+    return (
+        "  ┃  You hit your weekly limit.\n"
+        "  ┃\n"
+        "  ┃  1 (○) Upgrade tier      Upgrade to a higher tier for more usage\n"
+        "  ┃  2 (○) Buy more credits  Purchase credits to keep using Grok Build\n"
+        "  ┃  3 (○) Try Again         Resubmit the last prompt once you have usage again\n"
+        "  ┃\n"
+        "  ┃  ↑/↓ navigate · y copy                                                Enter:submit\n"
+        "  ┃\n"
+        "  Tab:next answer  │  Esc:scrollback  │  Shift+x:dismiss\n"
+    )
+
+
+def _raw_limit_picker() -> str:
+    """The same picker as grok writes it to the pipe-pane FIFO.
+
+    Cursor-positioned cells and SGR runs, not pre-rendered text, so callers
+    exercise ``strip_terminal_escapes`` the way ``StatusMonitor`` does.
+    """
+
+    return (
+        "\x1b[30;1H\x1b[38;5;203m┃\x1b[6G\x1b[1mYou hit your weekly limit.\x1b[0m"
+        "\x1b[31;1H\x1b[38;5;203m┃\x1b[0m"
+        "\x1b[32;1H\x1b[38;5;203m┃\x1b[6G\x1b[0m1 (○) Upgrade tier"
+        "\x1b[32GUpgrade to a higher tier for more usage"
+        "\x1b[33;1H\x1b[38;5;203m┃\x1b[6G\x1b[0m2 (○) Buy more credits"
+        "\x1b[32GPurchase credits to keep using Grok Build"
+        "\x1b[34;1H\x1b[38;5;203m┃\x1b[6G\x1b[0m3 (○) Try Again"
+        "\x1b[32GResubmit the last prompt once you have usage again"
+        "\x1b[35;1H\x1b[38;5;203m┃\x1b[6G\x1b[2m↑/↓ navigate · y copy"
+        "\x1b[70GEnter:submit\x1b[0m"
+        "\x1b[36;1H\x1b[2mTab:next answer\x1b[22G│\x1b[25GEsc:scrollback"
+        "\x1b[42G│\x1b[45GShift+x:dismiss\x1b[0m"
+    )
+
+
+def _raw_generic_picker() -> str:
+    """A picker with the same 1.0.13 footers but no usage-limit refusal."""
+
+    return (
+        "\x1b[30;1H\x1b[38;5;203m┃\x1b[6G\x1b[1mPick an option\x1b[0m"
+        "\x1b[31;1H\x1b[38;5;203m┃\x1b[6G\x1b[0m1 (○) Option A"
+        "\x1b[32;1H\x1b[38;5;203m┃\x1b[6G\x1b[0m2 (○) Option B"
+        "\x1b[33;1H\x1b[38;5;203m┃\x1b[6G\x1b[2m↑/↓ navigate · y copy"
+        "\x1b[70GEnter:submit\x1b[0m"
+        "\x1b[34;1H\x1b[2mTab:next answer\x1b[22G│\x1b[25GEsc:scrollback"
+        "\x1b[42G│\x1b[45GShift+x:dismiss\x1b[0m"
+    )
+
+
+def _raw_processing_frame() -> str:
+    """The spinner redraw grok emits while a turn is actually running."""
+
+    return (
+        "\x1b[40;1H\x1b[2m⠦\x1b[4GWaiting for response… 0.7s\x1b[0m"
+        "\x1b[49;1H\x1b[2mShift+Tab:mode\x1b[20G│\x1b[23GEsc:cancel\x1b[0m"
+    )
+
+
+def test_weekly_limit_picker_after_stale_waiting_is_error():
+    """grok 1.0.13's weekly-limit picker classifies as ERROR so a blocking
+    handoff fails immediately instead of reporting PROCESSING until timeout.
+
+    Guards the issue #756 regression: the stale "Waiting for response…"/
+    "Esc:cancel" PROCESSING marker left by the turn that hit the limit still
+    precedes the picker in the buffer, and the picker's own footer
+    ("Tab:next answer"/"Enter:submit") also matches WAITING_USER_PATTERN, so
+    this pane previously reported PROCESSING indefinitely.
+    """
+    output = "Waiting for response…\nEsc:cancel\n" + _limit_picker()
+    assert make_provider().get_status(output) == TerminalStatus.ERROR
+
+
+def test_generic_picker_with_tab_next_answer_is_waiting_user_answer():
+    """A picker of the same shape but without the limit refusal stays
+    WAITING_USER_ANSWER.
+
+    Guards against the limit-picker ERROR check widening into "any picker
+    carrying a Tab:next answer / Enter:submit footer is an error".
+    """
+    picker = (
+        "  ┃  Pick an option\n"
+        "  ┃\n"
+        "  ┃  1 (○) Option A\n"
+        "  ┃  2 (○) Option B\n"
+        "  ┃\n"
+        "  ┃  ↑/↓ navigate · y copy                                                Enter:submit\n"
+        "  ┃\n"
+        "  Tab:next answer  │  Esc:scrollback  │  Shift+x:dismiss\n"
+    )
+    assert make_provider().get_status(picker) == TerminalStatus.WAITING_USER_ANSWER
+
+
+def test_raw_limit_picker_after_stale_processing_is_error():
+    """The captured picker still classifies as ERROR when fed as a raw frame.
+
+    Positive control for the recency ordering added below: the picker is the
+    newest structure in the append-only buffer, so the stale
+    "Waiting for response…"/"Esc:cancel" marker of the turn that hit the limit
+    must not pull the pane back to PROCESSING.
+    """
+    output = _raw_processing_frame() + _raw_limit_picker()
+    assert make_provider().get_status(output) == TerminalStatus.ERROR
+
+
+def test_limit_picker_erased_by_clear_screen_before_processing_is_processing():
+    """A limit picker that ``ESC[2J ESC[H`` erased must not beat the frame that
+    replaced it.
+
+    Guards the P2 review finding: the raw FIFO buffer is append-only and
+    ``strip_terminal_escapes`` drops the erase sequence without removing the
+    picker text, so the boxed refusal and its own footer still match here. Only
+    position distinguishes them, so the limit-picker ERROR check is ordered
+    against ``last_processing``; base (pre-PR) behavior for this frame is
+    PROCESSING and this must match it.
+    """
+    output = _raw_limit_picker() + "\x1b[2J\x1b[H" + _raw_processing_frame()
+    assert make_provider().get_status(output) == TerminalStatus.PROCESSING
+
+
+def test_limit_picker_erased_by_home_and_erase_to_end_before_processing_is_processing():
+    """Same regression as above for the home-plus-erase-to-end redraw form.
+
+    ``ESC[H ESC[J`` clears from the cursor to the end of the screen instead of
+    clearing the whole screen; both leave the erased picker in the raw buffer,
+    so both must fall through to the newer processing frame.
+    """
+    output = _raw_limit_picker() + "\x1b[H\x1b[J" + _raw_processing_frame()
+    assert make_provider().get_status(output) == TerminalStatus.PROCESSING
+
+
+def test_quoted_limit_picker_panel_before_processing_is_processing():
+    """A full boxed-panel quotation of the refusal cannot abort a live turn.
+
+    Guards the review's second reproduction: an assistant answer that reprints
+    the whole panel -- box glyphs, options and picker footers -- satisfies the
+    structural check, so the ERROR branch must still lose to the processing
+    evidence that follows it.
+    """
+    output = (
+        "     ❯ Show me exactly what grok prints when the quota runs out.\n\n"
+        "    It draws this panel:\n\n" + _limit_picker() + "\n" + _raw_processing_frame()
+    )
+    assert make_provider().get_status(output) == TerminalStatus.PROCESSING
+
+
+def test_generic_picker_erased_before_processing_is_processing():
+    """An erased ordinary picker must not report WAITING_USER_ANSWER over a
+    live turn either.
+
+    Guards the companion half of the P2 finding: the 1.0.13 footers
+    ("Tab:next answer"/"Enter:submit") are classified through their own check
+    ordered against ``last_processing`` rather than being added to
+    ``WAITING_USER_PATTERN``, whose branch is gated only against completion and
+    ready evidence.
+    """
+    output = _raw_generic_picker() + "\x1b[2J\x1b[H" + _raw_processing_frame()
+    assert make_provider().get_status(output) == TerminalStatus.PROCESSING
+
+
+def test_old_error_then_current_processing_is_processing():
+    """A stale "Error:" line must not abort a turn that is still running.
+
+    Guards the ordering of the generic ERROR check against newer processing
+    evidence: an earlier error followed by a live "Waiting for response…"/
+    "Esc:cancel" frame is PROCESSING, not ERROR.
+    """
+    output = "Error: transient tool failure\n" + "⠦ Waiting for response… 0.7s\nEsc:cancel\n"
+    assert make_provider().get_status(output) == TerminalStatus.PROCESSING
+
+
+def test_quoted_weekly_limit_prose_without_picker_is_processing():
+    """Assistant prose quoting the limit sentence must not classify as ERROR.
+
+    Guards the structural anchor on the limit pattern: only the boxed picker
+    line (plus a picker footer after it) counts, never an arbitrary transcript
+    substring during a working turn.
+    """
+    output = (
+        "     ❯ What does grok print once the quota runs out?\n\n"
+        '    It answers with "You hit your weekly limit." and offers three choices.\n\n'
+        "    ⠦ Waiting for response… 0.7s\n"
+        "  Shift+Tab:mode  │  Esc:cancel\n"
+    )
+    assert make_provider().get_status(output) == TerminalStatus.PROCESSING
+
+
+def test_old_error_then_current_ready_footer_is_idle():
+    """A stale "Error:" line followed by a current ready footer stays IDLE.
+
+    Guards the unchanged base behavior for the plain old-error case that has
+    no picker and no newer processing marker.
+    """
+    output = "Error: old transient error\n" + load_fixture("grok_cli_idle.txt")
+    assert make_provider().get_status(output) == TerminalStatus.IDLE
+
+
 def test_old_idle_then_current_processing_is_processing():
     output = load_fixture("grok_cli_idle.txt") + "\n" + load_fixture("grok_cli_processing.txt")
     assert make_provider().get_status(output) == TerminalStatus.PROCESSING


### PR DESCRIPTION
Fixes #756.

## Summary

Grok Build 1.0.13 renders its usage-limit picker (`You hit your weekly limit.` with Upgrade / Buy credits / Try Again options and a `Tab:next answer` footer) and stops. `grok_cli` kept reporting PROCESSING because the picker matched neither `WAITING_USER_PATTERN` (which knows `Tab:next option`) nor `ERROR_PATTERN`, and the stale `Waiting for response…` marker above it kept winning. A blocking handoff therefore ran to its timeout with no signal.

## Change

- The refusal is recognized structurally, not by wording: `USAGE_LIMIT_PATTERN` requires the sentence to be drawn inside the picker box (`┃  You hit your weekly limit`), and `get_status()` additionally requires a picker footer after that line in the same tail, so only a picker still on screen is classified. That structure returns ERROR ahead of WAITING and PROCESSING, but only while it is the newest evidence in the tail: status is read from an append-only raw buffer and escape stripping leaves erased text in place, so position is the only thing separating a live picker from one a redraw replaced or a transcript quoting one. The real refusal still wins, because the stale processing marker belongs to the turn that hit the limit and sits before the picker.
- Generic error text is untouched: `ERROR_PATTERN` is identical to `main` and the generic check keeps its original precedence, ordered against newer processing evidence.
- The 1.0.13 footer shapes `Tab:next answer` and `Enter:submit` make an ordinary picker of that shape read WAITING_USER_ANSWER. They are classified by their own check, ordered against newer processing evidence for the same reason, so `WAITING_USER_PATTERN` and upstream's own waiting branch stay byte-identical to main and the diff against main removes no lines.
- Tests: the real picker after a stale `Waiting for response…`/`Esc:cancel` marker → ERROR; a generic picker → WAITING_USER_ANSWER; an old `Error:` line followed by a live processing frame → PROCESSING; assistant prose quoting the limit sentence mid-turn → PROCESSING; an old error before a current ready footer → IDLE. Frame captured on a personal account and scrubbed per CONTRIBUTING.
- `docs/grok-cli.md`: the behaviour bullet now states that a waiting `handoff` fails with the generic terminal-ERROR message and that the picker's text is not propagated to the caller.

## Design note

ERROR rather than WAITING_USER_ANSWER is deliberate: no orchestrated answer to this picker makes the turn succeed, and ERROR is what ends a `handoff` promptly.

There is no captured 1.0.13 fixture file, so the raw test frames are synthesized from the captured picker text and the shapes already in the fixtures.

## Tests

`test/providers/`: 1537 passed, 3 skipped, 1 xfailed. `test/security/test_status_pattern_redos.py`: passes on both new patterns. `black`, `isort`, `mypy` clean on touched files. Rebased onto `main` (405750f8).
