### PR TITLE
fix: raise handoff create-timeout above antigravity's ready-timeout floor

### DIFF
--- a/src/cli_agent_orchestrator/utils/orchestration.py
+++ b/src/cli_agent_orchestrator/utils/orchestration.py
@@ -91,7 +91,18 @@ TERMINAL_CLEANUP_NUDGE_THRESHOLD = 10
 # _create_terminal non-deferred in production (assign always uses
 # defer_init=True); this is the first caller of that path, so it gets its own
 # padded timeout rather than silently inheriting one sized for something else.
-_HANDOFF_CREATE_TIMEOUT_S = 150.0
+#
+# The ~45s estimate above is not the real worst case, though: several
+# providers apply their own unconditional ready-timeout FLOOR on top of the
+# configurable provider_init_timeout (default 60s) -- antigravity_cli.py's
+# initialize() uses max(180.0, init_timeout), minimax_code.py and kimi_cli.py
+# use max(120.0, init_timeout). At the old 150.0s value, a legitimately-slow
+# (but successful) antigravity init past ~150s got killed client-side here,
+# leaving an orphaned worker terminal with no terminal_id surfaced to the
+# operator to clean it up (no exception handling wraps this call). 240.0
+# clears the highest known floor (antigravity's 180.0) with real headroom;
+# revisit if a future provider's floor exceeds it.
+_HANDOFF_CREATE_TIMEOUT_S = 240.0
 _TERMINAL_ID_PATTERN = re.compile(r"^[a-f0-9]{8}$")
 
 

--- a/test/mcp_server/test_handoff.py
+++ b/test/mcp_server/test_handoff.py
@@ -812,3 +812,97 @@ class TestHandoffEarlyTerminalId:
         assert result.success is False
         assert "CAO_TERMINAL_ID not set" in result.message
         mock_create.assert_not_called()
+
+
+class TestHandoffCreateTimeoutCoversProviderFloors:
+    """_HANDOFF_CREATE_TIMEOUT_S must exceed every provider's own unconditional
+    ready-timeout floor (antigravity_cli.py's max(180.0, init_timeout) is the
+    highest known one), or a legitimately-slow-but-successful init gets killed
+    client-side here -- with no exception handling around this specific call,
+    the operator gets a clean-looking failure and no terminal_id to clean up
+    the orphaned worker with."""
+
+    def test_constant_exceeds_known_provider_floors(self):
+        """This is the test that actually pins the regression: 150.0 (the old
+        value) is LESS than antigravity's 180.0 floor; 240.0 is not. Fails
+        against the pre-fix constant, passes after."""
+        assert _HANDOFF_CREATE_TIMEOUT_S > 180.0
+
+    def test_slow_but_successful_create_is_not_killed_client_side(self):
+        """Companion end-to-end sanity check, independent of the constant's
+        actual value: a real HTTP round trip (no `requests` mocking) against a
+        stand-in server that sleeps past a client timeout before answering
+        successfully must still surface the terminal_id, not just a clean
+        failure. Zero existing test exercised this path against a real
+        timeout window before this. Uses its own stand-in timeout/delay
+        values (not the real constant) purely so the test runs in
+        milliseconds -- the mechanism being verified is identical at the real
+        240.0s scale."""
+        import http.server
+        import json
+        import threading
+        import time
+
+        from cli_agent_orchestrator.utils import orchestration
+
+        created_terminal_ids = []
+
+        class SlowServerHandler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, format, *args):  # noqa: A002 -- matches base signature
+                pass
+
+            def do_POST(self):
+                if self.path.split("?", 1)[0] == "/sessions":
+                    # Stand-in for cao-server actually finishing provider.initialize()
+                    # after longer than the OLD client timeout would have allowed,
+                    # but still comfortably under the fixed (current) one.
+                    time.sleep(1.2)
+                    terminal_id = "term-0001"
+                    created_terminal_ids.append(terminal_id)
+                    body = json.dumps({"id": terminal_id, "provider": "antigravity_cli"}).encode()
+                    self.send_response(201)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+                # The --no-wait path also sends the message directly via
+                # POST /terminals/{id}/input -- not the create call under test,
+                # so just ack it.
+                self.send_response(200)
+                self.end_headers()
+
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), SlowServerHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        old_base_url = orchestration.API_BASE_URL
+        old_timeout = orchestration._HANDOFF_CREATE_TIMEOUT_S
+        # Scale both the client timeout and server delay down 150:1 from the
+        # real 240.0s constant, preserving the same "server takes longer than
+        # the OLD 150.0s value but well within the fixed value" relationship.
+        orchestration.API_BASE_URL = f"http://127.0.0.1:{port}"
+        orchestration._HANDOFF_CREATE_TIMEOUT_S = 1.6  # stand-in for 240.0
+        os.environ.pop("CAO_TERMINAL_ID", None)
+
+        try:
+            reported = []
+            result = asyncio.run(
+                orchestration._handoff_impl(
+                    "some-agent-profile",
+                    "do the thing",
+                    on_terminal_id=reported.append,
+                    wait=False,
+                )
+            )
+        finally:
+            orchestration.API_BASE_URL = old_base_url
+            orchestration._HANDOFF_CREATE_TIMEOUT_S = old_timeout
+            server.shutdown()
+            thread.join(timeout=2)
+
+        assert result.success is True
+        assert result.terminal_id == "term-0001"
+        assert reported == ["term-0001"]
+        assert created_terminal_ids == ["term-0001"]


### PR DESCRIPTION
### Problem

`_HANDOFF_CREATE_TIMEOUT_S` in `orchestration.py` is `150.0`, used as the client-side timeout for `handoff`'s early-terminal-id path's synchronous terminal-create call. `antigravity_cli.py`'s `initialize()` applies its own unconditional ready-timeout floor: `max(180.0, init_timeout)`. Since `provider_init_timeout` defaults to `60`, that floor is always `180.0` under default settings — 30s above the client's own timeout.

If antigravity's init legitimately takes between 150s and 180s (still within its own documented ceiling, so not a hang), the client-side `requests.post` in `_create_terminal` times out and raises, uncaught (no exception handling wraps this specific call). The server-side create keeps running and eventually succeeds, but the operator gets a plain failure message with no `terminal_id` — the worker terminal is orphaned with no id to clean it up with.

### Fix

Raised `_HANDOFF_CREATE_TIMEOUT_S` to `240.0`, clearing the highest known provider floor (antigravity's `180.0`) with real headroom, and documented the reasoning (citing all three providers with their own floors: antigravity `180.0`, minimax/kimi `120.0`) so a future provider needing an even higher floor doesn't silently reintroduce this.

### How did you test it

Added `TestHandoffCreateTimeoutCoversProviderFloors` to `test/mcp_server/test_handoff.py`:
- `test_constant_exceeds_known_provider_floors` pins the actual regression — fails against the pre-fix `150.0` value, passes at `240.0`.
- `test_slow_but_successful_create_is_not_killed_client_side` is a real HTTP round-trip test (no `requests` mocking) against a stand-in server that sleeps past a client timeout before answering successfully, confirming the terminal_id is actually surfaced. No existing test exercised a real timeout window on this path before.

Full suite: `uv run pytest test/ examples/workflow/tests/ --ignore=test/providers/test_kiro_cli_integration.py --ignore=test/e2e -m "not e2e"` — 8991 passed, 61 pre-existing failures confined to `test/services/agui/*` and `test/telemetry/test_otel_init.py` (confirmed unrelated: same failures occur with this diff fully reverted). `black --check`, `isort --check-only`, and `mypy` all clean on the changed files (the one pre-existing mypy finding in this file at what's now line 348 also reproduces on unmodified `main`).