### PR TITLE
fix(ops-mcp): surface provider on launch_session and resolve session names for the ops tools

### DIFF
--- a/docs/control-planes.md
+++ b/docs/control-planes.md
@@ -125,6 +125,12 @@ The current tools are grouped by purpose:
 Installed [plugins](plugins.md#mcp-tool-surfaces) can register additional tools on this
 server through `on_mcp_server`, the same hook `cao-mcp-server` honours.
 
+`launch_session` returns the resolved `provider` alongside `session_name` and
+`terminal_id`, so a caller can confirm a worker landed on the provider it asked
+for before sending work. CAO stores session names with a `cao-` prefix
+(`launch_session(session_name="acc-1")` creates `cao-acc-1`); the name-taking
+tools accept either the stored name or the bare name you passed at launch.
+
 MCP tool discovery is authoritative for clients. The declarations in
 [`ops_mcp_server/server.py`](../src/cli_agent_orchestrator/ops_mcp_server/server.py)
 are the source of truth when the server surface changes.

--- a/examples/ops-mcp/README.md
+++ b/examples/ops-mcp/README.md
@@ -79,8 +79,8 @@ get_session_info       -> verify the session is actually gone
 
 Three details are load-bearing rather than incidental.
 
-**`launch_session` returns immediately.** It hands back `session_name` and
-`terminal_id` while provider startup and message delivery continue in the
+**`launch_session` returns immediately.** It hands back `session_name`,
+`terminal_id` and the resolved `provider` while provider startup and message delivery continue in the
 background, so the caller must poll. `--timeout` bounds each turn.
 
 **A ready status is not proof your turn ran.** This is the subtle one. `idle` can

--- a/src/cli_agent_orchestrator/ops_mcp_server/models.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/models.py
@@ -20,6 +20,10 @@ class LaunchResult(BaseModel):
         default=None,
         description="The created terminal ID",
     )
+    provider: Optional[str] = Field(
+        default=None,
+        description="The CLI provider the session was launched with",
+    )
 
 
 class ProfileListResult(BaseModel):

--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -6,7 +6,7 @@ import requests  # type: ignore[import-untyped]
 from fastmcp import FastMCP
 from pydantic import Field
 
-from cli_agent_orchestrator.constants import API_BASE_URL
+from cli_agent_orchestrator.constants import API_BASE_URL, SESSION_PREFIX
 from cli_agent_orchestrator.ops_mcp_server.models import (
     InstallResult,
     LaunchResult,
@@ -90,6 +90,128 @@ def _request_json(
         return None, f"{operation} failed: invalid JSON response ({exc})"
 
 
+def _canonical_session_name(session_name: str) -> str:
+    """The name a CAO session is ALWAYS stored under, per the naming contract.
+
+    Both creation paths enforce it: ``terminal_service.create_terminal``
+    prepends SESSION_PREFIX ("cao-") to a new session's name unless it already
+    starts with it, and ``POST /sessions`` validates that same effective
+    prefixed name at the boundary. So every CAO session name starts with
+    "cao-", and an UNPREFIXED name can never be a CAO session -- at most it is
+    a caller's alias for one (launch_session echoes back the bare
+    ``session_name`` it was given), or an unrelated native tmux session that
+    merely shares the name.
+
+    Canonicalization is therefore total, and it is the identity rule every
+    name-taking ops tool addresses. It is a pure function of the name --
+    deliberately NOT a question about what is live right now -- for two
+    reasons: the cleanup identity has to survive the backend session being gone
+    while its registry row remains, and a successful GET on an unprefixed name
+    is not evidence of CAO identity (``session_service.get_session`` reads the
+    backend directly, without the SESSION_PREFIX filter ``list_sessions``
+    applies, and the shipped tmux backend lists native sessions too).
+    """
+    if session_name.startswith(SESSION_PREFIX):
+        return session_name
+    return f"{SESSION_PREFIX}{session_name}"
+
+
+def _request_session_json(
+    method: str,
+    session_name: str,
+    *,
+    operation: str,
+) -> tuple[Optional[Any], Optional[str]]:
+    """Request ``/sessions/{name}`` against the CANONICAL name, once.
+
+    The read paths share the delete path's identity rule
+    (``_canonical_session_name``) rather than probing the literal name first: a
+    native tmux ``review`` and a CAO ``cao-review`` can legitimately coexist and
+    both answer GET, and preferring the literal made ``get_session_info("review")``
+    return the native session with none of CAO's terminals. An unprefixed name
+    can never BE a CAO session, so a successful GET on one proves nothing about
+    CAO identity and must never select the target.
+
+    This replaces an earlier 404-triggered retry of the prefixed name: with
+    canonicalization total, there is nothing left to retry.
+    """
+    return _request_json(
+        method,
+        f"/sessions/{_canonical_session_name(session_name)}",
+        operation=operation,
+    )
+
+
+def _lookup_session(candidate: str) -> tuple[bool, Optional[str]]:
+    """Probe ``GET /sessions/{candidate}`` for one of THREE outcomes.
+
+    Returns ``(found, error)``:
+
+    * ``(True, None)``   -- resolved: the GET answered below 400.
+    * ``(False, None)``  -- confirmed absent: the GET answered 404. Only a 404
+      is evidence of absence.
+    * ``(False, error)`` -- unresolved: a transport failure, 5xx, 403 or any
+      other non-404 status. The lookup did not answer the question, so the
+      caller must not treat it as absence. ``GET /sessions/{name}`` really does
+      return 500 when reading a terminal's live status fails
+      (``api/main.py``'s handler maps any non-ValueError to 500), and a 403
+      simply means this token lacks read scope while still holding admin.
+    """
+    try:
+        response = requests.request(
+            "get", f"{API_BASE_URL}/sessions/{candidate}", params=None, json=None
+        )
+    except requests.RequestException as exc:
+        return False, f"lookup of session '{candidate}' failed: {exc}"
+
+    if response.status_code < 400:
+        return True, None
+    if response.status_code == 404:
+        return False, None
+    return False, f"lookup of session '{candidate}' failed: {_response_detail(response)}"
+
+
+def _resolve_session_name(session_name: str) -> tuple[Optional[str], Optional[str]]:
+    """The name to mutate: the CANONICAL one, or ``(None, error)``.
+
+    The target comes from the naming contract (``_canonical_session_name``),
+    never from which name happens to answer a GET. Probing the literal name
+    first and taking any success was how ``shutdown_session("review")`` deleted
+    an unrelated NATIVE tmux ``review`` -- reporting success -- while
+    ``cao-review`` and its registry row stayed alive.
+
+    The read-only GET that remains is a safety check on that single canonical
+    name, not a selector, because ``DELETE /sessions/{name}`` cannot report the
+    problem itself: it is idempotent -- ``session_service.delete_session()``
+    puts an absent name straight into ``deleted`` -- so it answers 200 for a
+    name that never existed. Its three outcomes (``_lookup_session``):
+
+    * Resolved (below 400) or confirmed absent (404) -- return the canonical
+      name either way, so the single DELETE lands on the CAO session when it is
+      live, and is the endpoint's idempotent "already gone" success when it is
+      not. Confirmed absence is NOT a reason to retarget: after a deferred
+      cleanup (``dismantle_terminal_runtime`` returning False keeps the row,
+      answers 409 and reports the session in ``errors``) the backend session is
+      gone -- so ``get_session``, which requires it, 404s -- while the retained
+      registry row, the only handle the retry has, still lives under the
+      canonical name.
+    * Unresolved (transport error / 5xx / 403 / any non-404) -- return
+      ``(None, error)``. NOTHING is mutated. Collapsing this into "absent" is
+      how an unresolved name became a successful no-op DELETE: the canonical
+      session and its registry row survive while the caller is told cleanup
+      happened.
+    """
+    canonical_name = _canonical_session_name(session_name)
+
+    # The "found" half is deliberately discarded: presence does not choose the
+    # target here, it only distinguishes the two outcomes that share one.
+    _found, error = _lookup_session(canonical_name)
+    if error is not None:
+        return None, error
+
+    return canonical_name, None
+
+
 def _serialize_allowed_tools(allowed_tools: Optional[List[str]]) -> Optional[str]:
     """Serialize allowed tools for the session creation API."""
     if not allowed_tools:
@@ -169,6 +291,7 @@ async def _launch_session_impl(
         )
 
     terminal_id = str(session_data["id"])
+    launched_provider = session_data.get("provider")
     message = (
         f"Session '{resolved_session_name}' launched; initial message delivery is in progress"
         if initial_message is not None
@@ -179,6 +302,7 @@ async def _launch_session_impl(
         message=message,
         session_name=resolved_session_name,
         terminal_id=terminal_id,
+        provider=launched_provider,
     )
 
 
@@ -432,9 +556,9 @@ def _read_session_output_impl(
     if not resolved_terminal_id:
         if not session_name:
             return {"success": False, "message": "Provide either terminal_id or session_name"}
-        info, error = _request_json(
+        info, error = _request_session_json(
             "get",
-            f"/sessions/{session_name}",
+            session_name,
             operation=f"Resolve terminals for session '{session_name}'",
         )
         if error:
@@ -671,9 +795,9 @@ async def get_session_info(
     Returns:
         Dict with session fields, or {"success": False, "message": ...} on error
     """
-    data, error = _request_json(
+    data, error = _request_session_json(
         "get",
-        f"/sessions/{session_name}",
+        session_name,
         operation=f"Get session info for '{session_name}'",
     )
     if error:
@@ -691,16 +815,38 @@ async def shutdown_session(
 
     Exits all providers, kills the tmux session, and removes database records.
 
+    A bare name is canonicalized to the name CAO actually stores the session
+    under ("cao-<name>") before anything is deleted, so an unrelated NATIVE
+    tmux session sharing the bare name is never the target. When the canonical
+    lookup cannot answer -- transport failure, 5xx, 403, anything but a 404 --
+    no delete is issued at all and the lookup failure is reported instead of a
+    false cleanup success.
+
     Args:
         session_name: CAO session name to shut down
 
     Returns:
         Dict with success status and cleanup details, or failure dict on error
     """
+    # Resolve first, then delete exactly once against the canonical name: the
+    # DELETE route cannot report a bad target itself, because it never returns
+    # 404 for an absent session (see _resolve_session_name).
+    resolved_name, lookup_error = _resolve_session_name(session_name)
+    if lookup_error is not None or resolved_name is None:
+        # Unresolved, not absent: nothing has been mutated, and nothing will be.
+        # Deleting an unresolved alias would answer 200 and report a cleanup that
+        # never happened, so the coordinator sees the lookup problem instead.
+        return {
+            "success": False,
+            "message": (
+                f"Shutdown session '{session_name}' aborted: {lookup_error}; "
+                "no delete was issued"
+            ),
+        }
     data, error = _request_json(
         "delete",
-        f"/sessions/{session_name}",
-        operation=f"Shutdown session '{session_name}'",
+        f"/sessions/{resolved_name}",
+        operation=f"Shutdown session '{resolved_name}'",
     )
     if error:
         return {"success": False, "message": error}

--- a/test/ops_mcp_server/test_read_session_output.py
+++ b/test/ops_mcp_server/test_read_session_output.py
@@ -76,6 +76,30 @@ class TestReadSessionOutputImpl:
         assert result["terminal_id"] == "term-9"
         assert result["output"] == "abc"
 
+    def test_resolves_session_by_bare_name_against_the_canonical_name(self) -> None:
+        """A bare session_name (not yet "cao-"-prefixed) must still resolve,
+        since sessions are stored with SESSION_PREFIX applied.
+
+        The lookup addresses ``cao-<name>`` only. The literal name is never
+        read: it cannot be a CAO session (both creation paths enforce the
+        prefix), so an unrelated native tmux session answering that GET would
+        hand back the wrong session's terminals.
+        """
+        responses = [
+            _response(json_data={"name": "cao-acc-agy", "terminals": [{"id": "term-9"}]}),
+            _response(json_data={"output": "abc", "mode": "full"}),
+        ]
+        with patch(REQUEST, side_effect=responses) as mock_request:
+            result = _read_session_output_impl(None, "acc-agy", "full", None)
+
+        assert result["success"] is True
+        assert result["terminal_id"] == "term-9"
+        assert result["output"] == "abc"
+        assert mock_request.call_args_list[0].args[:2] == (
+            "get",
+            "http://127.0.0.1:9889/sessions/cao-acc-agy",
+        )
+
     def test_session_resolve_error_is_returned(self) -> None:
         """An API error while resolving a session is surfaced without an output read."""
         with patch(

--- a/test/ops_mcp_server/test_server.py
+++ b/test/ops_mcp_server/test_server.py
@@ -346,6 +346,26 @@ class TestSessionLifecycleTools:
             json=None,
         )
 
+    async def test_launch_session_result_includes_provider_from_api_response(self) -> None:
+        """The Terminal model's provider field should be surfaced on LaunchResult."""
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(json_data={"id": "term-789", "provider": "codex"}),
+        ):
+            result = await launch_session(
+                agent_profile="developer",
+                provider="codex",
+                session_name="provider-session",
+            )
+
+        assert result == LaunchResult(
+            success=True,
+            message="Session 'provider-session' launched successfully",
+            session_name="provider-session",
+            terminal_id="term-789",
+            provider="codex",
+        )
+
     async def test_launch_session_passes_model_and_initial_message(self) -> None:
         """The model stays in routing params and the first task stays in JSON."""
         initial_message = "Review the current change"
@@ -684,6 +704,169 @@ class TestSessionLifecycleTools:
             "message": "Get session info for 'cao-123' failed: boom",
         }
 
+    async def test_get_session_info_reads_the_canonical_name_only(self) -> None:
+        """A bare name (e.g. what launch_session's session_name echoed back)
+        must resolve, since sessions are actually stored as "cao-<name>".
+
+        It is read as ``cao-<name>`` directly, never as the literal name first:
+        an unprefixed name can never BE a CAO session (both creation paths
+        enforce the prefix), so a native tmux session answering that GET would
+        be the wrong session entirely.
+        """
+        payload = {"name": "cao-acc-agy", "terminals": [{"id": "term-1"}]}
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(json_data=payload),
+        ) as mock_request:
+            result = await get_session_info("acc-agy")
+
+        assert result == payload
+        mock_request.assert_called_once_with(
+            "get", "http://127.0.0.1:9889/sessions/cao-acc-agy", params=None, json=None
+        )
+
+    async def test_get_session_info_does_not_retry_when_already_prefixed(self) -> None:
+        """A name already carrying the prefix must not be retried again on 404."""
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(status_code=404, json_data={"detail": "Session not found"}),
+        ) as mock_request:
+            result = await get_session_info("cao-missing")
+
+        assert result == {
+            "success": False,
+            "message": "Get session info for 'cao-missing' failed: Session not found",
+        }
+        mock_request.assert_called_once_with(
+            "get", "http://127.0.0.1:9889/sessions/cao-missing", params=None, json=None
+        )
+
+    async def test_get_session_info_surfaces_a_non_404_error_without_a_second_read(
+        self,
+    ) -> None:
+        """A non-404 error (e.g. 500) is reported from the one canonical read."""
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(status_code=500, json_data={"detail": "Internal error"}),
+        ) as mock_request:
+            result = await get_session_info("acc-agy")
+
+        assert result == {
+            "success": False,
+            "message": "Get session info for 'acc-agy' failed: Internal error",
+        }
+        mock_request.assert_called_once_with(
+            "get", "http://127.0.0.1:9889/sessions/cao-acc-agy", params=None, json=None
+        )
+
+    async def test_shutdown_session_canonicalizes_a_bare_name_before_deleting(
+        self,
+    ) -> None:
+        """A bare name is canonicalized, checked by GET, and deleted once.
+
+        The literal name is never probed, let alone deleted: it cannot be a CAO
+        session, and a native tmux session under it would answer the GET. The
+        delete cannot report a wrong target itself either -- the real endpoint
+        answers 200 for an absent session (it is idempotent), so a bare-name
+        DELETE would report success while ``cao-acc-agy`` stayed live. See
+        ``test_shutdown_session_canonical_name.py`` for the same contract proven
+        against the real route with a native session actually present.
+        """
+        payload = {"success": True, "deleted": ["cao-acc-agy"], "errors": []}
+        responses = [
+            _response(json_data={"session": {"id": "cao-acc-agy"}, "terminals": []}),
+            _response(json_data=payload),
+        ]
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            side_effect=responses,
+        ) as mock_request:
+            result = await shutdown_session("acc-agy")
+
+        assert result == payload
+        assert [call.args[:2] for call in mock_request.call_args_list] == [
+            ("get", "http://127.0.0.1:9889/sessions/cao-acc-agy"),
+            ("delete", "http://127.0.0.1:9889/sessions/cao-acc-agy"),
+        ]
+
+    async def test_shutdown_session_deletes_an_already_canonical_name_directly(
+        self,
+    ) -> None:
+        """A prefixed name resolves on the first read and is deleted as given."""
+        payload = {"success": True, "deleted": ["cao-acc-agy"], "errors": []}
+        responses = [
+            _response(json_data={"session": {"id": "cao-acc-agy"}, "terminals": []}),
+            _response(json_data=payload),
+        ]
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            side_effect=responses,
+        ) as mock_request:
+            result = await shutdown_session("cao-acc-agy")
+
+        assert result == payload
+        assert [call.args[:2] for call in mock_request.call_args_list] == [
+            ("get", "http://127.0.0.1:9889/sessions/cao-acc-agy"),
+            ("delete", "http://127.0.0.1:9889/sessions/cao-acc-agy"),
+        ]
+
+    async def test_shutdown_session_deletes_the_canonical_name_when_it_is_absent(
+        self,
+    ) -> None:
+        """The canonical name confirmed absent (404): delete it anyway, once.
+
+        Live-backend presence is not the cleanup identity. ``get_session``
+        requires the backend session, so a deferred cleanup -- whose retained
+        registry row is the retry handle -- 404s once the backend session is
+        gone; that row lives under ``cao-<name>``. Retargeting anything else
+        would answer 200 and clean up nothing. For a name that never existed,
+        the canonical delete is the same idempotent "already gone" success
+        rather than an invented client-side error.
+        """
+        payload = {"success": True, "deleted": ["cao-acc-agy"], "errors": []}
+        responses = [
+            _response(status_code=404, json_data={"detail": "Session 'cao-acc-agy' not found"}),
+            _response(json_data=payload),
+        ]
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            side_effect=responses,
+        ) as mock_request:
+            result = await shutdown_session("acc-agy")
+
+        assert result == payload
+        assert [call.args[:2] for call in mock_request.call_args_list] == [
+            ("get", "http://127.0.0.1:9889/sessions/cao-acc-agy"),
+            ("delete", "http://127.0.0.1:9889/sessions/cao-acc-agy"),
+        ]
+
+    async def test_shutdown_session_aborts_when_the_lookup_cannot_resolve(self) -> None:
+        """A non-404 lookup failure is unresolved, not absent: delete nothing.
+
+        Only a 404 is evidence of absence. A 500 (the real route returns one
+        when reading a terminal's status fails), a 403 or a transport error
+        leaves the cleanup target unknown, and deleting an unresolved alias
+        would answer 200 while the canonical session stayed live.
+        """
+        with patch(
+            "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
+            return_value=_response(
+                status_code=500, json_data={"detail": "Failed to get session: boom"}
+            ),
+        ) as mock_request:
+            result = await shutdown_session("acc-agy")
+
+        assert result == {
+            "success": False,
+            "message": (
+                "Shutdown session 'acc-agy' aborted: lookup of session 'cao-acc-agy' "
+                "failed: Failed to get session: boom; no delete was issued"
+            ),
+        }
+        assert [call.args[:2] for call in mock_request.call_args_list] == [
+            ("get", "http://127.0.0.1:9889/sessions/cao-acc-agy"),
+        ]
+
     async def test_shutdown_session_returns_success_payload(self) -> None:
         """Shutdown should return the API success payload."""
         payload = {"success": True, "deleted_terminals": 2}
@@ -696,7 +879,11 @@ class TestSessionLifecycleTools:
         assert result == payload
 
     async def test_shutdown_session_returns_failure_for_not_found(self) -> None:
-        """Missing sessions should be surfaced as failures."""
+        """A DELETE that does 404 is surfaced as a failure.
+
+        The real endpoint is idempotent and does not answer 404, but a proxy or
+        a future revision could; the canonical name is what was targeted.
+        """
         with patch(
             "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
             return_value=_response(status_code=404, json_data={"detail": "Session not found"}),
@@ -705,21 +892,31 @@ class TestSessionLifecycleTools:
 
         assert result == {
             "success": False,
-            "message": "Shutdown session 'missing' failed: Session not found",
+            "message": "Shutdown session 'cao-missing' failed: Session not found",
         }
 
     async def test_shutdown_session_returns_failure_on_api_error(self) -> None:
-        """Shutdown transport errors should be converted into failures."""
+        """Shutdown transport errors should be converted into failures.
+
+        An unreachable API fails at the lookup, which is unresolved rather than
+        absent, so no DELETE is issued at all.
+        """
         with patch(
             "cli_agent_orchestrator.ops_mcp_server.server.requests.request",
             side_effect=requests.ConnectionError("delete failed"),
-        ):
+        ) as mock_request:
             result = await shutdown_session("cao-123")
 
         assert result == {
             "success": False,
-            "message": "Shutdown session 'cao-123' failed: delete failed",
+            "message": (
+                "Shutdown session 'cao-123' aborted: lookup of session 'cao-123' "
+                "failed: delete failed; no delete was issued"
+            ),
         }
+        assert [call.args[:2] for call in mock_request.call_args_list] == [
+            ("get", "http://127.0.0.1:9889/sessions/cao-123"),
+        ]
 
 
 @pytest.mark.asyncio

--- a/test/ops_mcp_server/test_shutdown_session_canonical_name.py
+++ b/test/ops_mcp_server/test_shutdown_session_canonical_name.py
@@ -1,0 +1,413 @@
+"""shutdown_session against the REAL delete route and deletion service.
+
+The bare-name contract cannot be proven with a mocked DELETE. ``DELETE
+/sessions/{name}`` is idempotent: ``session_service.delete_session()`` puts an
+absent name straight into ``deleted``, so the route answers HTTP 200 for a
+session that never existed. A test that mocks a 404 DELETE therefore asserts a
+response the API never produces, and a bare-name delete that silently no-ops
+while ``cao-<name>`` stays live would pass it.
+
+So these tests drive the ops tool's real ``requests`` call into an in-process
+``TestClient`` over the real FastAPI app (the seam ``test/mcp_server/conftest.py``
+established for the in-session MCP tools), with the REAL ``delete_session``
+reconciliation running underneath it against the in-memory tmux backend and the
+per-test SQLite registry that ``test/services/test_session_teardown_atomic.py``
+already models the teardown side effects with. What is asserted is the thing the
+coordinator cares about: the session is actually gone from the backend and the
+registry, and the tool issued exactly one destructive request.
+
+The routed responses are httpx responses rather than ``requests`` ones. That is
+faithful for this surface: the ops helpers only read ``status_code``/``json()``/
+``text``, and both libraries raise a ``ValueError`` subclass from ``json()`` on a
+non-JSON body. No in-process transport can raise ``requests.RequestException``,
+which is what the mocked unit tests in ``test_server.py`` still cover.
+"""
+
+from __future__ import annotations
+
+from test.api.conftest import TestClientWithHost
+from test.services.test_session_teardown_atomic import FakeTmuxBackend
+from typing import Dict, List, Tuple
+
+import pytest
+import requests
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cli_agent_orchestrator.api.main import app
+from cli_agent_orchestrator.backends.registry import set_backend
+from cli_agent_orchestrator.clients import database
+from cli_agent_orchestrator.models.terminal import TerminalStatus
+from cli_agent_orchestrator.ops_mcp_server import server as ops_server
+from cli_agent_orchestrator.plugins import PluginRegistry
+from cli_agent_orchestrator.services import terminal_service
+
+
+class ListableFakeTmuxBackend(FakeTmuxBackend):
+    """``FakeTmuxBackend`` plus the listing ``GET /sessions/{name}`` needs.
+
+    ``session_service.get_session`` resolves a session out of
+    ``list_sessions()``, which the teardown-focused fake has no reason to
+    implement. Everything the delete path exercises is inherited unchanged.
+    """
+
+    def list_sessions(self) -> List[Dict[str, str]]:
+        return [{"id": name, "name": name, "status": "detached"} for name in sorted(self._sessions)]
+
+
+@pytest.fixture
+def real_db(tmp_path, monkeypatch):
+    """Point ``clients.database`` at a fresh per-test SQLite registry."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'cao.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    database.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(
+        database,
+        "SessionLocal",
+        sessionmaker(autocommit=False, autoflush=False, bind=engine),
+    )
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setattr(terminal_service, "TERMINAL_LOG_DIR", log_dir)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    """Install the in-memory tmux backend for the duration of the test."""
+    fake = ListableFakeTmuxBackend()
+    set_backend(fake)
+
+    # Teardown touches the FIFO reader, status buffers and provider registration
+    # of each terminal; none of those exist in-process here.
+    monkeypatch.setattr(terminal_service.fifo_manager, "stop_reader", lambda tid: None)
+    monkeypatch.setattr(terminal_service.status_monitor, "clear_terminal", lambda tid: None)
+    monkeypatch.setattr(terminal_service.provider_manager, "cleanup_provider", lambda tid: None)
+
+    # GET /sessions/{name} asks the status monitor for each terminal's live
+    # status, which would shell out to tmux.
+    from cli_agent_orchestrator.services import status_monitor as status_monitor_module
+
+    monkeypatch.setattr(
+        status_monitor_module.status_monitor,
+        "get_status",
+        lambda tid: TerminalStatus.IDLE,
+    )
+    try:
+        yield fake
+    finally:
+        set_backend(None)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def routed_requests(monkeypatch):
+    """Route ``ops_mcp_server.server.requests.request`` into a TestClient.
+
+    Returns the list of ``(method, path)`` pairs that reached the app, so a test
+    can assert how many destructive requests were issued, not merely what came
+    back.
+    """
+    app.state.plugin_registry = PluginRegistry()
+    client = TestClientWithHost(app)
+    calls: List[Tuple[str, str]] = []
+
+    def _dispatch(method, url, params=None, json=None):
+        # The helpers build f"{API_BASE_URL}{path}"; TestClient wants the path.
+        path = "/" + str(url).split("://", 1)[1].split("/", 1)[1]
+        calls.append((method.lower(), path))
+        return client.request(method.upper(), path, params=params, json=json)
+
+    monkeypatch.setattr(ops_server.requests, "request", _dispatch)
+    return calls
+
+
+def _seed(backend, session_name: str, terminals: List[Tuple[str, str]]) -> None:
+    """Create backend windows plus the matching registry rows."""
+    backend.add_session(session_name, {window for _, window in terminals})
+    for terminal_id, window_name in terminals:
+        database.create_terminal(
+            terminal_id=terminal_id,
+            tmux_session=session_name,
+            tmux_window=window_name,
+            provider="claude_code",
+            agent_profile="developer",
+        )
+
+
+def _deletes(calls: List[Tuple[str, str]]) -> List[str]:
+    return [path for method, path in calls if method == "delete"]
+
+
+@pytest.mark.asyncio
+class TestShutdownSessionAgainstRealRoute:
+    """The bare/canonical name contract, proven against the real endpoint."""
+
+    async def test_bare_name_deletes_the_prefixed_session(
+        self, real_db, backend, routed_requests
+    ) -> None:
+        """``shutdown_session("review-alias")`` must kill ``cao-review-alias``.
+
+        This is the case a 404-triggered retry cannot reach: the bare-name DELETE
+        succeeds with ``deleted: ["review-alias"]`` while the real session lives
+        on, so the coordinator is told cleanup worked when nothing was killed.
+        """
+        _seed(backend, "cao-review-alias", [("t1", "w1")])
+
+        result = await ops_server.shutdown_session("review-alias")
+
+        # The session is really gone from BOTH stores ...
+        assert backend.session_exists("cao-review-alias") is False
+        assert database.list_terminals_by_session("cao-review-alias") == []
+        # ... and the caller is told so under the canonical name.
+        assert result["success"] is True
+        assert result["deleted"] == ["cao-review-alias"]
+        assert result["errors"] == []
+        # Exactly one destructive request, against the resolved name. The bare
+        # name is never sent to DELETE: that request would "succeed" as a no-op.
+        assert _deletes(routed_requests) == ["/sessions/cao-review-alias"]
+
+    async def test_already_canonical_name_is_unchanged(
+        self, real_db, backend, routed_requests
+    ) -> None:
+        """A caller that already passes ``cao-<name>`` sees the prior behaviour."""
+        _seed(backend, "cao-canonical", [("t1", "w1")])
+
+        result = await ops_server.shutdown_session("cao-canonical")
+
+        assert backend.session_exists("cao-canonical") is False
+        assert database.list_terminals_by_session("cao-canonical") == []
+        assert result["success"] is True
+        assert result["deleted"] == ["cao-canonical"]
+        assert result["errors"] == []
+        assert _deletes(routed_requests) == ["/sessions/cao-canonical"]
+
+    async def test_missing_session_keeps_idempotent_success(
+        self, real_db, backend, routed_requests
+    ) -> None:
+        """Nothing under either name: still the endpoint's idempotent success.
+
+        Confirmed absence must not turn "already gone" into a new error, and it
+        must not fan out into a second delete. The single delete goes to the
+        CANONICAL name -- the cleanup identity the naming contract gives this
+        alias -- which for a name that never existed is an equally idempotent
+        no-op.
+        """
+        result = await ops_server.shutdown_session("ghost")
+
+        assert result["success"] is True
+        assert result["deleted"] == ["cao-ghost"]
+        assert result["errors"] == []
+        assert _deletes(routed_requests) == ["/sessions/cao-ghost"]
+
+    async def test_get_session_info_resolves_bare_name(
+        self, real_db, backend, routed_requests
+    ) -> None:
+        """The read path's prefix retry works against the real 404 too."""
+        _seed(backend, "cao-readable", [("t1", "w1")])
+
+        result = await ops_server.get_session_info("readable")
+
+        assert result["session"]["id"] == "cao-readable"
+        assert [t["id"] for t in result["terminals"]] == ["t1"]
+        assert _deletes(routed_requests) == []
+
+    async def test_unresolvable_lookup_deletes_nothing(
+        self, real_db, backend, routed_requests, monkeypatch
+    ) -> None:
+        """A 500 from the canonical GET must not be read as "absent".
+
+        ``GET /sessions/{name}`` really can fail with 500 while the session is
+        alive: reading a terminal's live status is part of the handler, and
+        ``api/main.py`` maps any non-ValueError to 500. Treating that as
+        confirmed absence used to DELETE the bare alias -- a 200 no-op -- and
+        report cleanup success while the canonical session and its registry row
+        stayed exactly where they were.
+        """
+        _seed(backend, "cao-flaky", [("t1", "w1")])
+
+        from cli_agent_orchestrator.services import status_monitor as status_monitor_module
+
+        def _unreadable_status(terminal_id: str) -> TerminalStatus:
+            raise RuntimeError("status socket unavailable")
+
+        monkeypatch.setattr(status_monitor_module.status_monitor, "get_status", _unreadable_status)
+
+        result = await ops_server.shutdown_session("flaky")
+
+        # Nothing was mutated at all ...
+        assert _deletes(routed_requests) == []
+        assert backend.session_exists("cao-flaky") is True
+        assert [t["id"] for t in database.list_terminals_by_session("cao-flaky")] == ["t1"]
+        # ... and the coordinator is told why, under the name that failed.
+        assert result["success"] is False
+        assert "cao-flaky" in result["message"]
+        assert "status socket unavailable" in result["message"]
+
+    async def test_lookup_transport_failure_deletes_nothing(
+        self, real_db, backend, routed_requests, monkeypatch
+    ) -> None:
+        """An unreachable API is unresolved too, not evidence of absence.
+
+        This is the one case the in-process transport cannot produce on its own
+        (see the module docstring), so the routed dispatcher is wrapped to raise
+        on the lookups only -- a DELETE, if the tool wrongly issued one, would
+        still reach the real app and be recorded.
+        """
+        _seed(backend, "cao-unreachable", [("t1", "w1")])
+
+        routed = ops_server.requests.request
+
+        def _failing_get(method, url, params=None, json=None):
+            if method.lower() == "get":
+                raise requests.ConnectionError("connection refused")
+            return routed(method, url, params=params, json=json)
+
+        monkeypatch.setattr(ops_server.requests, "request", _failing_get)
+
+        result = await ops_server.shutdown_session("unreachable")
+
+        assert _deletes(routed_requests) == []
+        assert backend.session_exists("cao-unreachable") is True
+        assert [t["id"] for t in database.list_terminals_by_session("cao-unreachable")] == ["t1"]
+        assert result["success"] is False
+        assert "connection refused" in result["message"]
+
+    async def test_deferred_cleanup_retry_with_bare_name_finishes_the_job(
+        self, real_db, backend, routed_requests, monkeypatch
+    ) -> None:
+        """The supported cleanup retry, end to end, driven with the BARE name.
+
+        A deferred provider cleanup (#596) is a partially-complete teardown: the
+        backend session is killed, but the registry row is KEPT as the retry
+        handle and the session comes back in ``errors`` as a 409. The retry is
+        the case live-backend presence cannot resolve -- ``get_session``
+        requires the backend session, so by then BOTH GETs 404 while the row
+        that still needs cleaning lives under the canonical name. Targeting the
+        typed alias would "succeed" without retrying anything.
+        """
+        _seed(backend, "cao-deferred", [("t1", "w1")])
+
+        deferred = {"pending": True}
+
+        def _cleanup_provider(terminal_id: str):
+            # False is exactly what defers the teardown in
+            # terminal_service.dismantle_terminal_runtime.
+            return False if deferred["pending"] else None
+
+        monkeypatch.setattr(
+            terminal_service.provider_manager, "cleanup_provider", _cleanup_provider
+        )
+
+        first = await ops_server.shutdown_session("deferred")
+
+        assert first["success"] is False
+        assert "cleanup deferred" in first["message"]
+        assert _deletes(routed_requests) == ["/sessions/cao-deferred"]
+        # Backend gone, row kept: the state the retry has to reconcile.
+        assert backend.session_exists("cao-deferred") is False
+        assert [t["id"] for t in database.list_terminals_by_session("cao-deferred")] == ["t1"]
+
+        deferred["pending"] = False
+        routed_requests.clear()
+
+        second = await ops_server.shutdown_session("deferred")
+
+        assert second["success"] is True
+        assert second["deleted"] == ["cao-deferred"]
+        assert second["errors"] == []
+        assert database.list_terminals_by_session("cao-deferred") == []
+        assert _deletes(routed_requests) == ["/sessions/cao-deferred"]
+
+    async def test_bare_name_never_targets_a_coexisting_native_session(
+        self, real_db, backend, routed_requests
+    ) -> None:
+        """A native tmux ``review`` and a CAO ``cao-review`` can coexist.
+
+        ``session_service.get_session`` reads the backend directly, WITHOUT the
+        SESSION_PREFIX filter ``list_sessions`` applies, and the shipped tmux
+        backend lists native sessions too -- so both names answer GET. Probing
+        the literal name first and taking any success deleted the unrelated
+        NATIVE session, reported ``success: true``, and left ``cao-review`` and
+        its row alive. The canonical name is the only cleanup identity.
+        """
+        backend.add_session("review", {"native-w"})  # not created through CAO: no rows
+        _seed(backend, "cao-review", [("t1", "w1")])
+
+        result = await ops_server.shutdown_session("review")
+
+        # The CAO session is gone from both stores ...
+        assert backend.session_exists("cao-review") is False
+        assert database.list_terminals_by_session("cao-review") == []
+        # ... and the native session was never touched.
+        assert backend.session_exists("review") is True
+        assert backend.windows("review") == {"native-w"}
+        assert result["success"] is True
+        assert result["deleted"] == ["cao-review"]
+        assert result["errors"] == []
+        assert _deletes(routed_requests) == ["/sessions/cao-review"]
+
+    async def test_get_session_info_reads_the_cao_session_not_the_native_one(
+        self, real_db, backend, routed_requests
+    ) -> None:
+        """The read path shares the same identity rule.
+
+        With both present, the literal-first lookup returned the native session
+        -- which has no CAO terminals at all -- as if it were the CAO one.
+        """
+        backend.add_session("review", {"native-w"})
+        _seed(backend, "cao-review", [("t1", "w1")])
+
+        result = await ops_server.get_session_info("review")
+
+        assert result["session"]["id"] == "cao-review"
+        assert [t["id"] for t in result["terminals"]] == ["t1"]
+        assert _deletes(routed_requests) == []
+
+    async def test_deferred_retry_with_only_the_native_session_live(
+        self, real_db, backend, routed_requests, monkeypatch
+    ) -> None:
+        """The retained-row retry, with a native session under the bare name.
+
+        This is where the two defects meet: after the deferred first delete the
+        CAO backend session is gone, so the canonical GET 404s, while the native
+        ``review`` still answers one. Treating that answer as the target killed
+        the native session and left the canonical retry row behind.
+        """
+        backend.add_session("review", {"native-w"})
+        _seed(backend, "cao-review", [("t1", "w1")])
+
+        deferred = {"pending": True}
+        monkeypatch.setattr(
+            terminal_service.provider_manager,
+            "cleanup_provider",
+            lambda terminal_id: False if deferred["pending"] else None,
+        )
+
+        first = await ops_server.shutdown_session("review")
+
+        assert first["success"] is False
+        assert "cleanup deferred" in first["message"]
+        assert _deletes(routed_requests) == ["/sessions/cao-review"]
+        # Only the native session is live now; the CAO row is the retry handle.
+        assert backend.session_exists("cao-review") is False
+        assert backend.session_exists("review") is True
+        assert [t["id"] for t in database.list_terminals_by_session("cao-review")] == ["t1"]
+
+        deferred["pending"] = False
+        routed_requests.clear()
+
+        second = await ops_server.shutdown_session("review")
+
+        assert second["success"] is True
+        assert second["deleted"] == ["cao-review"]
+        assert second["errors"] == []
+        assert database.list_terminals_by_session("cao-review") == []
+        assert _deletes(routed_requests) == ["/sessions/cao-review"]
+        # The native session survived both attempts.
+        assert backend.session_exists("review") is True
+        assert backend.windows("review") == {"native-w"}


### PR DESCRIPTION
## Summary

Two gaps hit while driving CAO from an external coordinator (ordinary Codex CLI talking to `cao-ops-mcp-server`):

1. `launch_session` did not return the resolved provider, so a coordinator could not confirm a worker had landed on the provider it asked for without a second `get_terminal_status` call. (When the in-session MCP subprocess cannot load a profile it silently falls back to the parent provider, so this check matters.)
2. `launch_session(session_name="acc-agy")` creates `cao-acc-agy`, but `get_session_info("acc-agy")` and `shutdown_session("acc-agy")` did not resolve; the coordinator had to discover the stored name through `list_sessions`.

## Change

- `LaunchResult` carries `provider`, populated from the `/sessions` response.
- Every name-taking tool addresses the CANONICAL name. Both creation paths enforce the `cao-` prefix, so an unprefixed name can never be a CAO session: it is either a caller's alias for one or an unrelated native tmux session that shares the name. A successful lookup on an unprefixed name is therefore not evidence of CAO identity and never selects a target, which is what keeps `shutdown_session("review")` off a native `review` sitting beside `cao-review`. The read paths share the rule, so no prefix retry is needed.
- `shutdown_session` canonicalizes first, then issues exactly one DELETE against that name. The read-only GET that remains is a safety check, not a selector. It cannot use the 404 retry: `DELETE /sessions/{name}` is idempotent — `session_service.delete_session()` reports an absent name in `deleted` and the route answers 200 — so a bare name would return success after one request while `cao-<name>` and its terminal stayed live. A lookup has three outcomes, not two: resolved (below 400), confirmed absent (404 only), and unresolved (transport failure, 5xx, 403, anything else). An unresolved lookup issues no delete at all and reports the lookup failure, since deleting an unresolved alias would answer 200 and claim a cleanup that never happened. When both candidates are confirmed absent the target is the canonical name from the naming contract rather than the alias the caller typed, which is what lets a deferred-cleanup retry finish: the backend session is gone so both lookups 404, while the retained registry row still lives under the canonical name. A name that never existed anywhere still gets the endpoint's idempotent success, and an already-canonical call is unchanged.
- Tests: the bare-name contract, the unresolved-lookup abort, the deferred-cleanup retry and a native session coexisting with a CAO one are proven against the real route and the real deletion service (in-process TestClient over the FastAPI app, in-memory tmux backend, per-test SQLite registry), asserting the prefixed session is actually gone from both stores and that exactly one destructive request was issued. The earlier test that mocked a 404 DELETE is removed — that is a response the API never produces.
- `docs/control-planes.md` and `examples/ops-mcp/README.md` describe the result shape and the name handling.

## Cost

Resolution adds one GET per shutdown, two when the bare name misses. That is the price of not being able to trust this endpoint's DELETE status code.

## Tests

`test/ops_mcp_server/`: 80 passed. `black`, `isort`, `mypy` clean on touched files. Rebased onto `main` (405750f8).

