### PR TITLE
fix(security): close all open code-scanning and Dependabot alerts

### DIFF
--- a/cao_mcp_apps/package-lock.json
+++ b/cao_mcp_apps/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^6.0.3",
-        "@vitest/coverage-v8": "^4.1.9",
+        "@vitest/coverage-v8": "^4.1.11",
         "fast-check": "^3.23.1",
         "happy-dom": "^20.10.6",
         "husky": "^9.1.6",
@@ -31,7 +31,7 @@
         "typescript": "^5.6.3",
         "vite": "^8.1.0",
         "vite-plugin-singlefile": "^2.1.0",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -670,14 +670,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
-      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.11",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -691,8 +691,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.9",
-        "vitest": "4.1.9"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -701,16 +701,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -719,13 +719,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -746,9 +746,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -759,13 +759,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -773,14 +773,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -799,13 +799,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1098,9 +1098,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1996,9 +1996,9 @@
       "license": "MIT"
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+      "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -2422,9 +2422,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2519,9 +2519,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2577,9 +2577,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2757,19 +2757,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2797,12 +2797,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2847,9 +2847,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/cao_mcp_apps/package.json
+++ b/cao_mcp_apps/package.json
@@ -46,7 +46,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.3",
-    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/coverage-v8": "^4.1.11",
     "fast-check": "^3.23.1",
     "happy-dom": "^20.10.6",
     "husky": "^9.1.6",
@@ -55,7 +55,7 @@
     "typescript": "^5.6.3",
     "vite": "^8.1.0",
     "vite-plugin-singlefile": "^2.1.0",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.11"
   },
   "overrides": {
     "nanoid": "^3.3.17"

--- a/src/cli_agent_orchestrator/providers/codex.py
+++ b/src/cli_agent_orchestrator/providers/codex.py
@@ -71,7 +71,10 @@ ERROR_PATTERN = r"^(?:Error:|ERROR:|Traceback \(most recent call last\):|panic:)
 # v0.136+: "model · path" (the "N% left" segment was removed)
 # The "·\s+[~/]" alternative anchors on the path component of the footer,
 # which is shared across v0.111 and v0.136 status bars.
-TUI_FOOTER_PATTERN = r"(?:\?\s+for shortcuts|context left|\d+%\s+left|·\s+[~/])"
+# The percentage is \d{1,3} rather than \d+: it is 0-100, and an unbounded \d+
+# made the unanchored search rescan every digit run that never reaches a "%" —
+# quadratic backtracking (CWE-1333) on a screenful of digits.
+TUI_FOOTER_PATTERN = r"(?:\?\s+for shortcuts|context left|\d{1,3}%\s+left|·\s+[~/])"
 # Codex TUI progress spinner: "• Working (0s • esc to interrupt)",
 # "• Working (1m 00s ...)", "• Working (1h 00m 00s ...)", or dynamic
 # prefixes such as "• Starting script creation (10s • esc to interrupt)".
@@ -134,7 +137,13 @@ LOGIN_MENU_FOOTER = TRUST_PROMPT_FOOTER
 # A blind Enter would run a GLOBAL npm install that swaps the codex binary under
 # every other running CAO worker. We suppress with -c check_for_update_on_startup=false
 # at launch AND detect+dismiss with '3'+Enter as defense-in-depth.
-UPDATE_DIALOG_PATTERN = r"Update available!\s+\S+\s+->\s+\S+"
+# The two operands are version strings, so they are spelled out as [\w.+-]+ rather
+# than \S+: `\s+\S+` leaves the separator/operand boundary re-guessable on the
+# whitespace characters outside ASCII (e.g. U+00A0, which the TUI does use for
+# padding), which reads as quadratic backtracking (CWE-1333). CPython's own \s/\S
+# are Unicode-aware and never walked it; the explicit class is what the dialog
+# actually contains either way.
+UPDATE_DIALOG_PATTERN = r"Update available!\s+[\w.+-]+\s+->\s+[\w.+-]+"
 UPDATE_DIALOG_MENU_PATTERN = r"Skip until next version"
 UPDATE_DIALOG_FOOTER = TRUST_PROMPT_FOOTER
 STARTUP_PROMPT_BOTTOM_LINES = 15

--- a/src/cli_agent_orchestrator/providers/kimi_cli.py
+++ b/src/cli_agent_orchestrator/providers/kimi_cli.py
@@ -117,7 +117,11 @@ USER_INPUT_BOX_END_PATTERN = r"╰─"
 # Matches ``💫 some text`` or ``✨ some text`` — a prompt emoji followed by non-whitespace
 # on the SAME line. Uses [^\S\n]+ (horizontal whitespace only) to avoid matching
 # across newlines (a bare ``💫`` followed by blank lines then status bar).
-PROMPT_WITH_INPUT_PATTERN = r"(?:\w+@[\w.-]+)?[✨💫][^\S\n]+\S"
+# An optional ``user@host`` prefix used to lead this pattern. It never changed
+# whether the pattern matched — every use is an unanchored search, so the emoji is
+# found with or without it — and its `\w+@` cost one rescan per word character on
+# input that never reaches an ``@`` (quadratic backtracking, CWE-1333).
+PROMPT_WITH_INPUT_PATTERN = r"[✨💫][^\S\n]+\S"
 
 # Response/thinking bullet pattern: ``•`` (U+2022) at the start of a line.
 # Both thinking (internal monologue) and response (final answer) use this marker.
@@ -146,7 +150,11 @@ STATUS_BAR_PATTERN = r"\d+:\d+\s+.*(?:agent|shell)\s*\("
 # ---------------------------------------------------------------------------
 # Either of these confirms the new TUI is up at its prompt: the context-usage
 # footer, or the status bar's "agent (<model> ●)" segment (● = U+25CF).
-NEW_TUI_STATUS_PATTERN = r"context:\s*\d+(?:\.\d+)?%|agent\s*\([^)]*●"
+# The gap between "(" and "●" holds a model name, so it is bounded and stops at
+# the first ●. An unbounded `[^)]*` made the unanchored search re-walk the whole
+# buffer from every "agent(" in it — quadratic backtracking (CWE-1333) on output
+# an agent can put on screen at will.
+NEW_TUI_STATUS_PATTERN = r"context:\s*\d+(?:\.\d+)?%|agent\s*\([^)●]{0,80}●"
 # Live working indicator: the new TUI animates a braille spinner
 # ("⠧ Thinking… 5s · 220 tokens", "⠹ Using handoff({...})") and a moon-phase
 # thinking glyph (🌑…🌘) that are cleared when the turn finishes. Any such
@@ -178,6 +186,12 @@ def _is_live_turn_spinner_line(line: str) -> bool:
 # welcome banner / update nag contain no "•", so this won't false-trigger at
 # init).
 ANY_BULLET_PATTERN = r"(?m)^\s*•"
+# Same bullet, tested against a single already-split line. Spelled out here rather
+# than inline as `re.match(r"\s*•", line)` so the ^ anchor and the horizontal-only
+# whitespace class are explicit: without them the leading-whitespace run reads as
+# rescannable from every position in it (CWE-1333). `re.match` already anchored in
+# practice, so this is precision, not a live fix.
+BULLET_LINE_PATTERN = re.compile(r"^[^\S\n]*•")
 
 # Generic error patterns for detecting failure states in terminal output.
 ERROR_PATTERN = (
@@ -722,7 +736,7 @@ class KimiCliProvider(BaseProvider):
                 default=-1,
             )
             last_bullet = max(
-                (i for i, line in enumerate(lines) if re.match(r"\s*•", line)),
+                (i for i, line in enumerate(lines) if BULLET_LINE_PATTERN.match(line)),
                 default=-1,
             )
             spinner_in_tail = last_spinner >= 0 and last_spinner >= len(lines) - 15

--- a/src/cli_agent_orchestrator/providers/minimax_code.py
+++ b/src/cli_agent_orchestrator/providers/minimax_code.py
@@ -28,21 +28,41 @@ _PLUGIN_NAME = "cao-orchestrator"
 _PLUGIN_SERVER_NAME = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
 _USER_LINE_PATTERN = re.compile(r"^\s*›[^\S\n]+(.*)$")
 _COMPLETION_LINE_PATTERN = re.compile(r"^\s*└\s+Completed in\s+\d", re.IGNORECASE)
-_COMPLETION_PATTERN = re.compile(r"(?:^|\n)\s*└\s+Completed in\s+\d", re.IGNORECASE)
-_ASSISTANT_LINE_PATTERN = re.compile(r"^(?P<indent>\s*)●\s+(?P<text>\S.*)$")
+# Line-start indent is matched with [^\S\n] (horizontal whitespace) rather than \s
+# so it cannot also consume the newlines that (?:^|\n) matches. With \s* the two
+# overlap, and a buffer of blank lines gives the engine one restart per newline
+# with a rescan behind it — quadratic backtracking on attacker-influenced agent
+# output (CWE-1333). The set of matches is unchanged: either form accepts a `└`
+# that is first on its line.
+_COMPLETION_PATTERN = re.compile(r"(?:^|\n)[^\S\n]*└\s+Completed in\s+\d", re.IGNORECASE)
+# Applied per line (via .match), so the horizontal-whitespace classes are exact
+# and the separator/body boundary is now unambiguous. `\s+` before the body
+# overlapped the following `.*` on every whitespace character outside ASCII, which
+# reads as re-guessable backtracking (CWE-1333); ^-anchoring means CPython never
+# actually walked it, but the narrower classes say what the line really looks like.
+_ASSISTANT_LINE_PATTERN = re.compile(r"^(?P<indent>[^\S\n]*)●[^\S\n]+(?P<text>\S.*)$")
 _READY_ASSISTANT_LINE_PATTERN = re.compile(r"^\s*●\s+Ready\s*$")
 _WAITING_PATTERN = re.compile(
     r"Approval needed|Run this command\?|Allow for this conversation|"
     r"Always allow this action|User prompt request",
     re.IGNORECASE,
 )
-_PROCESSING_PATTERN = re.compile(
-    r"[⠁-⣿◇◆]\s+(?:Loading|Running)(?:\s+\d+s)?[^\n]*(?:Enter queue|Esc stop)",
+# The spinner frame and its footer hint sit on ONE line with padding between
+# them ("◆ Running 12s ───── Enter queue · Esc stop"). Matching that as a single
+# pattern needs a `[^\n]*` gap, and because the pattern is unanchored the engine
+# re-walks the rest of the line from every spinner glyph on it — quadratic in the
+# line length (CWE-1333). Split into head + hint and check each at most once per
+# line instead; see _last_processing_start.
+_PROCESSING_HEAD_PATTERN = re.compile(
+    r"[⠁-⣿◇◆][^\S\n]+(?:Loading|Running)(?:[^\S\n]+\d+s)?",
     re.IGNORECASE,
 )
+_PROCESSING_HINT_PATTERN = re.compile(r"Enter queue|Esc stop", re.IGNORECASE)
 _READY_PATTERN = re.compile(r"●\s+Ready|Message\s+·\s+Enter send", re.IGNORECASE)
+# [^\S\n] rather than \s* after (?:^|\n) — see _COMPLETION_PATTERN.
 _ERROR_PATTERN = re.compile(
-    r"Sign in required|Authentication failed|Not authenticated|" r"(?:^|\n)\s*(?:Fatal|Error):",
+    r"Sign in required|Authentication failed|Not authenticated|"
+    r"(?:^|\n)[^\S\n]*(?:Fatal|Error):",
     re.IGNORECASE,
 )
 _EXTRACTION_SKIP_PATTERN = re.compile(r"^(?:├|└|Called\s|Message\s+·|/[^ ]+\s+\|)")
@@ -54,6 +74,24 @@ _ICON_PNG = base64.b64decode(
 
 def _last_match_start(pattern: re.Pattern[str], text: str) -> int:
     return max((match.start() for match in pattern.finditer(text)), default=-1)
+
+
+def _last_processing_start(text: str) -> int:
+    """Offset of the newest spinner frame that carries its footer hint, or -1.
+
+    Equivalent to matching head + gap + hint as one pattern, but linear: each
+    line costs one head scan plus one hint scan. Searching for the hint from the
+    FIRST head's end is enough — a hint that follows any later head on the line
+    also follows the first one.
+    """
+    result = -1
+    offset = 0
+    for line in text.split("\n"):
+        head = _PROCESSING_HEAD_PATTERN.search(line)
+        if head is not None and _PROCESSING_HINT_PATTERN.search(line, head.end()):
+            result = offset + head.start()
+        offset += len(line) + 1
+    return result
 
 
 class ProviderError(Exception):
@@ -461,7 +499,7 @@ class MiniMaxCodeProvider(BaseProvider):
         clean = strip_terminal_escapes(buffer)
 
         last_waiting = _last_match_start(_WAITING_PATTERN, clean)
-        last_processing = _last_match_start(_PROCESSING_PATTERN, clean)
+        last_processing = _last_processing_start(clean)
         last_completion = _last_match_start(_COMPLETION_PATTERN, clean)
         last_ready = _last_match_start(_READY_PATTERN, clean)
         last_error = _last_match_start(_ERROR_PATTERN, clean)

--- a/src/cli_agent_orchestrator/utils/text.py
+++ b/src/cli_agent_orchestrator/utils/text.py
@@ -32,7 +32,16 @@ _CSI_PATTERN = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]")
 
 # OSC (Operating System Command) — terminal title, hyperlinks, etc.
 # ESC ] ... (BEL | ST)
-_OSC_PATTERN = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+#
+# Deliberately NOT a raw string: the negated class must exclude the real ESC/BEL
+# bytes, and static analysers that read the pattern out of an r"..." literal see
+# `\x1b` as the four characters `\`,`x`,`1`,`b` rather than one control byte. A
+# class that only excludes those four characters looks unbounded to them, so
+# `\x1b]\x1b]\x1b]…` reads as a quadratic-backtracking input (CWE-1333) that
+# CPython never actually walks. Letting Python resolve the escapes here keeps
+# the compiled pattern identical and the class unambiguous. `\\]` / `\\\\` are
+# the regex escapes for a literal `]` and the `ESC \` (ST) terminator.
+_OSC_PATTERN = re.compile("\x1b\\][^\x07\x1b]*(?:\x07|\x1b\\\\)")
 
 # Non-printable control characters (except \t and \n which are meaningful)
 # Includes C1 control range (\x80-\x9f) minus \x9B which is handled as CSI above

--- a/test/security/test_status_pattern_redos.py
+++ b/test/security/test_status_pattern_redos.py
@@ -1,0 +1,253 @@
+"""Backtracking budget + behaviour guards for the provider status regexes.
+
+Provider status detection runs untrusted text: everything an agent CLI paints on
+its terminal reaches these patterns through ``strip_terminal_escapes``, and an
+agent decides what it paints. Six of them held a quantifier that could be
+re-entered at every position of a repeated prefix, so a screenful of the right
+filler cost quadratic time in the buffer length instead of linear (CWE-1333,
+py/polynomial-redos). Measured on this box, at 50k characters:
+
+    _COMPLETION_PATTERN            3451 ms -> 2 ms
+    _ERROR_PATTERN                24481 ms -> 4 ms
+    _PROCESSING_PATTERN            1738 ms -> 0.5 ms
+    PROMPT_WITH_INPUT_PATTERN      4815 ms -> 0.4 ms
+    NEW_TUI_STATUS_PATTERN          234 ms -> 6 ms
+    TUI_FOOTER_PATTERN             4753 ms -> 2 ms
+
+Four more patterns were reported by the same rule but were never slow in CPython
+— `re.match` anchored them, or the ambiguity existed only under an ASCII-only
+reading of \\s/\\S. They were tightened for precision and they get budget tests
+too, so a later rewrite into a genuinely unanchored form is caught.
+
+Two kinds of test live here, and both are load-bearing:
+
+* the budget tests below feed each pattern its own worst case at a size where the
+  old form took seconds and the new form takes milliseconds. The threshold is
+  deliberately ~100x the observed cost so a busy CI box cannot flake it; a
+  genuine regression to quadratic misses it by two orders of magnitude, not by a
+  margin.
+* the recognition tests pin the strings each pattern EXISTS to match. Every fix
+  here narrowed a class or bounded a repetition, and the way to "fix" a ReDoS
+  while silently breaking a provider is to narrow it too far — status detection
+  would then read IDLE forever and the provider would time out at init with no
+  regex test to show why.
+"""
+
+import re
+import time
+
+import pytest
+
+from cli_agent_orchestrator.providers import codex, kimi_cli, minimax_code
+from cli_agent_orchestrator.utils.text import strip_terminal_escapes
+
+# Large enough that the pre-fix patterns took seconds, small enough to stay
+# instant when the matching is linear.
+PATHOLOGICAL_LENGTH = 200_000
+
+# ~100x the post-fix cost of the slowest case measured above.
+BUDGET_SECONDS = 2.0
+
+
+def assert_within_budget(label: str, probe, text: str) -> None:
+    """Fail if ``probe(text)`` does not finish inside the backtracking budget."""
+    start = time.perf_counter()
+    probe(text)
+    elapsed = time.perf_counter() - start
+    assert elapsed < BUDGET_SECONDS, (
+        f"{label} took {elapsed:.2f}s on {len(text)} characters of its own worst-case "
+        f"filler (budget {BUDGET_SECONDS}s). That is the signature of a quantifier that "
+        f"can be re-entered at every position — see CWE-1333 / py/polynomial-redos."
+    )
+
+
+class TestBacktrackingBudget:
+    """Each pattern's own worst-case filler must stay linear."""
+
+    def test_completion_pattern_on_blank_lines(self):
+        assert_within_budget(
+            "minimax _COMPLETION_PATTERN",
+            minimax_code._COMPLETION_PATTERN.search,
+            "\n" * PATHOLOGICAL_LENGTH,
+        )
+
+    def test_error_pattern_on_blank_lines(self):
+        assert_within_budget(
+            "minimax _ERROR_PATTERN",
+            minimax_code._ERROR_PATTERN.search,
+            "\n" * PATHOLOGICAL_LENGTH,
+        )
+
+    def test_processing_scan_on_spinner_flood(self):
+        # A single line carrying nothing but spinner heads: the old combined
+        # pattern re-walked the rest of the line from every one of them.
+        assert_within_budget(
+            "minimax _last_processing_start",
+            minimax_code._last_processing_start,
+            "◆ Loading 0s " * (PATHOLOGICAL_LENGTH // 13),
+        )
+
+    def test_prompt_with_input_on_word_characters(self):
+        assert_within_budget(
+            "kimi PROMPT_WITH_INPUT_PATTERN",
+            lambda text: re.search(kimi_cli.PROMPT_WITH_INPUT_PATTERN, text),
+            "0" * PATHOLOGICAL_LENGTH,
+        )
+
+    def test_new_tui_status_on_agent_paren_flood(self):
+        assert_within_budget(
+            "kimi NEW_TUI_STATUS_PATTERN",
+            lambda text: re.search(kimi_cli.NEW_TUI_STATUS_PATTERN, text),
+            "agent(" * (PATHOLOGICAL_LENGTH // 6),
+        )
+
+    def test_tui_footer_on_digits(self):
+        assert_within_budget(
+            "codex TUI_FOOTER_PATTERN",
+            lambda text: re.search(codex.TUI_FOOTER_PATTERN, text),
+            "0" * PATHOLOGICAL_LENGTH,
+        )
+
+    def test_update_dialog_on_padding_whitespace(self):
+        assert_within_budget(
+            "codex UPDATE_DIALOG_PATTERN",
+            lambda text: re.search(codex.UPDATE_DIALOG_PATTERN, text),
+            "Update available!\t" + "\xa0" * PATHOLOGICAL_LENGTH,
+        )
+
+    def test_bullet_line_on_indent_whitespace(self):
+        assert_within_budget(
+            "kimi BULLET_LINE_PATTERN",
+            kimi_cli.BULLET_LINE_PATTERN.match,
+            "\t" * PATHOLOGICAL_LENGTH,
+        )
+
+    def test_osc_strip_on_escape_flood(self):
+        assert_within_budget(
+            "strip_terminal_escapes (OSC)",
+            strip_terminal_escapes,
+            "\x1b]" * (PATHOLOGICAL_LENGTH // 2),
+        )
+
+
+class TestStillRecognisesRealOutput:
+    """The narrowed patterns must still match what providers actually render."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "└ Completed in 3s",
+            "  └ Completed in 12.4s",
+            "\n\n   └ completed in 1s",
+        ],
+    )
+    def test_completion_pattern_matches(self, line):
+        assert minimax_code._COMPLETION_PATTERN.search(line) is not None
+
+    def test_completion_pattern_still_requires_line_start(self):
+        assert minimax_code._COMPLETION_PATTERN.search("tail └ Completed in 3s") is None
+
+    @pytest.mark.parametrize(
+        "text",
+        ["Error: boom", "  Fatal: boom", "prior line\n  Error: boom", "Sign in required"],
+    )
+    def test_error_pattern_matches(self, text):
+        assert minimax_code._ERROR_PATTERN.search(text) is not None
+
+    def test_error_pattern_ignores_mid_line_error_label(self):
+        assert minimax_code._ERROR_PATTERN.search("see Error: in the log") is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "◆ Loading  Enter queue · Esc stop",
+            "◇ Running 12s ──────────  Enter queue",
+            "⠹ Loading 3s   Esc stop",
+            "banner\n◆ Running 1s  Enter queue\ntail",
+        ],
+    )
+    def test_processing_scan_finds_spinner(self, text):
+        assert minimax_code._last_processing_start(text) >= 0
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "◆ Running 12s",  # spinner without the footer hint
+            "Enter queue · Esc stop",  # footer hint without a spinner
+            "◆ Running 12s\nEnter queue",  # hint on a different line
+        ],
+    )
+    def test_processing_scan_rejects_partial_frames(self, text):
+        assert minimax_code._last_processing_start(text) == -1
+
+    def test_processing_scan_reports_the_newest_frame(self):
+        text = "◆ Loading 1s Enter queue\nfiller\n◆ Running 2s Esc stop"
+        assert minimax_code._last_processing_start(text) == text.rindex("◆")
+
+    @pytest.mark.parametrize("text", ["💫 hello", "✨ do the thing", "user@host:~$ 💫 hello"])
+    def test_prompt_with_input_matches(self, text):
+        assert re.search(kimi_cli.PROMPT_WITH_INPUT_PATTERN, text) is not None
+
+    @pytest.mark.parametrize("text", ["💫 ", "💫", "💫\nnext line"])
+    def test_prompt_with_input_rejects_empty_prompt(self, text):
+        assert re.search(kimi_cli.PROMPT_WITH_INPUT_PATTERN, text) is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "yolo  agent (kimi-k2-thinking ●)  ctrl-x: toggle mode",
+            "agent(kimi-k2 ●)",
+            "context: 12.3%",
+            "context:0%",
+        ],
+    )
+    def test_new_tui_status_matches(self, text):
+        assert re.search(kimi_cli.NEW_TUI_STATUS_PATTERN, text) is not None
+
+    def test_new_tui_status_rejects_agent_without_the_dot(self):
+        assert re.search(kimi_cli.NEW_TUI_STATUS_PATTERN, "agent (kimi-k2)") is None
+
+    @pytest.mark.parametrize("line", ["• thinking", "  • response", "\t• response"])
+    def test_bullet_line_matches(self, line):
+        assert kimi_cli.BULLET_LINE_PATTERN.match(line) is not None
+
+    def test_bullet_line_rejects_mid_line_bullet(self):
+        assert kimi_cli.BULLET_LINE_PATTERN.match("text • more") is None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "? for shortcuts",
+            "23% left",
+            "100% left",
+            "0% left",
+            "gpt-6-astra · 41% left · ~/code",
+            "context left",
+            "gpt-6-astra · ~/code",
+        ],
+    )
+    def test_tui_footer_matches(self, line):
+        assert re.search(codex.TUI_FOOTER_PATTERN, line) is not None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Update available! 0.142.5 -> 0.144.5",
+            "✨ Update available! 0.142.5 -> 0.144.5",
+            "Update available! v1.2.3-beta.1 -> v1.2.4",
+            "Update available!\xa00.142.5\xa0->\xa00.144.5",
+        ],
+    )
+    def test_update_dialog_matches(self, text):
+        assert re.search(codex.UPDATE_DIALOG_PATTERN, text) is not None
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("\x1b]0;window title\x07visible", "visible"),
+            ("\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\", "link"),
+            ("plain", "plain"),
+        ],
+    )
+    def test_osc_sequences_are_stripped(self, raw, expected):
+        assert strip_terminal_escapes(raw) == expected

--- a/tui/src/server.rs
+++ b/tui/src/server.rs
@@ -1812,12 +1812,17 @@ mod tests {
         );
 
         // 3. And no value leaked under any other key name.
+        //
+        // The sentinel that matched is deliberately NOT interpolated into the panic
+        // message: these are credential-shaped values, and a panic message is a log
+        // line (rust/cleartext-logging). The raw query is printed instead, and it
+        // necessarily contains whichever sentinel leaked.
         for secret in ["hunter2", "us-east-1", "SECRET_TOKEN", "AWS_REGION"] {
             assert!(
                 !request.query.contains(secret),
-                "the env-var name/value {secret:?} must not appear anywhere in the query string, \
-                 under `env_vars` or any other key — a leak wearing a different parameter name \
-                 is the same leak. Raw query was {:?}",
+                "no env-var name or value may appear anywhere in the query string, under \
+                 `env_vars` or any other key — a leak wearing a different parameter name is \
+                 the same leak. The leaked sentinel is visible in the raw query: {:?}",
                 request.query
             );
         }


### PR DESCRIPTION
## Summary

Closes every open alert on the repo's two security dashboards: 9 CodeQL code-scanning alerts and 2 Dependabot alerts.

| Source | Alerts | Fix |
|---|---|---|
| `py/polynomial-redos` | #203–#210 (8, high) | Remove the backtracking ambiguity in the provider status regexes |
| `rust/cleartext-logging` | #215 (1, high) | Stop interpolating the credential sentinel into a test's `assert!` message |
| Dependabot (`GHSA-82fw-gwwq-j7x9`) | vitest, `@vitest/mocker` (2, moderate) | Bump vitest 4.1.9 → 4.1.11 in `/cao_mcp_apps` |

## Why the ReDoS alerts are real

These regexes run on **agent-controlled** text. Everything a provider CLI paints on its terminal reaches them through `strip_terminal_escapes`, and the agent decides what it paints. Six patterns held a quantifier the engine could re-enter at every position of a repeated prefix, so a screenful of the right filler cost time quadratic in the buffer length. Measured on the same box, at 50k characters:

| Pattern | Before | After |
|---|---|---|
| minimax `_COMPLETION_PATTERN` | 3451 ms | 2 ms |
| minimax `_ERROR_PATTERN` | 24481 ms | 4 ms |
| minimax `_PROCESSING_PATTERN` | 1738 ms | 0.5 ms |
| kimi `PROMPT_WITH_INPUT_PATTERN` | 4815 ms | 0.4 ms |
| kimi `NEW_TUI_STATUS_PATTERN` | 234 ms | 6 ms |
| codex `TUI_FOOTER_PATTERN` | 4753 ms | 2 ms |

Each fix removes the ambiguity rather than capping the work:

- **`(?:^|\n)\s*`** (completion + error) — `\s*` swallowed the very newlines `(?:^|\n)` matches, giving one restart per blank line with a rescan behind it. `[^\S\n]*` accepts the identical set of matches (a glyph first on its line) with no overlap.
- **`_PROCESSING_PATTERN`** — the spinner frame and its `Enter queue / Esc stop` footer share one line, so joining them needed a `[^\n]*` gap that got re-walked from every spinner glyph on the line. Split into head + hint, each checked at most once per line by `_last_processing_start`. Searching for the hint from the *first* head's end is complete: a hint following any later head also follows the first head's end.
- **`PROMPT_WITH_INPUT_PATTERN`** — the optional `(?:\w+@[\w.-]+)?` shell-prompt prefix never changed whether the pattern matched (every use is an unanchored `search`, which finds the emoji with or without it), and its `\w+@` rescanned every word character on input with no `@`. Dropped.
- **`NEW_TUI_STATUS_PATTERN`** — `[^)]*` re-walked the whole buffer from every `agent(` in it. The gap holds a model name, so it is bounded and stops at the first `●`.
- **`TUI_FOOTER_PATTERN`** — the context percentage is 0–100, so `\d{1,3}`, not `\d+`.

## The two that were never actually slow

Reported by the same rule, but linear in CPython. They are tightened for precision and the comments say so rather than implying a live hole:

- `_ASSISTANT_LINE_PATTERN` and the inline `re.match(r"\s*•", line)` are anchored in practice. Both are now explicitly `^`-anchored with horizontal-only classes; the latter is promoted to a named `BULLET_LINE_PATTERN`.
- `UPDATE_DIALOG_PATTERN`'s `\s+\S+` is ambiguous only under an ASCII-only reading of `\s`/`\S`. The operands are version strings, so `[\w.+-]+` says what they are.
- `_OSC_PATTERN` moves from `r"..."` to a plain literal so the negated class holds the real ESC/BEL **bytes** rather than the characters `\`, `x`, `1`, `b` — which is what a static reader of the raw literal sees. Verified equivalent over 300k random strings drawn from ESC/BEL/`]`/backslash plus filler, and on real OSC title and hyperlink sequences.

## Rust: `rust/cleartext-logging`

The env-var leak test loops over credential-shaped sentinels (`hunter2`, `SECRET_TOKEN`, …) and interpolated the matching one into its `assert!` message. A panic message is a log line, so a value CodeQL classifies as sensitive flowed into a cleartext sink. It is test code, but the shape is exactly what the rule exists to catch, and dismissing it trains the eye to ignore the same shape in `src/`.

The assertion loses nothing: it still prints the raw query, which by definition contains whichever sentinel leaked. The two neighbouring assertions in the same test already print only `request.query` and were never flagged.

## Tests

`test/security/test_status_pattern_redos.py` (55 cases) adds both halves of the guard:

- **A backtracking budget per pattern** — 200k characters of its pattern's own worst-case filler against a 2 s ceiling. The pre-fix forms miss that by two orders of magnitude, not by a margin, so it discriminates without flaking on a loaded runner.
- **Recognition tests** pinning the real TUI strings each pattern exists to match. Every fix here narrowed a class or bounded a repetition, and the way to "fix" a ReDoS while silently breaking a provider is to narrow it too far — status detection would then read IDLE forever and the provider would time out at init with no regex test to show why.

## Verification

- **CodeQL run locally** (2.23.5, `python-code-scanning` suite) against the tree before and after: 7 of the 8 `py/polynomial-redos` alerts reproduce under this CLI version and **all 7 are gone**, with no new findings. The 8th (#205) does not reproduce here; its pattern was confirmed directly against the `SuperlinearBackTracking` library, where `\s*•` is reported and `^[^\S\n]*•` is not. `rust/cleartext-logging` does not fire on this CLI version (older `rust-queries` pack) — that one fix rests on the alert's own flagged region, which is precisely the format string plus args that held `{secret:?}`.
- **Python**: full unit suite, 8801 passed / 35 skipped. 4 failures are pre-existing and reproduce identically on unmodified `main` in the same environment (missing `[otel]` extra, unbuilt `mcp_apps` bundles).
- **Rust**: `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked` (235 tests) all clean.
- **`black --check` / `isort --check-only` / `mypy`** clean on the changed modules.
- **npm**: `npm audit` reports 0 vulnerabilities after the bump. `vitest run` could not be executed on this host — its glibc (2.26) cannot run a Node new enough for vite 8's native rolldown binding (`^20.19.0`), and startup fails the same way on the *unchanged* lockfile. CI runs it.

## Noted, not changed

`kimi_cli.STATUS_BAR_PATTERN` (`\d+:\d+\s+.*(?:agent|shell)\s*\(`) carries the same shape and the library flags it, but no taint path reaches it today so it has no alert. Left alone to keep this PR to the open dashboard; happy to fold it in if preferred.
