### PR TITLE
feat(ops-mcp): register plugin MCP surfaces on the operations server

### DIFF
--- a/docs/control-planes.md
+++ b/docs/control-planes.md
@@ -87,6 +87,9 @@ The current tools are grouped by purpose:
   `get_terminal_output`
 - Session lifecycle: `list_sessions`, `get_session_info`, `shutdown_session`
 
+Installed [plugins](plugins.md#mcp-tool-surfaces) can register additional tools on this
+server through `on_mcp_server`, the same hook `cao-mcp-server` honours.
+
 MCP tool discovery is authoritative for clients. The declarations in
 [`ops_mcp_server/server.py`](../src/cli_agent_orchestrator/ops_mcp_server/server.py)
 are the source of truth when the server surface changes.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -165,6 +165,17 @@ Fires after a terminal has been shut down.
 
 Example use: remove the terminal from an external inventory or dashboard.
 
+## MCP tool surfaces
+
+Besides event hooks, a plugin can add MCP tools. Override `CaoPlugin.on_mcp_server(mcp)`; it is
+called once at MCP-server startup with the FastMCP instance, and anything registered on it with
+`@mcp.tool()` (or resources) becomes part of that server's surface. The hook runs for **both** CAO
+MCP servers: `cao-mcp-server`, which agents use inside a session, and `cao-ops-mcp-server`, which
+an external coordinator uses to manage the fleet, so a plugin's tools reach whichever side needs
+them. Registration is best-effort and isolated per plugin: an exception in one plugin's hook is
+logged and never prevents the server, or other plugins, from starting. The built-in `mcp_apps`
+plugin uses this hook for the MCP Apps surface.
+
 ## Authoring a plugin
 
 This document focuses on installing and using plugins. For a full plugin-authoring guide — scaffolding a plugin package, subclassing `CaoPlugin`, wiring up `@hook` methods, and testing — see the [`cao-plugin` skill](../skills/cao-plugin/SKILL.md).

--- a/src/cli_agent_orchestrator/ops_mcp_server/server.py
+++ b/src/cli_agent_orchestrator/ops_mcp_server/server.py
@@ -709,6 +709,15 @@ async def shutdown_session(
     return {"success": False, "message": "Shutdown session failed: invalid response payload"}
 
 
+# Plugins may add operator-facing tools here too (the cao_quota plugin's
+# provider_availability / record_provider_refusal, for example): an external
+# coordinator that only speaks to cao-ops otherwise has no way to reach them.
+# Same best-effort entry-point registration the in-session server performs.
+from cli_agent_orchestrator.plugins.registry import register_mcp_server_surfaces  # noqa: E402
+
+register_mcp_server_surfaces(mcp)
+
+
 def main() -> None:
     """Run the operations MCP server."""
     mcp.run()

--- a/test/ops_mcp_server/test_server.py
+++ b/test/ops_mcp_server/test_server.py
@@ -822,3 +822,18 @@ def test_main_runs_mcp_server() -> None:
         main()
 
     mock_run.assert_called_once_with()
+
+
+def test_plugin_mcp_surfaces_are_registered_on_ops_server() -> None:
+    """Entry-point plugins get on_mcp_server() called with the ops server's FastMCP
+    instance, so plugin tools reach external coordinators too."""
+    import importlib
+
+    import cli_agent_orchestrator.ops_mcp_server.server as ops_server
+
+    with patch(
+        "cli_agent_orchestrator.plugins.registry.register_mcp_server_surfaces"
+    ) as mock_register:
+        reloaded = importlib.reload(ops_server)
+        mock_register.assert_called_once_with(reloaded.mcp)
+    importlib.reload(ops_server)


### PR DESCRIPTION
## Summary

`cao-mcp-server` calls `register_mcp_server_surfaces(mcp)` so plugins can add tools through `CaoPlugin.on_mcp_server`, but `cao-ops-mcp-server` never did. A plugin that adds operator-facing tools (a provider-availability report, for instance) is therefore invisible to an external coordinator that only speaks to the ops server.

## Change

- `ops_mcp_server/server.py` registers plugin MCP surfaces the same best-effort, per-plugin-isolated way the in-session server does.
- Test: the hook is invoked with the ops server's FastMCP instance.
- Docs: `docs/plugins.md` gains a "MCP tool surfaces" section (the `on_mcp_server` hook was undocumented) and `docs/control-planes.md` notes that plugin tools appear on the ops server.

Registration failures stay logged and non-fatal, as today. If maintainers would rather gate this behind a setting the way the MCP Apps surface is, that is a small follow-up.

Tests: `uv run pytest test/ops_mcp_server` (68 passed) plus the CI command over `test/` on a branch stacking all five of my open PRs: 8829 passed, 31 skipped, 1 xfailed, 0 failed (clean `main`: 8813 passed). `black`/`isort` clean on touched files; gitleaks over the commit found nothing.
