### PR TITLE
fix(workflow): validate script step IDs and retain diagnostics

### DIFF
--- a/src/cli_agent_orchestrator/api/main.py
+++ b/src/cli_agent_orchestrator/api/main.py
@@ -6190,6 +6190,7 @@ async def get_workflow_run_result_endpoint(
         for s in steps
     ]
     error_kind = _resolve_error_kind(row, steps)
+    run_error = getattr(row, "error", None)
     result = WorkflowRunResult(
         run_id=row.run_id,
         workflow_name=row.workflow_name,
@@ -6198,6 +6199,7 @@ async def get_workflow_run_result_endpoint(
         started_at=row.started_at,
         finished_at=row.finished_at,
         kind=error_kind,
+        warnings=[run_error] if run_error else [],
     )
     body = result.model_dump()
 

--- a/src/cli_agent_orchestrator/cli/commands/workflow.py
+++ b/src/cli_agent_orchestrator/cli/commands/workflow.py
@@ -352,6 +352,10 @@ def _render_result(result):
     for step in result.get("steps", []):
         click.echo(f"  - {step['id']}: {step['state']} (attempts={step.get('attempts')})")
     _render_failure_envelope(result.get("failure_envelope"))
+    if result.get("state") == "failed" and result.get("warnings"):
+        click.echo("Diagnostics:")
+        for warning in result["warnings"]:
+            click.echo(f"  {warning}")
 
 
 def _render_failure_envelope(envelope):

--- a/src/cli_agent_orchestrator/clients/database.py
+++ b/src/cli_agent_orchestrator/clients/database.py
@@ -1023,6 +1023,9 @@ def _migrate_workflow_run() -> None:
     This column is NOT indexed (ADR-583-12: re-approval compares a ``plan_id``
     read out of the envelope and no query filters on it). Writing and reading it
     belong to the ``manifest-freeze`` unit, not to this migrator.
+
+    Issue #753 additively appends nullable ``error`` for the redacted, bounded
+    script-level failure diagnostic. Existing and non-script rows remain NULL.
     """
     import sqlite3
 
@@ -1056,6 +1059,9 @@ def _migrate_workflow_run() -> None:
             if "manifest_json" not in columns:
                 conn.execute("ALTER TABLE workflow_run ADD COLUMN manifest_json TEXT DEFAULT NULL")
                 logger.info("Migration: added manifest_json column to workflow_run")
+            if "error" not in columns:
+                conn.execute("ALTER TABLE workflow_run ADD COLUMN error TEXT DEFAULT NULL")
+                logger.info("Migration: added error column to workflow_run")
     except Exception as e:  # noqa: BLE001 — derived/recoverable; logged at debug (B4-RD-4)
         logger.debug(f"workflow_run migration skipped: {e}")
 

--- a/src/cli_agent_orchestrator/models/workflow.py
+++ b/src/cli_agent_orchestrator/models/workflow.py
@@ -365,6 +365,8 @@ class LintFinding(BaseModel):
         "missing-recovery-policy",
         "unverifiable-recovery-policy",
         "unenforced-recovery-policy",
+        # issue #753 — literal script step ids rejected by the run-step route.
+        "invalid-step-id",
     ]
     severity: Literal["error", "warning"]
     line: int

--- a/src/cli_agent_orchestrator/services/script_lint.py
+++ b/src/cli_agent_orchestrator/services/script_lint.py
@@ -1,9 +1,8 @@
-"""Static script linter (issue #312, Bolt 2 / U1, C2; extended by issue #583).
+"""Static script linter (issue #312, extended by issues #583 and #753).
 
 Issue #312 established the module and its first four rules; issue #583's
 ``recovery-decision-intake`` added the three recovery-policy rules catalogued
-below. Rule ids and ``BR-n`` citations therefore come from TWO rule sets, so
-each is named with its source rather than left bare.
+below; issue #753 adds literal step-id validation.
 
 A pure, dependency-free function of the source text: one ``ast.parse`` plus
 exactly one ``ast.walk`` — no filesystem, no network, no state, and **no
@@ -12,8 +11,7 @@ guarantee). Path safety is the caller's job; ``display_path`` is used only
 for message rendering. ``lint_script`` never raises on bad input — a syntax
 error is a finding, not an exception (U1-BR-6).
 
-Rule catalogue — seven rules (U1 business-rules.md; the three
-recovery-policy rules are issue #583's business-rules.md):
+Rule catalogue — eight rules:
 - ``syntax`` (ERROR) — ``ast.parse`` failed; anchored at ``e.lineno`` or 1.
 - ``disallowed-import`` (ERROR) — static or literal-string dynamic import
   whose first dotted segment is in ``SCRIPT_LINT_DISALLOWED_IMPORT_PREFIXES``
@@ -50,6 +48,10 @@ recovery-policy rules are issue #583's business-rules.md):
   "never validated"; that was false, corrected by PR #628's review.) ``step()``
   is the surface that checks early, and this rule is the only layer that can see
   the difference statically.
+- ``invalid-step-id`` (ERROR) — a CAO ``step()`` or ``run_step()`` call whose
+  explicit ``step_id=`` is a string literal that does not match the shared
+  ``WORKFLOW_NAME_RE`` accepted by the server. Computed ids are left to the
+  existing runtime validation because static analysis cannot resolve them.
 
 ``status == "fail"`` iff at least one ERROR finding (U1-BR-1); ERRORs are
 mirrored into the legacy ``errors`` list as ``"line N: [rule_id] message"``
@@ -77,15 +79,18 @@ from __future__ import annotations
 
 import ast
 import logging
-from typing import List, Literal
+import re
+from typing import List, Literal, Sequence
 
 from cli_agent_orchestrator.constants import (
     SCRIPT_LINT_DISALLOWED_IMPORT_PREFIXES,
     SCRIPT_LINT_NONDETERMINISM_MODULES,
+    WORKFLOW_NAME_RE,
 )
 from cli_agent_orchestrator.models.workflow import LintFinding, ScriptValidationResult
 
 logger = logging.getLogger(__name__)
+_NAME_RE = re.compile(WORKFLOW_NAME_RE)
 
 
 def lint_script(source: str, display_path: str) -> ScriptValidationResult:
@@ -156,7 +161,17 @@ def _walk_tree(tree: ast.AST, findings: List[LintFinding]) -> None:
     their attribute access and why every ``rule_id`` below must appear in
     ``LintFinding``'s ``Literal``.
     """
-    for node in ast.walk(tree):
+    nodes = list(ast.walk(tree))
+    cao_modules, cao_steps, cao_run_steps = _cao_workflow_bindings(tree, nodes)
+    for node in nodes:
+        if isinstance(node, ast.Call) and _is_bound_cao_step_call(
+            node.func,
+            cao_modules,
+            cao_steps,
+            cao_run_steps,
+        ):
+            _check_literal_step_id(node, findings)
+
         if isinstance(node, ast.Import):
             for alias in node.names:
                 _check_module(alias.name, node.lineno, findings)
@@ -252,6 +267,97 @@ def _walk_tree(tree: ast.AST, findings: List[LintFinding]) -> None:
                 )
 
 
+def _cao_workflow_bindings(
+    tree: ast.AST,
+    nodes: Sequence[ast.AST],
+) -> tuple[set[str], set[str], set[str]]:
+    """Return top-level names explicitly imported from ``cao_workflow``.
+
+    The literal-id rule is blocking, so name shape alone is insufficient:
+    another package may export ``run_step`` and a script may define its own
+    ``step``. Top-level imports cover the supported authoring forms while any
+    name rebound elsewhere in the script is treated as ambiguous and left to
+    the existing runtime validation.
+    """
+    module_names: set[str] = set()
+    step_names: set[str] = set()
+    run_step_names: set[str] = set()
+    if not isinstance(tree, ast.Module):
+        return module_names, step_names, run_step_names
+
+    cao_import_aliases: set[int] = set()
+    for top_node in tree.body:
+        if isinstance(top_node, ast.Import):
+            for alias in top_node.names:
+                if alias.name == "cao_workflow":
+                    bound_name = _import_bound_name(alias)
+                    module_names.add(bound_name)
+                    cao_import_aliases.add(id(alias))
+        elif (
+            isinstance(top_node, ast.ImportFrom)
+            and top_node.level == 0
+            and top_node.module == "cao_workflow"
+        ):
+            for alias in top_node.names:
+                bound_name = alias.asname or alias.name
+                if alias.name == "step":
+                    step_names.add(bound_name)
+                    cao_import_aliases.add(id(alias))
+                elif alias.name == "run_step":
+                    run_step_names.add(bound_name)
+                    cao_import_aliases.add(id(alias))
+
+    ambiguous = (
+        (module_names & step_names)
+        | (module_names & run_step_names)
+        | (step_names & run_step_names)
+    )
+    for node in nodes:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                if alias.name == "*":
+                    ambiguous.update(module_names | step_names | run_step_names)
+                    continue
+                bound_name = _import_bound_name(alias)
+                if id(alias) not in cao_import_aliases:
+                    ambiguous.add(bound_name)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            ambiguous.add(node.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            ambiguous.add(node.name)
+        elif isinstance(node, ast.arg):
+            ambiguous.add(node.arg)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            ambiguous.add(node.name)
+        elif isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name:
+            ambiguous.add(node.name)
+
+    return (
+        module_names - ambiguous,
+        step_names - ambiguous,
+        run_step_names - ambiguous,
+    )
+
+
+def _import_bound_name(alias: ast.alias) -> str:
+    """Return the local name created by one import alias."""
+    return alias.asname or alias.name.split(".", 1)[0]
+
+
+def _is_bound_cao_step_call(
+    func: ast.expr,
+    module_names: set[str],
+    step_names: set[str],
+    run_step_names: set[str],
+) -> bool:
+    """Match a CAO step call only when its top-level import establishes provenance."""
+    if isinstance(func, ast.Name):
+        return func.id in step_names or func.id in run_step_names
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return func.value.id in module_names and func.attr in {"step", "run_step"}
+    return False
+
+
 def _is_dynamic_import_call(func: ast.expr) -> bool:
     """Match ``importlib.import_module(...)``, bare ``import_module(...)``
     (from-import shape), and ``__import__(...)`` on a best-effort static basis."""
@@ -315,6 +421,31 @@ def _is_run_step_call(func: ast.expr) -> bool:
     if isinstance(func, ast.Name):
         return func.id == "run_step"
     return False
+
+
+def _check_literal_step_id(node: ast.Call, findings: List[LintFinding]) -> None:
+    """Reject a literal step id the shared server-side identifier rule rejects."""
+    for keyword in node.keywords:
+        if keyword.arg != "step_id":
+            continue
+        value = keyword.value
+        if (
+            isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+            and not _NAME_RE.fullmatch(value.value)
+        ):
+            findings.append(
+                LintFinding(
+                    rule_id="invalid-step-id",
+                    severity="error",
+                    line=node.lineno,
+                    message=(
+                        "step_id literal is invalid "
+                        "(must be a 1-64 char [A-Za-z0-9_-] identifier)"
+                    ),
+                )
+            )
+        return
 
 
 def _check_module(dotted: str, lineno: int, findings: List[LintFinding]) -> None:

--- a/src/cli_agent_orchestrator/services/script_runner.py
+++ b/src/cli_agent_orchestrator/services/script_runner.py
@@ -949,10 +949,15 @@ def _delete_temp_file(path: Optional[str]) -> None:
 # ---------------------------------------------------------------------------
 # _finalize (INV-5) — construct the tier-neutral WorkflowRunResult
 # ---------------------------------------------------------------------------
-def _journal_run_state(record: ScriptRunRecord) -> None:
+def _journal_run_state(record: ScriptRunRecord, error: Optional[str]) -> None:
     """Best-effort terminal-state write-through (INV-4/INV-5). Never raises."""
     try:
-        workflow_journal.update_run_state(record.run_id, record.state.value, record.finished_at)
+        workflow_journal.update_run_state(
+            record.run_id,
+            record.state.value,
+            record.finished_at,
+            error,
+        )
     except (
         Exception
     ) as e:  # noqa: BLE001 — journal write is best-effort; result still returned (INV-4)
@@ -999,7 +1004,7 @@ async def _finalize(
     record.state = state
     record.current_step_id = None
     record.finished_at = _now()
-    await asyncio.to_thread(_journal_run_state, record)
+    await asyncio.to_thread(_journal_run_state, record, _sanitise_error(error))
     # ``WorkflowRunResult`` has no top-level ``error`` field (per-step only), so a
     # run-level error (stderr tail on crash/timeout) is surfaced in ``warnings`` —
     # the FAILED state + ``kind`` already carry the failure semantics; the tail is

--- a/src/cli_agent_orchestrator/services/workflow_journal.py
+++ b/src/cli_agent_orchestrator/services/workflow_journal.py
@@ -89,6 +89,7 @@ _REQUIRED_RUN_COLUMNS = frozenset(
         # ``test_workflow_journal_connection_posture.py::test_the_required_column_sets_match_what_the_migrators_produce``
         # exists to catch.
         "manifest_json",
+        "error",
     }
 )
 _REQUIRED_STEP_COLUMNS = frozenset(
@@ -129,6 +130,8 @@ class RunRow:
     # same shape ``StepRow``'s docstring describes for U1's nullable fields: a row written before this
     # (or by a YAML run, which never freezes) reads back observably identical to its previous shape.
     manifest_json: Optional[str] = None
+    # Issue #753: redacted, bounded script-level failure diagnostic.
+    error: Optional[str] = None
 
 
 @dataclass
@@ -546,11 +549,18 @@ def update_run_current_step(run_id: str, current_step_id: Optional[str]) -> None
         )
 
 
-def update_run_state(run_id: str, state: str, finished_at: Optional[str]) -> None:
-    """UPDATE ``workflow_run.state`` (+ ``finished_at``) on a run transition (E1).
+def update_run_state(
+    run_id: str,
+    state: str,
+    finished_at: Optional[str],
+    error: Optional[str] = None,
+) -> None:
+    """UPDATE run state, finish time, and optional run-level diagnostic (E1).
 
     ``finished_at`` is set on a terminal transition and cleared (``None``) when a
     resume re-opens a previously-settled run (business-logic-model §3).
+    ``error`` is cleared by every caller that omits it, preventing a resumed or
+    subsequently completed run from retaining a stale script failure.
 
     UNCONDITIONAL BY CONTRACT. Do NOT add a ``WHERE state = ...`` predicate here:
     the resume path calls this to write state BACK to ``running`` on an already
@@ -561,8 +571,8 @@ def update_run_state(run_id: str, state: str, finished_at: Optional[str]) -> Non
     """
     with _connect() as conn:
         conn.execute(
-            "UPDATE workflow_run SET state = ?, finished_at = ? WHERE run_id = ?",
-            (state, finished_at, run_id),
+            "UPDATE workflow_run SET state = ?, finished_at = ?, error = ? WHERE run_id = ?",
+            (state, finished_at, error, run_id),
         )
 
 
@@ -864,7 +874,7 @@ def get_run(run_id: str) -> Optional[RunRow]:
     with _connect() as conn:
         row = conn.execute(
             "SELECT run_id, workflow_name, spec_snapshot, inputs_json, state, "
-            "current_step_id, started_at, finished_at, tier, generation, manifest_json "
+            "current_step_id, started_at, finished_at, tier, generation, manifest_json, error "
             "FROM workflow_run WHERE run_id = ?",
             (run_id,),
         ).fetchone()
@@ -884,6 +894,7 @@ def get_run(run_id: str) -> Optional[RunRow]:
         # issue #583 Bolt 2, ``approval-gate``: NULL for every YAML run and for any run whose freeze
         # failed. Both read back as None, which the resume gate refuses when enforcement is on.
         manifest_json=row[10],
+        error=row[11],
     )
 
 

--- a/test/api/test_workflow_run_surface_tier.py
+++ b/test/api/test_workflow_run_surface_tier.py
@@ -90,6 +90,23 @@ class TestValidateTierDispatch:
         assert body["status"] == "fail"
         assert any(f["rule_id"] == "syntax" for f in body["findings"])
 
+    def test_py_arm_rejects_literal_step_id_the_run_step_route_rejects(
+        self, client, isolated_db, spec_dir
+    ):
+        path = _write_script(
+            spec_dir,
+            "bad_step_id",
+            "from cao_workflow import run_step\n"
+            "run_step('p', 'a', 'x', step_id='t006:makefile')\n",
+        )
+
+        resp = client.post("/workflows/validate", json={"path": str(path)})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "fail"
+        assert [f["rule_id"] for f in body["findings"]] == ["invalid-step-id"]
+
     def test_unrecognized_extension_400(self, client, isolated_db, spec_dir):
         path = spec_dir / "bad.txt"
         path.write_text("hello")

--- a/test/api/test_workflow_runs.py
+++ b/test/api/test_workflow_runs.py
@@ -1852,6 +1852,26 @@ def test_failure_envelope_assembled_for_failed_run_from_journal(client, read_sur
     assert env["next_command"] == "cao workflow result failrun"
 
 
+def test_retained_result_surfaces_durable_run_error_as_warning(client, monkeypatch):
+    """Issue #753: the detached result must retain a failed script's diagnostic."""
+    row = SimpleNamespace(
+        run_id="script-fail",
+        workflow_name="wf",
+        state=RunState.FAILED.value,
+        current_step_id=None,
+        started_at="2026-09-09T00:00:00Z",
+        finished_at="2026-09-09T00:00:01Z",
+        error="Traceback: script failed",
+    )
+    monkeypatch.setattr(workflow_journal, "get_run", lambda run_id: row)
+    monkeypatch.setattr(workflow_journal, "get_steps", lambda run_id: [])
+
+    body = client.get("/workflows/runs/script-fail/result").json()
+
+    assert body["state"] == "failed"
+    assert body["warnings"] == ["Traceback: script failed"]
+
+
 def test_failure_envelope_timeout_kind_and_hint(client, read_surface_db):
     """U9-T6 (EF-4): a timeout failure surfaces error_kind='timeout' and a stable
     next_command hint keyed on the run id."""

--- a/test/cli/commands/test_workflow.py
+++ b/test/cli/commands/test_workflow.py
@@ -685,6 +685,18 @@ def test_result_renders_failure_envelope_for_failed_run(runner):
     assert "cao workflow result run1" in out  # next command hint
 
 
+def test_result_renders_retained_run_diagnostic(runner):
+    """Issue #753: human output must show the stderr retained in warnings."""
+    body = _failed_result_body()
+    body["warnings"] = ["Traceback: script failed"]
+    with patch("cli_agent_orchestrator.cli.commands.workflow.requests") as mock_req:
+        mock_req.get.return_value = _resp(200, body)
+        result = runner.invoke(workflow, ["result", "run1"])
+
+    assert result.exit_code == 0
+    assert "Traceback: script failed" in result.output
+
+
 def test_result_failed_json_verbatim_carries_envelope(runner):
     """U9-T8 (ST-1 / NFR-3): ``result --json`` for a failed run emits the server
     body verbatim — the failure envelope (and its stable next_command hint) is in

--- a/test/clients/test_workflow_run_migration.py
+++ b/test/clients/test_workflow_run_migration.py
@@ -70,6 +70,7 @@ def test_workflow_run_columns(patched_db):
         "tier",
         "generation",
         "manifest_json",
+        "error",
     }
     # run_id is the primary key; the nullable columns are current_step_id/finished_at.
     assert cols["run_id"][5] == 1
@@ -93,6 +94,9 @@ def test_workflow_run_columns(patched_db):
     # proves presence, these two prove the shape a reader depends on.
     assert cols["manifest_json"][2] == "TEXT"
     assert cols["manifest_json"][4] == "NULL"
+    assert cols["error"][2] == "TEXT"
+    assert cols["error"][3] == 0
+    assert cols["error"][4] == "NULL"
 
 
 def test_workflow_run_no_loop_columns(patched_db):
@@ -295,6 +299,7 @@ def test_workflow_run_indexes_do_not_change_columns(patched_db):
         # workflow_journal._REQUIRED_RUN_COLUMNS — guarded by its own equality assertion in
         # test_workflow_journal_connection_posture.py. Three places, one column set.
         "manifest_json",
+        "error",
     }
 
 

--- a/test/e2e/script_runner/test_script_runner_e2e.py
+++ b/test/e2e/script_runner/test_script_runner_e2e.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import pytest
 
 from cli_agent_orchestrator.models.workflow_runtime import RunState
-from cli_agent_orchestrator.services import script_runner
+from cli_agent_orchestrator.services import script_runner, workflow_journal
 from cli_agent_orchestrator.services.script_runner import run_script_workflow
 
 pytestmark = [pytest.mark.e2e, pytest.mark.asyncio]
@@ -99,8 +99,11 @@ async def test_real_hang_is_reaped_within_bound(tmp_path, monkeypatch):
 
 
 async def test_real_nonzero_exit_is_failed(tmp_path):
-    """A real script exiting nonzero -> FAILED, kind=error."""
+    """A real nonzero script persists stderr after the child process exits."""
     spec = _RealSpec(tmp_path, source='import sys\nsys.stderr.write("boom\\n")\nsys.exit(3)\n')
     result = await run_script_workflow(spec, {}, "e2e-crash")
     assert result.state == RunState.FAILED
     assert result.kind == "error"
+    row = workflow_journal.get_run("e2e-crash")
+    assert row is not None
+    assert row.error == "boom"

--- a/test/services/test_script_lint.py
+++ b/test/services/test_script_lint.py
@@ -248,6 +248,122 @@ class TestTotalityProperty:
 SHIM_IMPORT = "from cao_workflow import run_step, step\n\n"
 
 
+class TestLiteralStepIdRule:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            "step('p', 'a', 'x', step_id='t006:makefile', recovery='idempotent')",
+            "run_step('p', 'a', 'x', step_id='t006:makefile')",
+            "cao_workflow.step('p', 'a', 'x', step_id='t006:makefile', recovery='manual')",
+            "cao_workflow.run_step('p', 'a', 'x', step_id='t006:makefile')",
+        ],
+    )
+    def test_invalid_literal_step_id_is_a_blocking_error(self, call):
+        source = "import cao_workflow\n" + SHIM_IMPORT + call + "\n"
+        result = lint_script(source, "s.py")
+
+        findings = _findings_by_rule(result, "invalid-step-id")
+        assert result.status == "fail"
+        assert len(findings) == 1
+        assert findings[0].severity == "error"
+        assert findings[0].line == 4
+        assert "[A-Za-z0-9_-]" in findings[0].message
+        assert result.errors == [f"line 4: [invalid-step-id] {findings[0].message}"]
+
+    @pytest.mark.parametrize("step_id", ["a", "makefile_incremental", "step-64"])
+    def test_valid_literal_step_id_is_accepted(self, step_id):
+        source = SHIM_IMPORT + f"step('p', 'a', 'x', step_id='{step_id}', recovery='idempotent')\n"
+        result = lint_script(source, "s.py")
+
+        assert _findings_by_rule(result, "invalid-step-id") == []
+        assert result.status == "pass"
+
+    def test_computed_step_id_is_left_to_runtime_validation(self):
+        source = (
+            SHIM_IMPORT
+            + "step_id = make_step_id()\n"
+            + "step('p', 'a', 'x', step_id=step_id, recovery='idempotent')\n"
+        )
+        result = lint_script(source, "s.py")
+
+        assert _findings_by_rule(result, "invalid-step-id") == []
+        assert result.status == "pass"
+
+    def test_unrelated_run_step_method_is_not_blocked(self):
+        source = "runner.run_step('p', 'a', 'x', step_id='not:a:cao:id')\n"
+        result = lint_script(source, "s.py")
+
+        assert _findings_by_rule(result, "invalid-step-id") == []
+        assert result.status == "pass"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            (
+                "from domain_workflow import run_step\n"
+                "run_step('p', 'a', 'x', step_id='not:a:cao:id')\n"
+            ),
+            (
+                "def step(*args, **kwargs):\n"
+                "    return None\n"
+                "step('p', 'a', 'x', step_id='not:a:cao:id', recovery='manual')\n"
+            ),
+        ],
+    )
+    def test_unrelated_bare_call_is_not_blocked(self, source):
+        result = lint_script(source, "s.py")
+
+        assert _findings_by_rule(result, "invalid-step-id") == []
+        assert result.status == "pass"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            (
+                "from cao_workflow import step as cao_step\n"
+                "cao_step('p', 'a', 'x', step_id='t006:makefile', recovery='manual')\n"
+            ),
+            ("import cao_workflow as cw\n" "cw.run_step('p', 'a', 'x', step_id='t006:makefile')\n"),
+        ],
+    )
+    def test_cao_import_alias_is_checked(self, source):
+        result = lint_script(source, "s.py")
+
+        assert result.status == "fail"
+        assert len(_findings_by_rule(result, "invalid-step-id")) == 1
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            (
+                "from cao_workflow import step\n"
+                "def step(*args, **kwargs):\n"
+                "    return None\n"
+                "step('p', 'a', 'x', step_id='not:a:cao:id', recovery='manual')\n"
+            ),
+            (
+                "from cao_workflow import step as cao_step\n"
+                "cao_step = domain_step\n"
+                "cao_step('p', 'a', 'x', step_id='not:a:cao:id', recovery='manual')\n"
+            ),
+            (
+                "import cao_workflow as cw\n"
+                "import domain_workflow as cw\n"
+                "cw.run_step('p', 'a', 'x', step_id='not:a:cao:id')\n"
+            ),
+            (
+                "import cao_workflow as workflow, domain_workflow as workflow\n"
+                "workflow.run_step('p', 'a', 'x', step_id='not:a:cao:id')\n"
+            ),
+        ],
+    )
+    def test_shadowed_cao_import_is_left_to_runtime(self, source):
+        result = lint_script(source, "s.py")
+
+        assert _findings_by_rule(result, "invalid-step-id") == []
+        assert result.status == "pass"
+
+
 class TestMissingRecoveryPolicyRule:
     """BR-5 — the blocking ERROR. FR-5's rejection-at-validation."""
 
@@ -541,6 +657,7 @@ class TestRecoveryRuleIdSeverityAndModelAdmission:
             ("missing-recovery-policy", "error"),
             ("unverifiable-recovery-policy", "warning"),
             ("unenforced-recovery-policy", "warning"),
+            ("invalid-step-id", "error"),
         ],
     )
     def test_new_rule_id_is_admitted_by_lint_finding(self, rule_id, severity):

--- a/test/services/test_script_runner.py
+++ b/test/services/test_script_runner.py
@@ -314,14 +314,15 @@ async def test_happy_completed_result_shape_and_sentinel(monkeypatch: pytest.Mon
 
 @pytest.mark.asyncio
 async def test_crash_nonzero_exit_failed_kind_error(monkeypatch: pytest.MonkeyPatch):
-    """Nonzero exit -> FAILED, kind=error, stderr tail surfaced, sweep fired."""
+    """Nonzero exit -> FAILED with a redacted durable diagnostic and a swept worker."""
     swept = {"run": None}
+    aws_key = "AKIAIOSFODNN7EXAMPLE"
 
     async def _fake_sweep(run_id):
         swept["run"] = run_id
 
     monkeypatch.setattr(script_runner, "_reconcile_orphans", _fake_sweep)
-    proc = _FakeProcess(exit_rc=1, stderr=b"Traceback: boom\n")
+    proc = _FakeProcess(exit_rc=1, stderr=f"Traceback: boom with {aws_key}\n".encode())
     _install_fake_spawn(monkeypatch, proc)
 
     result = await run_script_workflow(_FakeScriptSpec(), {}, "run-crash")
@@ -329,6 +330,10 @@ async def test_crash_nonzero_exit_failed_kind_error(monkeypatch: pytest.MonkeyPa
     assert result.kind == "error"
     assert any("boom" in w for w in result.warnings)  # stderr tail surfaced
     assert swept["run"] == "run-crash"
+    row = workflow_journal.get_run("run-crash")
+    assert row is not None
+    assert getattr(row, "error", None) == "Traceback: boom with [REDACTED:aws_access_key]"
+    assert aws_key not in getattr(row, "error", "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reject literal CAO `step_id` values that violate the server identifier rule before spawning the script
- persist redacted, bounded script-level failure diagnostics for retained results
- surface retained diagnostics through the API and CLI
- keep ambiguous, computed, or shadowed step bindings on the existing runtime-validation path

## Validation

- 313 focused tests passed
- real subprocess stderr-persistence test passed
- Black, isort, Ruff, mypy, and `git diff --check` passed
- independent scoped review approved

The repository-wide suite also ran: 8,687 passed and 62 failed. Representative failures from each residual category reproduce on the exact unmodified base (`b2fb40b`) and are unrelated to this change (missing AG-UI/OpenTelemetry optional dependencies and the existing built-in profile expectation).

Fixes #753