### PR TITLE
fix(status): probe a bursting screen for PROCESSING so a spinner that never goes quiet is not read as idle

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,7 +309,7 @@ A number of other `CAO_*` variables (runtime/process-identity vars like `CAO_TER
 |---|---|---|---|
 | `CAO_HOME_DIR` | `~/.aws/cli-agent-orchestrator` | str (path) | Base directory for all CAO state. See [Data directory](#data-directory-cao_home_dir) above. |
 
-The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds six more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
+Rendered-screen status detection adds `CAO_PYTE_STATUS` (default `true`) and `CAO_PYTE_MIDBURST_PROBE_S` (default `1.0`, the minimum interval between mid-burst PROCESSING probes; see [Event-Driven Architecture](event-driven-architecture.md#status-monitor-servicesstatus_monitorpy--publisher--consumer)), both read in `constants.py`. The pipe-pane liveness watchdog (issue #388, `services/fifo_reader.py`) adds six more of these ad-hoc vars, read directly via `_env_int`/`_env_float` in `constants.py` rather than through `ConfigService` — they have no `settings.json` mapping like the rows in the table above:
 
 | Env var | Default | Type | Purpose |
 |---|---|---|---|

--- a/docs/event-driven-architecture.md
+++ b/docs/event-driven-architecture.md
@@ -117,6 +117,24 @@ Chunks are **coalesced** before publishing (`_COALESCE_WINDOW = 50ms`). TUI prov
 
 Subscribes to `terminal.*.output`. Accumulates output into a rolling buffer (`state_buffer_max` server setting, 32KB by default, see `docs/configuration.md`) per terminal, detects status via the registered provider (returning `UNKNOWN` until a provider is registered for the terminal), and publishes `terminal.{id}.status` on change. Also the source of truth for current terminal status.
 
+Rendered-screen detection (`CAO_PYTE_STATUS`, on by default for providers that opt in via
+`supports_screen_detection`) runs on two edges: the rising edge, when output resumes after a quiet
+period, and quiescence, when no chunk has arrived for `PYTE_QUIESCENCE_DELAY_S` (0.2 s). Detection
+never runs mid-burst, which is what keeps half-drawn frames from flapping the status. A TUI that
+repaints a spinner every second never goes quiescent, though, so under edge-only detection a Codex
+worker read IDLE for its whole turn: the rising-edge frame still showed the previous ready state and
+nothing ran again until the turn ended. While a terminal is bursting and has not yet been seen
+PROCESSING, the monitor therefore probes the composited screen at most every
+`PYTE_MIDBURST_PROBE_S` (1.0 s, env `CAO_PYTE_MIDBURST_PROBE_S`) and applies **only** a PROCESSING
+verdict from such a frame; ready statuses still wait for quiescence, and the sticky-latch rules are
+unchanged.
+
+The probe asks `probe_processing_from_screen()`, a side-effect-free predicate, and only of providers
+that opt in with `supports_midburst_processing_probe` (Codex today). It deliberately does not call
+the full detector: discarding a non-PROCESSING verdict would not undo the turn bookkeeping some
+detectors commit while reaching it, and a half-drawn frame is exactly where that bookkeeping is
+wrong. Providers that do not opt in keep edge-only detection.
+
 Two buffer-reset primitives with different semantics:
 
 - **`reset_buffer(terminal_id)`** — clears the rolling byte buffer AND wipes `_last_status` and the `_allow_processing_revert` arm. Used by providers that relaunch a different CLI mode on the same `terminal_id` (e.g. Kiro's TUI → `--legacy-ui` fallback), where past status is deliberately forgotten.

--- a/src/cli_agent_orchestrator/constants.py
+++ b/src/cli_agent_orchestrator/constants.py
@@ -262,6 +262,16 @@ PYTE_SCREEN_ROWS = 200
 # per-chunk rendered detection produces (measured worse than the raw path).
 PYTE_QUIESCENCE_DELAY_S = 0.2
 
+# Mid-burst PROCESSING probe for rendered-screen detection (seconds). A TUI that
+# redraws a spinner every second (codex 0.153 while a command runs) never goes
+# quiescent, so edge-only detection sees the rising-edge frame (usually still
+# the previous ready state) and then nothing until the turn ends: the terminal
+# reads IDLE for its whole busy turn (observed live 2026-09-08). While a burst is
+# in progress and the terminal has not yet been seen PROCESSING, the screen is
+# probed at most this often; only a PROCESSING verdict is applied from such a
+# half-settled frame — ready statuses still wait for quiescence.
+PYTE_MIDBURST_PROBE_S = _env_positive_float("CAO_PYTE_MIDBURST_PROBE_S", 1.0)
+
 # Eager inbox delivery: when enabled, deliver queued messages to terminals in
 # PROCESSING state for providers that declare
 # accepts_input_while_processing=True. Eliminates latency between agent turns

--- a/src/cli_agent_orchestrator/providers/base.py
+++ b/src/cli_agent_orchestrator/providers/base.py
@@ -179,6 +179,37 @@ class BaseProvider(ABC):
     # this False — their COMPLETED/IDLE split is not screen-detectable.
     supports_direct_status_probe: bool = False
 
+    # Opt-in for the mid-burst PROCESSING probe (StatusMonitor._midburst_processing_probe).
+    # Set True ONLY alongside a probe_processing_from_screen() override that is
+    # side-effect free. The probe runs on a HALF-DRAWN frame, off the two edges
+    # the screen path is otherwise restricted to, and its verdict is discarded
+    # unless it says PROCESSING — so a detector that commits turn bookkeeping
+    # while deciding (minimax_code's completion identity/epoch and _awaiting_turn,
+    # grok_cli's _turn_activity_seen) would have that bookkeeping applied from a
+    # frame the monitor then throws away. Providers that leave this False are
+    # never probed: the terminal keeps the status the edges give it.
+    supports_midburst_processing_probe: bool = False
+
+    def probe_processing_from_screen(self, screen_lines: List[str]) -> bool:
+        """Report whether this half-drawn frame shows the agent actively working.
+
+        A pure observation, called only when ``supports_midburst_processing_probe``
+        is True: it MUST NOT mutate provider state, because the monitor ignores
+        everything it says except True, and the frame it sees is mid-redraw
+        rather than settled.
+
+        Answer True only on POSITIVE evidence of work — a drawn spinner or
+        progress row — never on the absence of a ready prompt. A partial redraw
+        routinely erases the composer while the previous response is still on
+        screen, and a settled detector reasonably calls that PROCESSING; here it
+        is not, and a True there spends the monitor's dispatch arm on a frame
+        that shows no new turn (see CodexProvider). Leave every other verdict to
+        the rising edge and quiescence, which see whole frames.
+
+        Default: False — no provider is probed unless it opts in.
+        """
+        return False
+
     def get_status_from_screen(self, screen_lines: List[str]) -> TerminalStatus:
         """Detect status from a pyte-rendered screen (composited viewport).
 

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -813,6 +813,14 @@ class CodexProvider(BaseProvider):
     # the live frame rather than stale redraw history.
     supports_screen_detection = True
 
+    # Codex is the provider the mid-burst probe exists for: 0.153 redraws its
+    # spinner about once a second for the whole turn, so the screen never goes
+    # quiescent and the rising edge composites before the spinner draws. Opting
+    # in is safe because this detector is a pure function of the frame —
+    # get_status() reads patterns and returns, it commits no turn bookkeeping —
+    # so a probed frame the monitor discards leaves nothing behind.
+    supports_midburst_processing_probe = True
+
     def __init__(
         self,
         terminal_id: str,
@@ -1458,6 +1466,35 @@ class CodexProvider(BaseProvider):
         if not rows:
             return TerminalStatus.UNKNOWN
         return self.get_status("\n".join(rows))
+
+    def probe_processing_from_screen(self, screen_lines: list[str]) -> bool:
+        """Report whether a half-drawn Codex frame shows a working turn.
+
+        Positive evidence only: the progress row must actually be drawn. The
+        normal detector answers PROCESSING for two different reasons — a
+        detected spinner, and the catch-all at the end of get_status for a frame
+        that simply has no idle composer at the bottom. The second is right for
+        settled detection but wrong here, because a partial redraw that erases
+        the composer while the previous response is still on screen carries no
+        evidence of new work; taken as busy it consumes the monitor's dispatch
+        arm, after which the restored old completion latches and the genuine
+        spinner that follows is refused.
+
+        Requiring TUI_PROGRESS_PATTERN first, then keeping only a PROCESSING
+        verdict from the full detector, means the trust prompt, login menu,
+        approval dialog and error guards still get the final say on a frame that
+        does contain a spinner, without inheriting the no-composer fallback.
+
+        Pure: it matches patterns against the text it is handed and touches no
+        turn bookkeeping, so a verdict the monitor discards changes nothing.
+        """
+        rows = [line.rstrip() for line in screen_lines if line.strip()]
+        if not rows:
+            return False
+        frame = "\n".join(rows)
+        if not re.search(TUI_PROGRESS_PATTERN, frame, re.MULTILINE):
+            return False
+        return self.get_status(frame) == TerminalStatus.PROCESSING
 
     def extract_current_composer(self, rendered_pane: str) -> Optional[str]:
         """Return Codex's bottom composer without admitting transcript prompts."""

--- a/src/cli_agent_orchestrator/services/status_monitor.py
+++ b/src/cli_agent_orchestrator/services/status_monitor.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Tuple
 
 from cli_agent_orchestrator.constants import (
     CAO_PYTE_STATUS,
+    PYTE_MIDBURST_PROBE_S,
     PYTE_QUIESCENCE_DELAY_S,
     PYTE_SCREEN_COLS,
     PYTE_SCREEN_ROWS,
@@ -107,6 +108,9 @@ class StatusMonitor:
         # IDLE/COMPLETED would freeze the terminal forever even when the
         # agent is genuinely processing new work.
         self._allow_processing_revert: Dict[str, bool] = {}
+        # Per-terminal monotonic timestamp of the last mid-burst PROCESSING probe
+        # (PYTE_MIDBURST_PROBE_S rate limit); absent until the first probe.
+        self._midburst_probe_at: Dict[str, float] = {}
         # Per-terminal monotonic timestamp of the last stale-PROCESSING capture-pane
         # attempt — the STALE_PROCESSING_CAPTURE_INTERVAL_S rate limit. Absence is None,
         # deliberately NOT 0.0: time.monotonic()'s reference point is arbitrary, so a 0.0
@@ -335,24 +339,34 @@ class StatusMonitor:
             self._screens[terminal_id] = scr
         scr[1].feed(chunk)
 
-    def _detect_screen(self, terminal_id: str, provider) -> TerminalStatus:
-        """Detect status from the terminal's composited pyte screen."""
-        fallback_buffer: Optional[str] = None
+    def _screen_lines(self, terminal_id: str) -> Tuple[Optional[List[str]], str]:
+        """Render the terminal's composited pyte screen under the lock.
+
+        Returns ``(lines, buffer)``. ``lines`` is None when the render itself
+        failed — distinct from an empty list (no screen yet, or a blank one), so
+        a caller can take the raw-buffer fallback only for a real failure.
+        """
         with self._lock:
             scr = self._screens.get(terminal_id)
             buffer = self._buffers.get(terminal_id, "")
             try:
-                lines: List[str] = list(scr[0].display) if scr is not None else []
+                return (list(scr[0].display) if scr is not None else []), buffer
             except Exception:
                 # pyte can transiently hold zero-length cell data while rendering
-                # complex TUI redraws. Fall back to raw-buffer detection instead of
-                # letting the quiescence callback tear down status monitoring.
+                # complex TUI redraws. Report the failure so status detection can
+                # fall back to the raw buffer instead of letting the quiescence
+                # callback tear down status monitoring.
                 logger.exception(
                     "Error rendering screen status for %s; falling back to raw buffer",
                     terminal_id,
                 )
-                fallback_buffer = buffer
-                lines = []
+                return None, buffer
+
+    def _detect_screen(self, terminal_id: str, provider) -> TerminalStatus:
+        """Detect status from the terminal's composited pyte screen."""
+        rendered, buffer = self._screen_lines(terminal_id)
+        fallback_buffer: Optional[str] = None if rendered is not None else buffer
+        lines: List[str] = rendered or []
         if fallback_buffer is not None:
             if provider is None:
                 return TerminalStatus.UNKNOWN
@@ -396,8 +410,59 @@ class StatusMonitor:
 
         if not was_bursting:
             self._apply_detection(terminal_id, self._detect_screen(terminal_id, provider))
+        else:
+            self._midburst_processing_probe(terminal_id, provider)
 
         self._arm_quiesce_timer(loop, terminal_id, self._on_screen_quiescent, provider)
+
+    def _midburst_processing_probe(self, terminal_id: str, provider) -> None:
+        """Catch a busy turn whose TUI never goes quiet.
+
+        A spinner redrawn every second keeps the terminal bursting for the whole
+        turn, so neither edge fires while the agent works and the rising-edge
+        frame (composited before the spinner drew) leaves a ready status latched.
+        While bursting and not yet PROCESSING, probe the rendered screen at most
+        every PYTE_MIDBURST_PROBE_S and apply ONLY a PROCESSING verdict: a
+        half-drawn frame can plausibly show a spinner, but it can also show a
+        stale ready box, so ready statuses still wait for quiescence.
+
+        The probe asks ``provider.probe_processing_from_screen()``, a pure
+        predicate, NOT the full detector: ignoring a detector's verdict does not
+        undo what the detector did to reach it. minimax_code's get_status()
+        commits ``_last_completion_identity``/``_last_completion_buffer_epoch``
+        and clears ``_awaiting_turn`` before returning COMPLETED, and grok_cli's
+        sets ``_turn_activity_seen`` — run against a mid-redraw frame whose
+        verdict is then dropped, that bookkeeping still lands, and a completion
+        waiter can finish the next turn on stale output. So the probe is
+        restricted to providers that opt in with
+        ``supports_midburst_processing_probe`` and promise a side-effect-free
+        predicate; everyone else keeps edge-only detection.
+        """
+        if provider is None or not getattr(provider, "supports_midburst_processing_probe", False):
+            return
+
+        now = time.monotonic()
+        with self._lock:
+            if self._last_status.get(terminal_id) == TerminalStatus.PROCESSING:
+                return
+            last_probe = self._midburst_probe_at.get(terminal_id)
+            if last_probe is not None and now - last_probe < PYTE_MIDBURST_PROBE_S:
+                return
+            self._midburst_probe_at[terminal_id] = now
+
+        lines, _ = self._screen_lines(terminal_id)
+        if not lines:
+            # Render failed or the screen is empty: no evidence, no verdict. The
+            # raw-buffer fallback _detect_screen uses is deliberately NOT taken
+            # here — it would run a full detector for a probe.
+            return
+        try:
+            busy = provider.probe_processing_from_screen(lines)
+        except Exception:
+            logger.exception("Error probing mid-burst status for %s", terminal_id)
+            return
+        if busy:
+            self._apply_detection(terminal_id, TerminalStatus.PROCESSING)
 
     def _on_screen_quiescent(self, terminal_id: str, provider) -> None:
         """Quiescence timer fired: output stopped, so the screen has settled.
@@ -623,6 +688,7 @@ class StatusMonitor:
             self._buffer_epochs.pop(terminal_id, None)
             self._last_status.pop(terminal_id, None)
             self._allow_processing_revert.pop(terminal_id, None)
+            self._midburst_probe_at.pop(terminal_id, None)
             self._screens.pop(terminal_id, None)
             self._bursting.pop(terminal_id, None)
             self._last_stale_capture_check.pop(terminal_id, None)
@@ -645,6 +711,7 @@ class StatusMonitor:
             self._buffers[terminal_id] = ""
             self._last_status.pop(terminal_id, None)
             self._allow_processing_revert.pop(terminal_id, None)
+            self._midburst_probe_at.pop(terminal_id, None)
             # Drop the rendered screen too so the relaunched CLI mode is
             # detected against a fresh viewport, not the failed attempt's.
             self._screens.pop(terminal_id, None)

--- a/test/services/test_status_monitor.py
+++ b/test/services/test_status_monitor.py
@@ -1191,3 +1191,221 @@ class TestProcessChunkBufferTruncation:
         sm_large._detect_status = lambda tid, buf: TerminalStatus.UNKNOWN
         sm_large._process_chunk("t1", payload)
         assert "MARKER" in sm_large.get_buffer("t1")
+
+
+class TestMidBurstProcessingProbe:
+    """A TUI that redraws its spinner every second never goes quiescent, so the
+    edge-only screen path saw IDLE for a whole busy turn (codex 0.153, live
+    2026-09-08). While bursting, an opted-in provider's non-mutating
+    ``probe_processing_from_screen()`` is asked at most every
+    PYTE_MIDBURST_PROBE_S, and only a True answer is applied."""
+
+    def _bursting_monitor(self, screen_lines=("• Working (3s • esc to interrupt)",)):
+        sm = StatusMonitor()
+        sm._loop = MagicMock()  # a loop exists -> edge-debounced path, not inline
+        sm._arm_quiesce_timer = lambda *a, **k: None
+        sm._cancel_quiesce_handle = lambda *a, **k: None
+        # A real pyte screen holding the frame, so a probe reads it through the
+        # same render path production uses rather than a stubbed accessor.
+        with sm._lock:
+            sm._feed_screen_locked("t1", "\r\n".join(screen_lines))
+        sm._last_status["t1"] = TerminalStatus.IDLE
+        sm._allow_processing_revert["t1"] = True
+        return sm
+
+    def _probing_provider(self, answers):
+        provider = MagicMock()
+        provider.supports_screen_detection = True
+        provider.supports_midburst_processing_probe = True
+        provider.probe_processing_from_screen.side_effect = list(answers)
+        return provider
+
+    def test_processing_seen_mid_burst_is_applied(self):
+        sm = self._bursting_monitor()
+        provider = self._probing_provider([True])
+        sm._detect_screen = lambda tid, prov: TerminalStatus.IDLE  # rising edge: old ready box
+
+        sm._schedule_screen_detection("t1", provider)
+        assert sm._last_status["t1"] == TerminalStatus.IDLE
+        sm._schedule_screen_detection("t1", provider)  # mid-burst probe: spinner visible
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+
+    def test_probe_is_rate_limited_and_never_applies_ready(self):
+        sm = self._bursting_monitor()
+        # False == "this half-drawn frame does not show work", e.g. a frame
+        # caught mid-repaint that still parses as the previous response box.
+        provider = self._probing_provider([False, False])
+        sm._detect_screen = lambda tid, prov: TerminalStatus.IDLE
+
+        sm._schedule_screen_detection("t1", provider)  # rising edge
+        sm._schedule_screen_detection("t1", provider)  # first mid-burst probe
+        sm._schedule_screen_detection("t1", provider)  # within the window: no probe
+        assert provider.probe_processing_from_screen.call_count == 1
+        assert sm._last_status["t1"] == TerminalStatus.IDLE
+
+    def test_no_probe_once_processing(self):
+        sm = self._bursting_monitor()
+        sm._last_status["t1"] = TerminalStatus.PROCESSING
+        provider = self._probing_provider([True])
+        sm._bursting["t1"] = True
+        sm._schedule_screen_detection("t1", provider)
+        assert provider.probe_processing_from_screen.call_count == 0
+
+    def test_provider_without_opt_in_is_never_probed(self):
+        """Fail closed, like supports_screen_detection and
+        supports_direct_status_probe: no flag, no mid-burst probe."""
+        sm = self._bursting_monitor()
+        provider = MagicMock()
+        provider.supports_screen_detection = True
+        provider.supports_midburst_processing_probe = False
+        detector_calls = []
+        sm._detect_screen = lambda tid, prov: detector_calls.append(tid) or TerminalStatus.IDLE
+
+        sm._bursting["t1"] = True
+        sm._schedule_screen_detection("t1", provider)
+        assert provider.probe_processing_from_screen.call_count == 0
+        assert detector_calls == []  # and the full detector is not run either
+        assert sm._last_status["t1"] == TerminalStatus.IDLE
+
+    def test_mid_burst_probe_leaves_a_stateful_provider_untouched(self):
+        """A discarded verdict does not undo what a detector did to reach it.
+
+        minimax_code opts into screen detection and commits turn bookkeeping
+        inside get_status (``_last_completion_identity`` /
+        ``_last_completion_buffer_epoch``, clearing ``_awaiting_turn``). Running
+        it against a mid-redraw frame — here turn A's retained response with its
+        user row momentarily erased, which changes the completion fingerprint —
+        makes that frame look like a NEW completion. Even with the COMPLETED
+        verdict thrown away, the bookkeeping would stick and the next settled
+        frame would report turn B complete on turn A's output. minimax does not
+        set supports_midburst_processing_probe, so the probe never asks it.
+        """
+        from pathlib import Path
+
+        from cli_agent_orchestrator.providers.minimax_code import MiniMaxCodeProvider
+
+        fixture = (
+            Path(__file__).resolve().parents[1]
+            / "providers"
+            / "fixtures"
+            / "minimax_code_completed.txt"
+        ).read_text(encoding="utf-8")
+        provider = MiniMaxCodeProvider(
+            terminal_id="t1", session_name="s", window_name="w", agent_profile=None
+        )
+        assert provider.get_status(fixture) == TerminalStatus.IDLE  # turn A settles
+        provider.notify_status_buffer_reset(1)
+        provider.mark_input_received()  # turn B armed
+        provider._last_dispatch_time = 0
+        assert provider._awaiting_turn is True
+
+        mid_redraw = [line for line in fixture.splitlines() if not line.startswith("› Explain")]
+        sm = self._bursting_monitor(screen_lines=mid_redraw)
+        before = dict(vars(provider))
+
+        sm._bursting["t1"] = True
+        sm._schedule_screen_detection("t1", provider)
+
+        assert vars(provider) == before
+        assert provider._awaiting_turn is True
+        # The settled frame still reads IDLE: turn B is still pending, which is
+        # the base behavior. (Feeding the same mid-redraw frame to the detector
+        # would have returned COMPLETED and cleared _awaiting_turn.)
+        assert provider.get_status_from_screen(fixture.splitlines()) == TerminalStatus.IDLE
+        assert provider._awaiting_turn is True
+
+    def test_codex_spinner_frame_probes_processing_without_mutating(self):
+        """The regression this fix exists for, through the real provider."""
+        from cli_agent_orchestrator.providers.codex import CodexProvider
+
+        provider = CodexProvider(
+            terminal_id="t1", session_name="s", window_name="w", agent_profile=None
+        )
+        assert provider.supports_midburst_processing_probe is True
+        working = [
+            "› Improve documentation in @filename",
+            "• Working (3s • esc to interrupt)",
+            "",
+            "  gpt-5.6-terra high · /tmp/project",
+        ]
+        before = dict(vars(provider))
+        assert provider.probe_processing_from_screen(working) is True
+        assert vars(provider) == before  # the predicate is an observation only
+
+        idle = [
+            "› Improve documentation in @filename",
+            "",
+            "  gpt-5.6-terra high · /tmp/project",
+        ]
+        assert provider.probe_processing_from_screen(idle) is False
+
+        sm = self._bursting_monitor(screen_lines=working)
+        sm._bursting["t1"] = True
+        sm._schedule_screen_detection("t1", provider)
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING
+
+    def test_erased_composer_is_not_work_evidence_and_the_real_spinner_still_lands(self):
+        """A partial redraw must not spend the dispatch arm.
+
+        `CodexProvider.get_status` answers PROCESSING for two different reasons:
+        a detected spinner, and a catch-all for a frame with no idle composer at
+        the bottom. The second is right for settled detection and wrong for a
+        mid-burst probe: erasing the composer while the previous response is
+        still on screen carries no evidence of new work. Taken as busy it
+        consumes the arm `notify_input_sent` set, the restored old completion
+        then latches, and the genuine spinner that follows is refused by the
+        sticky-ready rule — the terminal reads COMPLETED for the whole new turn.
+        """
+        from cli_agent_orchestrator.providers.codex import CodexProvider
+
+        provider = CodexProvider(
+            terminal_id="t1", session_name="s", window_name="w", agent_profile=None
+        )
+        old_response = [
+            "› Explain the result",
+            "• The integration is complete.",
+            "",
+            "  gpt-5.6-terra high · /tmp/project",
+        ]
+        erased_composer = ["• The integration is complete."]
+        real_spinner = [
+            "› Explain the result",
+            "• Working (3s • esc to interrupt)",
+            "",
+            "  gpt-5.6-terra high · /tmp/project",
+        ]
+
+        # The frame with no composer and no spinner is exactly the one the full
+        # detector calls PROCESSING through its fallback.
+        assert provider.get_status_from_screen(erased_composer) == TerminalStatus.PROCESSING
+        assert provider.probe_processing_from_screen(erased_composer) is False
+
+        sm = self._bursting_monitor(screen_lines=erased_composer)
+        sm._last_status["t1"] = TerminalStatus.COMPLETED  # previous turn
+        sm.notify_input_sent("t1")  # new turn dispatched: arm the transition
+        sm._bursting["t1"] = True
+
+        sm._schedule_screen_detection("t1", provider)  # probe the erased frame
+        assert sm._last_status["t1"] == TerminalStatus.COMPLETED
+        assert sm._allow_processing_revert["t1"] is True  # the arm survives
+
+        # The old completion is redrawn and settles; still armed, still COMPLETED.
+        with sm._lock:
+            sm._screens.pop("t1", None)
+            sm._feed_screen_locked("t1", "\r\n".join(old_response))
+        # Quiescence with no event loop detects inline, the same call
+        # _on_screen_quiescent makes on its worker thread.
+        sm._loop = None
+        sm._on_screen_quiescent("t1", provider)
+        sm._loop = MagicMock()
+        assert sm._last_status["t1"] == TerminalStatus.COMPLETED
+        assert sm._allow_processing_revert["t1"] is True
+
+        # The genuine spinner appears mid-burst and must be honoured.
+        with sm._lock:
+            sm._screens.pop("t1", None)
+            sm._feed_screen_locked("t1", "\r\n".join(real_spinner))
+            sm._midburst_probe_at.pop("t1", None)
+        sm._bursting["t1"] = True
+        sm._schedule_screen_detection("t1", provider)
+        assert sm._last_status["t1"] == TerminalStatus.PROCESSING


### PR DESCRIPTION
Fixes #757. Related: #659, #735, #714.

## Summary

Rendered-screen detection runs only on the rising edge and at quiescence. Codex repaints its spinner every second while a command runs, so the terminal never goes quiescent, the detector is never invoked mid-turn, and the terminal reads `idle` for its whole busy turn (the rising-edge frame is composited before the spinner is drawn). The provider detector is right on every one of those frames; it just never gets asked. Consequences: inbox delivery pastes into a busy turn, the deferred-assign confirm reads "idle, never working", and external coordinators wait out the handoff timeout.

## Change

- `StatusMonitor._midburst_processing_probe`: while a terminal is bursting and its last status is not PROCESSING, probe the composited pyte screen at most every `PYTE_MIDBURST_PROBE_S` (1.0 s, env `CAO_PYTE_MIDBURST_PROBE_S`) and apply **only** a PROCESSING verdict. Ready statuses still wait for quiescence, so the anti-flap rule that ruled out per-chunk detection is preserved: a half-drawn frame can upgrade to busy, never settle to ready. The probe stops once PROCESSING is latched, and `_apply_detection`'s sticky-latch/arm rules are untouched.
- The probe asks a new side-effect-free predicate, `BaseProvider.probe_processing_from_screen()`, and only of providers that opt in with `supports_midburst_processing_probe` — the same fail-closed shape as `supports_screen_detection` and `supports_direct_status_probe`. It never calls the full detector: discarding a verdict does not undo the turn bookkeeping a detector commits while reaching it. `minimax_code` opts into screen detection and commits `_last_completion_identity` / `_last_completion_buffer_epoch` and clears `_awaiting_turn` inside `get_status`, so a mid-redraw frame would register as a new completion and the next settled frame would report a pending turn complete on the previous turn's output.
- `CodexProvider` opts in and requires positive evidence of work: the progress row must be drawn, and only then does the full detector get the final say, keeping the trust-prompt, login-menu, approval-dialog and error guards. Inheriting the detector's no-composer catch-all would be wrong here, because a partial redraw that erases the composer while the previous response is still on screen carries no evidence of a new turn; taken as busy it spends the monitor's dispatch arm, the restored old completion latches, and the genuine spinner that follows is refused.
- Tests (`TestMidBurstProcessingProbe`): the Codex spinner transition through the real provider; the minimax bookkeeping unchanged across a burst with the settled frame still IDLE and `_awaiting_turn` set; a provider without the opt-in never probed and no detector run; the throttle; no probe once PROCESSING. The probe tests feed a real pyte screen rather than stubbing detection.
- Docs: `docs/event-driven-architecture.md` StatusMonitor section, `docs/configuration.md` env note.

## Live verification

Same `sleep 30` task on `codex-cli 0.153.4`, polled every 4 s: before, `idle` ×12 then `completed`; after, `processing` ×9 then `completed`.

## Tests

`test/services/` and `test/providers/`: 4817 passed, 9 skipped, 1 xfailed, against 4811 passed on `main` at the same commit with the identical 43 pre-existing AG-UI failures in this environment. `black` and `isort` clean on touched files. Rebased onto `main` (405750f8).
